### PR TITLE
chore(spidertools): Added support for optional API parameters and setting default crawl limit

### DIFF
--- a/cookbook/tools/spider_tools.py
+++ b/cookbook/tools/spider_tools.py
@@ -1,5 +1,5 @@
 from phi.agent import Agent
 from phi.tools.spider import SpiderTools
 
-agent = Agent(tools=[SpiderTools()])
+agent = Agent(tools=[SpiderTools(optional_params={"proxy_enabled": True})])
 agent.print_response('Can you scrape the first search result from a search on "news in USA"?')


### PR DESCRIPTION
Hi, member of Spider team here, would love to add these changes to the tool.

## Description

- **Summary of changes**: Updated tool to allow passing in custom params when instantiating SpiderTools class. Added a default limit of `10` for crawling, to reduce token waste.

- **Motivation and context**: Allowing custom parameters to be passed allows the developer to handle more use cases or control the scraping ability of a given URL (e.g. turning on proxy etc).
- **Environment or dependencies**: No changes in dependencies or environment configurations required for this update.

## Type of change

Please check the options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update
- [ ] Infrastructure change

## Checklist

- [x] My code follows Phidata's style guidelines and best practices
- [x] I have performed a self-review of my code
- [ ] I have added docstrings and comments for complex logic
- [x] My changes generate no new warnings or errors
- [x] I have added cookbook examples for my new addition (if needed)
- [ ] I have updated requirements.txt/pyproject.toml (if needed)
- [x] I have verified my changes in a clean environment