### PR TITLE
Fix tool calls with response model

### DIFF
--- a/cookbook/providers/azure_openai/knowledge.py
+++ b/cookbook/providers/azure_openai/knowledge.py
@@ -18,10 +18,5 @@ knowledge_base = PDFUrlKnowledgeBase(
 )
 knowledge_base.load(recreate=False)  # Comment out after first run
 
-agent = Agent(
-    model=AzureOpenAIChat(id="gpt-4o"),
-    knowledge=knowledge_base,
-    show_tool_calls=True,
-    debug_mode=True
-)
+agent = Agent(model=AzureOpenAIChat(id="gpt-4o"), knowledge=knowledge_base, show_tool_calls=True, debug_mode=True)
 agent.print_response("How to make Thai curry?", markdown=True)

--- a/cookbook/providers/mistral/structured_output.py
+++ b/cookbook/providers/mistral/structured_output.py
@@ -30,7 +30,7 @@ json_mode_agent = Agent(
     description="You help people write movie scripts.",
     response_model=MovieScript,
     show_tool_calls=True,
-    # debug_mode=True,
+    debug_mode=True,
 )
 
 # Get the response in a variable

--- a/cookbook/providers/mistral/structured_output.py
+++ b/cookbook/providers/mistral/structured_output.py
@@ -5,6 +5,7 @@ from rich.pretty import pprint  # noqa
 from pydantic import BaseModel, Field
 from phi.agent import Agent, RunResponse  # noqa
 from phi.model.mistral import MistralChat
+from phi.tools.duckduckgo import DuckDuckGo
 
 mistral_api_key = os.getenv("MISTRAL_API_KEY")
 
@@ -25,8 +26,10 @@ json_mode_agent = Agent(
         id="mistral-large-latest",
         api_key=mistral_api_key,
     ),
+    tools=[DuckDuckGo()],
     description="You help people write movie scripts.",
     response_model=MovieScript,
+    show_tool_calls=True,
     # debug_mode=True,
 )
 
