### PR TITLE
fix: accept assistant with output_model when delegating tasks to a team

### DIFF
--- a/phi/llm/base.py
+++ b/phi/llm/base.py
@@ -163,9 +163,13 @@ class LLM(BaseModel):
             function_call_success = function_call.execute()
             _function_call_timer.stop()
 
+            content = function_call.result if function_call_success else function_call.error
+            if isinstance(content, BaseModel):
+                content = content.model_dump_json()
+
             _function_call_result = Message(
                 role=role,
-                content=function_call.result if function_call_success else function_call.error,
+                content=content,
                 tool_call_id=function_call.call_id,
                 tool_call_name=function_call.function.name,
                 tool_call_error=not function_call_success,


### PR DESCRIPTION
### Issue
When delegating a task to an assistant, the function call is encapsulated in a `Message` object. However, if the assistant utilizes an `output_model`, the validation for the `Message` object fails because the `content` attribute expects a string, but the `output_model` does not meet that requirement.

### Fix
To resolve this, the `output_model` can be serialized into a JSON string before constructing the `Message` object, ensuring it passes the validation.