### PR TITLE
fixes defect in phi/llm/ollama/chat.py

### DIFF
--- a/phi/llm/ollama/chat.py
+++ b/phi/llm/ollama/chat.py
@@ -350,7 +350,7 @@ class Ollama(LLM):
                 tool_calls_result: MessageToolCallExtractionResult = extract_tool_calls(_tool_call_content)
 
                 # it is a tool call?
-                if tool_calls_result.tool_calls is None and not tool_calls_result.invalid_json_format:
+                if tool_calls_result.tool_calls is not None and not tool_calls_result.invalid_json_format:
                     if tool_calls_result.invalid_json_format:
                         assistant_message.tool_call_error = True
 


### PR DESCRIPTION
When using the ollama model and triggering a function call, tool_calls_result.tool_calls should not be None.