### PR TITLE
[SQLtools] fix exception "Object of type datetime is not JSON serializable" with MySQL server

### DIFF
--- a/phi/tools/sql.py
+++ b/phi/tools/sql.py
@@ -111,7 +111,7 @@ class SQLTools(Toolkit):
         """
 
         try:
-            return json.dumps(self.run_sql(sql=query, limit=limit))
+            return json.dumps(self.run_sql(sql=query, limit=limit), default=str)
         except Exception as e:
             logger.error(f"Error running query: {e}")
             return f"Error running query: {e}"


### PR DESCRIPTION
As we discussed on discord, when using sqltools if you connect it to a MySQL server it gives error when trying to serialize a datetime field and this could be easily avoided by giving a default when serializing the results to json.

```py
return json.dumps(self.run_sql(sql=query, limit=limit), default=str)
```