### PR TITLE
fixes #4611 - Added Fallback models in OpenRouter

### DIFF
--- a/cookbook/models/openrouter/README.md
+++ b/cookbook/models/openrouter/README.md
@@ -49,10 +49,8 @@ python cookbook/models/openrouter/tool_use.py
 python cookbook/models/openrouter/structured_output.py
 ```
 
-### 7. Run Agent with fallback models
+### 7. Run Agent with dynamic model router
 
 ```shell
-python cookbook/models/openrouter/fallback_models.py
+python cookbook/models/openrouter/dynamic_model_router.py
 ```
-
-

--- a/cookbook/models/openrouter/dynamic_model_router.py
+++ b/cookbook/models/openrouter/dynamic_model_router.py
@@ -1,26 +1,26 @@
 """
-This example demonstrates how to use fallback models with OpenRouter.
+This example demonstrates how to use dynamic model router with OpenRouter.
 
-Fallback models provide automatic failover when the primary model encounters:
+Dynamic models provide automatic failover when the primary model encounters:
 - Rate limits
 - Timeouts
 - Unavailability
 - Model overload
 
-OpenRouter will automatically try the fallback models in order until one succeeds.
+OpenRouter will automatically try the models defined in order until one succeeds.
 """
 
 from agno.agent import Agent
 from agno.models.openrouter import OpenRouter
 
-# Create an agent with fallback models
-# If the primary model fails, OpenRouter will automatically try the fallback models in order
+# Create an agent with dynamic models
+# If the primary model fails, OpenRouter will automatically try the models defined in order
 agent = Agent(
     model=OpenRouter(
         id="anthropic/claude-sonnet-4",  # Primary model
-        fallback_models=[
-            "deepseek/deepseek-r1",  # First fallback
-            "openai/gpt-4o",  # Second fallback
+        models=[
+            "deepseek/deepseek-r1",  # First fallback model
+            "openai/gpt-4o",  # Second fallback model
         ],
     ),
     markdown=True,

--- a/libs/agno/agno/models/openrouter/openrouter.py
+++ b/libs/agno/agno/models/openrouter/openrouter.py
@@ -32,7 +32,7 @@ class OpenRouter(OpenAILike):
     api_key: Optional[str] = field(default_factory=lambda: getenv("OPENROUTER_API_KEY"))
     base_url: str = "https://openrouter.ai/api/v1"
     max_tokens: int = 1024
-    fallback_models: Optional[List[str]] = None
+    models: Optional[List[str]] = None  # Dynamic model routing https://openrouter.ai/docs/features/model-routing
 
     def get_request_params(
         self,
@@ -53,12 +53,12 @@ class OpenRouter(OpenAILike):
         )
 
         # Add fallback models to extra_body if specified
-        if self.fallback_models:
+        if self.models:
             # Get existing extra_body or create new dict
             extra_body = request_params.get("extra_body") or {}
 
             # Merge fallback models into extra_body
-            extra_body["models"] = self.fallback_models
+            extra_body["models"] = self.models
 
             # Update request params
             request_params["extra_body"] = extra_body


### PR DESCRIPTION
## Summary
fixes #4611

OpenRouter natively supports fallback models through its API, but this feature wasn't exposed in the Agno. Users previously had to handle model failures manually or implement custom retry logic.

  - Added fallback_models parameter to OpenRouter class
    - Type: Optional[List[str]] - list of model IDs to use as fallbacks
    - Default: None - backward compatible, no breaking changes
    - Automatically merges into OpenRouter's extra_body parameter as models array
  - Changed get_request_params() method to include fallback configuration
    - Preserves existing extra_body fields
    - Only adds fallback configuration when fallback_models is specified

  1. User specifies fallback_models when creating OpenRouter instance
  2. get_request_params() merges fallback models into extra_body
  3. OpenRouter API receives request with models array
  4. If primary model fails → OpenRouter tries fallback models in order
  5. First successful response is returned to agent (transparent failover)


## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
