### PR TITLE
feat: Add dedicated events for session summary operations

### DIFF
--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -130,6 +130,9 @@ class RunEvent(str, Enum):
     memory_update_started = "MemoryUpdateStarted"
     memory_update_completed = "MemoryUpdateCompleted"
 
+    session_summary_started = "SessionSummaryStarted"
+    session_summary_completed = "SessionSummaryCompleted"
+
     parser_model_response_started = "ParserModelResponseStarted"
     parser_model_response_completed = "ParserModelResponseCompleted"
 
@@ -288,6 +291,16 @@ class MemoryUpdateCompletedEvent(BaseAgentRunEvent):
 
 
 @dataclass
+class SessionSummaryStartedEvent(BaseAgentRunEvent):
+    event: str = RunEvent.session_summary_started.value
+
+
+@dataclass
+class SessionSummaryCompletedEvent(BaseAgentRunEvent):
+    event: str = RunEvent.session_summary_completed.value
+
+
+@dataclass
 class ReasoningStartedEvent(BaseAgentRunEvent):
     event: str = RunEvent.reasoning_started.value
 
@@ -364,6 +377,8 @@ RunOutputEvent = Union[
     ReasoningCompletedEvent,
     MemoryUpdateStartedEvent,
     MemoryUpdateCompletedEvent,
+    SessionSummaryStartedEvent,
+    SessionSummaryCompletedEvent,
     ToolCallStartedEvent,
     ToolCallCompletedEvent,
     ParserModelResponseStartedEvent,
@@ -391,6 +406,8 @@ RUN_EVENT_TYPE_REGISTRY = {
     RunEvent.reasoning_completed.value: ReasoningCompletedEvent,
     RunEvent.memory_update_started.value: MemoryUpdateStartedEvent,
     RunEvent.memory_update_completed.value: MemoryUpdateCompletedEvent,
+    RunEvent.session_summary_started.value: SessionSummaryStartedEvent,
+    RunEvent.session_summary_completed.value: SessionSummaryCompletedEvent,
     RunEvent.tool_call_started.value: ToolCallStartedEvent,
     RunEvent.tool_call_completed.value: ToolCallCompletedEvent,
     RunEvent.parser_model_response_started.value: ParserModelResponseStartedEvent,

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -126,6 +126,9 @@ class TeamRunEvent(str, Enum):
     memory_update_started = "TeamMemoryUpdateStarted"
     memory_update_completed = "TeamMemoryUpdateCompleted"
 
+    session_summary_started = "TeamSessionSummaryStarted"
+    session_summary_completed = "TeamSessionSummaryCompleted"
+
     parser_model_response_started = "TeamParserModelResponseStarted"
     parser_model_response_completed = "TeamParserModelResponseCompleted"
 
@@ -274,6 +277,16 @@ class MemoryUpdateCompletedEvent(BaseTeamRunEvent):
 
 
 @dataclass
+class SessionSummaryStartedEvent(BaseTeamRunEvent):
+    event: str = TeamRunEvent.session_summary_started.value
+
+
+@dataclass
+class SessionSummaryCompletedEvent(BaseTeamRunEvent):
+    event: str = TeamRunEvent.session_summary_completed.value
+
+
+@dataclass
 class ReasoningStartedEvent(BaseTeamRunEvent):
     event: str = TeamRunEvent.reasoning_started.value
 
@@ -348,6 +361,8 @@ TeamRunOutputEvent = Union[
     ReasoningCompletedEvent,
     MemoryUpdateStartedEvent,
     MemoryUpdateCompletedEvent,
+    SessionSummaryStartedEvent,
+    SessionSummaryCompletedEvent,
     ToolCallStartedEvent,
     ToolCallCompletedEvent,
     ParserModelResponseStartedEvent,
@@ -372,6 +387,8 @@ TEAM_RUN_EVENT_TYPE_REGISTRY = {
     TeamRunEvent.reasoning_completed.value: ReasoningCompletedEvent,
     TeamRunEvent.memory_update_started.value: MemoryUpdateStartedEvent,
     TeamRunEvent.memory_update_completed.value: MemoryUpdateCompletedEvent,
+    TeamRunEvent.session_summary_started.value: SessionSummaryStartedEvent,
+    TeamRunEvent.session_summary_completed.value: SessionSummaryCompletedEvent,
     TeamRunEvent.tool_call_started.value: ToolCallStartedEvent,
     TeamRunEvent.tool_call_completed.value: ToolCallCompletedEvent,
     TeamRunEvent.parser_model_response_started.value: ParserModelResponseStartedEvent,

--- a/libs/agno/agno/utils/events.py
+++ b/libs/agno/agno/utils/events.py
@@ -25,6 +25,8 @@ from agno.run.agent import (
     RunOutput,
     RunPausedEvent,
     RunStartedEvent,
+    SessionSummaryCompletedEvent,
+    SessionSummaryStartedEvent,
     ToolCallCompletedEvent,
     ToolCallStartedEvent,
 )
@@ -44,6 +46,8 @@ from agno.run.team import RunCompletedEvent as TeamRunCompletedEvent
 from agno.run.team import RunContentEvent as TeamRunContentEvent
 from agno.run.team import RunErrorEvent as TeamRunErrorEvent
 from agno.run.team import RunStartedEvent as TeamRunStartedEvent
+from agno.run.team import SessionSummaryCompletedEvent as TeamSessionSummaryCompletedEvent
+from agno.run.team import SessionSummaryStartedEvent as TeamSessionSummaryStartedEvent
 from agno.run.team import TeamRunInput, TeamRunOutput
 from agno.run.team import ToolCallCompletedEvent as TeamToolCallCompletedEvent
 from agno.run.team import ToolCallStartedEvent as TeamToolCallStartedEvent
@@ -271,6 +275,42 @@ def create_memory_update_completed_event(from_run_response: RunOutput) -> Memory
 
 def create_team_memory_update_completed_event(from_run_response: TeamRunOutput) -> TeamMemoryUpdateCompletedEvent:
     return TeamMemoryUpdateCompletedEvent(
+        session_id=from_run_response.session_id,
+        team_id=from_run_response.team_id,  # type: ignore
+        team_name=from_run_response.team_name,  # type: ignore
+        run_id=from_run_response.run_id,
+    )
+
+
+def create_session_summary_started_event(from_run_response: RunOutput) -> SessionSummaryStartedEvent:
+    return SessionSummaryStartedEvent(
+        session_id=from_run_response.session_id,
+        agent_id=from_run_response.agent_id,  # type: ignore
+        agent_name=from_run_response.agent_name,  # type: ignore
+        run_id=from_run_response.run_id,
+    )
+
+
+def create_team_session_summary_started_event(from_run_response: TeamRunOutput) -> TeamSessionSummaryStartedEvent:
+    return TeamSessionSummaryStartedEvent(
+        session_id=from_run_response.session_id,
+        team_id=from_run_response.team_id,  # type: ignore
+        team_name=from_run_response.team_name,  # type: ignore
+        run_id=from_run_response.run_id,
+    )
+
+
+def create_session_summary_completed_event(from_run_response: RunOutput) -> SessionSummaryCompletedEvent:
+    return SessionSummaryCompletedEvent(
+        session_id=from_run_response.session_id,
+        agent_id=from_run_response.agent_id,  # type: ignore
+        agent_name=from_run_response.agent_name,  # type: ignore
+        run_id=from_run_response.run_id,
+    )
+
+
+def create_team_session_summary_completed_event(from_run_response: TeamRunOutput) -> TeamSessionSummaryCompletedEvent:
+    return TeamSessionSummaryCompletedEvent(
         session_id=from_run_response.session_id,
         team_id=from_run_response.team_id,  # type: ignore
         team_name=from_run_response.team_name,  # type: ignore


### PR DESCRIPTION
## Summary

Added `SessionSummaryStarted` and `SessionSummaryCompleted` events for both Agent and Team to enable separate tracking of session summary operations
  - Added `SessionSummaryStarted` and `SessionSummaryCompleted` events for Agent
  - Added `TeamSessionSummaryStarted` and `TeamSessionSummaryCompleted` events for Team
  - Created event dataclasses and registered them in `RUN_EVENT_TYPE_REGISTRY` and `TEAM_RUN_EVENT_TYPE_REGISTRY`
  - Added helper functions in `utils/events.py` for creating events
  - Modified `_make_memories_and_summaries()` methods in both `agent/agent.py` and `team/team.py` (sync and async versions)
  - Events are properly nested within MemoryUpdate events to show hierarchical relationship
  - 
## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