@@ -34,4 +37,4 @@ json_mode_agent = Agent(
 # json_mode_response: RunResponse = json_mode_agent.run("New York")
 # pprint(json_mode_response.content)
 
-json_mode_agent.print_response("New York")
+json_mode_agent.print_response("Find a cool movie idea about London and write it.")

--- a/cookbook/teams/01_hn_team.py
+++ b/cookbook/teams/01_hn_team.py
@@ -2,6 +2,7 @@
 1. Run: `pip install openai duckduckgo-search newspaper4k lxml_html_clean phidata` to install the dependencies
 2. Run: `python cookbook/teams/01_hn_team.py` to run the agent
 """
+
 from typing import List
 
 from pydantic import BaseModel

--- a/cookbook/teams/01_hn_team.py
+++ b/cookbook/teams/01_hn_team.py
@@ -2,11 +2,21 @@
 1. Run: `pip install openai duckduckgo-search newspaper4k lxml_html_clean phidata` to install the dependencies
 2. Run: `python cookbook/teams/01_hn_team.py` to run the agent
 """
+from typing import List
+
+from pydantic import BaseModel
 
 from phi.agent import Agent
 from phi.tools.hackernews import HackerNews
 from phi.tools.duckduckgo import DuckDuckGo
 from phi.tools.newspaper4k import Newspaper4k
+
+
+class Article(BaseModel):
+    title: str
+    summary: str
+    reference_links: List[str]
+
 
 hn_researcher = Agent(
     name="HackerNews Researcher",
@@ -37,6 +47,7 @@ hn_team = Agent(
         "Then, ask the web searcher to search for each story to get more information.",
         "Finally, provide a thoughtful and engaging summary.",
     ],
+    response_model=Article,
     show_tool_calls=True,
     markdown=True,
 )

--- a/cookbook/tools/reddit_tools.py
+++ b/cookbook/tools/reddit_tools.py
@@ -23,6 +23,7 @@ Steps to get Reddit credentials:
    - password: Your Reddit account password
 
 """
+
 from phi.agent import Agent
 from phi.tools.reddit import RedditTools
 

--- a/cookbook/tools/trello_tools.py
+++ b/cookbook/tools/trello_tools.py
@@ -38,6 +38,6 @@ agent = Agent(
 )
 
 agent.print_response(
-"Create a board called ai-agent and inside it create list called 'todo' and 'doing' and inside each of them create card called 'create agent'",
+    "Create a board called ai-agent and inside it create list called 'todo' and 'doing' and inside each of them create card called 'create agent'",
     stream=True,
 )

--- a/phi/agent/agent.py
+++ b/phi/agent/agent.py
@@ -2021,15 +2021,17 @@ class Agent(BaseModel):
             # Otherwise convert the response to the structured format
             if isinstance(run_response.content, str):
                 try:
-                    structured_output = self.response_model.model_validate_json(run_response.content)
-                except ValidationError:
-                    # Check if response starts with ```json
-                    if run_response.content.startswith("```json"):
-                        run_response.content = run_response.content.replace("```json\n", "").replace("\n```", "")
-                        try:
-                            structured_output = self.response_model.model_validate_json(run_response.content)
-                        except ValidationError as exc:
-                            logger.warning(f"Failed to convert response to pydantic model: {exc}")
+                    structured_output = None
+                    try:
+                        structured_output = self.response_model.model_validate_json(run_response.content)
+                    except ValidationError:
+                        # Check if response starts with ```json
+                        if run_response.content.startswith("```json"):
+                            run_response.content = run_response.content.replace("```json\n", "").replace("\n```", "")
+                            try:
+                                structured_output = self.response_model.model_validate_json(run_response.content)
+                            except ValidationError as exc:
+                                logger.warning(f"Failed to convert response to pydantic model: {exc}")
 
                     # -*- Update Agent response
                     if structured_output is not None:
@@ -2337,16 +2339,17 @@ class Agent(BaseModel):
             # Otherwise convert the response to the structured format
             if isinstance(run_response.content, str):
                 try:
-                    structured_output = self.response_model.model_validate_json(run_response.content)
-                except ValidationError as exc:
-                    logger.warning(f"Failed to convert response to pydantic model: {exc}")
-                    # Check if response starts with ```json
-                    if run_response.content.startswith("```json"):
-                        run_response.content = run_response.content.replace("```json\n", "").replace("\n```", "")
-                        try:
-                            structured_output = self.response_model.model_validate_json(run_response.content)
-                        except ValidationError as exc:
-                            logger.warning(f"Failed to convert response to pydantic model: {exc}")
+                    structured_output = None
+                    try:
+                        structured_output = self.response_model.model_validate_json(run_response.content)
+                    except ValidationError:
+                        # Check if response starts with ```json
+                        if run_response.content.startswith("```json"):
+                            run_response.content = run_response.content.replace("```json\n", "").replace("\n```", "")
+                            try:
+                                structured_output = self.response_model.model_validate_json(run_response.content)
+                            except ValidationError as exc:
+                                logger.warning(f"Failed to convert response to pydantic model: {exc}")
 
                     # -*- Update Agent response
                     if structured_output is not None:

--- a/phi/agent/agent.py
+++ b/phi/agent/agent.py
@@ -42,7 +42,6 @@ from phi.tools import Tool, Toolkit, Function
 from phi.utils.log import logger, set_log_level_to_debug, set_log_level_to_info
 from phi.utils.message import get_text_from_message
 from phi.utils.merge_dict import merge_dictionaries
-from phi.utils.string import extract_valid_json
 from phi.utils.timer import Timer
 
 

--- a/phi/document/chunking/semantic.py
+++ b/phi/document/chunking/semantic.py
@@ -9,7 +9,7 @@ from phi.utils.log import logger
 try:
     from chonkie import SemanticChunker
 except ImportError:
-    logger.warning("`chonkie` is required for semantic chunking, please install using `pip install chonkie`")
+    logger.warning("`chonkie` is required for semantic chunking, please install using `pip install chonkie[all]`")
 
 
 class SemanticChunking(ChunkingStrategy):

--- a/phi/embedder/sentence_transformer.py
+++ b/phi/embedder/sentence_transformer.py
@@ -27,7 +27,7 @@ class SentenceTransformerEmbedder(Embedder):
         model = SentenceTransformer(model_name_or_path=self.model)
         embedding = model.encode(text)
         try:
-            return embedding
+            return embedding  # type: ignore
         except Exception as e:
             logger.warning(e)
             return []

--- a/phi/playground/router.py
+++ b/phi/playground/router.py
@@ -144,6 +144,7 @@ def get_playground_router(
             for file in files:
                 if file.content_type == "application/pdf":
                     from phi.document.reader.pdf import PDFReader
+
                     contents = file.file.read()
                     pdf_file = BytesIO(contents)
                     pdf_file.name = file.filename
@@ -152,6 +153,7 @@ def get_playground_router(
                         agent.knowledge.load_documents(file_content)
                 elif file.content_type == "text/csv":
                     from phi.document.reader.csv_reader import CSVReader
+
                     contents = file.file.read()
                     csv_file = BytesIO(contents)
                     csv_file.name = file.filename
@@ -160,6 +162,7 @@ def get_playground_router(
                         agent.knowledge.load_documents(file_content)
                 elif file.content_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
                     from phi.document.reader.docx import DocxReader
+
                     contents = file.file.read()
                     docx_file = BytesIO(contents)
                     docx_file.name = file.filename
@@ -168,6 +171,7 @@ def get_playground_router(
                         agent.knowledge.load_documents(file_content)
                 elif file.content_type == "text/plain":
                     from phi.document.reader.text import TextReader
+
                     contents = file.file.read()
                     text_file = BytesIO(contents)
                     text_file.name = file.filename
@@ -519,6 +523,7 @@ def get_async_playground_router(
             for file in files:
                 if file.content_type == "application/pdf":
                     from phi.document.reader.pdf import PDFReader
+
                     contents = await file.read()
                     pdf_file = BytesIO(contents)
                     pdf_file.name = file.filename
@@ -527,6 +532,7 @@ def get_async_playground_router(
                         agent.knowledge.load_documents(file_content)
                 elif file.content_type == "text/csv":
                     from phi.document.reader.csv_reader import CSVReader
+
                     contents = await file.read()
                     csv_file = BytesIO(contents)
                     csv_file.name = file.filename
@@ -535,6 +541,7 @@ def get_async_playground_router(
                         agent.knowledge.load_documents(file_content)
                 elif file.content_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
                     from phi.document.reader.docx import DocxReader
+
                     contents = await file.read()
                     docx_file = BytesIO(contents)
                     docx_file.name = file.filename
@@ -543,6 +550,7 @@ def get_async_playground_router(
                         agent.knowledge.load_documents(file_content)
                 elif file.content_type == "text/plain":
                     from phi.document.reader.text import TextReader
+
                     contents = await file.read()
                     text_file = BytesIO(contents)
                     text_file.name = file.filename

--- a/phi/run/response.py
+++ b/phi/run/response.py
@@ -42,7 +42,6 @@ class RunResponse(BaseModel):
     content: Optional[Any] = None
     content_type: str = "str"
     event: str = RunEvent.run_response.value
-    tool_calls_content: Optional[str] = None
     messages: Optional[List[Message]] = None
     metrics: Optional[Dict[str, Any]] = None
     model: Optional[str] = None

--- a/phi/run/response.py
+++ b/phi/run/response.py
@@ -41,8 +41,8 @@ class RunResponse(BaseModel):
 
     content: Optional[Any] = None
     content_type: str = "str"
-    tool_calls_content: str = None
     event: str = RunEvent.run_response.value
+    tool_calls_content: Optional[str] = None
     messages: Optional[List[Message]] = None
     metrics: Optional[Dict[str, Any]] = None
     model: Optional[str] = None

--- a/phi/run/response.py
+++ b/phi/run/response.py
@@ -41,6 +41,7 @@ class RunResponse(BaseModel):
 
     content: Optional[Any] = None
     content_type: str = "str"
+    tool_calls_content: str = None
     event: str = RunEvent.run_response.value
     messages: Optional[List[Message]] = None
     metrics: Optional[Dict[str, Any]] = None

--- a/phi/tools/slack.py
+++ b/phi/tools/slack.py
@@ -78,15 +78,15 @@ class SlackTools(Toolkit):
         try:
             response = self.client.conversations_history(channel=channel, limit=limit)
             messages = [
-            {
-                "text": msg.get("text", ""),
-                "user": "webhook" if msg.get("subtype") == "bot_message" else msg.get("user", "unknown"),
-                "ts": msg.get("ts", ""),
-                "sub_type": msg.get("subtype", "unknown"),
-                "attachments": msg.get("attachments", []) if msg.get("subtype") == "bot_message" else "n/a"
-            }
-            for msg in response.get("messages", [])
-        ]
+                {
+                    "text": msg.get("text", ""),
+                    "user": "webhook" if msg.get("subtype") == "bot_message" else msg.get("user", "unknown"),
+                    "ts": msg.get("ts", ""),
+                    "sub_type": msg.get("subtype", "unknown"),
+                    "attachments": msg.get("attachments", []) if msg.get("subtype") == "bot_message" else "n/a",
+                }
+                for msg in response.get("messages", [])
+            ]
             return json.dumps(messages)
         except SlackApiError as e:
             logger.error(f"Error getting channel history: {e}")

--- a/phi/utils/string.py
+++ b/phi/utils/string.py
@@ -1,7 +1,6 @@
 import hashlib
 import json
-import re
-from typing import Optional, Dict, Any, Tuple
+from typing import Optional, Dict, Any
 
 
 def hash_string_sha256(input_string):

--- a/phi/utils/string.py
+++ b/phi/utils/string.py
@@ -1,4 +1,9 @@
 import hashlib
+import json
+import re
+from typing import Optional, Dict, Any, Tuple
+
+from phi.utils.log import logger
 
 
 def hash_string_sha256(input_string):
@@ -15,3 +20,34 @@ def hash_string_sha256(input_string):
     hex_digest = sha256_hash.hexdigest()
 
     return hex_digest
+
+
+def extract_valid_json(content: str) -> Tuple[Optional[Dict[str, Any]], str]:
+    """
+    Extract the first valid JSON object from a string and return the JSON object
+    along with the rest of the string without the JSON.
+
+    Args:
+        content (str): The input string containing potential JSON data.
+
+    Returns:
+        Tuple[Optional[Dict[str, Any]], str]:
+            - Extracted JSON dictionary if valid, else None.
+            - The rest of the string without the extracted JSON.
+    """
+    json_pattern = r'\{.*?\}'
+    matches = re.finditer(json_pattern, content, re.DOTALL)
+
+    for match in matches:
+        try:
+            # Attempt to load the matched string as JSON
+            json_obj = json.loads(match.group())
+            if isinstance(json_obj, dict):  # Ensure it's a JSON object
+                # Remove the matched JSON object from the string
+                remaining_content = content[:match.start()] + content[match.end():]
+                return json_obj, remaining_content.strip()
+        except json.JSONDecodeError:
+            continue  # Skip invalid JSON matches
+
+    # If no valid JSON is found, return None and the original string
+    return None, content

--- a/phi/utils/string.py
+++ b/phi/utils/string.py
@@ -3,8 +3,6 @@ import json
 import re
 from typing import Optional, Dict, Any, Tuple
 
-from phi.utils.log import logger
-
 
 def hash_string_sha256(input_string):
     # Encode the input string to bytes
@@ -35,7 +33,7 @@ def extract_valid_json(content: str) -> Tuple[Optional[Dict[str, Any]], str]:
             - Extracted JSON dictionary if valid, else None.
             - The rest of the string without the extracted JSON.
     """
-    json_pattern = r'\{.*?\}'
+    json_pattern = r"\{.*?\}"
     matches = re.finditer(json_pattern, content, re.DOTALL)
 
     for match in matches:
@@ -44,7 +42,7 @@ def extract_valid_json(content: str) -> Tuple[Optional[Dict[str, Any]], str]:
             json_obj = json.loads(match.group())
             if isinstance(json_obj, dict):  # Ensure it's a JSON object
                 # Remove the matched JSON object from the string
-                remaining_content = content[:match.start()] + content[match.end():]
+                remaining_content = content[: match.start()] + content[match.end() :]
                 return json_obj, remaining_content.strip()
         except json.JSONDecodeError:
             continue  # Skip invalid JSON matches

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ check_untyped_defs = true
 no_implicit_optional = true
 warn_unused_configs = true
 plugins = ["pydantic.mypy"]
-exclude = ["phienv*", "aienv*", "scratch*", "wip*", "tmp*", "cookbook/assistants/examples/*", "phi/assistant/openai/*"]
+exclude = ["phienv*", "aienv*", "scratch*", "wip*", "tmp*", "cookbook/assistants/examples/*", "phi/assistant/openai/*", "tests/*"]
 
 [[tool.mypy.overrides]]
 module = [

--- a/tests/unit/utils/test_string.py
+++ b/tests/unit/utils/test_string.py
@@ -1,43 +1,51 @@
 from phi.utils.string import extract_valid_json
 
+
 def test_extract_valid_json_with_valid_json():
-    content = "Here is some text {\"key\": \"value\"} and more text."
+    content = 'Here is some text {"key": "value"} and more text.'
     expected_json = {"key": "value"}
     extracted_json = extract_valid_json(content)
     assert extracted_json == expected_json
 
+
 def test_extract_valid_json_with_nested_json():
-    content = "Start {\"key\": {\"nested_key\": \"nested_value\"}} End"
+    content = 'Start {"key": {"nested_key": "nested_value"}} End'
     expected_json = {"key": {"nested_key": "nested_value"}}
     extracted_json = extract_valid_json(content)
     assert extracted_json == expected_json
 
+
 def test_extract_valid_json_with_multiple_json_objects():
-    content = "First {\"key1\": \"value1\"} Second {\"key2\": \"value2\"}"
+    content = 'First {"key1": "value1"} Second {"key2": "value2"}'
     expected_json = {"key1": "value1"}  # Only the first JSON should be returned
     extracted_json = extract_valid_json(content)
     assert extracted_json == expected_json
+
 
 def test_extract_valid_json_with_no_json():
     content = "This is a string without JSON."
     extracted_json = extract_valid_json(content)
     assert extracted_json is None
 
+
 def test_extract_valid_json_with_invalid_json():
     content = "This string contains {invalid JSON}."
     extracted_json = extract_valid_json(content)
     assert extracted_json is None
 
+
 def test_extract_valid_json_with_json_array():
-    content = "Here is a JSON array: [\"item1\", \"item2\"]."
+    content = 'Here is a JSON array: ["item1", "item2"].'
     extracted_json = extract_valid_json(content)
     assert extracted_json is None  # Only JSON objects are extracted
+
 
 def test_extract_valid_json_with_empty_json():
     content = "Some text {} more text."
     expected_json = {}
     extracted_json = extract_valid_json(content)
     assert extracted_json == expected_json
+
 
 def test_extract_valid_json_with_multiline_json():
     content = """
@@ -46,12 +54,10 @@ def test_extract_valid_json_with_multiline_json():
         "another_key": "another_value"
     } and more text.
     """
-    expected_json = {
-        "key": "value",
-        "another_key": "another_value"
-    }
+    expected_json = {"key": "value", "another_key": "another_value"}
     extracted_json = extract_valid_json(content)
     assert extracted_json == expected_json
+
 
 def test_extract_valid_json_with_json_in_quotes():
     content = 'Text before "{\\"key\\": \\"value\\"}" text after.'

--- a/tests/unit/utils/test_string.py
+++ b/tests/unit/utils/test_string.py
@@ -1,0 +1,59 @@
+from phi.utils.string import extract_valid_json
+
+def test_extract_valid_json_with_valid_json():
+    content = "Here is some text {\"key\": \"value\"} and more text."
+    expected_json = {"key": "value"}
+    extracted_json = extract_valid_json(content)
+    assert extracted_json == expected_json
+
+def test_extract_valid_json_with_nested_json():
+    content = "Start {\"key\": {\"nested_key\": \"nested_value\"}} End"
+    expected_json = {"key": {"nested_key": "nested_value"}}
+    extracted_json = extract_valid_json(content)
+    assert extracted_json == expected_json
+
+def test_extract_valid_json_with_multiple_json_objects():
+    content = "First {\"key1\": \"value1\"} Second {\"key2\": \"value2\"}"
+    expected_json = {"key1": "value1"}  # Only the first JSON should be returned
+    extracted_json = extract_valid_json(content)
+    assert extracted_json == expected_json
+
+def test_extract_valid_json_with_no_json():
+    content = "This is a string without JSON."
+    extracted_json = extract_valid_json(content)
+    assert extracted_json is None
+
+def test_extract_valid_json_with_invalid_json():
+    content = "This string contains {invalid JSON}."
+    extracted_json = extract_valid_json(content)
+    assert extracted_json is None
+
+def test_extract_valid_json_with_json_array():
+    content = "Here is a JSON array: [\"item1\", \"item2\"]."
+    extracted_json = extract_valid_json(content)
+    assert extracted_json is None  # Only JSON objects are extracted
+
+def test_extract_valid_json_with_empty_json():
+    content = "Some text {} more text."
+    expected_json = {}
+    extracted_json = extract_valid_json(content)
+    assert extracted_json == expected_json
+
+def test_extract_valid_json_with_multiline_json():
+    content = """
+    Here is some text {
+        "key": "value",
+        "another_key": "another_value"
+    } and more text.
+    """
+    expected_json = {
+        "key": "value",
+        "another_key": "another_value"
+    }
+    extracted_json = extract_valid_json(content)
+    assert extracted_json == expected_json
+
+def test_extract_valid_json_with_json_in_quotes():
+    content = 'Text before "{\\"key\\": \\"value\\"}" text after.'
+    extracted_json = extract_valid_json(content)
+    assert extracted_json is None  # JSON inside quotes should not be parsed


### PR DESCRIPTION
## Description

Tool calling does not work correctly with response models. This will use the response model if there is one, overriding any tool calling. The tool calls are then displayed separately.

This also solves the issue for teams.

Fixes #1792 

## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update
- [ ] Infrastructure change

## Checklist

- [ ] My code follows Phidata's style guidelines and best practices
- [ ] I have performed a self-review of my code
- [ ] I have added docstrings and comments for complex logic
- [ ] My changes generate no new warnings or errors
- [ ] I have added cookbook examples for my new addition (if needed)
- [ ] I have updated requirements.txt/pyproject.toml (if needed)
- [ ] I have verified my changes in a clean environment
