### PR TITLE
[fix] Preserve complete Pydantic schema structure in AWS Bedrock tool formatting

### DIFF
--- a/libs/agno/agno/models/aws/bedrock.py
+++ b/libs/agno/agno/models/aws/bedrock.py
@@ -179,14 +179,10 @@ class AwsBedrock(Model):
                 required = []
 
                 for param_name, param_info in func_def.get("parameters", {}).get("properties", {}).items():
-                    param_type = param_info.get("type")
-                    if isinstance(param_type, list):
-                        param_type = [t for t in param_type if t != "null"][0]
+                    properties[param_name] = param_info.copy()
 
-                    properties[param_name] = {
-                        "type": param_type or "string",
-                        "description": param_info.get("description") or "",
-                    }
+                    if "description" not in properties[param_name]:
+                        properties[param_name]["description"] = ""
 
                     if "null" not in (
                         param_info.get("type") if isinstance(param_info.get("type"), list) else [param_info.get("type")]


### PR DESCRIPTION
## Summary
- Fix tool schema extraction in AWS Bedrock model to preserve complete Pydantic structure
- Same issue as PR #4400 but for AWS Bedrock model instead of Claude
- Previously stripped nested schema details causing LLM tool call failures

## Changes
- Replace selective field extraction with full `param_info.copy()`
- Preserve complete schema structure including nested properties, arrays, etc.
- Ensure description field exists with fallback to empty string
- Maintain existing required field logic

## Test Plan
- [x] Run formatting checks (`./scripts/format.sh`)
- [x] Run validation checks (`./scripts/validate.sh`) 
- [x] Run unit tests (`python -m pytest libs/agno/tests/unit/`)
- [x] Verify changes follow same pattern as PR #4400

Fixes the same tool schema extraction issue as #4400 but for AWS Bedrock.

🤖 Generated with [Claude Code](https://claude.ai/code)