### PR TITLE
added condition of use_tantivy

### DIFF
--- a/phi/vectordb/lancedb/lance_db.py
+++ b/phi/vectordb/lancedb/lance_db.py
@@ -87,7 +87,7 @@ class LanceDb(VectorDb):
         self.fts_index_exists = False
         self.use_tantivy = use_tantivy
 
-        if self.use_tantivy:
+        if self.use_tantivy and (self.search_type in [SearchType.keyword, SearchType.hybrid]):
             try:
                 import tantivy  # noqa: F401
             except ImportError:


### PR DESCRIPTION
## Description
**Summary of changes**: 
Modified LanceDB initialization to make Tantivy dependency optional when only using vector search capabilities. The Tantivy import check is now conditional based on the search type being used.

**Related issues**: 
Fixes #1827 - ImportError being raised for vector-only search due to missing Tantivy dependency

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows Phidata's style guidelines and best practices
- [x] I have performed a self-review of my code
- [x] I have added docstrings and comments for complex logic
- [x] My changes generate no new warnings or errors
- [x] I have verified my changes in a clean environment.