### PR TITLE
[chore] tools/google_bigquery - add job_config with fully qualified default_dataset to _run_sql

### DIFF
--- a/libs/agno/agno/tools/google_bigquery.py
+++ b/libs/agno/agno/tools/google_bigquery.py
@@ -106,7 +106,7 @@ class GoogleBigQueryTools(Toolkit):
         try:
             log_debug(f"Running Google SQL |\n{sql}")
             cleaned_query = sql.replace("\\n", " ").replace("\n", "").replace("\\", "")
-            job_config = bigquery.QueryJobConfi(
+            job_config = bigquery.QueryJobConfig(
                 default_dataset=f"{self.project}.{self.dataset}"
             )
             query_job = self.client.query(cleaned_query, job_config)


### PR DESCRIPTION

## Summary

I had some issues executing queries as agent would not construct queries with fully qualified selection "project_id.dataset.table". I propose to add job_config to the query to ensure there are no issues executing the queries.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
