### PR TITLE
Fix: Added instructions for setting DEEPSEEK_API_KEY and restarting e…

### DIFF
--- a/cookbook/agents/07_monitoring.py
+++ b/cookbook/agents/07_monitoring.py
@@ -1,6 +1,6 @@
 # IMPORTANT: Before running this script, ensure that the (ANY MODEL )API_KEY environment variable is set.
 # To set the API key, follow the instructions below:
-# 
+# For example for DEEPSEEK
 # On Windows:
 # Open Command Prompt as Administrator and run:
 # setx DEEPSEEK_API_KEY "your-api-key-here"

--- a/cookbook/agents/07_monitoring.py
+++ b/cookbook/agents/07_monitoring.py
@@ -1,4 +1,29 @@
-from phi.agent import Agent
+from phi.agent import Agent, RunResponse
+from phi.model.deepseek import DeepSeekChat
 
-agent = Agent(markdown=True, monitoring=True)
-agent.print_response("Share a 2 sentence horror story")
+# IMPORTANT: Before running this script, ensure that the (ANY MODEL )API_KEY environment variable is set.
+# To set the API key, follow the instructions below:
+# 
+# On Windows:
+# Open Command Prompt as Administrator and run:
+# setx DEEPSEEK_API_KEY "your-api-key-here"
+#
+# On Unix/Linux:
+# Open a terminal and run:
+# export DEEPSEEK_API_KEY="your-api-key-here"
+#
+# NOTE: After setting the API key, restart your terminal or environment to apply the changes  by shuting down the terminal and run the script again. 
+
+# Initialize the agent with the DeepSeekChat model
+agent = Agent(model=DeepSeekChat(), markdown=True)
+
+# Example 1: Get the response in a variable
+# Uncomment the following lines to use:
+# run: RunResponse = agent.run("Share a 2 sentence horror story.")
+# print(run.content)
+
+# Example 2: Print the response in the terminal
+print("Printing the response in the terminal")
+agent.print_response(
+    "Give me a code for a React app which says 'Hello World' and provide all file code"
+)

--- a/cookbook/agents/07_monitoring.py
+++ b/cookbook/agents/07_monitoring.py
@@ -1,6 +1,3 @@
-from phi.agent import Agent, RunResponse
-from phi.model.deepseek import DeepSeekChat
-
 # IMPORTANT: Before running this script, ensure that the (ANY MODEL )API_KEY environment variable is set.
 # To set the API key, follow the instructions below:
 # 

--- a/cookbook/agents/07_monitoring.py
+++ b/cookbook/agents/07_monitoring.py
@@ -13,17 +13,7 @@ from phi.model.deepseek import DeepSeekChat
 # export DEEPSEEK_API_KEY="your-api-key-here"
 #
 # NOTE: After setting the API key, restart your terminal or environment to apply the changes  by shuting down the terminal and run the script again. 
+from phi.agent import Agent
 
-# Initialize the agent with the DeepSeekChat model
-agent = Agent(model=DeepSeekChat(), markdown=True)
-
-# Example 1: Get the response in a variable
-# Uncomment the following lines to use:
-# run: RunResponse = agent.run("Share a 2 sentence horror story.")
-# print(run.content)
-
-# Example 2: Print the response in the terminal
-print("Printing the response in the terminal")
-agent.print_response(
-    "Give me a code for a React app which says 'Hello World' and provide all file code"
-)
+agent = Agent(markdown=True, monitoring=True)
+agent.print_response("Share a 2 sentence horror story")


### PR DESCRIPTION
This PR resolves issue #1602, where users face an error when trying to use other large models due to missing DEEPSEEK_API_KEY.
- Added instructions in the script to set the DEEPSEEK_API_KEY environment variable.
- Included comments on restarting the environment after setting the API key.


- Follow the steps provided in the comments of the updated script.
- Set the API key using the command prompt or terminal.
- Restart the environment and run the script to verify the fix.

Fixes #1602
