### PR TITLE
Fix NoneType AttributeError in Gemini Vertex AI Search citations

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -793,12 +793,18 @@ class Gemini(Model):
                 grounding_metadata = response.candidates[0].grounding_metadata.model_dump()
                 citations_raw["grounding_metadata"] = grounding_metadata
 
-                chunks = grounding_metadata.get("grounding_chunks", [])
-                citation_pairs = [
-                    (chunk.get("web", {}).get("uri"), chunk.get("web", {}).get("title"))
-                    for chunk in chunks
-                    if chunk.get("web", {}).get("uri")
-                ]
+                chunks = grounding_metadata.get("grounding_chunks", []) or []
+                citation_pairs = []
+                for chunk in chunks:
+                    if not isinstance(chunk, dict):
+                        continue
+                    web = chunk.get("web")
+                    if not isinstance(web, dict):
+                        continue
+                    uri = web.get("uri")
+                    title = web.get("title")
+                    if uri:
+                        citation_pairs.append((uri, title))
 
                 # Create citation objects from filtered pairs
                 grounding_urls = [UrlCitation(url=url, title=title) for url, title in citation_pairs]
@@ -907,11 +913,17 @@ class Gemini(Model):
 
                 # Extract url and title
                 chunks = grounding_metadata.pop("grounding_chunks", None) or []
-                citation_pairs = [
-                    (chunk.get("web", {}).get("uri"), chunk.get("web", {}).get("title"))
-                    for chunk in chunks
-                    if chunk.get("web", {}).get("uri")
-                ]
+                citation_pairs = []
+                for chunk in chunks:
+                    if not isinstance(chunk, dict):
+                        continue
+                    web = chunk.get("web")
+                    if not isinstance(web, dict):
+                        continue
+                    uri = web.get("uri")
+                    title = web.get("title")
+                    if uri:
+                        citation_pairs.append((uri, title))
 
                 # Create citation objects from filtered pairs
                 citations.urls = [UrlCitation(url=url, title=title) for url, title in citation_pairs]


### PR DESCRIPTION
## Summary

Fix NoneType error when parsing Vertex AI Search citation chunks in the Gemini model.

Previously, if a chunk in the provider response was None (or not a dict), the code attempted to call .get("web"), causing an AttributeError.

The new implementation adds type checks to ensure only valid dictionary entries are processed, preventing errors from malformed data and improving reliability of citation handling.

## issue number: #4334 

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [X] Code complies with style guidelines
- [X] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [X] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [X] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

- The change affects agno/models/google/gemini.py, specifically the parse_provider_response method.
- No deployment or security impact.
- Tested locally with Vertex AI Search and verified that the AttributeError no longer occurs.