### PR TITLE
fix-azure-openai-streaming-phi-937

### DIFF
--- a/cookbook/llms/azure_openai/assistant.py
+++ b/cookbook/llms/azure_openai/assistant.py
@@ -2,7 +2,7 @@ from phi.assistant import Assistant
 from phi.llm.azure import AzureOpenAIChat
 
 assistant = Assistant(
-    llm=AzureOpenAIChat(model="gpt-35-turbo"),
+    llm=AzureOpenAIChat(model="gpt-4o"),
     description="You help people with their health and fitness goals.",
 )
 assistant.print_response("Share a 2 sentence quick and healthy breakfast recipe.", markdown=True)

--- a/cookbook/llms/azure_openai/assistant_stream_off.py
+++ b/cookbook/llms/azure_openai/assistant_stream_off.py
@@ -2,7 +2,7 @@ from phi.assistant import Assistant
 from phi.llm.azure import AzureOpenAIChat
 
 assistant = Assistant(
-    llm=AzureOpenAIChat(model="gpt-35-turbo"),
+    llm=AzureOpenAIChat(model="gpt-4o"),
     description="You help people with their health and fitness goals.",
 )
 assistant.print_response("Share a 2 sentence quick and healthy breakfast recipe.", markdown=True, stream=False)

--- a/phi/llm/anthropic/claude.py
+++ b/phi/llm/anthropic/claude.py
@@ -222,6 +222,7 @@ class Claude(LLM):
                 self.metrics["output_tokens"] = self.metrics.get("output_tokens", 0) + output_tokens
 
             if input_tokens is not None and output_tokens is not None:
+                assistant_message.metrics["total_tokens"] = input_tokens + output_tokens
                 self.metrics["total_tokens"] = self.metrics.get("total_tokens", 0) + input_tokens + output_tokens
 
         # -*- Add assistant message to messages
@@ -355,6 +356,7 @@ class Claude(LLM):
                 self.metrics["output_tokens"] = self.metrics.get("output_tokens", 0) + output_tokens
 
             if input_tokens is not None and output_tokens is not None:
+                assistant_message.metrics["total_tokens"] = input_tokens + output_tokens
                 self.metrics["total_tokens"] = self.metrics.get("total_tokens", 0) + input_tokens + output_tokens
 
         # -*- Add assistant message to messages


### PR DESCRIPTION
Changes:

- Added a custom `invoke_stream` function for `AzureOpenAIChat` as it does not support `stream_options={"include_usage": True},` parameter to get token usage details when streaming

Known bug:

As is does not support this parameter, token usage information for `AzureOpenAIChat` while streaming is not stored. 