### PR TITLE
Add model_copy to make ollama chat deep copy work with a set client

### DIFF
--- a/cookbook/agents/14_generate_image.py
+++ b/cookbook/agents/14_generate_image.py
@@ -18,4 +18,3 @@ if images and isinstance(images, list):
     for image_response in images:
         image_url = image_response.url
         print(image_url)
-

--- a/cookbook/agents/14_generate_image.py
+++ b/cookbook/agents/14_generate_image.py
@@ -16,9 +16,6 @@ image_agent.print_response("Generate an image of a white siamese cat")
 images = image_agent.get_images()
 if images and isinstance(images, list):
     for image_response in images:
-        image_data = image_response.get("data")  # type: ignore
-        if image_data:
-            for image in image_data:
-                image_url = image.get("url")  # type: ignore
-                if image_url:
-                    print(image_url)
+        image_url = image_response.url
+        print(image_url)
+

--- a/cookbook/providers/ollama/agent_set_client.py
+++ b/cookbook/providers/ollama/agent_set_client.py
@@ -1,0 +1,18 @@
+"""Run `pip install yfinance` to install dependencies."""
+
+from ollama import Client as OllamaClient
+from phi.agent import Agent, RunResponse  # noqa
+from phi.model.ollama import Ollama
+from phi.playground import Playground, serve_playground_app
+from phi.tools.yfinance import YFinanceTools
+
+agent = Agent(
+    model=Ollama(id="llama3.1:8b", client=OllamaClient()),
+    tools=[YFinanceTools(stock_price=True)],
+    markdown=True,
+)
+
+app = Playground(agents=[agent]).get_app()
+
+if __name__ == "__main__":
+    serve_playground_app("agent_set_client:app", reload=True)

--- a/phi/model/ollama/chat.py
+++ b/phi/model/ollama/chat.py
@@ -722,3 +722,8 @@ class Ollama(Model):
             async for post_tool_call_response in self.ahandle_post_tool_call_messages_stream(messages=messages):
                 yield post_tool_call_response
         logger.debug("---------- Ollama Async Response End ----------")
+
+    def model_copy(self, *, update: dict[str, Any] | None = None, deep: bool = False) -> Model:
+        new_model = Ollama(**self.model_dump(exclude={"client"}), client=self.client)
+        return new_model
+

--- a/phi/model/ollama/chat.py
+++ b/phi/model/ollama/chat.py
@@ -723,6 +723,6 @@ class Ollama(Model):
                 yield post_tool_call_response
         logger.debug("---------- Ollama Async Response End ----------")
 
-    def model_copy(self, *, update: dict[str, Any] | None = None, deep: bool = False) -> "Ollama":
+    def model_copy(self, *, update: Optional[dict[str, Any]] = None, deep: bool = False) -> "Ollama":
         new_model = Ollama(**self.model_dump(exclude={"client"}), client=self.client)
         return new_model

--- a/phi/model/ollama/chat.py
+++ b/phi/model/ollama/chat.py
@@ -723,7 +723,6 @@ class Ollama(Model):
                 yield post_tool_call_response
         logger.debug("---------- Ollama Async Response End ----------")
 
-    def model_copy(self, *, update: dict[str, Any] | None = None, deep: bool = False) -> Model:
+    def model_copy(self, *, update: dict[str, Any] | None = None, deep: bool = False) -> "Ollama":
         new_model = Ollama(**self.model_dump(exclude={"client"}), client=self.client)
         return new_model
-

--- a/phi/tools/eleven_labs_tools.py
+++ b/phi/tools/eleven_labs_tools.py
@@ -130,8 +130,7 @@ class ElevenLabsTools(Toolkit):
         """
         try:
             audio_generator = self.eleven_labs_client.text_to_sound_effects.convert(
-                text=prompt,
-                duration_seconds=duration_seconds
+                text=prompt, duration_seconds=duration_seconds
             )
 
             base64_audio = self._process_audio(audio_generator)


### PR DESCRIPTION
## Description
If you set the client manually for Ollama, then there is an issue when the agent model is copied where certain properties can't be pickled. This resolves it.


## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update
- [ ] Infrastructure change

## Checklist

- [x] My code follows Phidata's style guidelines and best practices
- [x] I have performed a self-review of my code
- [x] I have added docstrings and comments for complex logic
- [x] My changes generate no new warnings or errors
- [x] I have added cookbook examples for my new addition (if needed)
- [x] I have updated requirements.txt/pyproject.toml (if needed)
- [x] I have verified my changes in a clean environment
