### PR TITLE
Fix: Variable 'result' is referenced before assignment in Get Knowledge Contents MySQLDb

### DIFF
--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -1654,9 +1654,9 @@ class MySQLDb(BaseDb):
                     if page is not None:
                         stmt = stmt.offset((page - 1) * limit)
 
-                    result = sess.execute(stmt).fetchall()
-                    if not result:
-                        return [], 0
+                result = sess.execute(stmt).fetchall()
+                if not result:
+                    return [], 0
 
                 return [KnowledgeRow.model_validate(record._mapping) for record in result], total_count
 


### PR DESCRIPTION
## Summary
In Knowledge class:
- `get_content` calls `get_knowledge_contents` from `BaseDb`, in this case I am using `MySQLDb`.
- `get_content` is called in `_get_filters_from_db` which is called in `validate_filters`
- When adding `search_knowledge_base` tool in Team or Agent, `validate_filters` is called.

However, in MySQLDb, get_knowledge_contents is buggy in MySQLDb.
In the current implementation. If there is no limit provided, the query won't be executed at all.

(If applicable, issue number: #5018)

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [X] Code complies with style guidelines
- [X] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [X] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [X] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
