### PR TITLE
Fix for slack tool crash - caused by webhooks and certain bot messages

### DIFF
--- a/phi/tools/slack.py
+++ b/phi/tools/slack.py
@@ -77,7 +77,16 @@ class SlackTools(Toolkit):
         """
         try:
             response = self.client.conversations_history(channel=channel, limit=limit)
-            messages = [{"text": msg["text"], "user": msg["user"], "ts": msg["ts"]} for msg in response["messages"]]
+            messages = [
+            {
+                "text": msg.get("text", ""),
+                "user": "webhook" if msg.get("subtype") == "bot_message" else msg.get("user", "unknown"),
+                "ts": msg.get("ts", ""),
+                "sub_type": msg.get("subtype", "unknown"),
+                "attachments": msg.get("attachments", []) if msg.get("subtype") == "bot_message" else "n/a"
+            }
+            for msg in response.get("messages", [])
+        ]
             return json.dumps(messages)
         except SlackApiError as e:
             logger.error(f"Error getting channel history: {e}")


### PR DESCRIPTION
## Description

* Slack Tool fix for when the "user" field is blank or not available. Changed to safer ".get()" method.
* Added additional logic for webhooks/bots/etc, which caused crashes before. Tested in large/diverse Slack instance and after the fix it seems to work perfectly.


Fixes # (issue)

* https://github.com/phidatahq/phidata/issues/1753

## Type of change

Please check the options that are relevant:

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows Phidata's style guidelines and best practices
- [x] I have performed a self-review of my code
- [X] My changes generate no new warnings or errors
- [X] I have verified my changes in a clean environment

## Additional Notes

N/A