### PR TITLE
Update requirements.txt to include docx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ pydantic==2.9.2
 pydantic-core==2.23.4
 pydantic-settings==2.5.2
 pygments==2.18.0
+python-docx==1.1.2
 python-dotenv==1.0.1
 pyyaml==6.0.2
 rich==13.9.2


### PR DESCRIPTION
## Description
- **Summary of changes**: This is a very small one line change to include docx.
- **Related issues**: In v.2.7.7 there was an issue preventing custom agents from loading in the playground which relates to #1738
Since then the playground functionality has been working but users must install python-docx. This change installs docx by default.
- **Motivation and context**: Change improves dx by including a core dependency by default rather than forcing the users to manually add in the dependency themselves. 
- **Environment or dependencies**: No config changes but must reinstall reqs or manually install python-docx still. 
- **Impact on AI/ML components**: No changes here

Fixes #1797 


## Type of change

Please check the options that are relevant:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update
- [ ] Infrastructure change

## Checklist

- [X] My code follows Phidata's style guidelines and best practices
- [X] I have performed a self-review of my code
- [X] I have added docstrings and comments for complex logic **(N/A)**
-  [X] My changes generate no new warnings or errors
- [X] I have added cookbook examples for my new addition (if needed) **(N/A)**
- [X] I have updated requirements.txt/pyproject.toml (if needed) **(N/A)**
- [X] I have verified my changes in a clean environment **(N/A)**

## Additional Notes 
1.1.2 is the latest stable version for python-docx and doesn't appear to have any major bugs nor does it appear to cause any conflicts with any other dependencies of phidata thus the selected version.
