### PR TITLE
Fix: Certain dbs containing null created_at fields

### DIFF
--- a/libs/agno/agno/storage/gcs_json.py
+++ b/libs/agno/agno/storage/gcs_json.py
@@ -222,7 +222,7 @@ class GCSJsonStorage(JsonStorage):
         try:
             data = session.to_dict()
             data["updated_at"] = int(time.time())
-            if "created_at" not in data:
+            if "created_at" not in data or data["created_at"] is None:
                 data["created_at"] = data["updated_at"]
             json_data = self.serialize(data)
             blob.upload_from_string(json_data, content_type="application/json")

--- a/libs/agno/agno/storage/json.py
+++ b/libs/agno/agno/storage/json.py
@@ -206,8 +206,9 @@ class JsonStorage(Storage):
                 data = session.to_dict()
             else:
                 data = asdict(session)
+
             data["updated_at"] = int(time.time())
-            if "created_at" not in data:
+            if "created_at" not in data or data["created_at"] is None:
                 data["created_at"] = data["updated_at"]
 
             with open(self.dir_path / f"{session.session_id}.json", "w", encoding="utf-8") as f:

--- a/libs/agno/agno/storage/redis.py
+++ b/libs/agno/agno/storage/redis.py
@@ -294,7 +294,7 @@ class RedisStorage(Storage):
             else:
                 data = asdict(session)
             data["updated_at"] = int(time.time())
-            if "created_at" not in data:
+            if "created_at" not in data or data["created_at"] is None:
                 data["created_at"] = data["updated_at"]
 
             key = self._get_key(session.session_id)

--- a/libs/agno/agno/storage/yaml.py
+++ b/libs/agno/agno/storage/yaml.py
@@ -213,7 +213,7 @@ class YamlStorage(Storage):
             else:
                 data = asdict(session)
             data["updated_at"] = int(time.time())
-            if "created_at" not in data:
+            if "created_at" not in data or data["created_at"] is None:
                 data["created_at"] = data["updated_at"]
             with open(self.dir_path / f"{session.session_id}.yaml", "w", encoding="utf-8") as f:
                 f.write(self.serialize(data))


### PR DESCRIPTION
## Summary

The bug was in the created_at field handling logic in a couple of storage implementations. When a WorkflowSession is created, the created_at field defaults to None. When then converting the session to a dictionary, the created_at key exists in the dictionary but has a None value.

Reported by user here:
https://github.com/agno-agi/agno/issues/4034

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
