### PR TITLE
feat: support updating an OS instance in a FastAPI lifespan function

### DIFF
--- a/cookbook/agent_os/update_from_lifespan.py
+++ b/cookbook/agent_os/update_from_lifespan.py
@@ -23,15 +23,11 @@ agent2 = Agent(
 # Lifespan function receiving the AgentOS instance as parameter.
 @asynccontextmanager
 async def lifespan(app, agent_os):
-    # Add the new agent to the AgentOS.
+    # Add the new Agent
     agent_os.agents.append(agent2)
-    agent_os._initialize_agents()
 
-    # Add the new agent's database to the AgentOS.
-    agent_os._auto_discover_databases()
-
-    # Add the new agent's Knowledge bases to the AgentOS.
-    agent_os._auto_discover_knowledge_instances()
+    # Resync the AgentOS
+    agent_os.resync()
 
     yield
 

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -224,6 +224,14 @@ class AgentOS:
         except (ValueError, TypeError):
             return lifespan
 
+    def resync(self) -> None:
+        """Resync the AgentOS to discover, initialize and configure: agents, teams, workflows, databases and knowledge bases."""
+        self._initialize_agents()
+        self._initialize_teams()
+        self._initialize_workflows()
+        self._auto_discover_databases()
+        self._auto_discover_knowledge_instances()
+
     def _make_app(self, lifespan: Optional[Any] = None) -> FastAPI:
         # Adjust the FastAPI app lifespan to handle MCP connections if relevant
         app_lifespan = lifespan


### PR DESCRIPTION
This makes it possible to add Agents, Teams and Worfklows to a running AgentOS instance via a lifespan function.

- Abstract the logic to init and configure and agent to work in the OS into a `_initialize_agent()`method. Same for teams/workflows.
- Add logic to pass the AgentOS instance to lifespan functions with `agent_os` as param