### PR TITLE
fix: deactivate function calls when we already have the result to avoir multiple round trips

### DIFF
--- a/phi/llm/openai/chat.py
+++ b/phi/llm/openai/chat.py
@@ -353,7 +353,12 @@ class OpenAIChat(LLM):
                 final_response = ""
                 if self.show_tool_calls and function_call is not None:
                     final_response += f"\n - Running: {function_call.get_call_str()}\n\n"
+                # -*- Deactivate function calls when we already have the result
+                previous_tool_choice = self.tool_choice
+                self.deactivate_function_calls()
                 final_response += self.response(messages=messages)
+                # -*- Reset tool choice
+                self.tool_choice = previous_tool_choice
                 return final_response
             elif assistant_message.tool_calls is not None:
                 final_response = ""
@@ -393,8 +398,13 @@ class OpenAIChat(LLM):
                 function_call_results = self.run_function_calls(function_calls_to_run)
                 if len(function_call_results) > 0:
                     messages.extend(function_call_results)
+                # -*- Deactivate function calls when we already have the result
+                previous_tool_choice = self.tool_choice
+                self.deactivate_function_calls()
                 # -*- Get new response using result of tool call
                 final_response += self.response(messages=messages)
+                # -*- Reset tool choice
+                self.tool_choice = previous_tool_choice
                 return final_response
         logger.debug("---------- OpenAI Response End ----------")
         # -*- Return content if no function calls are present
@@ -478,7 +488,12 @@ class OpenAIChat(LLM):
                 final_response = ""
                 if self.show_tool_calls and function_call is not None:
                     final_response += f"\n - Running: {function_call.get_call_str()}\n\n"
+                # -*- Deactivate function calls when we already have the result
+                previous_tool_choice = self.tool_choice
+                self.deactivate_function_calls()
                 final_response += self.response(messages=messages)
+                # -*- Reset tool choice
+                self.tool_choice = previous_tool_choice
                 return final_response
             elif assistant_message.tool_calls is not None:
                 final_response = ""
@@ -518,8 +533,13 @@ class OpenAIChat(LLM):
                 function_call_results = self.run_function_calls(function_calls_to_run)
                 if len(function_call_results) > 0:
                     messages.extend(function_call_results)
+                # -*- Deactivate function calls when we already have the result
+                previous_tool_choice = self.tool_choice
+                self.deactivate_function_calls()
                 # -*- Get new response using result of tool call
                 final_response += await self.aresponse(messages=messages)
+                # -*- Reset tool choice
+                self.tool_choice = previous_tool_choice
                 return final_response
         logger.debug("---------- OpenAI Async Response End ----------")
         # -*- Return content if no function calls are present


### PR DESCRIPTION
### Issue:
When using `output_model` in combination with a tool, the LLM repeatedly requests Function Calls, leading to multiple round trips. Here’s a snippet that reproduces the behavior: https://gist.github.com/nlenepveu/dceb6e0f27cf1d897f3768736070f1aa

### Fix:
While the `tool_call_limit` parameter limits the total number of tool executions, there are instances where the LLM requests for multiple tool calls within a single response, and this parameter cannot enforce a single round trip. Since the LLM’s behavior is unpredictable in terms of how many calls it requests in a single response, the current `tool_call_limit` parameter is insufficient.

The proposed fix is to modify the default behavior to automatically set the `tool_choice` to "none" after the first round trip. This ensures the LLM doesn't attempt additional tool calls once it has already received the necessary results from the initial tool execution.