### PR TITLE
fix(kb): correctly call aupdate_content

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -501,7 +501,7 @@ class Knowledge:
         await self._add_to_contents_db(content)
         if self._should_skip(content.content_hash, skip_if_exists):  # type: ignore[arg-type]
             content.status = ContentStatus.COMPLETED
-            self._update_content(content)
+            await self._aupdate_content(content)
             return
 
         if self.vector_db.__class__.__name__ == "LightRag":
@@ -725,7 +725,7 @@ class Knowledge:
             await self._add_to_contents_db(content)
             if self._should_skip(content.content_hash, skip_if_exists):
                 content.status = ContentStatus.COMPLETED
-                self._update_content(content)
+                await self._aupdate_content(content)
                 return
 
             if self.vector_db.__class__.__name__ == "LightRag":
@@ -741,7 +741,7 @@ class Knowledge:
                 log_error(f"No reader available for topic: {topic}")
                 content.status = ContentStatus.FAILED
                 content.status_message = "No reader available for topic"
-                self._update_content(content)
+                await self._aupdate_content(content)
                 continue
 
             read_documents = content.reader.read(topic)


### PR DESCRIPTION
## Summary

Addresses bug where loading from URL's and topics fails due to `ValueError`:

```
raise ValueError(\nValueError: update_content() is not supported with an async DB. Please use aupdate_content() instead."}
```

Linked tickets
- https://github.com/agno-agi/agno/issues/5214

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Currently breaks uploading URL's when using async Postgres
