### PR TITLE
Gemini import fix

### DIFF
--- a/phi/document/reader/docx.py
+++ b/phi/document/reader/docx.py
@@ -4,6 +4,7 @@ from phi.document.base import Document
 from phi.document.reader.base import Reader
 from phi.utils.log import logger
 import io
+
 try:
     from docx import Document as DocxDocument  # type: ignore
 except ImportError:

--- a/phi/model/google/__init__.py
+++ b/phi/model/google/__init__.py
@@ -1,2 +1,11 @@
 from phi.model.google.gemini import Gemini
-from phi.model.google.gemini_openai import GeminiOpenAIChat
+
+try:
+    from phi.model.google.gemini_openai import GeminiOpenAIChat
+except ImportError:
+
+    class GeminiOpenAIChat:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "GeminiOpenAIChat requires the 'openai' library. Please install it via `pip install openai`"
+            )

--- a/phi/tools/duckduckgo.py
+++ b/phi/tools/duckduckgo.py
@@ -47,7 +47,12 @@ class DuckDuckGo(Toolkit):
         """
         logger.debug(f"Searching DDG for: {query}")
         ddgs = DDGS(headers=self.headers, proxy=self.proxy, proxies=self.proxies, timeout=self.timeout)
-        return json.dumps(ddgs.text(keywords=self.modifier+" "+query, max_results=(self.fixed_max_results or max_results)), indent=2)
+        if not self.modifier:
+            return json.dumps(ddgs.text(keywords=query, max_results=(self.fixed_max_results or max_results)), indent=2)
+        return json.dumps(
+            ddgs.text(keywords=self.modifier + " " + query, max_results=(self.fixed_max_results or max_results)),
+            indent=2,
+        )
 
     def duckduckgo_news(self, query: str, max_results: int = 5) -> str:
         """Use this function to get the latest news from DuckDuckGo.

--- a/phi/vectordb/cassandra/cassandra.py
+++ b/phi/vectordb/cassandra/cassandra.py
@@ -1,4 +1,5 @@
 from typing import Optional, List, Dict, Any, Iterable
+
 from phi.vectordb.base import VectorDb
 from phi.embedder import Embedder
 from phi.document import Document

--- a/phi/vectordb/cassandra/extra_param_mixin.py
+++ b/phi/vectordb/cassandra/extra_param_mixin.py
@@ -1,6 +1,7 @@
+from typing import List
+
 from cassio.table.mixins.base_table import BaseTableMixin
 from cassio.table.table_types import ColumnSpecType
-from typing import List
 
 
 class ExtraParamMixin(BaseTableMixin):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ module = [
   "boto3.*",
   "botocore.*",
   "bs4.*",
+  "cassio.*",
   "chonkie.*",
   "chromadb.*",
   "clickhouse_connect.*",


### PR DESCRIPTION
## Description

Fixes `openai` not installed error when using Gemini 

## Type of change

Please check the options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update
- [ ] Infrastructure change

## Checklist

- [ ] My code follows Phidata's style guidelines and best practices
- [ ] I have performed a self-review of my code
- [ ] I have added docstrings and comments for complex logic
- [ ] My changes generate no new warnings or errors
- [ ] I have added cookbook examples for my new addition (if needed)
- [ ] I have updated requirements.txt/pyproject.toml (if needed)
- [ ] I have verified my changes in a clean environment