### PR TITLE
Fix handling of folder names with spaces in create_venv.sh

### DIFF
--- a/scripts/create_venv.sh
+++ b/scripts/create_venv.sh
@@ -9,26 +9,26 @@
 ############################################################################
 
 CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$( dirname ${CURR_DIR} )"
+REPO_ROOT="$(dirname "${CURR_DIR}")"
 VENV_DIR="${REPO_ROOT}/phienv"
-source ${CURR_DIR}/_utils.sh
+source "${CURR_DIR}/_utils.sh"
 
 main() {
   print_heading "phidata dev setup"
   print_heading "Creating venv: ${VENV_DIR}"
 
   print_status "Removing existing venv: ${VENV_DIR}"
-  rm -rf ${VENV_DIR}
+  rm -rf "${VENV_DIR}"
 
   print_status "Creating python3 venv: ${VENV_DIR}"
-  python3 -m venv ${VENV_DIR}
+  python3 -m venv "${VENV_DIR}"
 
   print_status "Installing base python packages"
   pip3 install --upgrade pip pip-tools twine build
 
   # Install workspace
-  source ${VENV_DIR}/bin/activate
-  source ${CURR_DIR}/install.sh
+  source "${VENV_DIR}/bin/activate"
+  source "${CURR_DIR}/install.sh"
 
   print_heading "Activate using: source ${VENV_DIR}/bin/activate"
 }


### PR DESCRIPTION
This commit addresses an issue where folder names containing spaces caused
errors in the create_venv.sh script. Changes were made to properly handle
folder names with spaces by enclosing variable expansions in double quotes
and using double quotes around variable references throughout the script.
This ensures correct interpretation of paths and prevents errors when
dealing with folder names containing spaces.

Modified lines:
- Enclosed variable expansions for CURR_DIR, REPO_ROOT, and VENV_DIR in double quotes.
- Used double quotes around variable references when printing messages or executing commands.

