### PR TITLE
fix: update team rename session name function

### DIFF
--- a/cookbook/teams/team_events_route.py
+++ b/cookbook/teams/team_events_route.py
@@ -6,7 +6,6 @@ from agno.models.openai.chat import OpenAIChat
 from agno.team import Team, TeamRunEvent
 from agno.tools.yfinance import YFinanceTools
 
-
 stock_searcher = Agent(
     name="Stock Searcher",
     model=OpenAIChat("gpt-4o"),
@@ -39,8 +38,9 @@ team = Team(
     members=[stock_searcher, company_info_agent],
     markdown=True,
     # If you want to disable the member events, set this to False (default is True)
-    # stream_member_events=False  
+    # stream_member_events=False
 )
+
 
 async def run_team_with_events(prompt: str):
     content_started = False
@@ -76,12 +76,11 @@ async def run_team_with_events(prompt: str):
             print(f"\nMEMBER EVENT: {run_response_event.event}")
             print(f"TOOL CALL: {run_response_event.tool.tool_name}")
             print(f"TOOL CALL ARGS: {run_response_event.tool.tool_args}")
-            
+
         if run_response_event.event in [RunEvent.tool_call_completed]:
             print(f"\nMEMBER EVENT: {run_response_event.event}")
             print(f"MEMBER TOOL CALL: {run_response_event.tool.tool_name}")
             print(f"MEMBER TOOL CALL RESULT: {run_response_event.tool.result}")
-
 
         if run_response_event.event in [TeamRunEvent.run_response_content]:
             if not content_started:
@@ -94,6 +93,7 @@ async def run_team_with_events(prompt: str):
                 print("MEMBER CONTENT:")
                 member_content_started = True
             print(run_response_event.content, end="")
+
 
 if __name__ == "__main__":
     asyncio.run(

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -6486,6 +6486,9 @@ class Team:
 
         session_id = session_id or self.session_id
 
+        # Ensure storage mode is set to "team" before reading
+        self._set_storage_mode()
+
         # -*- Read from storage
         self.read_from_storage(session_id=session_id)  # type: ignore
         # -*- Rename session

--- a/libs/agno/agno/tools/google_bigquery.py
+++ b/libs/agno/agno/tools/google_bigquery.py
@@ -106,9 +106,7 @@ class GoogleBigQueryTools(Toolkit):
         try:
             log_debug(f"Running Google SQL |\n{sql}")
             cleaned_query = sql.replace("\\n", " ").replace("\n", "").replace("\\", "")
-            job_config = bigquery.QueryJobConfig(
-                default_dataset=f"{self.project}.{self.dataset}"
-            )
+            job_config = bigquery.QueryJobConfig(default_dataset=f"{self.project}.{self.dataset}")
             query_job = self.client.query(cleaned_query, job_config)
             results = query_job.result()
             results_str = str([dict(row) for row in results])


### PR DESCRIPTION
## Summary

- Calling `team.rename_session(...)` raises an AttributeError because the `AgentSession` object does not have the `team_data` attribute.
- Now sets the `storage_mode` to `team` before rename session is executed
fixes: https://github.com/agno-agi/agno/issues/3595

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
