### PR TITLE
[fix] Make Gemini aware of pre-tool messages

### DIFF
--- a/libs/agno/agno/embedder/google.py
+++ b/libs/agno/agno/embedder/google.py
@@ -35,7 +35,7 @@ class GeminiEmbedder(Embedder):
 
         _client_params: Dict[str, Any] = {}
         vertexai = self.vertexai or getenv("GOOGLE_GENAI_USE_VERTEXAI", "false").lower() == "true"
-        
+
         if not vertexai:
             self.api_key = self.api_key or getenv("GOOGLE_API_KEY")
             if not self.api_key:
@@ -46,9 +46,9 @@ class GeminiEmbedder(Embedder):
             _client_params["vertexai"] = True
             _client_params["project"] = self.project_id or getenv("GOOGLE_CLOUD_PROJECT")
             _client_params["location"] = self.location or getenv("GOOGLE_CLOUD_LOCATION")
-        
+
         _client_params = {k: v for k, v in _client_params.items() if v is not None}
-        
+
         if self.client_params:
             _client_params.update(self.client_params)
 

--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -388,8 +388,8 @@ class Gemini(Model):
             message_parts: List[Any] = []
 
             # Function calls
-            if (not content or role == "model") and message.tool_calls is not None and len(message.tool_calls) > 0:
-                if content:
+            if role == "model" and message.tool_calls is not None and len(message.tool_calls) > 0:
+                if content is not None:
                     message_parts.append(Part.from_text(text=content))
                 for tool_call in message.tool_calls:
                     message_parts.append(
@@ -398,7 +398,7 @@ class Gemini(Model):
                             args=json.loads(tool_call["function"]["arguments"]),
                         )
                     )
-            # Function results
+            # Function call results
             elif message.tool_calls is not None and len(message.tool_calls) > 0:
                 for tool_call in message.tool_calls:
                     message_parts.append(


### PR DESCRIPTION
## Summary

Fixes #4250
When a tool call message also includes text, Gemini should be aware of it and use it as part of the conversation flow.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
