### PR TITLE
Fix tool parsing for ollama

### DIFF
--- a/cookbook/providers/ollama/agent.py
+++ b/cookbook/providers/ollama/agent.py
@@ -2,6 +2,7 @@
 
 from phi.agent import Agent, RunResponse  # noqa
 from phi.model.ollama import Ollama
+from phi.tools.crawl4ai_tools import Crawl4aiTools
 from phi.tools.yfinance import YFinanceTools
 
 agent = Agent(
@@ -18,3 +19,13 @@ agent = Agent(
 
 # Print the response in the terminal
 agent.print_response("What is the stock price of NVDA and TSLA")
+
+
+
+agent = Agent(
+    model=Ollama(id="llama3.1:8b"),
+    tools=[Crawl4aiTools(max_length=1000)],
+    show_tool_calls=True
+)
+agent.print_response("Summarize me the key points in bullet points of this: https://blog.google/products/gemini/google-gemini-deep-research/",
+                     stream=True)

--- a/cookbook/providers/ollama/agent.py
+++ b/cookbook/providers/ollama/agent.py
@@ -2,7 +2,6 @@
 
 from phi.agent import Agent, RunResponse  # noqa
 from phi.model.ollama import Ollama
-from phi.tools.crawl4ai_tools import Crawl4aiTools
 from phi.tools.yfinance import YFinanceTools
 
 agent = Agent(
@@ -19,13 +18,3 @@ agent = Agent(
 
 # Print the response in the terminal
 agent.print_response("What is the stock price of NVDA and TSLA")
-
-
-
-agent = Agent(
-    model=Ollama(id="llama3.1:8b"),
-    tools=[Crawl4aiTools(max_length=1000)],
-    show_tool_calls=True
-)
-agent.print_response("Summarize me the key points in bullet points of this: https://blog.google/products/gemini/google-gemini-deep-research/",
-                     stream=True)

--- a/cookbook/providers/ollama/agent_stream.py
+++ b/cookbook/providers/ollama/agent_stream.py
@@ -3,6 +3,7 @@
 from typing import Iterator  # noqa
 from phi.agent import Agent, RunResponse  # noqa
 from phi.model.ollama import Ollama
+from phi.tools.crawl4ai_tools import Crawl4aiTools
 from phi.tools.yfinance import YFinanceTools
 
 agent = Agent(
@@ -20,3 +21,10 @@ agent = Agent(
 
 # Print the response in the terminal
 agent.print_response("What are analyst recommendations for NVDA and TSLA", stream=True)
+
+
+agent = Agent(model=Ollama(id="llama3.1:8b"), tools=[Crawl4aiTools(max_length=1000)], show_tool_calls=True)
+agent.print_response(
+    "Summarize me the key points in bullet points of this: https://blog.google/products/gemini/google-gemini-deep-research/",
+    stream=True,
+)

--- a/phi/model/ollama/chat.py
+++ b/phi/model/ollama/chat.py
@@ -134,6 +134,11 @@ class Ollama(Model):
             request_params["keep_alive"] = self.keep_alive
         if self.tools is not None:
             request_params["tools"] = self.get_tools_for_api()
+            # Ensure types are valid strings
+            for tool in request_params["tools"]:
+                for prop, obj in tool["function"]["parameters"]["properties"].items():
+                    if type(obj["type"]) == list:
+                        obj["type"] = obj["type"][0]
         if self.request_params is not None:
             request_params.update(self.request_params)
         return request_params

--- a/phi/model/ollama/chat.py
+++ b/phi/model/ollama/chat.py
@@ -137,7 +137,7 @@ class Ollama(Model):
             # Ensure types are valid strings
             for tool in request_params["tools"]:
                 for prop, obj in tool["function"]["parameters"]["properties"].items():
-                    if type(obj["type"]) == list:
+                    if isinstance(obj["type"], list):
                         obj["type"] = obj["type"][0]
         if self.request_params is not None:
             request_params.update(self.request_params)

--- a/phi/tools/function.py
+++ b/phi/tools/function.py
@@ -170,8 +170,6 @@ class Function(BaseModel):
                     if param.default == param.empty and name != "self" and name != "agent"
                 ]
 
-            # Param type should not be a list
-
             # logger.debug(f"JSON schema for {self.name}: {parameters}")
         except Exception as e:
             logger.warning(f"Could not parse args for {self.name}: {e}", exc_info=True)

--- a/phi/tools/function.py
+++ b/phi/tools/function.py
@@ -158,7 +158,6 @@ class Function(BaseModel):
 
             # Get JSON schema for parameters only
             parameters = get_json_schema(type_hints=param_type_hints, strict=strict)
-
             # If strict=True mark all fields as required
             # See: https://platform.openai.com/docs/guides/structured-outputs/supported-schemas#all-fields-must-be-required
             if strict:
@@ -170,6 +169,8 @@ class Function(BaseModel):
                     for name, param in sig.parameters.items()
                     if param.default == param.empty and name != "self" and name != "agent"
                 ]
+
+            # Param type should not be a list
 
             # logger.debug(f"JSON schema for {self.name}: {parameters}")
         except Exception as e:


### PR DESCRIPTION
## Description

Ollama requires a specific formatting for JSONschema tools where parameter types can only be a string, never a list of strings (which is actually valid JSONschema). To compensate for this we ensure optional parameters where the type is `['string', 'null']` is transformed to just `'string'` to be compatible. 
This should not have impact, because we provide a list of "required" parameters with function definitions.

Fixes #1584 

## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update
- [ ] Infrastructure change

## Checklist

- [x] My code follows Phidata's style guidelines and best practices
- [x] I have performed a self-review of my code
- [x] I have added docstrings and comments for complex logic
- [x] My changes generate no new warnings or errors
- [ ] I have added cookbook examples for my new addition (if needed)
- [ ] I have updated requirements.txt/pyproject.toml (if needed)
- [ ] I have verified my changes in a clean environment
