### PR TITLE
Fix a bug SqlAssistantStorage can't save data

### DIFF
--- a/phi/storage/assistant/sqllite.py
+++ b/phi/storage/assistant/sqllite.py
@@ -204,11 +204,21 @@ class SqlAssistantStorage(AssistantStorage):
 
             try:
                 sess.execute(stmt)
-            except OperationalError:
-                # Create table if it does not exist
-                self.create()
-                sess.execute(stmt)
-        return self.read(run_id=row.run_id)
+                sess.commit()  # Make sure to commit the changes to the database
+                return self.read(run_id=row.run_id)
+            except OperationalError as oe:
+                logger.error(f"OperationalError occurred: {oe}")
+                self.create()  # This will only create the table if it doesn't exist
+                try:
+                    sess.execute(stmt)
+                    sess.commit()
+                    return self.read(run_id=row.run_id)
+                except Exception as e:
+                    logger.error(f"Error during upsert: {e}")
+                    sess.rollback()  # Rollback the session in case of any error
+            except Exception as e:
+                logger.error(f"Error during upsert: {e}")
+                sess.rollback()
 
     def delete(self) -> None:
         if self.table_exists():


### PR DESCRIPTION
`SqlAssistantStorage` is great for developers who just need to create native applications.

HHowever, when I tested it, I found that the current SqlAssistantStorage doesn't successfully save data into SQlite because changes made to the database are **not committed** when using SQLAlchemy ORM.

So I added `sess.commit()` to commit the transaction and log an error message if an exception is caught. If OperationalError occurs, it will try to create the form and re-execute the operation. Other types of exceptions will be caught and the transaction will be rolled back after logging the error message.

Hope this helps!