### PR TITLE
Fix session states merge precedence

### DIFF
--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -7158,9 +7158,10 @@ class Team:
                     # If the team_session_state is already set, merge the team_session_state from the database with the current team_session_state
                     if self.team_session_state is not None and len(self.team_session_state) > 0:
                         # This updates team_session_state_from_db
-                        merge_dictionaries(team_session_state_from_db, self.team_session_state)
-                    # Update the current team_session_state
-                    self.team_session_state = team_session_state_from_db
+                        merge_dictionaries(self.team_session_state, team_session_state_from_db)
+                    else:
+                        # Update the current team_session_state
+                        self.team_session_state = team_session_state_from_db
 
             if "workflow_session_state" in session.session_data:
                 workflow_session_state_from_db = session.session_data.get("workflow_session_state")
@@ -7172,9 +7173,10 @@ class Team:
                     # If the workflow_session_state is already set, merge the workflow_session_state from the database with the current workflow_session_state
                     if self.workflow_session_state is not None and len(self.workflow_session_state) > 0:
                         # This updates workflow_session_state_from_db
-                        merge_dictionaries(workflow_session_state_from_db, self.workflow_session_state)
-                    # Update the current workflow_session_state
-                    self.workflow_session_state = workflow_session_state_from_db
+                        merge_dictionaries(self.workflow_session_state, workflow_session_state_from_db)
+                    else:
+                        # Update the current workflow_session_state
+                        self.workflow_session_state = workflow_session_state_from_db
 
             # Get the session_metrics from the database
             if "session_metrics" in session.session_data:


### PR DESCRIPTION
## Summary

When loading team session data, if any session state is found in the database, it should take precedence when merging with the initial state provided by the user so not to invalidate data stored on previous runs.

session state precedence was fixed on #3895, but team_session_state and workflow_session_state, the subjects of this pull request were not

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
