### PR TITLE
Add optional ddg modifier

### DIFF
--- a/cookbook/tools/duckduckgo_mod.py
+++ b/cookbook/tools/duckduckgo_mod.py
@@ -1,0 +1,6 @@
+from phi.agent import Agent
+from phi.tools.duckduckgo import DuckDuckGo
+
+# We will search DDG but limit the site to Politifact
+agent = Agent(tools=[DuckDuckGo(modifier="site:politifact.com")], show_tool_calls=True)
+agent.print_response("Is Taylor Swift promoting energy-saving devices with Elon Musk?", markdown=False)

--- a/phi/tools/duckduckgo.py
+++ b/phi/tools/duckduckgo.py
@@ -15,6 +15,7 @@ class DuckDuckGo(Toolkit):
         self,
         search: bool = True,
         news: bool = True,
+        modifier: Optional[str] = None,
         fixed_max_results: Optional[int] = None,
         headers: Optional[Any] = None,
         proxy: Optional[str] = None,
@@ -28,6 +29,7 @@ class DuckDuckGo(Toolkit):
         self.proxies: Optional[Any] = proxies
         self.timeout: Optional[int] = timeout
         self.fixed_max_results: Optional[int] = fixed_max_results
+        self.modifier: Optional[str] = modifier
         if search:
             self.register(self.duckduckgo_search)
         if news:
@@ -45,7 +47,7 @@ class DuckDuckGo(Toolkit):
         """
         logger.debug(f"Searching DDG for: {query}")
         ddgs = DDGS(headers=self.headers, proxy=self.proxy, proxies=self.proxies, timeout=self.timeout)
-        return json.dumps(ddgs.text(keywords=query, max_results=(self.fixed_max_results or max_results)), indent=2)
+        return json.dumps(ddgs.text(keywords=self.modifier+" "+query, max_results=(self.fixed_max_results or max_results)), indent=2)
 
     def duckduckgo_news(self, query: str, max_results: int = 5) -> str:
         """Use this function to get the latest news from DuckDuckGo.


### PR DESCRIPTION
## Description

Adds a simple "modifier" parameter to the DuckDuckGo (DDG) tool that let's users (not exposed to agents) modify the query so that DDG only searches specific sites, e.g "site:redhat.com", search for specific file types (e.g "filetype:pdf") or turn on/off safe search "!safeon"/"!safeoff".
See https://duckduckgo.com/duckduckgo-help-pages/results/syntax/ for more information.


## Type of change

Please check the options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update
- [ ] Infrastructure change

## Checklist

- [ ] My code follows Phidata's style guidelines and best practices
- [X] I have performed a self-review of my code
- [ ] I have added docstrings and comments for complex logic
- [X] My changes generate no new warnings or errors
- [ ] I have added cookbook examples for my new addition (if needed)
- [ ] I have updated requirements.txt/pyproject.toml (if needed)
- [ ] I have verified my changes in a clean environment

