### PR TITLE
fix: whatsapp router on agentos

### DIFF
--- a/libs/agno/agno/os/interfaces/whatsapp/router.py
+++ b/libs/agno/agno/os/interfaces/whatsapp/router.py
@@ -168,7 +168,7 @@ def attach_routes(router: APIRouter, agent: Optional[Agent] = None, team: Option
                         await _send_whatsapp_message(phone_number, response.content)  # type: ignore
                 await _send_whatsapp_message(phone_number, response.content)  # type: ignore
             else:
-                await _send_whatsapp_message(phone_number, response.content) #type:ignore
+                await _send_whatsapp_message(phone_number, response.content)  # type: ignore
 
         except Exception as e:
             log_error(f"Error processing message: {str(e)}")


### PR DESCRIPTION
## Summary

The whatsapp router didn't send the response when no reasoning content or images were present. 

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
