### PR TITLE
[docs] update wrong script path in README for standalone memory

### DIFF
--- a/cookbook/memory/README.md
+++ b/cookbook/memory/README.md
@@ -22,5 +22,5 @@ pip install -U psycopg sqlalchemy openai agno
 ### 3. Run a cookbook
 
 ```shell
-python cookbook/memory/01_standalone_memory.py
+python cookbook/memory/memory_manager/01_standalone_memory.py
 ```


### PR DESCRIPTION
Changed wrong script path in README.

## Summary

Changed wrong script path in README to `python cookbook/memory/memory_manager/01_standalone_memory.py`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---
