### PR TITLE
[fix] no run_response passed to model.get_request_params

### DIFF
--- a/cookbook/agent_os/agent_with_input_schema.py
+++ b/cookbook/agent_os/agent_with_input_schema.py
@@ -1,11 +1,11 @@
 from typing import List
 
 from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIChat
 from agno.os import AgentOS
 from agno.tools.hackernews import HackerNewsTools
 from pydantic import BaseModel, Field
-from agno.db.sqlite import SqliteDb
 
 
 class ResearchTopic(BaseModel):

--- a/cookbook/agent_os/team_with_input_schema.py
+++ b/cookbook/agent_os/team_with_input_schema.py
@@ -9,13 +9,14 @@ dictionary inputs into Pydantic models, ensuring type safety and data validation
 from typing import List
 
 from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
 from agno.models.openai import OpenAIChat
 from agno.os import AgentOS
 from agno.team.team import Team
 from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.tools.hackernews import HackerNewsTools
 from pydantic import BaseModel, Field
-from agno.db.sqlite import SqliteDb
+
 
 class ResearchProject(BaseModel):
     """Structured research project with validation requirements."""
@@ -28,9 +29,7 @@ class ResearchProject(BaseModel):
     depth_level: str = Field(
         description="Research depth level", pattern="^(basic|intermediate|advanced)$"
     )
-    max_sources: int = Field(
-        description="Maximum number of sources to use", default=10
-    )
+    max_sources: int = Field(description="Maximum number of sources to use", default=10)
     include_recent_only: bool = Field(
         description="Whether to focus only on recent sources", default=True
     )

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -1877,6 +1877,7 @@ class Agent:
                 tool_call_limit=self.tool_call_limit,
                 response_format=response_format,
                 send_media_to_model=self.send_media_to_model,
+                run_response=run_response,
             )
 
             # Check for cancellation after model call

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -483,6 +483,7 @@ class Model(ABC):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         tool_call_limit: Optional[int] = None,
         send_media_to_model: bool = True,
+        run_response: Optional[RunOutput] = None,
     ) -> ModelResponse:
         """
         Generate an asynchronous response from the model.
@@ -517,6 +518,7 @@ class Model(ABC):
                 response_format=response_format,
                 tools=_tool_dicts,
                 tool_choice=tool_choice or self._tool_choice,
+                run_response=run_response,
             )
 
             # Add assistant message to messages

--- a/libs/agno/agno/models/requesty/requesty.py
+++ b/libs/agno/agno/models/requesty/requesty.py
@@ -36,7 +36,9 @@ class Requesty(OpenAILike):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         run_response: Optional[RunOutput] = None,
     ) -> Dict[str, Any]:
-        params = super().get_request_params(response_format=response_format, tools=tools, tool_choice=tool_choice)
+        params = super().get_request_params(
+            response_format=response_format, tools=tools, tool_choice=tool_choice, run_response=run_response
+        )
 
         if "extra_body" not in params:
             params["extra_body"] = {}

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -2187,6 +2187,7 @@ class Team:
                 tool_call_limit=self.tool_call_limit,
                 response_format=response_format,
                 send_media_to_model=self.send_media_to_model,
+                run_response=run_response,
             )  # type: ignore
 
             # Check for cancellation after model call
@@ -3058,6 +3059,7 @@ class Team:
             tool_call_limit=self.tool_call_limit,
             stream_model_response=stream_model_response,
             send_media_to_model=self.send_media_to_model,
+            run_response=run_response,
         )  # type: ignore
         async for model_response_event in model_stream:
             for event in self._handle_model_response_chunk(

--- a/libs/agno/agno/tools/file.py
+++ b/libs/agno/agno/tools/file.py
@@ -97,7 +97,9 @@ class FileTools(Toolkit):
             log_error(f"Error reading file: {e}")
             return f"Error reading file: {e}"
 
-    def replace_file_chunk(self, file_name: str, start_line: int, end_line: int, chunk: str, encoding: str = "utf-8") -> str:
+    def replace_file_chunk(
+        self, file_name: str, start_line: int, end_line: int, chunk: str, encoding: str = "utf-8"
+    ) -> str:
         """Reads the contents of the file, replaces lines
         between start_line and end_line with chunk and writes the file
 
