### PR TITLE
fix: slack router prefix

### DIFF
--- a/libs/agno/agno/os/interfaces/slack/router.py
+++ b/libs/agno/agno/os/interfaces/slack/router.py
@@ -10,7 +10,7 @@ from agno.utils.log import log_info
 
 
 def attach_routes(router: APIRouter, agent: Optional[Agent] = None, team: Optional[Team] = None) -> APIRouter:
-    @router.post("/slack/events")
+    @router.post("/events")
     async def slack_events(request: Request, background_tasks: BackgroundTasks):
         body = await request.body()
         timestamp = request.headers.get("X-Slack-Request-Timestamp")


### PR DESCRIPTION
We were duplicating the prefix and exposing our slack endpoints on `.../slack/slack`

The prefix is already defined in the interface's get_router logic, this PR removes it from the endpoint itself