### PR TITLE
Adding Unify AI as an LLM Provider

### DIFF
--- a/cookbook/llms/unify/assistant.py
+++ b/cookbook/llms/unify/assistant.py
@@ -1,0 +1,14 @@
+from phi.assistant import Assistant
+from phi.tools.duckduckgo import DuckDuckGo
+from phi.llm.unify import UnifyChat
+
+assistant = Assistant(
+    llm=UnifyChat(
+        endpoint="gpt-4o@openai", 
+        api_key="",  
+    ),
+    tools=[DuckDuckGo()],
+    show_tool_calls=True,
+)
+
+assistant.print_response("Five learnings from Bhagwad Geeta?", markdown=True, stream=False)   

--- a/cookbook/llms/unify/finance.py
+++ b/cookbook/llms/unify/finance.py
@@ -1,0 +1,17 @@
+from phi.assistant import Assistant
+from phi.tools.yfinance import YFinanceTools
+from phi.llm.unify import UnifyChat
+
+assistant = Assistant(
+    llm=UnifyChat(
+        endpoint="gpt-4o@openai",  
+        api_key="", 
+    ), 
+    tools=[YFinanceTools(stock_price=True, analyst_recommendations=True, stock_fundamentals=True)],
+    show_tool_calls=True,
+    description="You are an investment analyst that researches stock prices, analyst recommendations, and stock fundamentals.",
+    instructions=["Use tables to display data where possible."],
+    markdown=True,
+)
+# assistant.print_response("Share the NVDA stock price and analyst recommendations")
+assistant.print_response("Summarize fundamentals for TSLA")

--- a/cookbook/llms/unify/report.py
+++ b/cookbook/llms/unify/report.py
@@ -1,0 +1,17 @@
+from phi.assistant import Assistant
+from phi.tools.duckduckgo import DuckDuckGo
+from phi.tools.website import WebsiteTools
+from phi.llm.unify import UnifyChat
+
+assistant = Assistant(
+    llm=UnifyChat(
+        endpoint="gpt-4o@openai",  
+        api_key="", 
+    ), 
+    tools=[DuckDuckGo(), WebsiteTools()], show_tool_calls=True
+)
+assistant.print_response(
+    "Produce a report about Unify AI. Search for their website. Read both urls and provide a detailed summary along with a unique fact.",
+    markdown=True,
+)
+

--- a/phi/llm/unify/__init__.py
+++ b/phi/llm/unify/__init__.py
@@ -1,0 +1,1 @@
+from phi.llm.unify.unify import UnifyChat

--- a/phi/llm/unify/__init__.py
+++ b/phi/llm/unify/__init__.py
@@ -1,1 +1,1 @@
-from phi.llm.unify.unify import UnifyChat
+from phi.llm.unify.unifyai import UnifyChat

--- a/phi/llm/unify/unify.py
+++ b/phi/llm/unify/unify.py
@@ -1,0 +1,204 @@
+from typing import Optional, List, Iterator, Dict, Any
+from phi.llm.base import LLM
+from phi.llm.message import Message
+from phi.utils.log import logger
+from phi.utils.timer import Timer
+
+try:
+    from unify.clients import Unify as UnifyClient, AsyncUnify as AsyncUnifyClient
+except ImportError:
+    logger.error("`unify` not installed")
+    raise
+
+
+class UnifyChat(LLM):
+    name: str = "UnifyChat"
+    model: Optional[str] = None
+    provider: Optional[str] = None
+    endpoint: Optional[str] = None
+    # -*- Request parameters
+    max_tokens: Optional[int] = None
+    temperature: Optional[float] = None
+    stop: Optional[List[str]] = None
+    request_params: Optional[Dict[str, Any]] = None
+    # -*- Client parameters
+    api_key: Optional[str] = None
+    client_params: Optional[Dict[str, Any]] = None
+    # -*- Provide the Unify client manually
+    unify_client: Optional[UnifyClient] = None
+    async_unify_client: Optional[AsyncUnifyClient] = None
+
+    def get_client(self) -> UnifyClient:
+        if self.unify_client:
+            return self.unify_client
+
+        _client_params: Dict[str, Any] = {}
+        if self.api_key:
+            _client_params["api_key"] = self.api_key
+        if self.endpoint:
+            _client_params["endpoint"] = self.endpoint
+        elif self.model and self.provider:
+            _client_params["model"] = self.model
+            _client_params["provider"] = self.provider
+        if self.client_params:
+            _client_params.update(self.client_params)
+        return UnifyClient(**_client_params)
+
+    def get_async_client(self) -> AsyncUnifyClient:
+        if self.async_unify_client:
+            return self.async_unify_client
+
+        _client_params: Dict[str, Any] = {}
+        if self.api_key:
+            _client_params["api_key"] = self.api_key
+        if self.endpoint:
+            _client_params["endpoint"] = self.endpoint
+        elif self.model and self.provider:
+            _client_params["model"] = self.model
+            _client_params["provider"] = self.provider
+        if self.client_params:
+            _client_params.update(self.client_params)
+        return AsyncUnifyClient(**_client_params)
+
+    @property
+    def api_kwargs(self) -> Dict[str, Any]:
+        _request_params: Dict[str, Any] = {}
+        if self.max_tokens:
+            _request_params["max_tokens"] = self.max_tokens
+        if self.temperature:
+            _request_params["temperature"] = self.temperature
+        if self.stop:
+            _request_params["stop"] = self.stop
+        if self.request_params:
+            _request_params.update(self.request_params)
+        return _request_params
+
+    def invoke(self, messages: List[Message]) -> Any:
+        client = self.get_client()
+        return client.generate(
+            messages=[m.to_dict() for m in messages],
+            **self.api_kwargs,
+        )
+
+    async def ainvoke(self, messages: List[Message]) -> Any:
+        client = self.get_async_client()
+        return await client.generate(
+            messages=[m.to_dict() for m in messages],
+            **self.api_kwargs,
+        )
+
+    def invoke_stream(self, messages: List[Message]) -> Iterator[Any]:
+        client = self.get_client()
+        return client.generate(
+            messages=[m.to_dict() for m in messages],
+            stream=True,
+            **self.api_kwargs,
+        )
+
+    async def ainvoke_stream(self, messages: List[Message]) -> Any:
+        client = self.get_async_client()
+        async for chunk in await client.generate(
+            messages=[m.to_dict() for m in messages],
+            stream=True,
+            **self.api_kwargs,
+        ):
+            yield chunk
+
+    def response(self, messages: List[Message]) -> str:
+        logger.debug("---------- Unify Response Start ----------")
+        # -*- Log messages for debugging
+        for m in messages:
+            m.log()
+
+        response_timer = Timer()
+        response_timer.start()
+        response = self.invoke(messages=messages)
+        response_timer.stop()
+        logger.debug(f"Time to generate response: {response_timer.elapsed:.4f}s")
+
+        # -*- Create assistant message
+        assistant_message = Message(
+            role="assistant",
+            content=response,
+        )
+
+        # -*- Update usage metrics
+        assistant_message.metrics["time"] = response_timer.elapsed
+        if "response_times" not in self.metrics:
+            self.metrics["response_times"] = []
+        self.metrics["response_times"].append(response_timer.elapsed)
+
+        # -*- Add assistant message to messages
+        messages.append(assistant_message)
+        assistant_message.log()
+
+        logger.debug("---------- Unify Response End ----------")
+        return assistant_message.get_content_string()
+
+    def response_stream(self, messages: List[Message]) -> Iterator[str]:
+        logger.debug("---------- Unify Response Start ----------")
+        # -*- Log messages for debugging
+        for m in messages:
+            m.log()
+
+        assistant_message_content = ""
+        completion_tokens = 0
+        response_timer = Timer()
+        response_timer.start()
+        for chunk in self.invoke_stream(messages=messages):
+            assistant_message_content += chunk
+            completion_tokens += 1
+            yield chunk
+
+        response_timer.stop()
+        logger.debug(f"Time to generate response: {response_timer.elapsed:.4f}s")
+
+        # -*- Create assistant message
+        assistant_message = Message(role="assistant", content=assistant_message_content)
+
+        # -*- Update usage metrics
+        assistant_message.metrics["time"] = response_timer.elapsed
+        if "response_times" not in self.metrics:
+            self.metrics["response_times"] = []
+        self.metrics["response_times"].append(response_timer.elapsed)
+
+        # -*- Add assistant message to messages
+        messages.append(assistant_message)
+        assistant_message.log()
+
+        logger.debug("---------- Unify Response End ----------")
+
+    async def aresponse(self, messages: List[Message]) -> str:
+        logger.debug("---------- Unify Async Response Start ----------")
+        # -*- Log messages for debugging
+        for m in messages:
+            m.log()
+
+        response_timer = Timer()
+        response_timer.start()
+        response = await self.ainvoke(messages=messages)
+        response_timer.stop()
+        logger.debug(f"Time to generate response: {response_timer.elapsed:.4f}s")
+
+        # -*- Create assistant message
+        assistant_message = Message(
+            role="assistant",
+            content=response,
+        )
+
+        # -*- Update usage metrics
+        assistant_message.metrics["time"] = response_timer.elapsed
+        if "response_times" not in self.metrics:
+            self.metrics["response_times"] = []
+        self.metrics["response_times"].append(response_timer.elapsed)
+
+        # -*- Add assistant message to messages
+        messages.append(assistant_message)
+        assistant_message.log()
+
+        logger.debug("---------- Unify Async Response End ----------")
+        return assistant_message.get_content_string()
+
+    def get_credit_balance(self) -> float:
+        client = self.get_client()
+        return client.get_credit_balance()

