### PR TITLE
Docs: Typo Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ MovieScript(
 
 </details>
 
-### Checkout the [cookbook](https://github.com/phidatahq/phidata/tree/main/cookbook) for more examples.
+### Check out the [cookbook](https://github.com/phidatahq/phidata/tree/main/cookbook) for more examples.
 
 ## Contributions
 


### PR DESCRIPTION
Corrected "Checkout" to "Check out" in [README.md].

This pull request addresses a minor typo found in repository. The typo has been corrected to improve clarity and maintain the quality of the documentation.

This change is purely cosmetic and does not affect functionality.