### PR TITLE
agnomemory-folder-cleanup-test-and-refactor-phi-2254

### DIFF
--- a/libs/agno/agno/memory/agent.py
+++ b/libs/agno/agno/memory/agent.py
@@ -215,8 +215,6 @@ class AgentMemory(BaseModel):
 
         if self.db is None:
             return
-        if not self.user_id:
-            return
 
         try:
             if self.retrieval in (MemoryRetrieval.last_n, MemoryRetrieval.first_n):


### PR DESCRIPTION
This change was breaking memories without a user id. Please test with: `cookbook/models/openai/memory.py`