### PR TITLE
Docs: Typo Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ python agent_team.py
 
 ## Reasoning Agents
 
-Reasoning helps agents work through a problem step-by-step, backtracking and correcting as needed. Let's give the reasonining agent a simple task that gpt-4o fails at. Create a file `reasoning_agent.py`
+Reasoning helps agents work through a problem step-by-step, backtracking and correcting as needed. Let's give the reasoning agent a simple task that gpt-4o fails at. Create a file `reasoning_agent.py`
 
 ```python
 from phi.agent import Agent


### PR DESCRIPTION
Corrected "reasonining" to "reasoning" in [README.md].

This pull request addresses a minor typo found in repository. The typo has been corrected to improve clarity and maintain the quality of the documentation.

This change is purely cosmetic and does not affect functionality.