### PR TITLE
Feature/limit tool call results in messages

### DIFF
--- a/phi/llm/base.py
+++ b/phi/llm/base.py
@@ -35,7 +35,6 @@ class LLM(BaseModel):
     # If True, shows function calls in the response.
     show_tool_calls: Optional[bool] = None
     tool_calls_in_messages: Optional[int] = None
-    tool_call_results_in_messages: Optional[int] = None
 
     # -*- Functions available to the LLM to call -*-
     # Functions extracted from the tools.
@@ -149,7 +148,7 @@ class LLM(BaseModel):
                     logger.warning(f"Could not add function {tool}: {e}")
 
     def clean_messages(self, messages: List[Message]) -> List[Message]:
-        if self.tool_call_results_in_messages is None:
+        if self.tool_calls_in_messages is None:
             return messages
 
         clean_messages: List[Message] = []
@@ -163,7 +162,7 @@ class LLM(BaseModel):
                 tool_calls_and_results.append(m)
 
         # Add the last n pairs of tool calls and results to clean_messages
-        clean_messages.extend(tool_calls_and_results[-self.tool_call_results_in_messages * 2 :])
+        clean_messages.extend(tool_calls_and_results[-self.tool_calls_in_messages * 2 :])
 
         return clean_messages
 

--- a/phi/llm/base.py
+++ b/phi/llm/base.py
@@ -34,6 +34,7 @@ class LLM(BaseModel):
     run_tools: bool = True
     # If True, shows function calls in the response.
     show_tool_calls: Optional[bool] = None
+    tool_call_results_in_messages: Optional[int] = None
 
     # -*- Functions available to the LLM to call -*-
     # Functions extracted from the tools.
@@ -145,6 +146,25 @@ class LLM(BaseModel):
                         logger.debug(f"Function {func.name} added to LLM.")
                 except Exception as e:
                     logger.warning(f"Could not add function {tool}: {e}")
+
+    def clean_messages(self, messages: List[Message]) -> List[Message]:
+        clean_messages = []
+        # Limit the number of tool calls sent to the LLM
+        if self.tool_call_results_in_messages is not None:
+            tool_call_results_included = 0
+            for m in messages:
+                if m.role in ["system", "user"]:
+                    clean_messages.append(m)
+                elif m.role == "assistant":
+                    if m.content is not None:
+                        clean_messages.append(m)
+                    elif m.function_call is not None or m.tool_calls is not None:
+                        if tool_call_results_included < self.tool_call_results_in_messages:
+                            clean_messages.append(m)
+                            tool_call_results_included += 1
+        else:
+            clean_messages = messages
+        return clean_messages
 
     def deactivate_function_calls(self) -> None:
         # Deactivate tool calls by setting future tool calls to "none"

--- a/phi/llm/openai/chat.py
+++ b/phi/llm/openai/chat.py
@@ -283,7 +283,7 @@ class OpenAIChat(LLM):
     def response(self, messages: List[Message]) -> str:
         logger.debug("---------- OpenAI Response Start ----------")
 
-        clean_messages = self.clean_messages(messages=messages)
+        messages = self.clean_messages(messages=messages)
 
         # -*- Log messages for debugging
         for m in messages:
@@ -603,6 +603,15 @@ class OpenAIChat(LLM):
 
     def response_stream(self, messages: List[Message]) -> Iterator[str]:
         logger.debug("---------- OpenAI Response Start ----------")
+
+        messages = self.clean_messages(messages=messages)
+
+        # logger.info(cleaned_messages)
+        logger.info(messages)
+
+        # logger.info(len(cleaned_messages))
+        logger.info(len(messages))
+
         # -*- Log messages for debugging
         for m in messages:
             m.log()

--- a/phi/llm/openai/chat.py
+++ b/phi/llm/openai/chat.py
@@ -282,6 +282,9 @@ class OpenAIChat(LLM):
 
     def response(self, messages: List[Message]) -> str:
         logger.debug("---------- OpenAI Response Start ----------")
+
+        clean_messages = self.clean_messages(messages=messages)
+
         # -*- Log messages for debugging
         for m in messages:
             m.log()

--- a/phi/llm/openai/chat.py
+++ b/phi/llm/openai/chat.py
@@ -606,12 +606,6 @@ class OpenAIChat(LLM):
 
         messages = self.clean_messages(messages=messages)
 
-        # logger.info(cleaned_messages)
-        logger.info(messages)
-
-        # logger.info(len(cleaned_messages))
-        logger.info(len(messages))
-
         # -*- Log messages for debugging
         for m in messages:
             m.log()


### PR DESCRIPTION
Changes:

- Adds a clean messages function to LLM class, to limit the number of tool calls and tool call results when `tool_call_results_in_messages` is specified. 
- The clean_messages function is applied to response and response_stream classes of OpenAIChat