### PR TITLE
Fixed the OAuth1UserHandler instance creation in twitter.py

### DIFF
--- a/phi/tools/twitter.py
+++ b/phi/tools/twitter.py
@@ -45,7 +45,9 @@ class TwitterTools(Toolkit):
             access_token=self.access_token,
             access_token_secret=self.access_token_secret,
         )
-        self.auth = tweepy.OAuth1UserHandler(consumer_key, consumer_secret, access_token, access_token_secret)
+        self.auth = tweepy.OAuth1UserHandler(
+            self.consumer_key, self.consumer_secret, self.access_token, self.access_token_secret
+        )
         self.api = tweepy.API(self.auth)
         self.register(self.create_tweet)
         self.register(self.reply_to_tweet)


### PR DESCRIPTION
## Description
If the user does not provide the parameters while creating an object of Twitter tool, the credentials are fetched from the environment variables. However, when initializing the OAuth1UserHandler, it is being initialized with default parameters, which are set to null. This causes the code to break.

Fixes # (issue)

## Type of change

Please check the options that are relevant:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Model update
- [ ] Infrastructure change

## Checklist

- [x] My code follows Phidata's style guidelines and best practices
- [x] I have performed a self-review of my code
- [ ] I have added docstrings and comments for complex logic
- [x] My changes generate no new warnings or errors
- [ ] I have added cookbook examples for my new addition (if needed)
- [ ] I have updated requirements.txt/pyproject.toml (if needed)
- [x] I have verified my changes in a clean environment

## Additional Notes

Include any deployment notes, performance implications, or other relevant information:
