### PR TITLE
fix: docs has same id with recursive chucking

### DIFF
--- a/phi/document/chunking/recursive.py
+++ b/phi/document/chunking/recursive.py
@@ -38,6 +38,7 @@ class RecursiveChunking(ChunkingStrategy):
             chunk_id = None
             if document.id:
                 chunk_id = f"{document.id}_{chunk_number}"
+            chunk_number += 1
             meta_data["chunk_size"] = len(chunk)
             chunks.append(Document(id=chunk_id, name=document.name, meta_data=meta_data, content=chunk))
 


### PR DESCRIPTION
## Description

This pull request fixes an issue encountered when using `RecursiveChunking` with large files. Previously, this could lead to a psycopg.errors.UniqueViolation error due to duplicate key violations during processing large files that more than one chunk, it generated same chunk record `id`.

Fixes #1588

## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update
- [ ] Infrastructure change

## Checklist

- [x] My code follows Phidata's style guidelines and best practices
- [x] I have performed a self-review of my code
- [ ] I have added docstrings and comments for complex logic
- [x] My changes generate no new warnings or errors
- [ ] I have added cookbook examples for my new addition (if needed)
- [ ] I have updated requirements.txt/pyproject.toml (if needed)
- [x] I have verified my changes in a clean environment

## Additional Notes

Include any deployment notes, performance implications, or other relevant information:
