### PR TITLE
Fix typo in pip install instructions (cookbook/assistants)

### DIFF
--- a/cookbook/assistants/README.md
+++ b/cookbook/assistants/README.md
@@ -80,7 +80,7 @@ docker run -d \
 - Install libraries
 
 ```shell
-pip install -U sqlalchemy pgvector "psycopg[binary]" pydpdf
+pip install -U sqlalchemy pgvector "psycopg[binary]" pypdf
 ```
 
 - RAG Assistant


### PR DESCRIPTION
Fix a small typo in the pip install instructions for pypdf