### PR TITLE
Update ecs task definition using phi ws phi 110

### DIFF
--- a/phidata/infra/aws/resource/ecs/cluster.py
+++ b/phidata/infra/aws/resource/ecs/cluster.py
@@ -17,6 +17,10 @@ class EcsCluster(AwsResource):
 
     # Name of the cluster.
     name: str
+    # Name for the cluster.
+    # Use name if not provided.
+    ecs_cluster_name: Optional[str] = None
+
     tags: Optional[List[Dict[str, str]]] = None
     # The setting to use when creating a cluster.
     settings: Optional[List[Dict[str, Any]]] = None
@@ -30,6 +34,9 @@ class EcsCluster(AwsResource):
     # is set for a cluster, when you call the RunTask or CreateService APIs with no capacity provider strategy or
     # launch type specified, the default capacity provider strategy for the cluster is used.
     default_capacity_provider_strategy: Optional[List[Dict[str, Any]]] = None
+
+    def get_ecs_cluster_name(self):
+        return self.ecs_cluster_name or self.name
 
     def _create(self, aws_client: AwsApiClient) -> bool:
         """Creates the EcsCluster
@@ -58,7 +65,7 @@ class EcsCluster(AwsResource):
         service_client = self.get_service_client(aws_client)
         try:
             create_response = service_client.create_cluster(
-                clusterName=self.get_resource_name(),
+                clusterName=self.get_ecs_cluster_name(),
                 **not_null_args,
             )
             logger.debug(f"EcsCluster: {create_response}")
@@ -86,7 +93,7 @@ class EcsCluster(AwsResource):
 
         service_client = self.get_service_client(aws_client)
         try:
-            cluster_name = self.get_resource_name()
+            cluster_name = self.get_ecs_cluster_name()
             describe_response = service_client.describe_clusters(
                 clusters=[cluster_name]
             )
@@ -121,7 +128,7 @@ class EcsCluster(AwsResource):
 
         try:
             delete_response = service_client.delete_cluster(
-                cluster=self.get_resource_name()
+                cluster=self.get_ecs_cluster_name()
             )
             logger.debug(f"EcsCluster: {delete_response}")
             print_info(

--- a/phidata/infra/aws/resource/ecs/service.py
+++ b/phidata/infra/aws/resource/ecs/service.py
@@ -291,4 +291,3 @@ class EcsService(AwsResource):
             print_error(f"{self.get_resource_type()} could not be updated.")
             print_error(e)
         return False
-

--- a/phidata/infra/aws/resource/ecs/service.py
+++ b/phidata/infra/aws/resource/ecs/service.py
@@ -64,6 +64,14 @@ class EcsService(AwsResource):
     enable_execute_command: Optional[bool] = None
 
     force_delete: Optional[bool] = None
+    # Force a new deployment of the service on update.
+    # By default, deployments aren't forced.
+    # You can use this option to start a new deployment with no service
+    # definition changes. For example, you can update a service's
+    # tasks to use a newer Docker image with the same
+    # image/tag combination (my_image:latest ) or
+    # to roll Fargate tasks onto a newer platform version.
+    force_new_deployment: Optional[bool] = None
 
     def get_ecs_service_name(self):
         return self.ecs_service_name or self.name
@@ -71,7 +79,7 @@ class EcsService(AwsResource):
     def get_ecs_cluster_name(self):
         if self.cluster is not None:
             if isinstance(self.cluster, EcsCluster):
-                return self.cluster.name
+                return self.cluster.get_ecs_cluster_name()
             else:
                 return self.cluster
 
@@ -226,4 +234,61 @@ class EcsService(AwsResource):
         """Update EcsService"""
         print_info(f"Updating {self.get_resource_type()}: {self.get_resource_name()}")
 
-        return True
+        # create a dict of args which are not null, otherwise aws type validation fails
+        not_null_args: Dict[str, Any] = {}
+
+        cluster_name = self.get_ecs_cluster_name()
+        if cluster_name is not None:
+            not_null_args["cluster"] = cluster_name
+        if self.desired_count is not None:
+            not_null_args["desiredCount"] = self.desired_count
+        if self.capacity_provider_strategy is not None:
+            not_null_args["capacityProviderStrategy"] = self.capacity_provider_strategy
+        if self.deployment_configuration is not None:
+            not_null_args["deploymentConfiguration"] = self.deployment_configuration
+        if self.network_configuration is not None:
+            not_null_args["networkConfiguration"] = self.network_configuration
+        if self.placement_constraints is not None:
+            not_null_args["placementConstraints"] = self.placement_constraints
+        if self.placement_strategy is not None:
+            not_null_args["placementStrategy"] = self.placement_strategy
+        if self.platform_version is not None:
+            not_null_args["platformVersion"] = self.platform_version
+        if self.force_new_deployment is not None:
+            not_null_args["forceNewDeployment"] = self.force_new_deployment
+        if self.health_check_grace_period_seconds is not None:
+            not_null_args[
+                "healthCheckGracePeriodSeconds"
+            ] = self.health_check_grace_period_seconds
+        if self.enable_execute_command is not None:
+            not_null_args["enableExecuteCommand"] = self.enable_execute_command
+        if self.enable_ecsmanaged_tags is not None:
+            not_null_args["enableECSManagedTags"] = self.enable_ecsmanaged_tags
+        if self.load_balancers is not None:
+            not_null_args["loadBalancers"] = self.load_balancers
+        if self.propagate_tags is not None:
+            not_null_args["propagateTags"] = self.propagate_tags
+        if self.service_registries is not None:
+            not_null_args["serviceRegistries"] = self.service_registries
+
+        # Update EcsService
+        service_client = self.get_service_client(aws_client)
+        try:
+            update_response = service_client.update_service(
+                service=self.get_ecs_service_name(),
+                taskDefinition=self.get_ecs_task_definition(),
+                **not_null_args,
+            )
+            logger.debug(f"EcsService: {update_response}")
+            resource_dict = update_response.get("service", {})
+
+            # Validate resource creation
+            if resource_dict is not None:
+                print_info(f"EcsService updated: {self.get_resource_name()}")
+                self.active_resource = update_response
+                return True
+        except Exception as e:
+            print_error(f"{self.get_resource_type()} could not be updated.")
+            print_error(e)
+        return False
+

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,7 +20,7 @@ main() {
     -r ${REPO_ROOT}/requirements.txt
 
   print_info "Installing phidata with [dev] extras"
-  pip3 install --editable "${REPO_ROOT}[dev]"
+  pip install --editable "${REPO_ROOT}[dev]"
 }
 
 main "$@"


### PR DESCRIPTION
## Update ECS [Task definitions](https://us-east-1.console.aws.amazon.com/ecs/v2/task-definitions?region=us-east-1) using `phi ws patch`

### Description

- `phi ws patch` should create a new ECS Task definitions

### How was this tested?

Run: `phi ws patch --env prd --config aws --name td`
Update task definition:

![image](https://user-images.githubusercontent.com/22579644/205731276-92fabe65-173c-449a-8f7f-c9a0096a8818.png)