@@ -119,7 +121,9 @@ class FileTools(Toolkit):
             lines = contents.split(self.line_separator)
             start = lines[0:start_line]
             end = lines[end_line + 1 :]
-            return self.save_file(file_name=file_name, contents=self.line_separator.join(start + [chunk] + end), encoding=encoding)
+            return self.save_file(
+                file_name=file_name, contents=self.line_separator.join(start + [chunk] + end), encoding=encoding
+            )
         except Exception as e:
             log_error(f"Error patching file: {e}")
             return f"Error patching file: {e}"

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -2514,7 +2514,7 @@ class Workflow:
 
         if self.agent and isinstance(self.agent, WorkflowAgent):
             add_history = self.agent.add_workflow_history
-            num_runs = self.agent.num_history_runs or 5  
+            num_runs = self.agent.num_history_runs or 5
 
         if add_history:
             history_context = (
@@ -3638,7 +3638,7 @@ class Workflow:
                     prepared_steps.append(Step(name=step_name, description=step.description, team=step))
                 if isinstance(step, Step) and step.add_workflow_history is True and self.db is None:
                     log_warning(
-                        f"Step '{step.name or f'step_{i+1}'}' has add_workflow_history=True "
+                        f"Step '{step.name or f'step_{i + 1}'}' has add_workflow_history=True "
                         "but no database is configured in the Workflow. "
                         "History won't be persisted. Add a database to persist runs across executions."
                     )

--- a/libs/agno/tests/unit/tools/test_filetools.py
+++ b/libs/agno/tests/unit/tools/test_filetools.py
@@ -128,6 +128,7 @@ def test_replace_file_chunk():
         new_contents = f.read_file(file_name="file1.txt")
         assert new_contents == "line0\nsome\nstuff\nline3\n"
 
+
 def test_check_escape():
     """Test check_escape service function"""
     with tempfile.TemporaryDirectory() as tempdirname:
@@ -137,12 +138,9 @@ def test_check_escape():
         assert flag
         assert path.resolve() == base_dir.resolve()
         flag, path = f.check_escape("..")
-        assert not(flag)
+        assert not (flag)
         flag, path = f.check_escape("a/b/..")
         assert flag
         assert path.resolve() == base_dir.joinpath(Path("a")).resolve()
         flag, path = f.check_escape("a/b/../../..")
-        assert not(flag)
-
-
-
+        assert not (flag)

--- a/libs/agno/tests/unit/vectordb/test_milvusdb.py
+++ b/libs/agno/tests/unit/vectordb/test_milvusdb.py
@@ -450,12 +450,13 @@ def test_delete_methods_error_handling(milvus_db, mock_milvus_client):
     assert milvus_db.delete_by_metadata({"type": "test"}) is False
     assert milvus_db.delete_by_content_id("test_content_id") is False
 
+
 def test_search_with_reranker(milvus_db, mock_milvus_client):
     """Test Milvus search with reranker applied"""
     with patch.object(milvus_db.embedder, "get_embedding", return_value=[0.1] * 768):
         # Mock search results from Milvus
-        mock_result1 = {"id": "id1", "entity": {"name": "doc_a", "content": "Content A", "vector": [0.1]*768}}
-        mock_result2 = {"id": "id2", "entity": {"name": "doc_b", "content": "Content B", "vector": [0.2]*768}}
+        mock_result1 = {"id": "id1", "entity": {"name": "doc_a", "content": "Content A", "vector": [0.1] * 768}}
+        mock_result2 = {"id": "id2", "entity": {"name": "doc_b", "content": "Content B", "vector": [0.2] * 768}}
         mock_milvus_client.search.return_value = [[mock_result1, mock_result2]]
 
         # Mock reranker that reverses results


### PR DESCRIPTION
## Summary

When working with Requesty noticed that their backend wasn't receiving trace_id (run_response.session_id in agno) and user_id (run_response.user_id in agno). Investigated and it turned out that it was a "plumbing" issue, no run_response being passed downstream in model.aresponse and below

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [x] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

None