### PR TITLE
fix: subsequent runs in same session not being stored

### DIFF
--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -234,8 +234,12 @@ async def handle_workflow_via_websocket(websocket: WebSocket, message: dict, os:
             return
 
         # Generate session_id if not provided
+        # Use workflow's default session_id if not provided in message
         if not session_id:
-            session_id = str(uuid4())
+            if workflow.session_id:
+                session_id = workflow.session_id
+            else:
+                session_id = str(uuid4())
 
         # Execute workflow in background with streaming
         await workflow.arun(

--- a/libs/agno/agno/session/workflow.py
+++ b/libs/agno/agno/session/workflow.py
@@ -85,14 +85,7 @@ class WorkflowSession:
                 try:
                     runs_data.append(run.to_dict())
                 except Exception as e:
-                    # If run serialization fails, create a minimal representation
-                    runs_data.append(
-                        {
-                            "run_id": getattr(run, "run_id", "unknown"),
-                            "status": str(getattr(run, "status", "unknown")),
-                            "error": f"Serialization failed: {str(e)}",
-                        }
-                    )
+                    raise ValueError(f"Serialization failed: {str(e)}")
         return {
             "session_id": self.session_id,
             "user_id": self.user_id,

--- a/libs/agno/agno/workflow/types.py
+++ b/libs/agno/agno/workflow/types.py
@@ -287,6 +287,18 @@ class StepOutput:
         if audio:
             audio = [AudioArtifact.model_validate(aud) for aud in audio]
 
+        metrics_data = data.get("metrics")
+        metrics = None
+        if metrics_data:
+            if isinstance(metrics_data, dict):
+                # Convert dict to Metrics object
+                from agno.models.metrics import Metrics
+
+                metrics = Metrics(**metrics_data)
+            else:
+                # Already a Metrics object
+                metrics = metrics_data
+
         # Handle nested steps
         steps_data = data.get("steps")
         steps = None
@@ -304,7 +316,7 @@ class StepOutput:
             images=images,
             videos=videos,
             audio=audio,
-            metrics=data.get("metrics"),
+            metrics=metrics,
             success=data.get("success", True),
             error=data.get("error"),
             stop=data.get("stop", False),
@@ -333,11 +345,25 @@ class StepMetrics:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "StepMetrics":
         """Create StepMetrics from dictionary"""
+
+        # Handle metrics properly
+        metrics_data = data.get("metrics")
+        metrics = None
+        if metrics_data:
+            if isinstance(metrics_data, dict):
+                # Convert dict to Metrics object
+                from agno.models.metrics import Metrics
+
+                metrics = Metrics(**metrics_data)
+            else:
+                # Already a Metrics object
+                metrics = metrics_data
+
         return cls(
             step_name=data["step_name"],
             executor_type=data["executor_type"],
             executor_name=data["executor_name"],
-            metrics=data.get("metrics"),
+            metrics=metrics,
         )
 
 


### PR DESCRIPTION
## Summary

- metrics serialization issue
- in router websocket was not handling session id part correctly.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
