### PR TITLE
:bug: fix: checking the class itself instead of it's instance

### DIFF
--- a/phi/agent/agent.py
+++ b/phi/agent/agent.py
@@ -396,7 +396,7 @@ class Agent(BaseModel):
                     yield "No response from the member agent."
                 elif isinstance(member_agent_run_response.content, str):
                     yield member_agent_run_response.content
-                elif issubclass(member_agent_run_response.content, BaseModel):
+                elif issubclass(type(member_agent_run_response.content), BaseModel):
                     try:
                         yield member_agent_run_response.content.model_dump_json(indent=2)
                     except Exception as e:


### PR DESCRIPTION
## Description

I have been facing the following error: `TypeError: issubclass() arg 1 must be a class`, each time i make the sub agent generate structured output based on BaseModel class, apparently the error occurs because `issubclass()` expects its first argument to be a class, but `member_agent_run_response.content` is an instance of the `response_model`, not the class itself.

To fix the error, i passed the class of the object (not the instance) to `issubclass()`. I used the `type()` function to get the class of the object as follow:

> issubclass(type(member_agent_run_response.content), BaseModel)

Fixes # (issue)

## Type of change

Please check the options that are relevant:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update
- [ ] Infrastructure change

## Checklist

- [X] My code follows Phidata's style guidelines and best practices
- [X] I have performed a self-review of my code
- [ ] I have added docstrings and comments for complex logic
- [ ] My changes generate no new warnings or errors
- [ ] I have added cookbook examples for my new addition (if needed)
- [ ] I have updated requirements.txt/pyproject.toml (if needed)
- [X] I have verified my changes in a clean environment

## Additional Notes

Include any deployment notes, performance implications, or other relevant information:
No additional notes.