### PR TITLE
Improvement: Better error handling when python-docx isn't installed

### DIFF
--- a/phi/document/reader/docx.py
+++ b/phi/document/reader/docx.py
@@ -4,7 +4,10 @@ from phi.document.base import Document
 from phi.document.reader.base import Reader
 from phi.utils.log import logger
 import io
-from docx import Document as DocxDocument  # type: ignore
+try:
+    from docx import Document as DocxDocument  # type: ignore
+except ImportError:
+    raise ImportError("docx is not installed. Please install it using `pip install python-docx`")
 
 
 class DocxReader(Reader):


### PR DESCRIPTION
## Description
There was no proper error handling when `python-docx` lib wasn't installed which caused users issue

## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update
- [ ] Infrastructure change

## Checklist

- [ ] My code follows Phidata's style guidelines and best practices
- [ ] I have performed a self-review of my code
- [ ] I have added docstrings and comments for complex logic
- [ ] My changes generate no new warnings or errors
- [ ] I have added cookbook examples for my new addition (if needed)
- [ ] I have updated requirements.txt/pyproject.toml (if needed)
- [ ] I have verified my changes in a clean environment

## Additional Notes

Include any deployment notes, performance implications, or other relevant information:
