### PR TITLE
[fix] JinaReaderTools search_query read timeout error due to invalid parameter

### DIFF
--- a/cookbook/tools/jinareader_tools.py
+++ b/cookbook/tools/jinareader_tools.py
@@ -2,4 +2,4 @@ from agno.agent import Agent
 from agno.tools.jina import JinaReaderTools
 
 agent = Agent(tools=[JinaReaderTools()], show_tool_calls=True)
-agent.print_response("Summarize: https://github.com/agno-agi")
+agent.print_response("Summarize: https://github.com/agno-agi/agno")

--- a/libs/agno/agno/tools/jina.py
+++ b/libs/agno/agno/tools/jina.py
@@ -28,7 +28,7 @@ class JinaReaderTools(Toolkit):
         timeout: Optional[int] = None,
         read_url: bool = True,
         search_query: bool = False,
-        search_query_content: bool = False,
+        search_query_content: bool = True,
         **kwargs,
     ):
         self.api_key = api_key or getenv("JINA_API_KEY")
@@ -52,7 +52,6 @@ class JinaReaderTools(Toolkit):
     def read_url(self, url: str) -> str:
         """Reads a URL and returns the truncated content using Jina Reader API."""
         full_url = f"{self.config.base_url}{url}"
-        log_info(f"Reading URL: {full_url}")
         try:
             response = httpx.get(full_url, headers=self._get_headers())
             response.raise_for_status()
@@ -71,7 +70,6 @@ class JinaReaderTools(Toolkit):
             headers["X-Respond-With"] = "no-content"  # to avoid returning full content in search results
 
         body = {"q": query}
-        log_info(f"Performing search: {full_url} {json.dumps(body)}")
         try:
             response = httpx.post(full_url, headers=headers, json=body)
             response.raise_for_status()

--- a/libs/agno/tests/unit/tools/test_jina.py
+++ b/libs/agno/tests/unit/tools/test_jina.py
@@ -7,7 +7,7 @@ import pytest
 from agno.tools.jina import JinaReaderTools, JinaReaderToolsConfig
 
 
-@pytest.fixture
+@pytest.fixture()
 def jina_tools():
     os.environ["JINA_API_KEY"] = "test_api_key"
     return JinaReaderTools()
@@ -158,8 +158,7 @@ def test_init_tools_selection_none():
 
 
 @patch("agno.tools.jina.httpx.get")
-@patch("agno.tools.jina.log_info")
-def test_read_url_successful(mock_log_info, mock_httpx_get, sample_read_url_response):
+def test_read_url_successful(mock_httpx_get, sample_read_url_response):
     """Test successful URL reading"""
     # Setup mock response
     mock_response = MagicMock()
@@ -174,7 +173,6 @@ def test_read_url_successful(mock_log_info, mock_httpx_get, sample_read_url_resp
         # Verify the call
         expected_url = f"{tools.config.base_url}https://example.com"
         mock_httpx_get.assert_called_once_with(expected_url, headers=tools._get_headers())
-        mock_log_info.assert_called_once_with(f"Reading URL: {expected_url}")
 
         # Verify result contains the response data
         assert str(sample_read_url_response) in result


### PR DESCRIPTION
## Summary

Fixed Jina.ai search query error due to invalid query parameter, switch to post method for cleaner search query request.
this is fixed for issue i stated in https://github.com/agno-agi/agno/issues/3905

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)
