### PR TITLE
Inside the `format.bat`, enable the .venv environment when available.

### DIFF
--- a/libs/agno/scripts/format.bat
+++ b/libs/agno/scripts/format.bat
@@ -6,9 +6,22 @@ REM ###########################################################################
 
 SETLOCAL ENABLEDELAYEDEXPANSION
 
-REM Get current directory
+REM Get current directory and set AGNO_DIR to parent folder
 SET "CURR_DIR=%~dp0"
 SET "AGNO_DIR=%CURR_DIR%\.."
+SET "VENV_PATH=%AGNO_DIR%\.venv"
+
+REM Normalize paths
+FOR %%I IN ("%AGNO_DIR%") DO SET "AGNO_DIR=%%~fI"
+FOR %%I IN ("%VENV_PATH%") DO SET "VENV_PATH=%%~fI"
+
+REM Try to activate virtual environment if it exists
+IF EXIST "%VENV_PATH%\Scripts\activate.bat" (
+    ECHO [INFO] Activating virtual environment: %VENV_PATH%
+    CALL "%VENV_PATH%\Scripts\activate.bat"
+) ELSE (
+    ECHO [INFO] No virtual environment found at %VENV_PATH%
+)
 
 ECHO.
 ECHO ##################################################
@@ -40,4 +53,4 @@ ECHO.
 python -m ruff check --select I --fix "%AGNO_DIR%"
 
 ECHO [INFO] agno formatting complete.
-EXIT /B 
+EXIT /B


### PR DESCRIPTION
It also makes the relative paths absolute for better error handling, but that is not what this change is about.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)
