### PR TITLE
Release 2.7.9

### DIFF
--- a/phi/tools/telegram.py
+++ b/phi/tools/telegram.py
@@ -13,9 +13,7 @@ class TelegramTools(Toolkit):
 
         self.token = token or os.getenv("TELEGRAM_TOKEN")
         if not self.token:
-            logger.error(
-                "TELEGRAM_TOKEN not set. Please set the TELEGRAM_TOKEN environment variable."
-            )
+            logger.error("TELEGRAM_TOKEN not set. Please set the TELEGRAM_TOKEN environment variable.")
 
         self.chat_id = chat_id
 
@@ -30,9 +28,7 @@ class TelegramTools(Toolkit):
         :param message: The message to send.
         :return: The response from the API.
         """
-        response = self._call_post_method(
-            "sendMessage", json={"chat_id": self.chat_id, "text": message}
-        )
+        response = self._call_post_method("sendMessage", json={"chat_id": self.chat_id, "text": message})
         try:
             response.raise_for_status()
             return response.text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "phidata"
-version = "2.7.8"
+version = "2.7.9"
 description = "Build multi-modal Agents with memory, knowledge and tools."
 requires-python = ">=3.7,<4"
 readme = "README.md"


### PR DESCRIPTION
# Changelog

## New Features:

- RedditTools added with cookbook examples
- TelegramTools added with a cookbook example

## Improvements:

- Updates the defaults on the GeminiEmbedder to use a more up-to-date model and incorporate recommendations from their [[docs](https://docs.phidata.com/embedder/gemini#params)](https://docs.phidata.com/embedder/gemini#params).

## Bug Fixes:

- Fix imports of `docx` being required for using the playground
- Fix AzureOpenAIEmbedder and AzureOpenAIChat compatibility
- Fix cases where SlackTool threw an exception when the "user" field is blank or not available
- Fix case where Response Models don’t work with show_tool_calls. This will use the response model if there is one, overriding any tool calling.
- Fix issue in Claude where memory blocks were stored in the raw claude format with TextBlock, etc
- Fix cases where you switch models from ChatGPT to Gemini with same history