### PR TITLE
feat: add num_summary_runs parameter for session summaries

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -156,6 +156,8 @@ class Agent:
     enable_session_summaries: bool = False
     # If True, the agent adds session summaries to the context
     add_session_summary_to_context: Optional[bool] = None
+    # Number of runs to include when generating session summary (None = all runs)
+    num_summary_runs: Optional[int] = None
     # Session summary manager
     session_summary_manager: Optional[SessionSummaryManager] = None
 
@@ -384,6 +386,7 @@ class Agent:
         add_memories_to_context: Optional[bool] = None,
         enable_session_summaries: bool = False,
         add_session_summary_to_context: Optional[bool] = None,
+        num_summary_runs: Optional[int] = None,
         session_summary_manager: Optional[SessionSummaryManager] = None,
         add_history_to_context: bool = False,
         num_history_runs: int = 3,
@@ -480,6 +483,7 @@ class Agent:
         self.session_summary_manager = session_summary_manager
         self.enable_session_summaries = enable_session_summaries
         self.add_session_summary_to_context = add_session_summary_to_context
+        self.num_summary_runs = num_summary_runs
 
         self.add_history_to_context = add_history_to_context
         self.num_history_runs = num_history_runs
@@ -688,11 +692,15 @@ class Agent:
 
     def _set_session_summary_manager(self) -> None:
         if self.enable_session_summaries and self.session_summary_manager is None:
-            self.session_summary_manager = SessionSummaryManager(model=self.model)
+            self.session_summary_manager = SessionSummaryManager(
+                model=self.model, num_summary_runs=self.num_summary_runs
+            )
 
         if self.session_summary_manager is not None:
             if self.session_summary_manager.model is None:
                 self.session_summary_manager.model = self.model
+            if self.session_summary_manager.num_summary_runs is None:
+                self.session_summary_manager.num_summary_runs = self.num_summary_runs
 
         if self.add_session_summary_to_context is None:
             self.add_session_summary_to_context = (

--- a/libs/agno/agno/session/agent.py
+++ b/libs/agno/agno/session/agent.py
@@ -189,6 +189,7 @@ class AgentSession:
 
     def get_messages_for_session(
         self,
+        last_n: Optional[int] = None,
         user_role: str = "user",
         assistant_role: Optional[List[str]] = None,
         skip_history_messages: bool = True,
@@ -204,7 +205,10 @@ class AgentSession:
         if not session_runs:
             return []
 
-        for run_response in session_runs:
+        # Limit to last_n runs if specified
+        runs_to_process = session_runs[-last_n:] if last_n is not None else session_runs
+
+        for run_response in runs_to_process:
             if run_response and run_response.messages:
                 user_message_from_run = None
                 assistant_message_from_run = None

--- a/libs/agno/agno/session/summary.py
+++ b/libs/agno/agno/session/summary.py
@@ -66,6 +66,9 @@ class SessionSummaryManager:
     # Prompt used for session summary generation
     session_summary_prompt: Optional[str] = None
 
+    # Number of runs to include when generating session summary (None = all runs)
+    num_summary_runs: Optional[int] = None
+
     # Whether session summaries were created in the last run
     summaries_updated: bool = False
 
@@ -126,7 +129,7 @@ class SessionSummaryManager:
         return (
             [
                 self.get_system_message(
-                    conversation=session.get_messages_for_session(),  # type: ignore
+                    conversation=session.get_messages_for_session(last_n=self.num_summary_runs),  # type: ignore
                     response_format=response_format,
                 ),
                 Message(role="user", content="Provide the summary of the conversation."),

--- a/libs/agno/agno/session/team.py
+++ b/libs/agno/agno/session/team.py
@@ -202,6 +202,7 @@ class TeamSession:
 
     def get_messages_for_session(
         self,
+        last_n: Optional[int] = None,
         user_role: str = "user",
         assistant_role: Optional[List[str]] = None,
         skip_history_messages: bool = True,
@@ -217,7 +218,10 @@ class TeamSession:
         if session_runs is None:
             return []
 
-        for run_response in session_runs:
+        # Limit to last_n runs if specified
+        runs_to_process = session_runs[-last_n:] if last_n is not None else session_runs
+
+        for run_response in runs_to_process:
             if run_response and run_response.messages:
                 user_message_from_run = None
                 assistant_message_from_run = None

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -321,6 +321,8 @@ class Team:
     session_summary_manager: Optional[SessionSummaryManager] = None
     # If True, the team adds session summaries to the context
     add_session_summary_to_context: Optional[bool] = None
+    # Number of runs to include when generating session summary (None = all runs)
+    num_summary_runs: Optional[int] = None
 
     # --- Team History ---
     # add_history_to_context=true adds messages from the chat history to the messages list sent to the Model.
@@ -447,6 +449,7 @@ class Team:
         enable_session_summaries: bool = False,
         session_summary_manager: Optional[SessionSummaryManager] = None,
         add_session_summary_to_context: Optional[bool] = None,
+        num_summary_runs: Optional[int] = None,
         add_history_to_context: bool = False,
         num_history_runs: int = 3,
         metadata: Optional[Dict[str, Any]] = None,
@@ -555,6 +558,7 @@ class Team:
         self.enable_session_summaries = enable_session_summaries
         self.session_summary_manager = session_summary_manager
         self.add_session_summary_to_context = add_session_summary_to_context
+        self.num_summary_runs = num_summary_runs
         self.add_history_to_context = add_history_to_context
         self.num_history_runs = num_history_runs
         self.metadata = metadata
@@ -746,11 +750,15 @@ class Team:
 
     def _set_session_summary_manager(self) -> None:
         if self.enable_session_summaries and self.session_summary_manager is None:
-            self.session_summary_manager = SessionSummaryManager(model=self.model)
+            self.session_summary_manager = SessionSummaryManager(
+                model=self.model, num_summary_runs=self.num_summary_runs
+            )
 
         if self.session_summary_manager is not None:
             if self.session_summary_manager.model is None:
                 self.session_summary_manager.model = self.model
+            if self.session_summary_manager.num_summary_runs is None:
+                self.session_summary_manager.num_summary_runs = self.num_summary_runs
 
         if self.add_session_summary_to_context is None:
             self.add_session_summary_to_context = (


### PR DESCRIPTION
- Introduced num_summary_runs to limit the number of runs included in session summaries.
- Updated Agent, SessionSummaryManager, and Team classes to support this new parameter.
- Enhanced get_messages_for_session method to process only the last_n runs if specified.

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
