### PR TITLE
GeminiEmbedder: update defaults

### DIFF
--- a/phi/embedder/google.py
+++ b/phi/embedder/google.py
@@ -1,3 +1,4 @@
+from os import getenv
 from types import ModuleType
 from typing import Optional, Dict, List, Tuple, Any, Union
 
@@ -27,6 +28,11 @@ class GeminiEmbedder(Embedder):
         if self.gemini_client:
             return self.gemini_client
         _client_params: Dict[str, Any] = {}
+
+        self.api_key = self.api_key or getenv("GOOGLE_API_KEY")
+        if not self.api_key:
+            logger.error("GOOGLE_API_KEY not set. Please set the GOOGLE_API_KEY environment variable.")
+
         if self.api_key:
             _client_params["api_key"] = self.api_key
         if self.client_params:

--- a/phi/embedder/google.py
+++ b/phi/embedder/google.py
@@ -13,7 +13,7 @@ except ImportError:
 
 
 class GeminiEmbedder(Embedder):
-    model: str = "models/embedding-004"
+    model: str = "models/text-embedding-004"
     task_type: str = "RETRIEVAL_QUERY"
     title: Optional[str] = None
     dimensions: Optional[int] = 768

--- a/phi/embedder/google.py
+++ b/phi/embedder/google.py
@@ -13,10 +13,10 @@ except ImportError:
 
 
 class GeminiEmbedder(Embedder):
-    model: str = "models/embedding-001"
+    model: str = "models/embedding-004"
     task_type: str = "RETRIEVAL_QUERY"
     title: Optional[str] = None
-    dimensions: Optional[int] = None
+    dimensions: Optional[int] = 768
     api_key: Optional[str] = None
     request_params: Optional[Dict[str, Any]] = None
     client_params: Optional[Dict[str, Any]] = None


### PR DESCRIPTION
- **Summary of changes**: This pull request updates the GeminiEmbedder class in the phidata library to use the "models/embedding-004" model and sets the default embedding dimensions to 768. Previously, it used the "models/embedding-001" model with no pre-defined dimensions, making it consistent with the official [documentation](https://docs.phidata.com/embedder/gemini#params).
- **Related issues**: This PR addresses inconsistencies between the code and the official documentation.
- **Motivation and context**: The motivation is to ensure that the `GeminiEmbedder` class aligns with the expected behavior and parameters defined in the official documentation, preventing confusion and potential errors for users. The `model` field was being overwritten with the second declaration, and `dimensions` default value wasn't explicitly defined.
- **Environment or dependencies**: There are no changes to dependencies or environment configurations required for this update.

## Type of change

Please check the options that are relevant:
- [x] Model update

## Checklist

- [x] I have performed a self-review of my code
- [x] My code follows Phidata's style guidelines and best practices
- [x] My changes generate no new warnings or errors
- [x] I have verified my changes in a clean environment

## Additional Notes
This is my first contribution. I appreciate your patience and feedback as I navigate this process.