### PR TITLE
feat(tools): add JinaReaderTools for web content retrieval

### DIFF
--- a/cookbook/examples/scraping/app.py
+++ b/cookbook/examples/scraping/app.py
@@ -1,0 +1,15 @@
+from phi.assistant import Assistant
+from phi.llm.openai import OpenAIChat
+from phi.tools.jina_tools import JinaReaderTools
+
+# Create an Assistant with JinaReaderTools
+assistant = Assistant(
+    llm=OpenAIChat(model="gpt-3.5-turbo"), tools=[JinaReaderTools(max_content_length=8000)], show_tool_calls=True
+)
+
+# Use the assistant to read a webpage
+assistant.print_response("Search on openai.com for content related to Q* and summarize its main points", markdown=True)
+
+
+# Use the assistant to search
+# assistant.print_response("I there new release from phidata, provide your sources", markdown=True)

--- a/phi/tools/__init__.py
+++ b/phi/tools/__init__.py
@@ -2,3 +2,4 @@ from phi.tools.tool import Tool
 from phi.tools.function import Function
 from phi.tools.toolkit import Toolkit
 from phi.tools.tool_registry import ToolRegistry
+from phi.tools.jina_tools import JinaReaderTools

--- a/phi/tools/jina_tools.py
+++ b/phi/tools/jina_tools.py
@@ -1,0 +1,71 @@
+from typing import Optional, Dict
+import requests
+from pydantic import BaseModel, HttpUrl, Field
+from phi.tools import Toolkit
+from phi.utils.log import logger
+
+
+class JinaReaderToolsConfig(BaseModel):
+    api_key: Optional[str] = Field(None, description="API key for Jina Reader")
+    base_url: HttpUrl = Field("https://r.jina.ai/", description="Base URL for Jina Reader API")
+    search_url: HttpUrl = Field("https://s.jina.ai/", description="Search URL for Jina Reader API")
+    max_content_length: int = Field(4000, description="Maximum content length in characters")
+
+
+class JinaReaderTools(Toolkit):
+    def __init__(self, api_key: Optional[str] = None, max_content_length: int = 4000):
+        super().__init__(name="jina_reader_tools")
+        config = JinaReaderToolsConfig(api_key=api_key, max_content_length=max_content_length)
+        self.api_key = config.api_key
+        self.base_url = config.base_url
+        self.search_url = config.search_url
+        self.max_content_length = config.max_content_length
+
+        self.register(self.read_url)
+        self.register(self.search_query)
+
+    def read_url(self, url: str) -> str:
+        """Reads a URL and returns the truncated content using Jina Reader API."""
+        full_url = f"{self.base_url}{url}"
+        logger.info(f"Reading URL: {full_url}")
+        try:
+            response = requests.get(full_url, headers=self._get_headers())
+            response.raise_for_status()
+            content = response.json()
+            return self._truncate_content(str(content))
+        except Exception as e:
+            error_msg = f"Error reading URL: {str(e)}"
+            logger.error(error_msg)
+            return error_msg
+
+    def search_query(self, query: str) -> str:
+        """Performs a web search using Jina Reader API and returns the truncated results."""
+        full_url = f"{self.search_url}{query}"
+        logger.info(f"Performing search: {full_url}")
+        try:
+            response = requests.get(full_url, headers=self._get_headers())
+            response.raise_for_status()
+            content = response.json()
+            return self._truncate_content(str(content))
+        except Exception as e:
+            error_msg = f"Error performing search: {str(e)}"
+            logger.error(error_msg)
+            return error_msg
+
+    def _get_headers(self) -> Dict[str, str]:
+        headers = {
+            "Accept": "application/json",
+            "X-With-Generated-Alt": "true",
+            "X-With-Links-Summary": "true",
+            "X-With-Images-Summary": "true",
+        }
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def _truncate_content(self, content: str) -> str:
+        """Truncate content to the maximum allowed length."""
+        if len(content) > self.max_content_length:
+            truncated = content[: self.max_content_length]
+            return truncated + "... (content truncated)"
+        return content

--- a/phi/utils/json_schema.py
+++ b/phi/utils/json_schema.py
@@ -31,10 +31,10 @@ def get_json_schema_for_arg(t: Any) -> Optional[Any]:
     type_origin = get_origin(t)
     # logger.info(f"Type origin: {type_origin}")
     if type_origin is not None:
-        if type_origin == list:
+        if isinstance(type_origin, list):
             json_schema_for_items = get_json_schema_for_arg(type_args[0])
             json_schema = {"type": "array", "items": json_schema_for_items}
-        elif type_origin == dict:
+        elif isinstance(type_origin, dict):
             json_schema = {"type": "object", "properties": {}}
         elif type_origin == Union:
             json_schema = {"type": [get_json_type_for_py_type(arg.__name__) for arg in type_args]}

--- a/tests/tools/test_jina_tools.py
+++ b/tests/tools/test_jina_tools.py
@@ -1,4 +1,3 @@
-import pytest
 from unittest.mock import patch, Mock
 from phi.tools.jina_tools import JinaReaderTools
 

--- a/tests/tools/test_jina_tools.py
+++ b/tests/tools/test_jina_tools.py
@@ -1,0 +1,56 @@
+import pytest
+from unittest.mock import patch, Mock
+from phi.tools.jina_tools import JinaReaderTools
+
+
+def test_jina_reader_tools_initialization():
+    tools = JinaReaderTools(api_key="test_key")
+    assert tools.api_key == "test_key"
+    assert str(tools.base_url) == "https://r.jina.ai/"
+    assert str(tools.search_url) == "https://s.jina.ai/"
+
+
+@patch("requests.get")
+def test_read_url(mock_get):
+    mock_response = Mock()
+    mock_response.json.return_value = {"content": "test content"}
+    mock_get.return_value = mock_response
+
+    tools = JinaReaderTools(api_key="test_key")
+    result = tools.read_url("https://example.com")
+
+    assert result == "{'content': 'test content'}"
+    mock_get.assert_called_once_with("https://r.jina.ai/https://example.com", headers=tools._get_headers())
+
+
+@patch("requests.get")
+def test_search_query(mock_get):
+    mock_response = Mock()
+    mock_response.json.return_value = {"results": ["result1", "result2"]}
+    mock_get.return_value = mock_response
+
+    tools = JinaReaderTools(api_key="test_key")
+    result = tools.search_query("test query")
+
+    assert result == "{'results': ['result1', 'result2']}"
+    mock_get.assert_called_once_with("https://s.jina.ai/test query", headers=tools._get_headers())
+
+
+@patch("requests.get")
+def test_read_url_error(mock_get):
+    mock_get.side_effect = Exception("Test error")
+
+    tools = JinaReaderTools(api_key="test_key")
+    result = tools.read_url("https://example.com")
+
+    assert result == "Error reading URL: Test error"
+
+
+@patch("requests.get")
+def test_search_query_error(mock_get):
+    mock_get.side_effect = Exception("Test error")
+
+    tools = JinaReaderTools(api_key="test_key")
+    result = tools.search_query("test query")
+
+    assert result == "Error performing search: Test error"


### PR DESCRIPTION
What inside:

- Implement JinaReaderTools (API from https://jina.ai/reader) to fetch and summarize web content
- Add read_url and search_query methods to interact with Jina Reader API
- Truncate content to a maximum length for better readability
- Include tests for JinaReaderTools functionality

The JinaReaderTools toolkit allows the Assistant to retrieve and summarize web content using the Jina Reader API. This enables the Assistant to search the web and provide relevant information to users.
