### PR TITLE
feat: include session_id in WhatsApp router for agent and team interactions

### DIFF
--- a/libs/agno/agno/os/interfaces/whatsapp/router.py
+++ b/libs/agno/agno/os/interfaces/whatsapp/router.py
@@ -123,6 +123,7 @@ def attach_routes(router: APIRouter, agent: Optional[Agent] = None, team: Option
                 response = await agent.arun(
                     message_text,
                     user_id=phone_number,
+                    session_id=f"wa:{phone_number}",
                     images=[Image(content=await get_media_async(message_image))] if message_image else None,
                     files=[File(content=await get_media_async(message_doc))] if message_doc else None,
                     videos=[Video(content=await get_media_async(message_video))] if message_video else None,
@@ -132,6 +133,7 @@ def attach_routes(router: APIRouter, agent: Optional[Agent] = None, team: Option
                 response = await team.arun(  # type: ignore
                     message_text,
                     user_id=phone_number,
+                    session_id=f"wa:{phone_number}",
                     files=[File(content=await get_media_async(message_doc))] if message_doc else None,
                     images=[Image(content=await get_media_async(message_image))] if message_image else None,
                     videos=[Video(content=await get_media_async(message_video))] if message_video else None,


### PR DESCRIPTION


- fixes #4825

## Summary

### Overview
Adds `session_id` to the WhatsApp interface to enable session isolation and state persistence.

### What Was Added
- `session_id=f"wa:{phone_number}"` to both `agent.arun()` and `team.arun()` calls
- Session ID format: `"wa:{phone_number}"` (e.g., `"wa:+1234567890"`)

### Benefits
- Session isolation per phone number
- Session-based state persistence
- Clear session identification with the "wa:" prefix
- Consistent behavior for agent and team

### Before vs After
**Before:**
```python
response = await agent.arun(
    message_text,
    user_id=phone_number,
    # ... other params
)
```

**After:**
```python
response = await agent.arun(
    message_text,
    user_id=phone_number,
    session_id=f"wa:{phone_number}",
    # ... other params
)
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
