### PR TITLE
Automate Python Package Deployment to PyPI via GitHub Actions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,39 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload Python Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install build
+    - name: Build package
+      run: python -m build
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| Ready | Feature | Yes |

> ⚠️ NOTE: Ensure that the PyPI API token is stored correctly in GitHub secrets before merging this PR.

## Problem

- Manual process of uploading Python packages to PyPI is time-consuming and error-prone.
- Lack of automation for package deployment upon release.

## Solution

- Introduced a GitHub Actions workflow to automate the package deployment process.
- The workflow triggers on release publication, builds the package, and publishes it to PyPI using the API token.

## Test results

_Add your screenshots or recording about testing_

## Other changes
- No other changes have been made.

## Deploy Notes

There are no new dependencies, scripts, or environment variables introduced with this PR.

**New environment variables**:

- `PYPI_API_TOKEN` : API token for authenticating with PyPI to publish packages. Ensure this is added to GitHub secrets.