### PR TITLE
chore: workflow agent changing run input used for session_name

### DIFF
--- a/libs/agno/agno/workflow/agent.py
+++ b/libs/agno/agno/workflow/agent.py
@@ -127,19 +127,17 @@ Guidelines:
             # Create a new run ID for this execution
             run_id = str(uuid4())
 
-            # Create workflow run response
             workflow_run_response = WorkflowRunOutput(
                 run_id=run_id,
-                input=query,
+                input=execution_input.input,  # Use original user input
                 session_id=session_from_db.session_id,
                 workflow_id=workflow.id,
                 workflow_name=workflow.name,
                 created_at=int(datetime.now().timestamp()),
             )
 
-            # Update the execution input with the agent's refined query
             workflow_execution_input = WorkflowExecutionInput(
-                input=query,
+                input=query,  # Agent's refined query for execution
                 additional_data=execution_input.additional_data,
                 audio=execution_input.audio,
                 images=execution_input.images,
@@ -244,10 +242,9 @@ Guidelines:
             # Create a new run ID for this execution
             run_id = str(uuid4())
 
-            # Create workflow run response
             workflow_run_response = WorkflowRunOutput(
                 run_id=run_id,
-                input=query,
+                input=execution_input.input,  # Use original user input
                 session_id=session_from_db.session_id,
                 workflow_id=workflow.id,
                 workflow_name=workflow.name,
@@ -255,7 +252,7 @@ Guidelines:
             )
 
             workflow_execution_input = WorkflowExecutionInput(
-                input=query,
+                input=query,  # Agent's refined query for execution
                 additional_data=execution_input.additional_data,
                 audio=execution_input.audio,
                 images=execution_input.images,


### PR DESCRIPTION
## Summary

workflow agent is changing the run input, so that affects the session name when `/session/runs` is called on refresh in chat page.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
