### PR TITLE
fix: Agent deep copy

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -398,6 +398,7 @@ class Agent:
         timezone_identifier: Optional[str] = None,
         resolve_in_context: bool = True,
         additional_input: Optional[List[Union[str, Dict, BaseModel, Message]]] = None,
+        user_message_role: str = "user",
         build_user_context: bool = True,
         retries: int = 0,
         delay_between_retries: int = 1,
@@ -495,7 +496,7 @@ class Agent:
         self.timezone_identifier = timezone_identifier
         self.resolve_in_context = resolve_in_context
         self.additional_input = additional_input
-
+        self.user_message_role = user_message_role
         self.build_user_context = build_user_context
 
         self.retries = retries

--- a/libs/agno/tests/unit/agent/test_basic.py
+++ b/libs/agno/tests/unit/agent/test_basic.py
@@ -30,3 +30,27 @@ def test_set_id_auto_generated():
     agent = Agent()
     agent.set_id()
     assert is_valid_uuid(agent.id)
+
+
+def test_deep_copy():
+    """Test that Agent.deep_copy() works with all dataclass fields.
+
+    This test ensures that all dataclass fields with defaults are properly
+    handled by deep_copy(), preventing TypeError for unexpected keyword arguments.
+    """
+    # Create agent with minimal configuration
+    # The key is that deep_copy will try to pass ALL dataclass fields to __init__
+    original = Agent(name="test-agent")
+
+    # This should not raise TypeError about unexpected keyword arguments
+    copied = original.deep_copy()
+
+    # Verify it's a different instance but with same values
+    assert copied is not original
+    assert copied.name == original.name
+    assert copied.user_message_role == "user"
+    assert copied.system_message_role == "system"
+
+    # Test deep_copy with update
+    updated = original.deep_copy(update={"name": "updated-agent"})
+    assert updated.name == "updated-agent"


### PR DESCRIPTION


## Summary

Fixed Agent.deep_copy() TypeError for user_message_role field

The Agent class uses @dataclass(init=False) with a custom __init__. The user_message_role field existed as a dataclass attribute but wasn't accepted by __init__, causing deep_copy() to fail when it tried to pass all dataclass fields to the constructor.

This PR added user_message_role parameter to Agent.__init__() method to match the dataclass field definition. I've also included a test to prevent any regressions

(If applicable, issue number: #4538)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
