### PR TITLE
Add depedency `"psycopg[binary,pool]"` in install command.

### DIFF
--- a/cookbook/providers/ollama_tools/knowledge.py
+++ b/cookbook/providers/ollama_tools/knowledge.py
@@ -1,4 +1,4 @@
-"""Run `pip install duckduckgo-search sqlalchemy pgvector pypdf openai ollama` to install dependencies."""
+"""Run `pip install duckduckgo-search sqlalchemy pgvector pypdf openai ollama "psycopg[binary,pool]"` to install dependencies."""
 
 from phi.agent import Agent
 from phi.model.ollama import OllamaTools


### PR DESCRIPTION
`"psycopg[binary,pool]"` is needed to establish and maintain robust connections between the postgresql db and python apps.

`pip install "psycopg[binary,pool]"`  # to install package and dependencies