### PR TITLE
bug-with-runresponse-model-when-no-model-is-provided-phi-1235

### DIFF
--- a/phi/agent/agent.py
+++ b/phi/agent/agent.py
@@ -836,7 +836,7 @@ class Agent(BaseModel):
         12. Log Agent Run
         """
         # Create the run_response object
-        run_response = RunResponse(run_id=str(uuid4()), model=self.model.model if self.model is not None else None)
+        run_response = RunResponse(run_id=str(uuid4()))
 
         logger.debug(f"*********** Agent Run Start: {run_response.run_id} ***********")
         # 1. Read existing session from storage
@@ -844,6 +844,7 @@ class Agent(BaseModel):
 
         # 2. Update the Model (set defaults, add tools, etc.)
         self.update_model()
+        run_response.model = self.model.model if self.model is not None else None
 
         # 3. Prepare the List of messages to send to the Model
         run_messages: List[Message] = []

--- a/phi/playground/playground.py
+++ b/phi/playground/playground.py
@@ -115,7 +115,9 @@ class Playground:
                         ),
                         enable_rag=agent.enable_rag,
                         tools=formatted_tools,
-                        memory={"name": agent.memory.db.__class__.__name__} if agent.memory and agent.memory.db else None,
+                        memory={"name": agent.memory.db.__class__.__name__}
+                        if agent.memory and agent.memory.db
+                        else None,
                         storage={"name": agent.storage.__class__.__name__} if agent.storage else None,
                         knowledge={"name": agent.knowledge.__class__.__name__} if agent.knowledge else None,
                         description=agent.description,
@@ -125,7 +127,9 @@ class Playground:
 
             return self.agent_list
 
-        def chat_response_streamer(agent: Agent, message: str, images: Optional[List[Union[str, Dict]]] = None) -> Generator:
+        def chat_response_streamer(
+            agent: Agent, message: str, images: Optional[List[Union[str, Dict]]] = None
+        ) -> Generator:
             run_response = agent.run(message, images=images, stream=True)
             for run_response_chunk in run_response:
                 run_response_chunk = cast(RunResponse, run_response_chunk)
@@ -133,13 +137,9 @@ class Playground:
 
         def process_image(file: UploadFile) -> List[Union[str, Dict]]:
             content = file.file.read()
-            encoded = base64.b64encode(content).decode('utf-8')
+            encoded = base64.b64encode(content).decode("utf-8")
 
-            image_info = {
-                "filename": file.filename,
-                "content_type": file.content_type,
-                "size": len(content)
-            }
+            image_info = {"filename": file.filename, "content_type": file.content_type, "size": len(content)}
 
             return [encoded, image_info]
 


### PR DESCRIPTION
Changes:

- `model` is now added to `run_response` after `self.update_model()` fn to avoid the edge case when model is not provided by the user 