### PR TITLE
added cookbook in knowledge to showcase how to use the PDFKnowledgeBase

### DIFF
--- a/cookbook/knowledge/pdf.py
+++ b/cookbook/knowledge/pdf.py
@@ -1,0 +1,34 @@
+# Knowledge base dependencies 
+from phi.knowledge.pdf import PDFKnowledgeBase, PDFReader
+from phi.vectordb.pgvector import PgVector2 
+from resources import vector_db 
+# Assistant dependencies 
+from phi.assistant import Assistant
+
+
+# Setting up knowledge base. 
+pdf_knowledge_base = PDFKnowledgeBase(
+    path = "data/pdfs",
+    vector_db = PgVector2(
+        collection = "pdf_documents", 
+        db_url = vector_db.get_db_connection_local(),
+    ),
+    reader = PDFReader(chunk=True),
+)
+# Instantiating an assistant to use the knowledge base 
+assistant = Assistant(
+    knowledge_base = pdf_knowledge_base,
+    add_references_to_prompt = True,
+)
+
+# reference to database
+print(vector_db.get_db_connection_local()) # can inspect database further via psql e.g. "psql -h localhost -p 5432 -U ai -d ai"
+
+#calling assistant 
+assistant.knowledge_base.load(recreate=False)
+assistant.print_response("what are the building hints from the lego building book?")
+
+
+
+
+


### PR DESCRIPTION
Added pdf.py where a user can enter "python cook/knowledge/pdf.py" to view an example of using the PDFKnowledgeBase. Additionally I've added comments displaying how the user can view the local database that the assistant is relying upon. 