### PR TITLE
Made changes to support structured output from OpenAI models along with tools calling

### DIFF
--- a/phi/agent/agent.py
+++ b/phi/agent/agent.py
@@ -462,7 +462,10 @@ class Agent(BaseModel):
         agent_tools = self.get_tools()
         if agent_tools is not None:
             for tool in agent_tools:
-                self.model.add_tool(tool)
+                if self.response_model is not None and self.structured_outputs:
+                    self.model.add_tool(tool, structured_outputs=True)
+                else:
+                    self.model.add_tool(tool)
 
         # Set show_tool_calls if it is not set on the Model
         if self.model.show_tool_calls is None and self.show_tool_calls is not None:

--- a/phi/model/base.py
+++ b/phi/model/base.py
@@ -123,12 +123,14 @@ class Model(BaseModel):
                 tools_for_api.append(tool)
         return tools_for_api
 
-    def add_tool(self, tool: Union[Tool, Toolkit, Callable, Dict, Function]) -> None:
+    def add_tool(self, tool: Union[Tool, Toolkit, Callable, Dict, Function], structured_outputs: bool = False) -> None:
         if self.tools is None:
             self.tools = []
 
         # If the tool is a Tool or Dict, add it directly to the Model
         if isinstance(tool, Tool) or isinstance(tool, Dict):
+            if structured_outputs:
+                tool.strict = True
             if tool not in self.tools:
                 self.tools.append(tool)
                 logger.debug(f"Added tool {tool} to model.")
@@ -141,6 +143,8 @@ class Model(BaseModel):
             if isinstance(tool, Toolkit):
                 # For each function in the toolkit
                 for name, func in tool.functions.items():
+                    if structured_outputs:
+                        func.strict = True
                     # If the function does not exist in self.functions, add to self.tools
                     if name not in self.functions:
                         self.functions[name] = func
@@ -148,6 +152,8 @@ class Model(BaseModel):
                         logger.debug(f"Function {name} from {tool.name} added to model.")
 
             elif isinstance(tool, Function):
+                if structured_outputs:
+                    tool.strict = True
                 if tool.name not in self.functions:
                     self.functions[tool.name] = tool
                     self.tools.append({"type": "function", "function": tool.to_dict()})
@@ -158,6 +164,8 @@ class Model(BaseModel):
                     function_name = tool.__name__
                     if function_name not in self.functions:
                         func = Function.from_callable(tool)
+                        if structured_outputs:
+                            func.strict = True
                         self.functions[func.name] = func
                         self.tools.append({"type": "function", "function": func.to_dict()})
                         logger.debug(f"Function {func.name} added to Model.")

--- a/phi/model/openai/chat.py
+++ b/phi/model/openai/chat.py
@@ -594,6 +594,10 @@ class OpenAIChat(Model):
                 if model_response.content is None:
                     model_response.content = ""
                 model_response.content += response_after_tool_calls.content
+            if response_after_tool_calls.parsed is not None:
+                # bubble up the parsed object, so that the final response has the parsed object
+                # that is visible to the agent
+                model_response.parsed = response_after_tool_calls.parsed
             return model_response
 
         # -*- Update model response

--- a/phi/tools/function.py
+++ b/phi/tools/function.py
@@ -16,19 +16,20 @@ class Function(BaseModel):
     # To describe a function that accepts no parameters, provide the value {"type": "object", "properties": {}}.
     parameters: Dict[str, Any] = {"type": "object", "properties": {}}
     entrypoint: Optional[Callable] = None
+    strict: bool = False
 
     # If True, the arguments are sanitized before being passed to the function.
     sanitize_arguments: bool = True
 
     def to_dict(self) -> Dict[str, Any]:
-        return self.model_dump(exclude_none=True, include={"name", "description", "parameters"})
+        return self.model_dump(exclude_none=True, include={"name", "description", "parameters", "strict"})
 
     @classmethod
     def from_callable(cls, c: Callable) -> "Function":
         from inspect import getdoc
         from phi.utils.json_schema import get_json_schema
 
-        parameters = {"type": "object", "properties": {}}
+        parameters = {"type": "object", "properties": {}, "required": [], "additionalProperties": False}
         try:
             # logger.info(f"Getting type hints for {c}")
             type_hints = get_type_hints(c)

--- a/phi/utils/json_schema.py
+++ b/phi/utils/json_schema.py
@@ -44,11 +44,12 @@ def get_json_schema_for_arg(t: Any) -> Optional[Any]:
 
 
 def get_json_schema(type_hints: Dict[str, Any]) -> Dict[str, Any]:
-    json_schema: Dict[str, Any] = {"type": "object", "properties": {}}
+    json_schema: Dict[str, Any] = {"type": "object", "properties": {}, "required": [], "additionalProperties": False}
     for k, v in type_hints.items():
         # logger.info(f"Parsing arg: {k} | {v}")
         if k == "return":
             continue
+        json_schema["required"].append(k)
         arg_json_schema = get_json_schema_for_arg(v)
         if arg_json_schema is not None:
             # logger.info(f"json_schema: {arg_json_schema}")


### PR DESCRIPTION
All this is in context of OpenAI models. Because of big test run logs, I am putting them in pastebin and linking them here, else this description becomes too big and github does not allow too big descriptions.

Details:
======
As of now structured output works, but only in case if agent is not given any tools. If we give tools to an agent and also expect it to give structured output, it fails with below error: https://pastebin.com/Ckgi1YCU

Here is the test script: https://pastebin.com/72SgZ00j

When either tools are not provided or below two arguments are not passed (or commented) in call to `Agent()`, the test pass without any issues. 
```
    structured_outputs=True,
    response_model=ResponseObj,
```

As from error, we can see that OpenAI expects functions to be marked as `"strict": True` when structured output is enabled. This diff is to make that change. With this diff now tools along with structured output can be used.

Here is the test run for tools with structured output: https://pastebin.com/xFYcfV8M

Here is the test run for tools without structured output (as markdown): https://pastebin.com/rEwcgrBA