### PR TITLE
Feat: Youtube Knowledge Base Video URLs

### DIFF
--- a/cookbook/knowledge/youtube_kb.py
+++ b/cookbook/knowledge/youtube_kb.py
@@ -1,0 +1,31 @@
+import os
+from os import getenv
+from phi.agent import Agent
+from phi.knowledge.youtube import YouTubeKnowledgeBase, YouTubeReader
+from phi.vectordb.qdrant import Qdrant
+
+api_key = getenv("QDRANT_API_KEY")
+qdrant_url = getenv("QDRANT_URL")
+
+vector_db = Qdrant(
+    collection="youtube-phidata",
+    url=qdrant_url,
+    api_key=api_key
+)
+
+os.environ['OPENAI_API_KEY'] = "<replace-with-openai-key>"
+
+# Create a knowledge base with the PDFs from the data/pdfs directory
+knowledge_base = YouTubeKnowledgeBase(
+    urls=['https://www.youtube.com/watch?v=CDC3GOuJyZ0'],
+    vector_db=vector_db,
+    reader=YouTubeReader(chunk=True),
+)
+knowledge_base.load(recreate=False) # only once, comment it out after first run
+
+agent = Agent(
+    knowledge=knowledge_base,
+    search_knowledge=True,
+)
+
+agent.print_response("what is the major focus of the knowledge provided?", markdown=True)

--- a/phi/document/reader/youtube_reader.py
+++ b/phi/document/reader/youtube_reader.py
@@ -1,0 +1,50 @@
+from typing import List, Union
+from phi.document.base import Document
+from phi.document.reader.base import Reader
+from phi.utils.log import logger
+
+
+class YouTubeReader(Reader):
+	"""Reader for YouTube video transcripts"""
+
+	def read(self, video_url: str) -> List[Document]:
+		if not video_url:
+			raise ValueError("No video URL provided")
+
+		try:
+			from youtube_transcript_api import YouTubeTranscriptApi
+		except ImportError:
+			raise ImportError("`youtube_transcript_api` not installed")
+
+		try:
+			# Extract video ID from URL
+			video_id = video_url.split("v=")[-1].split("&")[0]
+			logger.info(f"Reading transcript for video: {video_id}")
+
+			# Get transcript
+			transcript_list = YouTubeTranscriptApi.get_transcript(video_id)
+			
+			# Combine transcript segments into full text
+			transcript_text = ""
+			for segment in transcript_list:
+				transcript_text += f"{segment['text']} "
+
+			documents = [
+				Document(
+					name=f"youtube_{video_id}",
+					id=f"youtube_{video_id}",
+					meta_data={"video_url": video_url, "video_id": video_id},
+					content=transcript_text.strip(),
+				)
+			]
+
+			if self.chunk:
+				chunked_documents = []
+				for document in documents:
+					chunked_documents.extend(self.chunk_document(document))
+				return chunked_documents
+			return documents
+
+		except Exception as e:
+			logger.error(f"Error reading transcript for {video_url}: {e}")
+			return []

--- a/phi/document/reader/youtube_reader.py
+++ b/phi/document/reader/youtube_reader.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List
 from phi.document.base import Document
 from phi.document.reader.base import Reader
 from phi.utils.log import logger

--- a/phi/knowledge/youtube.py
+++ b/phi/knowledge/youtube.py
@@ -1,0 +1,21 @@
+from typing import List, Iterator
+
+from phi.document import Document
+from phi.document.reader.youtube_reader import YouTubeReader
+from phi.knowledge.agent import AgentKnowledge
+
+class YouTubeKnowledgeBase(AgentKnowledge):
+	urls: List[str] = []
+	reader: YouTubeReader = YouTubeReader()
+
+	@property
+	def document_lists(self) -> Iterator[List[Document]]:
+		"""Iterate over YouTube URLs and yield lists of documents.
+		Each object yielded by the iterator is a list of documents.
+
+		Returns:
+			Iterator[List[Document]]: Iterator yielding list of documents
+		"""
+		
+		for url in self.urls:
+			yield self.reader.read(video_url=url)


### PR DESCRIPTION
## Description

**Please include:**
- Include Youtube reader logic using Youtube-transcript-api
- Create a YouTube knowledge base useful for Agentic RAG over YouTube video
- Include example usage for YouTube Knowledge Base. 
- Attached screenshot with the result

<img width="1543" alt="Screenshot 2024-12-12 at 02 18 48" src="https://github.com/user-attachments/assets/7ee77d5b-fc83-4d23-9271-2492cdb48dea" />

Fixes # (issue)

## Type of change

Please check the options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update
- [ ] Infrastructure change

## Checklist

- [x] My code follows Phidata's style guidelines and best practices
- [x] I have performed a self-review of my code
- [x] I have added docstrings and comments for complex logic
- [x] My changes generate no new warnings or errors
- [x] I have added cookbook examples for my new addition (if needed)
- [ ] I have updated requirements.txt/pyproject.toml (if needed)
- [ ] I have verified my changes in a clean environment

## Additional Notes

Include any deployment notes, performance implications, or other relevant information: