### PR TITLE
fix-updated_at-for-pgvector2-upsert-phi-1114

### DIFF
--- a/phi/vectordb/pgvector/pgvector2.py
+++ b/phi/vectordb/pgvector/pgvector2.py
@@ -219,6 +219,7 @@ class PgVector2(VectorDb):
                         embedding=stmt.excluded.embedding,
                         usage=stmt.excluded.usage,
                         content_hash=stmt.excluded.content_hash,
+                        updated_at=text("now()"),
                     ),
                 )
                 sess.execute(stmt)


### PR DESCRIPTION
Changes:

- Bug fix to allow `updated_at` column of `Pgvector2` to work as expected. 

Notes:

- `on_conflict_do_update` in the upsert operation modifies the row in the database, but it doesn’t trigger SQLAlchemy’s `onupdate` logic because the database is managing the update internally.