--- a/phi/llm/unify/unifyai.py
+++ b/phi/llm/unify/unifyai.py
@@ -5,7 +5,7 @@ from phi.utils.log import logger
 from phi.utils.timer import Timer
 
 try:
-    from unify.clients import Unify as UnifyClient, AsyncUnify as AsyncUnifyClient
+    from unify import Unify as UnifyClient, AsyncUnify as AsyncUnifyClient
 except ImportError:
     logger.error("`unify` not installed")
     raise

--- a/phi/llm/unify/unifyai.py
+++ b/phi/llm/unify/unifyai.py
@@ -5,7 +5,7 @@ from phi.utils.log import logger
 from phi.utils.timer import Timer
 
 try:
-    from unifyai import Unify as UnifyClient, AsyncUnify as AsyncUnifyClient
+    from unify import Unify as UnifyClient, AsyncUnify as AsyncUnifyClient
 except ImportError:
     logger.error("`unify` not installed")
     raise

--- a/phi/llm/unify/unifyai.py
+++ b/phi/llm/unify/unifyai.py
@@ -5,7 +5,7 @@ from phi.utils.log import logger
 from phi.utils.timer import Timer
 
 try:
-    from unify import Unify as UnifyClient, AsyncUnify as AsyncUnifyClient
+    from unifyai import Unify as UnifyClient, AsyncUnify as AsyncUnifyClient
 except ImportError:
     logger.error("`unify` not installed")
     raise
@@ -75,30 +75,62 @@ class UnifyChat(LLM):
 
     def invoke(self, messages: List[Message]) -> Any:
         client = self.get_client()
+        if not messages:
+            raise ValueError("The messages list cannot be empty")
+        
+        last_message = messages[-1]
+        if last_message.role != "user":
+            raise ValueError("The last message must be from the user")
+
         return client.generate(
-            messages=[m.to_dict() for m in messages],
+            user_message=last_message.content,
+            messages=[m.to_dict() for m in messages[:-1]] if len(messages) > 1 else None,
             **self.api_kwargs,
         )
 
     async def ainvoke(self, messages: List[Message]) -> Any:
         client = self.get_async_client()
+        if not messages:
+            raise ValueError("The messages list cannot be empty")
+        
+        last_message = messages[-1]
+        if last_message.role != "user":
+            raise ValueError("The last message must be from the user")
+
         return await client.generate(
-            messages=[m.to_dict() for m in messages],
+            user_message=last_message.content,
+            messages=[m.to_dict() for m in messages[:-1]] if len(messages) > 1 else None,
             **self.api_kwargs,
         )
 
     def invoke_stream(self, messages: List[Message]) -> Iterator[Any]:
         client = self.get_client()
+        if not messages:
+            raise ValueError("The messages list cannot be empty")
+        
+        last_message = messages[-1]
+        if last_message.role != "user":
+            raise ValueError("The last message must be from the user")
+
         return client.generate(
-            messages=[m.to_dict() for m in messages],
+            user_message=last_message.content,
+            messages=[m.to_dict() for m in messages[:-1]] if len(messages) > 1 else None,
             stream=True,
             **self.api_kwargs,
         )
 
     async def ainvoke_stream(self, messages: List[Message]) -> Any:
         client = self.get_async_client()
+        if not messages:
+            raise ValueError("The messages list cannot be empty")
+        
+        last_message = messages[-1]
+        if last_message.role != "user":
+            raise ValueError("The last message must be from the user")
+
         async for chunk in await client.generate(
-            messages=[m.to_dict() for m in messages],
+            user_message=last_message.content,
+            messages=[m.to_dict() for m in messages[:-1]] if len(messages) > 1 else None,
             stream=True,
             **self.api_kwargs,
         ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,5 +144,6 @@ module = [
   "wikipedia.*",
   "yfinance.*",
   "youtube_transcript_api.*",
+  "unifyai.*",
 ]
 ignore_missing_imports = true


### PR DESCRIPTION
Added Support for [Unify AI](https://docs.unify.ai/basics/welcome) along with cookbook recipe.
- Phidata Users can now use all the Models (Open Sourced and Closed Sourced) from all the providers with just 1 single API key 

```
from phi.assistant import Assistant
from phi.tools.duckduckgo import DuckDuckGo
from phi.llm.unify import UnifyChat

assistant = Assistant(
    llm=UnifyChat(
        endpoint="gpt-4o@openai",  # or claude-3-sonnet@anthropic
        api_key="",  
    ),
    tools=[DuckDuckGo()],
    show_tool_calls=True,
)

assistant.print_response("Five learnings from Bhagwad Geeta?", markdown=True, stream=False)   
```