### PR TITLE
resend-tool-phi-339

### DIFF
--- a/cookbook/tools/duckduckgo.py
+++ b/cookbook/tools/duckduckgo.py
@@ -1,6 +1,5 @@
 from phi.assistant import Assistant
-from phi.tools.resend import ResendTools
-from phi.tools.arxiv import ArxivTools
+from phi.tools.duckduckgo import DuckDuckGo
 
-assistant = Assistant(tools=[ResendTools(), ArxivTools()], show_tool_calls=True)
-assistant.print_response('search arxiv for quantum computing and send me an email of the summary on yash@phidata.com')
+assistant = Assistant(tools=[DuckDuckGo()], show_tool_calls=True)
+assistant.print_response("Whats happening in France? Summarize top stories with sources.")

--- a/cookbook/tools/duckduckgo.py
+++ b/cookbook/tools/duckduckgo.py
@@ -1,5 +1,6 @@
 from phi.assistant import Assistant
-from phi.tools.duckduckgo import DuckDuckGo
+from phi.tools.resend import ResendTools
+from phi.tools.arxiv import ArxivTools
 
-assistant = Assistant(tools=[DuckDuckGo()], show_tool_calls=True)
-assistant.print_response("Whats happening in France? Summarize top stories with sources.")
+assistant = Assistant(tools=[ResendTools(), ArxivTools()], show_tool_calls=True)
+assistant.print_response('search arxiv for quantum computing and send me an email of the summary on yash@phidata.com')

--- a/phi/tools/resend.py
+++ b/phi/tools/resend.py
@@ -1,16 +1,23 @@
+from typing import Optional
+
 from phi.tools import ToolRegistry
 from phi.utils.log import logger
 
 try:
-    import resend
+    import resend # type: ignore
 except ImportError:
     raise ImportError("`resend` not installed. Please install using `pip install resend`.")
 
 
 class ResendTools(ToolRegistry):
-    def __init__(self, api_key: str):
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+    ):
         super().__init__(name="resend_tools")
+
         self.api_key = api_key
+
         self.register(self.send_email)
 
     def send_email(self, email: str, subject: str, body: str) -> str:
@@ -22,6 +29,8 @@ class ResendTools(ToolRegistry):
         :return: A string indicating if the email was sent successfully or an error message.
         """
 
+        if not self.api_key:
+            return "Please provide an API key"
         if not email:
             return "Please provide an email address"
 

--- a/phi/tools/resend.py
+++ b/phi/tools/resend.py
@@ -1,0 +1,45 @@
+from phi.tools import ToolRegistry
+from phi.utils.log import logger
+
+try:
+    import resend
+except ImportError:
+    raise ImportError("`resend` not installed. Please install using `pip install resend`.")
+
+
+class ResendTools(ToolRegistry):
+    def __init__(self, api_key: str):
+        super().__init__(name="resend_tools")
+        self.api_key = api_key
+        self.register(self.send_email)
+
+    def send_email(self, email: str, subject: str, body: str) -> str:
+        """Send an email using the Resend API. Returns if the email was sent successfully or an error message.
+
+        :email: The email address to send the email to.
+        :subject: The subject of the email.
+        :body: The body of the email.
+        :return: A string indicating if the email was sent successfully or an error message.
+        """
+
+        if not email:
+            return "Please provide an email address"
+
+        logger.info(f"Sending email to: {email}")
+
+        resend.api_key = self.api_key
+
+        try:
+            params = {
+                "from": "phidata <info@phidata.com>",
+                "to": email,
+                "subject": f"phidata: {subject}",
+                "html": body,
+            }
+
+            resend.Emails.send(params)
+
+            return "Email sent"
+        except Exception as e:
+            logger.warning(f"Failed to send email {e}")
+            return f"Error: {e}"


### PR DESCRIPTION
This commit adds a new tool class called `ResendTools`. The purpose of this class is to enable the assistant to send emails to users using Resend when provided with a Resend API key and an email address. This enhances the capability of the Assistant by adding communication and user interaction.