### PR TITLE
Very minor change - Just ignoring all possible virtual envs as people…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ wip
 dist
 
 # ignore virtualenvs
-.venv
+.venv*
 venv*
 phienv*
 aienv*


### PR DESCRIPTION
## Description
Very minor change - Just ignoring all possible virtual envs as people can name the venv with anything after venv. I normally name it like `.venv-<project-folder-name>`, so that on terminal I can see what project I am in :-)

**Please include:**

- **Summary of changes**: Just changed the `.gitignore` file ignore all possible virtual environments starting with `.venv`.
- **Related issues**: NA
- **Motivation and context**: Already explained in summary
- **Environment or dependencies**: NA
- **Impact on AI/ML components**: NA

Fixes # (issue)

## Type of change
Non-functional, devex

Please check the options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update
- [*] Infrastructure change

## Checklist

- [*] My code follows Phidata's style guidelines and best practices
- [*] I have performed a self-review of my code
- [ ] I have added docstrings and comments for complex logic
- [*] My changes generate no new warnings or errors
- [ ] I have added cookbook examples for my new addition (if needed)
- [ ] I have updated requirements.txt/pyproject.toml (if needed)
- [*] I have verified my changes in a clean environment

## Additional Notes

Include any deployment notes, performance implications, or other relevant information:
