### PR TITLE
Fix incorrect path initialization in cookbook_dir

### DIFF
--- a/cookbook/assistants/langchain_retriever.py
+++ b/cookbook/assistants/langchain_retriever.py
@@ -7,7 +7,7 @@ from langchain.document_loaders import TextLoader
 from langchain.text_splitter import CharacterTextSplitter
 from langchain.vectorstores import Chroma
 
-cookbook_dir = Path("__file__").parent
+cookbook_dir = Path(__file__).parent
 chroma_db_dir = cookbook_dir.joinpath("storage/chroma_db")
 
 


### PR DESCRIPTION
- Replace '__file__' string with __file__ identifier to correctly initialize Path object.
- This change ensures that the Path object uses the actual file location rather than the string '__file__'.