### PR TITLE
feat: use provided model for evaluator agent in accuracy evaluations

### DIFF
--- a/libs/agno/agno/os/routers/evals/utils.py
+++ b/libs/agno/agno/os/routers/evals/utils.py
@@ -33,6 +33,7 @@ async def run_accuracy_eval(
         additional_context=eval_run_input.additional_context,
         num_iterations=eval_run_input.num_iterations or 1,
         name=eval_run_input.name,
+        model=default_model,
     )
 
     result = accuracy_eval.run(print_results=False, print_summary=False)


### PR DESCRIPTION
- When using accuracy evaluations via the OS API, we should use the contextual default model for the evaluator agent if no model is specifically provided. Else the default OpenAI model is used, making it easy to run into missing keys problems if you use non-OpenAI models