### PR TITLE
Enable reranking for all vectordb instances in search

### DIFF
--- a/cookbook/rag/06_agentic_rag_with_reranking.py
+++ b/cookbook/rag/06_agentic_rag_with_reranking.py
@@ -1,0 +1,37 @@
+"""
+1. Run: `pip install openai lancedb tantivy pypdf sqlalchemy phidata cohere` to install the dependencies
+2. Run: `python cookbook/rag/03_traditional_rag_lancedb.py` to run the agent
+"""
+
+from phi.agent import Agent
+from phi.model.openai import OpenAIChat
+from phi.embedder.openai import OpenAIEmbedder
+from phi.knowledge.pdf import PDFUrlKnowledgeBase
+from phi.vectordb.lancedb import LanceDb, SearchType
+from phi.reranker.cohere import CohereReranker
+
+# Create a knowledge base of PDFs from URLs
+knowledge_base = PDFUrlKnowledgeBase(
+    urls=["https://phi-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf"],
+    # Use LanceDB as the vector database and store embeddings in the `recipes` table
+    vector_db=LanceDb(
+        table_name="recipes",
+        uri="tmp/lancedb",
+        search_type=SearchType.vector,
+        embedder=OpenAIEmbedder(model="text-embedding-3-small"),
+        reranker=CohereReranker(model="rerank-multilingual-v3.0"),  # Add a reranker
+    ),
+)
+# Load the knowledge base: Comment after first run as the knowledge base is already loaded
+knowledge_base.load()
+
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    knowledge=knowledge_base,
+    # Add a tool to search the knowledge base which enables agentic RAG.
+    # This is enabled by default when `knowledge` is provided to the Agent.
+    search_knowledge=True,
+    show_tool_calls=True,
+    markdown=True,
+)
+agent.print_response("How do I make chicken and galangal in coconut milk soup", stream=True)

--- a/phi/document/base.py
+++ b/phi/document/base.py
@@ -15,6 +15,7 @@ class Document(BaseModel):
     embedder: Optional[Embedder] = None
     embedding: Optional[List[float]] = None
     usage: Optional[Dict[str, Any]] = None
+    reranking_score: Optional[float] = None
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/phi/reranker/base.py
+++ b/phi/reranker/base.py
@@ -1,0 +1,13 @@
+from typing import List
+
+from pydantic import BaseModel, ConfigDict
+from phi.document import Document
+
+
+class Reranker(BaseModel):
+    """Base class for rerankers"""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True)
+
+    def rerank(self, query: str, documents: List[Document]) -> List[Document]:
+        raise NotImplementedError

--- a/phi/reranker/cohere.py
+++ b/phi/reranker/cohere.py
@@ -1,0 +1,52 @@
+from phi.reranker.base import Reranker
+from typing import List, Dict, Any, Optional
+from phi.document import Document
+from phi.utils.log import logger
+
+try:
+    from cohere import Client as CohereClient
+except ImportError:
+    raise ImportError("cohere not installed, please run pip install cohere")
+
+
+class CohereReranker(Reranker):
+    model: str = "rerank-multilingual-v3.0"
+    api_key: Optional[str] = None
+    cohere_client: Optional[CohereClient] = None
+    top_n: Optional[int] = None
+
+    @property
+    def client(self) -> CohereClient:
+        if self.cohere_client:
+            return self.cohere_client
+
+        _client_params: Dict[str, Any] = {}
+        if self.api_key:
+            _client_params["api_key"] = self.api_key
+        return CohereClient(**_client_params)
+
+    def _rerank(self, query: str, documents: List[Document]) -> List[Document]:
+        compressed_docs: list[Document] = []
+        if not documents:
+            return compressed_docs
+
+        _docs = [doc.content for doc in documents]
+        response = self.client.rerank(query=query, documents=_docs, model=self.model, top_n=self.top_n)
+        for r in response.results:
+            doc = documents[r.index]
+            doc.reranking_score = r.relevance_score
+            compressed_docs.append(doc)
+
+        # order by relevance score
+        compressed_docs.sort(
+            key=lambda x: x.reranking_score if x.reranking_score is not None else float("-inf"),
+            reverse=True,
+        )
+        return compressed_docs
+
+    def rerank(self, query: str, documents: List[Document]) -> List[Document]:
+        try:
+            return self._rerank(query=query, documents=documents)
+        except Exception as e:
+            logger.error(f"Error reranking documents: {e}. Returning original documents")
+            return documents

--- a/phi/vectordb/chroma/chromadb.py
+++ b/phi/vectordb/chroma/chromadb.py
@@ -17,6 +17,7 @@ from phi.embedder.openai import OpenAIEmbedder
 from phi.vectordb.base import VectorDb
 from phi.vectordb.distance import Distance
 from phi.utils.log import logger
+from phi.reranker.base import Reranker
 
 
 class ChromaDb(VectorDb):
@@ -27,6 +28,7 @@ class ChromaDb(VectorDb):
         distance: Distance = Distance.cosine,
         path: str = "tmp/chromadb",
         persistent_client: bool = False,
+        reranker: Optional[Reranker] = None,
         **kwargs,
     ):
         # Collection attributes
@@ -47,6 +49,9 @@ class ChromaDb(VectorDb):
         # Persistent Chroma client instance
         self.persistent_client: bool = persistent_client
         self.path: str = path
