### PR TITLE
add support for datetime arguments

### DIFF
--- a/phi/tools/function.py
+++ b/phi/tools/function.py
@@ -1,7 +1,7 @@
 from typing import Any, Dict, Optional, Callable, get_type_hints
 from pydantic import BaseModel, validate_call
-
 from phi.utils.log import logger
+from datetime import datetime
 
 
 class Function(BaseModel):
@@ -147,6 +147,13 @@ class FunctionCall(BaseModel):
                 return False
 
         try:
+            if self.arguments is not None:
+                for k, v in self.arguments.items():
+                    if isinstance(v, str):
+                        try:
+                            self.arguments[k] = datetime.fromisoformat(v)
+                        except ValueError:
+                            pass
             self.result = self.function.entrypoint(**self.arguments)
             return True
         except Exception as e:

--- a/phi/utils/json_schema.py
+++ b/phi/utils/json_schema.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, Union, get_args, get_origin, Optional
+from datetime import datetime
 
 from phi.utils.log import logger
 
@@ -18,6 +19,8 @@ def get_json_type_for_py_type(arg: str) -> str:
         return "string"
     elif arg == "bool":
         return "boolean"
+    elif arg == "datetime":
+        return "string"
     elif arg in ("NoneType", "None"):
         return "null"
     return arg
@@ -39,7 +42,10 @@ def get_json_schema_for_arg(t: Any) -> Optional[Any]:
         elif type_origin == Union:
             json_schema = {"type": [get_json_type_for_py_type(arg.__name__) for arg in type_args]}
     else:
-        json_schema = {"type": get_json_type_for_py_type(t.__name__)}
+        if t == datetime:
+            json_schema = {"type": "string", "format": "date-time"}
+        else:
+            json_schema = {"type": get_json_type_for_py_type(t.__name__)}
     return json_schema
 
 


### PR DESCRIPTION
closes #53

- updated `get_json_type_for_py_type` and `get_json_schema_for_arg` functions in `phi/utils/json_schema.py` to handle datetimes
- updated `execute` function in `phi/tools/function.py` to parse datetime strings into datetime objects