### PR TITLE
Fix: Add missing text_contents parameter to add_contents method signature

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -187,10 +187,14 @@ class Knowledge:
         paths: Optional[List[str]] = None,
         urls: Optional[List[str]] = None,
         metadata: Optional[Dict[str, str]] = None,
+        topics: Optional[List[str]] = None,
+        text_contents: Optional[List[str]] = None,
+        reader: Optional[Reader] = None,
         include: Optional[List[str]] = None,
         exclude: Optional[List[str]] = None,
         upsert: bool = True,
         skip_if_exists: bool = False,
+        remote_content: Optional[RemoteContent] = None,
     ) -> None: ...
 
     def add_contents(self, *args, **kwargs) -> None:
@@ -208,10 +212,14 @@ class Knowledge:
             paths: Optional list of file paths to load content from
             urls: Optional list of URLs to load content from
             metadata: Optional metadata dictionary to apply to all content
+            topics: Optional list of topics to add
+            text_contents: Optional list of text content strings to add
+            reader: Optional reader to use for processing content
             include: Optional list of file patterns to include
             exclude: Optional list of file patterns to exclude
             upsert: Whether to update existing content if it already exists
             skip_if_exists: Whether to skip adding content if it already exists
+            remote_content: Optional remote content (S3, GCS, etc.) to add
         """
         asyncio.run(self.add_contents_async(*args, **kwargs))
 


### PR DESCRIPTION
## Summary

The synchronous `add_contents` method was missing the `text_contents` parameter in its type signature and docstring, while the async `add_contents_async` method had it correctly defined. This caused confusion and prevented proper IDE autocomplete and type checking when users tried to use `knowledge.add_contents(text_contents=[...])`.

**Key changes:**
- Added `text_contents: Optional[List[str]]` parameter to the `add_contents` method overload
- Added `topics`, `reader`, and `remote_content` parameters for consistency with the async version
- Updated the docstring to document all newly added parameters

This fix resolves a GitHub issue where users reported that the parameter "contents" in `knowledge.add_contents` was incorrect and should be "text_contents".

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

The implementation of `add_contents` already forwarded all arguments correctly to `add_contents_async` using `*args, **kwargs`, so only the type signature and documentation needed updating. No behavior changes were made - this is purely a fix for the public API definition.

Existing cookbook examples in `cookbook/knowledge/basic_operations/15_text_content.py` already demonstrate correct usage of the `text_contents` parameter with the async version.

solves #5232