### PR TITLE
Resolve discrepancy between `LanceDb.create` and other `VectorDb.create` methods

### DIFF
--- a/phi/vectordb/lancedb/lancedb.py
+++ b/phi/vectordb/lancedb/lancedb.py
@@ -57,8 +57,10 @@ class LanceDb(VectorDb):
         # Lancedb kwargs
         self.kwargs = kwargs
 
-    def create(self) -> lancedb.db.LanceTable:
-        return self._init_table()
+    def create(self) -> None:
+        """Create the table if it does not exist."""
+        if not self.exists():
+            self.connection = self._init_table() # Connection update is needed
 
     def _init_table(self) -> lancedb.db.LanceTable:
         self._id = "id"


### PR DESCRIPTION
All implementations of `VectorDb.create` follows a "create if not exist" pattern **except for** `LanceDb.create`, which recreates the table regardless of its existence:
```python
def create(self) -> lancedb.db.LanceTable:
    return self._init_table()

def _init_table(self) -> lancedb.db.LanceTable:

    ...

    tbl = self.client.create_table(self.table_name, schema=schema, mode="overwrite") # Table overwritten here
    return tbl
```

This behavior, coupled with the fact that `AssistantKnowledge.load` and `AssistantKnowledge.load_documents` often invoke `VectorDb.create`, would cause a LanceDb-based AssistantKnowledge to **discard its contents** every time it loads data.

This pull request aims to address this issue by making the `LanceDb.create` method follow the "create if not exist" pattern.
