### PR TITLE
Implements get_embedding_and_usage on SentenceTransformerEmbedder

### DIFF
--- a/phi/embedder/sentence_transformer.py
+++ b/phi/embedder/sentence_transformer.py
@@ -33,4 +33,4 @@ class SentenceTransformerEmbedder(Embedder):
             return []
 
     def get_embedding_and_usage(self, text: str) -> Tuple[List[float], Optional[Dict]]:
-        return super().get_embedding_and_usage(text)
+        return self.get_embedding(text=text), None


### PR DESCRIPTION
With this PR users can be able to use SentenceTransformerEmbedder on VectorDB 🚀

```
vector_db = LanceDb(
    table_name="blablabla",
    uri="lancedb",
    search_type=SearchType.keyword,
    embedder=SentenceTransformerEmbedder()
)

knowledge_base = JSONKnowledgeBase(
    path="./data.json",
    # Table name: ai.json_documents
    vector_db=vector_db,
)
```