### PR TITLE
fix: migration script session field mapping fixes

### DIFF
--- a/libs/agno/agno/db/migrations/v1_to_v2.py
+++ b/libs/agno/agno/db/migrations/v1_to_v2.py
@@ -127,7 +127,7 @@ def safe_get_runs_from_memory(memory_data: Any) -> Any:
     if memory_data is None:
         return None
 
-    runs = []
+    runs: Any = []
 
     # If memory_data is a string, try to parse it as JSON
     if isinstance(memory_data, str):


### PR DESCRIPTION
- Add some extra checks when mapping v1 sessions to v2 sessions in the migration logic, to catch and avoid some some errors users are facing.
