### PR TITLE
refactor: passing down ssl verification as it's available in DDGS class

### DIFF
--- a/phi/tools/duckduckgo.py
+++ b/phi/tools/duckduckgo.py
@@ -20,7 +20,7 @@ class DuckDuckGo(Toolkit):
         proxy: Optional[str] = None,
         proxies: Optional[Any] = None,
         timeout: Optional[int] = 10,
-        verify: bool = True,
+        verify_ssl: bool = True,
     ):
         super().__init__(name="duckduckgo")
 
@@ -34,7 +34,7 @@ class DuckDuckGo(Toolkit):
         if news:
             self.register(self.duckduckgo_news)
 
-        self.verify: bool = verify
+        self.verify_ssl: bool = verify_ssl
 
     def duckduckgo_search(self, query: str, max_results: int = 5) -> str:
         """Use this function to search DuckDuckGo for a query.
@@ -48,7 +48,7 @@ class DuckDuckGo(Toolkit):
         """
         logger.debug(f"Searching DDG for: {query}")
         ddgs = DDGS(
-            headers=self.headers, proxy=self.proxy, proxies=self.proxies, timeout=self.timeout, verify=self.verify
+            headers=self.headers, proxy=self.proxy, proxies=self.proxies, timeout=self.timeout, verify=self.verify_ssl
         )
         return json.dumps(ddgs.text(keywords=query, max_results=(self.fixed_max_results or max_results)), indent=2)
 
@@ -64,6 +64,6 @@ class DuckDuckGo(Toolkit):
         """
         logger.debug(f"Searching DDG news for: {query}")
         ddgs = DDGS(
-            headers=self.headers, proxy=self.proxy, proxies=self.proxies, timeout=self.timeout, verify=self.verify
+            headers=self.headers, proxy=self.proxy, proxies=self.proxies, timeout=self.timeout, verify=self.verify_ssl
         )
         return json.dumps(ddgs.news(keywords=query, max_results=(self.fixed_max_results or max_results)), indent=2)

--- a/phi/tools/duckduckgo.py
+++ b/phi/tools/duckduckgo.py
@@ -47,7 +47,9 @@ class DuckDuckGo(Toolkit):
             The result from DuckDuckGo.
         """
         logger.debug(f"Searching DDG for: {query}")
-        ddgs = DDGS(headers=self.headers, proxy=self.proxy, proxies=self.proxies, timeout=self.timeout, verify=self.verify)
+        ddgs = DDGS(
+            headers=self.headers, proxy=self.proxy, proxies=self.proxies, timeout=self.timeout, verify=self.verify
+        )
         return json.dumps(ddgs.text(keywords=query, max_results=(self.fixed_max_results or max_results)), indent=2)
 
     def duckduckgo_news(self, query: str, max_results: int = 5) -> str:
@@ -61,5 +63,7 @@ class DuckDuckGo(Toolkit):
             The latest news from DuckDuckGo.
         """
         logger.debug(f"Searching DDG news for: {query}")
-        ddgs = DDGS(headers=self.headers, proxy=self.proxy, proxies=self.proxies, timeout=self.timeout, verify=self.verify)
+        ddgs = DDGS(
+            headers=self.headers, proxy=self.proxy, proxies=self.proxies, timeout=self.timeout, verify=self.verify
+        )
         return json.dumps(ddgs.news(keywords=query, max_results=(self.fixed_max_results or max_results)), indent=2)

--- a/phi/tools/duckduckgo.py
+++ b/phi/tools/duckduckgo.py
@@ -20,6 +20,7 @@ class DuckDuckGo(Toolkit):
         proxy: Optional[str] = None,
         proxies: Optional[Any] = None,
         timeout: Optional[int] = 10,
+        verify: bool = True,
     ):
         super().__init__(name="duckduckgo")
 
@@ -33,6 +34,8 @@ class DuckDuckGo(Toolkit):
         if news:
             self.register(self.duckduckgo_news)
 
+        self.verify: bool = verify
+
     def duckduckgo_search(self, query: str, max_results: int = 5) -> str:
         """Use this function to search DuckDuckGo for a query.
 
@@ -44,7 +47,7 @@ class DuckDuckGo(Toolkit):
             The result from DuckDuckGo.
         """
         logger.debug(f"Searching DDG for: {query}")
-        ddgs = DDGS(headers=self.headers, proxy=self.proxy, proxies=self.proxies, timeout=self.timeout)
+        ddgs = DDGS(headers=self.headers, proxy=self.proxy, proxies=self.proxies, timeout=self.timeout, verify=self.verify)
         return json.dumps(ddgs.text(keywords=query, max_results=(self.fixed_max_results or max_results)), indent=2)
 
     def duckduckgo_news(self, query: str, max_results: int = 5) -> str:
@@ -58,5 +61,5 @@ class DuckDuckGo(Toolkit):
             The latest news from DuckDuckGo.
         """
         logger.debug(f"Searching DDG news for: {query}")
-        ddgs = DDGS(headers=self.headers, proxy=self.proxy, proxies=self.proxies, timeout=self.timeout)
+        ddgs = DDGS(headers=self.headers, proxy=self.proxy, proxies=self.proxies, timeout=self.timeout, verify=self.verify)
         return json.dumps(ddgs.news(keywords=query, max_results=(self.fixed_max_results or max_results)), indent=2)


### PR DESCRIPTION
## Description

**Please include:**

- **Summary of changes**: DDGS provides SSL verification option (with verification enabled by default). Adding it to the DuckDuckGo tool also.
- **Related issues**: N/A
- **Motivation and context**: Experimenting with the introduction example, and ran into SSL issues (cough cough enterprise stuff cough cough)
- **Environment or dependencies**: No changes.
- **Impact on AI/ML components**: (If applicable) N/A

Fixes # N/A

## Type of change

Please check the options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update
- [ ] Infrastructure change

## Checklist

- [x] My code follows Phidata's style guidelines and best practices
- [x] I have performed a self-review of my code
- [ ] I have added docstrings and comments for complex logic
- [ ] My changes generate no new warnings or errors
- [ ] I have added cookbook examples for my new addition (if needed)
- [ ] I have updated requirements.txt/pyproject.toml (if needed)
- [ ] I have verified my changes in a clean environment

## Additional Notes

Include any deployment notes, performance implications, or other relevant information: When trying to format, according to the CONTRIBUTING.md, the `ruff` module wasn't installed by default using the create venv script. I can see it's in the dev modules inside the pyproject.toml. Is that expected? Thanks!

