### PR TITLE
Bug/fix response model openai phi 1313

### DIFF
--- a/phi/model/openai/chat.py
+++ b/phi/model/openai/chat.py
@@ -295,7 +295,10 @@ class OpenAIChat(Model):
         Returns:
             ChatCompletion: The chat completion response from the API.
         """
-        if self.response_format is not None and issubclass(self.response_format, BaseModel) and self.structured_outputs:
+        if (self.response_format is not None and 
+            isinstance(self.response_format, type) and 
+            issubclass(self.response_format, BaseModel) and 
+            self.structured_outputs):
             return self.get_client().beta.chat.completions.parse(
                 model=self.id,
                 messages=[m.to_dict() for m in messages],  # type: ignore


### PR DESCRIPTION
Error with Model Response and OpenAIChat.

```
from typing import List
from rich.pretty import pprint  # noqa
from pydantic import BaseModel, Field
from phi.agent import Agent, RunResponse  # noqa
from phi.model.openai import OpenAIChat


class MovieScript(BaseModel):
    setting: str = Field(..., description="Provide a nice setting for a blockbuster movie.")
    ending: str = Field(..., description="Ending of the movie. If not available, provide a happy ending.")
    genre: str = Field(
        ..., description="Genre of the movie. If not available, select action, thriller or romantic comedy."
    )
    name: str = Field(..., description="Give a name to this movie")
    characters: List[str] = Field(..., description="Name of characters for this movie.")
    storyline: str = Field(..., description="3 sentence storyline for the movie. Make it exciting!")


movie_writer = Agent(
    model=OpenAIChat(id="gpt-4o"),
    description="You help people write movie scripts.",
    response_model=MovieScript,
    # structured_outputs=True,
    # debug_mode=True,
)

# Get the response in a variable
# run: RunResponse = movie_agent.run("New York")
# pprint(run.content)

movie_writer.print_response("New York")
```

