### PR TITLE
Add: Example on how to use LanceDB as vectorDB.

### DIFF
--- a/cookbook/vectordb/lance_db.py
+++ b/cookbook/vectordb/lance_db.py
@@ -1,6 +1,5 @@
 # install lancedb - `pip install lancedb`
 
-import lancedb
 from phi.agent import Agent
 from phi.knowledge.pdf import PDFUrlKnowledgeBase
 from phi.vectordb.lancedb import LanceDb

--- a/cookbook/vectordb/lance_db.py
+++ b/cookbook/vectordb/lance_db.py
@@ -1,0 +1,25 @@
+# install lancedb - `pip install lancedb`
+
+import lancedb
+from phi.agent import Agent
+from phi.knowledge.pdf import PDFUrlKnowledgeBase
+from phi.vectordb.lancedb import LanceDb
+
+# Initialize LanceDB
+# By default, it stores data in /tmp/lancedb
+vector_db = LanceDb(
+    table_name="recipes",
+    uri="/tmp/lancedb"  # You can change this path to store data elsewhere
+)
+
+# Create knowledge base
+knowledge_base = PDFUrlKnowledgeBase(
+    urls=["https://phi-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf"],
+    vector_db=vector_db,
+)
+
+knowledge_base.load(recreate=False)  # Comment out after first run
+
+# Create and use the agent
+agent = Agent(knowledge_base=knowledge_base, use_tools=True, show_tool_calls=True)
+agent.print_response("How to make Tom Kha Gai", markdown=True) 


### PR DESCRIPTION
Added an example cookbook on how to use **LanceDB** as your Vectorstore to run your agent.
The Example code follows the same sturcture and style as that of other cookbooks. 

Lmk if there needs to be any change. Thanks. 

cc : @ashpreetbedi @manthanguptaa 