### PR TITLE
fix: bad response type in /anthropic/claude.py

### DIFF
--- a/phi/llm/anthropic/claude.py
+++ b/phi/llm/anthropic/claude.py
@@ -165,7 +165,12 @@ class Claude(LLM):
         logger.debug(f"Time to generate response: {response_timer.elapsed:.4f}s")
 
         # -*- Parse response
-        response_content: TextBlock = response.content[0].text  # type: ignore
+        response_content = response.content[0]  # type: ignore
+        if isinstance(response.content[0], ToolUseBlock):
+            response_content = response.content[0].input['query']
+            
+        elif isinstance(response.content[0],TextBlock):
+            response_content = response.content[0].text
 
         # -*- Create assistant message
         assistant_message = Message(


### PR DESCRIPTION
Bug: Running Anthropic with `search_knowledge=True` yields:

```
Traceback (most recent call last):
  File "C:\Users\hassa\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\phi\llm\anthropic\claude.py", line 405, in response_stream
    yield from self.response(messages=messages)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\hassa\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\phi\llm\anthropic\claude.py", line 168, in response
    response_content: TextBlock = response.content[0].text  # type: ignore
                                  ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\hassa\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0\LocalCache\local-packages\Python311\site-packages\pydantic\main.py", line 853, in __getattr__
    raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')
AttributeError: 'ToolUseBlock' object has no attribute 'text'
```
  
Steps to reproduce:
Run on a knowledge base with `search_knowledge=True` for 5-10 times - you will run into this error.

Fix:
Added type checking for both `TextBlock` & `ToolUseBlock`.