### PR TITLE
Fix response parsing to make gemini tool use work

### DIFF
--- a/cookbook/playground/gemini_agents.py
+++ b/cookbook/playground/gemini_agents.py
@@ -7,7 +7,7 @@ finance_agent = Agent(
     name="Finance Agent",
     model=Gemini(id="gemini-2.0-flash-exp"),
     tools=[YFinanceTools(stock_price=True)],
-    debug_mode=True
+    debug_mode=True,
 )
 
 app = Playground(agents=[finance_agent]).get_app(use_async=False)

--- a/cookbook/playground/gemini_agents.py
+++ b/cookbook/playground/gemini_agents.py
@@ -1,0 +1,16 @@
+from phi.agent import Agent
+from phi.tools.yfinance import YFinanceTools
+from phi.playground import Playground, serve_playground_app
+from phi.model.google import Gemini
+
+finance_agent = Agent(
+    name="Finance Agent",
+    model=Gemini(id="gemini-2.0-flash-exp"),
+    tools=[YFinanceTools(stock_price=True)],
+    debug_mode=True
+)
+
+app = Playground(agents=[finance_agent]).get_app(use_async=False)
+
+if __name__ == "__main__":
+    serve_playground_app("gemini_agents:app", reload=True)

--- a/phi/model/google/gemini.py
+++ b/phi/model/google/gemini.py
@@ -155,7 +155,7 @@ class Gemini(Model):
             content = message.content
             # Initialize message_parts to be used for Gemini
             message_parts: List[Any] = []
-            if not content or message.role in ["tool", "model"]:
+            if (not content or message.role in ["tool", "model"]) and hasattr(message, "parts"):
                 message_parts = message.parts  # type: ignore
             else:
                 if isinstance(content, str):

--- a/phi/playground/router.py
+++ b/phi/playground/router.py
@@ -93,7 +93,7 @@ def get_playground_router(
         run_response = agent.run(message, images=images, stream=True, stream_intermediate_steps=True)
         for run_response_chunk in run_response:
             run_response_chunk = cast(RunResponse, run_response_chunk)
-            yield json.dumps(run_response_chunk.to_dict())
+            yield run_response_chunk.to_json()
 
     def process_image(file: UploadFile) -> List[Union[str, Dict]]:
         content = file.file.read()
@@ -400,7 +400,7 @@ def get_async_playground_router(
         run_response = await agent.arun(message, images=images, stream=True, stream_intermediate_steps=True)
         async for run_response_chunk in run_response:
             run_response_chunk = cast(RunResponse, run_response_chunk)
-            yield run_response_chunk.model_dump_json()
+            yield run_response_chunk.to_json()
 
     async def process_image(file: UploadFile) -> List[Union[str, Dict]]:
         content = file.file.read()

--- a/phi/playground/router.py
+++ b/phi/playground/router.py
@@ -1,4 +1,5 @@
 import base64
+import json
 from typing import List, Optional, AsyncGenerator, Dict, cast, Union, Generator
 
 from fastapi import APIRouter, HTTPException, UploadFile
@@ -92,7 +93,7 @@ def get_playground_router(
         run_response = agent.run(message, images=images, stream=True, stream_intermediate_steps=True)
         for run_response_chunk in run_response:
             run_response_chunk = cast(RunResponse, run_response_chunk)
-            yield run_response_chunk.model_dump_json()
+            yield json.dumps(run_response_chunk.to_dict())
 
     def process_image(file: UploadFile) -> List[Union[str, Dict]]:
         content = file.file.read()

--- a/phi/playground/router.py
+++ b/phi/playground/router.py
@@ -1,5 +1,4 @@
 import base64
-import json
 from typing import List, Optional, AsyncGenerator, Dict, cast, Union, Generator
 
 from fastapi import APIRouter, HTTPException, UploadFile

--- a/phi/run/response.py
+++ b/phi/run/response.py
@@ -64,10 +64,13 @@ class RunResponse(BaseModel):
             exclude={"messages"},
         )
         if self.messages is not None:
-            _dict["messages"] = [m.model_dump(
-                exclude_none=True,
-                exclude={"parts"},  # Exclude what Gemini adds
-            ) for m in self.messages]
+            _dict["messages"] = [
+                m.model_dump(
+                    exclude_none=True,
+                    exclude={"parts"},  # Exclude what Gemini adds
+                )
+                for m in self.messages
+            ]
         return json.dumps(_dict, indent=2)
 
     def to_dict(self) -> Dict[str, Any]:

--- a/phi/run/response.py
+++ b/phi/run/response.py
@@ -1,3 +1,4 @@
+import json
 from time import time
 from enum import Enum
 from typing import Optional, Any, Dict, List
@@ -56,6 +57,18 @@ class RunResponse(BaseModel):
     created_at: int = Field(default_factory=lambda: int(time()))
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    def to_json(self) -> str:
+        _dict = self.model_dump(
+            exclude_none=True,
+            exclude={"messages"},
+        )
+        if self.messages is not None:
+            _dict["messages"] = self.model_dump(
+                exclude_none=True,
+                include={"role", "content", "name", "tool_call_id", "tool_calls", "audio", "images", "videos", "metrics"},
+            )
+        return json.dumps(_dict, indent=2)
 
     def to_dict(self) -> Dict[str, Any]:
         _dict = self.model_dump(

--- a/phi/run/response.py
+++ b/phi/run/response.py
@@ -64,10 +64,10 @@ class RunResponse(BaseModel):
             exclude={"messages"},
         )
         if self.messages is not None:
-            _dict["messages"] = self.model_dump(
+            _dict["messages"] = [m.model_dump(
                 exclude_none=True,
-                include={"role", "content", "name", "tool_call_id", "tool_calls", "audio", "images", "videos", "metrics"},
-            )
+                exclude={"parts"},  # Exclude what Gemini adds
+            ) for m in self.messages]
         return json.dumps(_dict, indent=2)
 
     def to_dict(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Description

Our run response parsing for the playground was not able to adequately parse `messages` in responses where tool_calls contained unserializable objects from Gemini. This resolves it.

Fixes #1509 

## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update
- [ ] Infrastructure change

## Checklist

- [x] My code follows Phidata's style guidelines and best practices
- [x] I have performed a self-review of my code
- [x] I have added docstrings and comments for complex logic
- [x] My changes generate no new warnings or errors
- [x] I have added cookbook examples for my new addition (if needed)
- [x] I have updated requirements.txt/pyproject.toml (if needed)
- [x] I have verified my changes in a clean environment

