### PR TITLE
fix: do not request the LLM to provide a $defs field

### DIFF
--- a/phi/assistant/assistant.py
+++ b/phi/assistant/assistant.py
@@ -535,7 +535,7 @@ class Assistant(BaseModel):
 
                     if len(output_model_properties) > 0:
                         json_output_prompt += "\n<json_fields>"
-                        json_output_prompt += f"\n{json.dumps(list(output_model_properties.keys()))}"
+                        json_output_prompt += f"\n{json.dumps([key for key in output_model_properties.keys() if key != '$defs'])}"
                         json_output_prompt += "\n</json_fields>"
                         json_output_prompt += "\nHere are the properties for each field:"
                         json_output_prompt += "\n<json_field_properties>"


### PR DESCRIPTION
### Issue

When using `output_model` with nested objects, an extra `$defs` field is listed in the json fields requested in the output. This field contains the definitions of nested objects, but it should not be included as a top-level field in the output JSON structure.


```md
Provide your output as a JSON containing the following fields:
<json_fields>
["entities", "$defs"] // HERE
</json_fields>
Here are the properties for each field:
<json_field_properties>
{
  "entities": {
    "description": "The list of entities.",
    "items": {
      "$ref": "#/$defs/EntityOutput"
    },
    "type": "array"
  },
  "$defs": {
    "EntityOutput": {
      "name": {
        "description": "The name of the category as output by the category lookup
tool.",
        "type": "string"
      }
    }
  }
}
</json_field_properties>
```

### Expected behavior

Even if the `$defs` field must be present in the json field properties description, it should not be listed in the json fields requested in the output.

```md
Provide your output as a JSON containing the following fields:
<json_fields>
["entities"]
</json_fields>
Here are the properties for each field:
<json_field_properties>
{
  "entities": {
    "description": "The list of entities.",
    "items": {
      "$ref": "#/$defs/EntityOutput"
    },
    "type": "array"
  },
  "$defs": {
    "EntityOutput": {
      "name": {
        "description": "The name of the category as output by the category lookup tool.",
        "type": "string"
      }
    }
  }
}
</json_field_properties>
```
