### PR TITLE
[fix] Add support for handling `provider_data` in agent response flow (fixes #4642)

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -3352,6 +3352,11 @@ class Agent:
                         model_response.reasoning_content += model_response_event.redacted_reasoning_content
                     run_response.reasoning_content = model_response.reasoning_content
 
+                if model_response_event.provider_data is not None:
+                    # We get citations in one chunk
+                    model_response.provider_data = model_response_event.provider_data
+                    run_response.provider_data = model_response.provider_data
+
                 if model_response_event.citations is not None:
                     # We get citations in one chunk
                     run_response.citations = model_response_event.citations
@@ -3372,6 +3377,7 @@ class Agent:
                     or model_response_event.reasoning_content is not None
                     or model_response_event.redacted_reasoning_content is not None
                     or model_response_event.citations is not None
+                    or model_response_event.provider_data is not None
                 ):
                     yield self._handle_event(
                         create_run_output_content_event(
@@ -3380,6 +3386,7 @@ class Agent:
                             reasoning_content=model_response_event.reasoning_content,
                             redacted_reasoning_content=model_response_event.redacted_reasoning_content,
                             citations=model_response_event.citations,
+                            provider_data=model_response_event.provider_data,
                         ),
                         run_response,
                         workflow_context=workflow_context,

--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -96,6 +96,7 @@ class RunContentEvent(BaseAgentRunEvent):
     content: Optional[Any] = None
     content_type: str = "str"
     reasoning_content: Optional[str] = None
+    provider_data: Optional[Dict[str, Any]] = None
     citations: Optional[Citations] = None
     response_audio: Optional[Audio] = None  # Model audio response
     image: Optional[Image] = None  # Image attached to the response
@@ -382,6 +383,8 @@ class RunOutput:
     reasoning_content: Optional[str] = None
     reasoning_steps: Optional[List[ReasoningStep]] = None
     reasoning_messages: Optional[List[Message]] = None
+
+    provider_data: Optional[Dict[str, Any]] = None
 
     model: Optional[str] = None
     model_provider: Optional[str] = None

--- a/libs/agno/agno/utils/events.py
+++ b/libs/agno/agno/utils/events.py
@@ -343,6 +343,7 @@ def create_run_output_content_event(
     content_type: Optional[str] = None,
     reasoning_content: Optional[str] = None,
     redacted_reasoning_content: Optional[str] = None,
+    provider_data: Optional[Dict[str, Any]] = None,
     citations: Optional[Citations] = None,
     response_audio: Optional[Audio] = None,
     image: Optional[Image] = None,
@@ -364,6 +365,7 @@ def create_run_output_content_event(
         additional_input=from_run_response.additional_input,
         reasoning_steps=from_run_response.reasoning_steps,
         reasoning_messages=from_run_response.reasoning_messages,
+        provider_data=provider_data,
     )
 
 


### PR DESCRIPTION
## Summary

Add support for handling `provider_data` in agent response flow

(If applicable, issue number: #4642)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [-] Documentation updated (comments, docstrings)
- [-] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [-] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
