### PR TITLE
[fix]  ensure agent does not crash on cancelled tool calls (#4861)

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1408,7 +1408,7 @@ class Model(ABC):
         function_call_timer = Timer()
         function_call_timer.start()
         success: Union[bool, AgentRunException] = False
-        result = None
+        result: FunctionExecutionResult
 
         try:
             if (
@@ -1430,9 +1430,29 @@ class Model(ABC):
                 success = result.status == "success"
         except AgentRunException as e:
             success = e
+            result = FunctionExecutionResult(
+                status="failure",
+                error=str(e),
+                updated_session_state=None,
+                result=None,
+                images=None,
+                videos=None,
+                audios=None,
+                files=None,
+            )
         except Exception as e:
             log_error(f"Error executing function {function_call.function.name}: {e}")
             success = False
+            result = FunctionExecutionResult(
+                status="failure",
+                error=str(e),
+                updated_session_state=None,
+                result=None,
+                images=None,
+                videos=None,
+                audios=None,
+                files=None,
+            )
             raise e
 
         function_call_timer.stop()


### PR DESCRIPTION
## Summary

Describe key changes, mention related issues or motivation for the changes.


This PR fixes Issue #4861: "Agno v2: Cancelled tool call causes failure".  
Agent runs would previously crash with an `UnboundLocalError` or `AttributeError` if a tool call was cancelled (e.g., via `StopAgentRun` in a tool hook), due to uninitialized or missing attributes in post-processing logic.

### Key changes:
- Always initialize `result = None` in `arun_function_call`, so it's defined even on exceptions or cancellations.
- Robustly guard against `None` and missing attributes (like `updated_session_state`, `images`, `videos`, etc.) when handling cancelled or failed tool results in `arun_function_calls`.
- Use `getattr` everywhere downstream code references `function_execution_result` fields, so cancellation or early exit will not crash the agent, and empty defaults are used instead.



(If applicable, issue number: #\_\_\_\_)

Fixes #4861.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
