### PR TITLE
[fix] Apply reranker to Milvus search results (fixes #5190)

### DIFF
--- a/libs/agno/agno/vectordb/milvus/milvus.py
+++ b/libs/agno/agno/vectordb/milvus/milvus.py
@@ -719,6 +719,11 @@ class Milvus(VectorDb):
                 )
             )
 
+        # Apply reranker if available
+        if self.reranker and search_results:
+            search_results = self.reranker.rerank(query=query, documents=search_results)
+            search_results = search_results[:limit]
+
         log_info(f"Found {len(search_results)} documents")
         return search_results
 

--- a/libs/agno/tests/unit/vectordb/test_milvusdb.py
+++ b/libs/agno/tests/unit/vectordb/test_milvusdb.py
@@ -449,3 +449,24 @@ def test_delete_methods_error_handling(milvus_db, mock_milvus_client):
     assert milvus_db.delete_by_name("test_name") is False
     assert milvus_db.delete_by_metadata({"type": "test"}) is False
     assert milvus_db.delete_by_content_id("test_content_id") is False
+
+def test_search_with_reranker(milvus_db, mock_milvus_client):
+    """Test Milvus search with reranker applied"""
+    with patch.object(milvus_db.embedder, "get_embedding", return_value=[0.1] * 768):
+        # Mock search results from Milvus
+        mock_result1 = {"id": "id1", "entity": {"name": "doc_a", "content": "Content A", "vector": [0.1]*768}}
+        mock_result2 = {"id": "id2", "entity": {"name": "doc_b", "content": "Content B", "vector": [0.2]*768}}
+        mock_milvus_client.search.return_value = [[mock_result1, mock_result2]]
+
+        # Mock reranker that reverses results
+        mock_reranker = Mock()
+        mock_reranker.rerank.side_effect = lambda query, documents: list(reversed(documents))
+        milvus_db.reranker = mock_reranker
+
+        results = milvus_db.search("query", limit=2)
+
+        # Verify reranker called
+        mock_reranker.rerank.assert_called_once()
+        # Verify results are reranked (reversed)
+        assert results[0].name == "doc_b"
+        assert results[1].name == "doc_a"


### PR DESCRIPTION
## Summary

This PR updates the Milvus.search method to apply a reranker to the search results, ensuring that results are reordered based on relevance after initial vector search.

Key changes:

- Added a check for self.reranker and non-empty search results.
- Applied self.reranker.rerank(query=query, documents=search_results) to reorder results.
- Enforced limit on the final results after reranking.
- Updated `libs/agno/tests/unit/vectordb/test_milvusdb.py` with a unit test validating the reranker integration.

This resolves the reported issue: [#5190]


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist


- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

- The reranker is optional; if self.reranker is not defined, the search behaves as before.
- The search limit is enforced after reranking to ensure returned results respect the limit parameter.
- Unit test uses a mocked reranker that reverses results to simulate reranking behavior.