### PR TITLE
context-creation-without-knowledge-base-phi-2019

### DIFF
--- a/phi/agent/agent.py
+++ b/phi/agent/agent.py
@@ -1013,7 +1013,7 @@ class Agent(BaseModel):
 
         # Get references from the knowledge base related to the user message
         context = None
-        if self.add_context and message and isinstance(message, str):
+        if self.add_context and message and isinstance(message, str) and self.knowledge:
             retrieval_timer = Timer()
             retrieval_timer.start()
             docs_from_knowledge = self.get_relevant_docs_from_knowledge(query=message, **kwargs)


### PR DESCRIPTION
Prevents creation of empty context when no knowledge base is provided. Example: 

```
  "context" : {
    "query" : "How do I make a Thai curry?",
    "time" : 0
  }
  ```