+
+        # Reranker instance
+        self.reranker: Optional[Reranker] = reranker
 
         # Chroma client kwargs
         self.kwargs = kwargs
@@ -217,6 +222,9 @@ class ChromaDb(VectorDb):
                 )
         except Exception as e:
             logger.error(f"Error building search results: {e}")
+
+        if self.reranker:
+            search_results = self.reranker.rerank(query=query, documents=search_results)
 
         return search_results
 

--- a/phi/vectordb/pgvector/pgvector.py
+++ b/phi/vectordb/pgvector/pgvector.py
@@ -25,6 +25,7 @@ from phi.vectordb.distance import Distance
 from phi.vectordb.search import SearchType
 from phi.vectordb.pgvector.index import Ivfflat, HNSW
 from phi.utils.log import logger
+from phi.reranker.base import Reranker
 
 
 class PgVector(VectorDb):
@@ -50,6 +51,7 @@ class PgVector(VectorDb):
         content_language: str = "english",
         schema_version: int = 1,
         auto_upgrade_schema: bool = False,
+        reranker: Optional[Reranker] = None,
     ):
         """
         Initialize the PgVector instance.
@@ -119,6 +121,9 @@ class PgVector(VectorDb):
         self.schema_version: int = schema_version
         # Automatically upgrade schema if True
         self.auto_upgrade_schema: bool = auto_upgrade_schema
+
+        # Reranker instance
+        self.reranker: Optional[Reranker] = reranker
 
         # Database session
         self.Session: scoped_session = scoped_session(sessionmaker(bind=self.db_engine))
@@ -501,6 +506,9 @@ class PgVector(VectorDb):
                         usage=result.usage,
                     )
                 )
+
+            if self.reranker:
+                search_results = self.reranker.rerank(query=query, documents=search_results)
 
             return search_results
         except Exception as e:

--- a/phi/vectordb/pgvector/pgvector2.py
+++ b/phi/vectordb/pgvector/pgvector2.py
@@ -23,6 +23,7 @@ from phi.vectordb.base import VectorDb
 from phi.vectordb.distance import Distance
 from phi.vectordb.pgvector.index import Ivfflat, HNSW
 from phi.utils.log import logger
+from phi.reranker.base import Reranker
 
 
 class PgVector2(VectorDb):
@@ -35,6 +36,7 @@ class PgVector2(VectorDb):
         embedder: Optional[Embedder] = None,
         distance: Distance = Distance.cosine,
         index: Optional[Union[Ivfflat, HNSW]] = HNSW(),
+        reranker: Optional[Reranker] = None,
     ):
         _engine: Optional[Engine] = db_engine
         if _engine is None and db_url is not None:
@@ -63,6 +65,9 @@ class PgVector2(VectorDb):
 
         # Distance metric
         self.distance: Distance = distance
+
+        # Reranker instance
+        self.reranker: Optional[Reranker] = reranker
 
         # Index for the collection
         self.index: Optional[Union[Ivfflat, HNSW]] = index
@@ -298,6 +303,9 @@ class PgVector2(VectorDb):
                     usage=neighbor.usage,
                 )
             )
+
+        if self.reranker:
+            search_results = self.reranker.rerank(query=query, documents=search_results)
 
         return search_results
 

--- a/phi/vectordb/qdrant/qdrant.py
+++ b/phi/vectordb/qdrant/qdrant.py
@@ -15,6 +15,7 @@ from phi.embedder.openai import OpenAIEmbedder
 from phi.vectordb.base import VectorDb
 from phi.vectordb.distance import Distance
 from phi.utils.log import logger
+from phi.reranker.base import Reranker
 
 
 class Qdrant(VectorDb):
@@ -34,6 +35,7 @@ class Qdrant(VectorDb):
         timeout: Optional[float] = None,
         host: Optional[str] = None,
         path: Optional[str] = None,
+        reranker: Optional[Reranker] = None,
         **kwargs,
     ):
         # Collection attributes
@@ -61,6 +63,9 @@ class Qdrant(VectorDb):
         self.timeout: Optional[float] = timeout
         self.host: Optional[str] = host
         self.path: Optional[str] = path
+
+        # Reranker instance
+        self.reranker: Optional[Reranker] = reranker
 
         # Qdrant client kwargs
         self.kwargs = kwargs
@@ -218,6 +223,9 @@ class Qdrant(VectorDb):
                     usage=result.payload["usage"],
                 )
             )
+
+        if self.reranker:
+            search_results = self.reranker.rerank(query=query, documents=search_results)
 
         return search_results
 


### PR DESCRIPTION
#1416

## Summary
This PR introduces a unified reranker implementation within phi.reranker to support reranking functionality across various vectordb instances, not limited to lancedb. It adds the CohereReranker to allow consistent reranking behavior across different vector databases. 

## Changes
- Implemented a common reranker under phi.reranker to standardize reranking across vectordb instances.
- Added `CohereReranker` to `phi.reranker.cohere.py`, enabling the integration of Cohere’s reranker with any vectordb instance.
- Updated search logic to conditionally apply the reranker, allowing flexible and consistent reranking during searches.
- Added `reranking_score` field to `Document` to store scores used in reranking.
- Added `06_agentic_rag_with_reranking.py` to `cookbook.rag` as an example demonstrating RAG (Retrieval-Augmented Generation) with reranking integration.

Verified functionality with `CohereReranker` specifically on `lancedb` to ensure consistent behavior.