### PR TITLE
fix: h11 0.14.0 has a known CVE vulnerability

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
 dependencies = [
   "docstring-parser",
   "gitpython",
+  "h11>=0.16.0",
   "httpx",
   "packaging",
   "pydantic-settings",

--- a/libs/agno/requirements.txt
+++ b/libs/agno/requirements.txt
@@ -16,9 +16,11 @@ gitdb==4.0.11
     # via gitpython
 gitpython==3.1.43
     # via agno (libs/agno/pyproject.toml)
-h11==0.14.0
-    # via httpcore
-httpcore==1.0.7
+h11==0.16.0
+    # via
+    #   agno (libs/agno/pyproject.toml)
+    #   httpcore
+httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via agno (libs/agno/pyproject.toml)


### PR DESCRIPTION
## Summary

update h11 version to fix h11 0.14.0 has a known CVE vulnerability

(If applicable, issue number: #4916 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
