### PR TITLE
fix: Some arguments have no effect in the Assistant's LLM Instructions

### DIFF
--- a/phi/assistant/assistant.py
+++ b/phi/assistant/assistant.py
@@ -578,7 +578,8 @@ class Assistant(BaseModel):
             raise Exception("LLM not set")
 
         # -*- Build a list of instructions for the Assistant
-        instructions = self.instructions.copy() if self.instructions is not None else []
+        instructions = self.instructions.copy() if self.instructions is not None else None
+
         # Add default instructions
         if instructions is None:
             instructions = []


### PR DESCRIPTION
Some arguments for the Assistant, such as `prevent_hallucinations` and `prevent_prompt_injection`, are intended to generate instructions for the LLM. However, these arguments have no effect and are never included in the prompt.

The following code snippet explains why:
```py
        # -*- Build a list of instructions for the Assistant
        instructions = self.instructions.copy() if self.instructions is not None else []
        # Add default instructions
        if instructions is None:
```

https://github.com/phidatahq/phidata/blob/v2.4.32/phi/assistant/assistant.py#L580-L583

If my understanding is correct, the condition `if instructions is None` will never be met, since `instructions` is either a copy of a list or initialized as an empty list.

Initializing instructions with `None` fixes the issue.