### PR TITLE
fix: outdated version of phidata in requirements.txt

### DIFF
--- a/cookbook/examples/personalization/requirements.txt
+++ b/cookbook/examples/personalization/requirements.txt
@@ -107,7 +107,7 @@ pandas==2.2.2
     #   streamlit
 pgvector==0.2.5
     # via -r cookbook/llms/openai/auto_rag/requirements.in
-phidata==2.4.10
+phidata==2.4.11
     # via -r cookbook/llms/openai/auto_rag/requirements.in
 pillow==10.3.0
     # via streamlit


### PR DESCRIPTION
- Personalized Memory & Auto RAG example breaking due to wrong phidata sdk version
