### PR TITLE
fix: update response_audio type in schemas to a single dict

### DIFF
--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -873,7 +873,7 @@ class RunSchema(BaseModel):
             videos=run_dict.get("videos", []),
             audio=run_dict.get("audio", []),
             files=run_dict.get("files", []),
-            response_audio=run_dict.get("response_audio", []),
+            response_audio=run_dict.get("response_audio", None),
             input_media=extract_input_media(run_dict),
             created_at=datetime.fromtimestamp(run_dict.get("created_at", 0), tz=timezone.utc)
             if run_dict.get("created_at") is not None
@@ -930,7 +930,7 @@ class TeamRunSchema(BaseModel):
             videos=run_dict.get("videos", []),
             audio=run_dict.get("audio", []),
             files=run_dict.get("files", []),
-            response_audio=run_dict.get("response_audio", []),
+            response_audio=run_dict.get("response_audio", None),
             input_media=extract_input_media(run_dict),
         )
 
@@ -982,7 +982,7 @@ class WorkflowRunSchema(BaseModel):
             videos=run_response.get("videos", []),
             audio=run_response.get("audio", []),
             files=run_response.get("files", []),
-            response_audio=run_response.get("response_audio", []),
+            response_audio=run_response.get("response_audio", None),
         )
 
 


### PR DESCRIPTION
Updated the `response_audio` field in `RunSchema`, `TeamRunSchema`, and `WorkflowRunSchema` from an optional list of dictionaries to an optional single dictionary for better structure and consistency in handling audio responses.

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
