### PR TITLE
chore: cancel previous workflow runs on new commits

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,10 @@ on:
       - "main"
       - "v2.0"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   style-check-agno:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -13,6 +13,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   style-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add concurrency control to prevent multiple workflow runs from the same branch running simultaneously. 

Meaning: new commits will automatically cancel any in-progress workflows coming from the same branch.