### PR TITLE
fix: allow Team as agent for OpenAIToolkit

### DIFF
--- a/libs/agno/agno/tools/openai.py
+++ b/libs/agno/agno/tools/openai.py
@@ -1,5 +1,5 @@
 from os import getenv
-from typing import Any, List, Literal, Optional
+from typing import Any, List, Literal, Optional, Union
 from uuid import uuid4
 
 from agno.agent import Agent


### PR DESCRIPTION
## Summary

The OpenAIToolkit has an agent entrypoint that gets automatically filled with the Agent OR Team:
```
        if "agent" in signature(self.function.entrypoint).parameters:  # type: ignore
            entrypoint_args["agent"] = self.function._agent
```

Problem is, the function signatures only accept Agent, not Team, which causes the function call to fail with a pydantic validation error.

DalleTools, for example, correctly accept both:
```
    def create_image(self, agent: Union[Agent, Team], prompt: str) -> str:
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

