### PR TITLE
Broken Link in multiple readme.md files

### DIFF
--- a/cookbook/assistants/integrations/singlestore/README.md
+++ b/cookbook/assistants/integrations/singlestore/README.md
@@ -17,7 +17,7 @@ pip install -U pymysql sqlalchemy pypdf openai phidata
 
 - For SingleStore
 
-> Note: If using a shared tier, please provide a certificate file for SSL connection [Read more](https://docs.singlestore.com/cloud/connect-to-your-workspace/connect-with-mysql/connect-with-mysql-client/connect-to-singlestore-helios-using-tls-ssl/)
+> Note: If using a shared tier, please provide a certificate file for SSL connection [Read more](https://docs.singlestore.com/cloud/connect-to-singlestore/connect-with-mysql/connect-with-mysql-client/connect-to-singlestore-helios-using-tls-ssl/)
 
 ```shell
 export SINGLESTORE_HOST="host"

--- a/cookbook/assistants/integrations/singlestore/ai_apps/README.md
+++ b/cookbook/assistants/integrations/singlestore/ai_apps/README.md
@@ -30,7 +30,7 @@ pip install -r cookbook/integrations/singlestore/ai_apps/requirements.txt
 
 - For SingleStore
 
-> Note: If using a shared tier, please provide a certificate file for SSL connection [Read more](https://docs.singlestore.com/cloud/connect-to-your-workspace/connect-with-mysql/connect-with-mysql-client/connect-to-singlestore-helios-using-tls-ssl/)
+> Note: If using a shared tier, please provide a certificate file for SSL connection [Read more](https://docs.singlestore.com/cloud/connect-to-singlestore/connect-with-mysql/connect-with-mysql-client/connect-to-singlestore-helios-using-tls-ssl/)
 
 ```shell
 export SINGLESTORE_HOST="host"

--- a/cookbook/integrations/singlestore/README.md
+++ b/cookbook/integrations/singlestore/README.md
@@ -17,7 +17,7 @@ pip install -U pymysql sqlalchemy pypdf openai phidata
 
 - For SingleStore
 
-> Note: If using a shared tier, please provide a certificate file for SSL connection [Read more](https://docs.singlestore.com/cloud/connect-to-your-workspace/connect-with-mysql/connect-with-mysql-client/connect-to-singlestore-helios-using-tls-ssl/)
+> Note: If using a shared tier, please provide a certificate file for SSL connection [Read more](https://docs.singlestore.com/cloud/connect-to-singlestore/connect-with-mysql/connect-with-mysql-client/connect-to-singlestore-helios-using-tls-ssl/)
 
 ```shell
 export SINGLESTORE_HOST="host"


### PR DESCRIPTION
In multiple readme.md file there is broken link of
> For SingleStore
> Note: If using a shared tier, please provide a certificate file for SSL connection [Read more](https://docs.singlestore.com/cloud/connect-to-your-workspace/connect-with-mysql/connect-with-mysql-client/connect-to-singlestore-helios-using-tls-ssl/)

![image](https://github.com/user-attachments/assets/d877a466-5e5f-4ff4-b456-d171d720a1d2)

Resolved the broken links and now redirects correctly

![image](https://github.com/user-attachments/assets/1e0d0498-a55f-434e-97ed-06af11d7b66d)
