### PR TITLE
fix: Remove highlights parameter (removed from Exa API v2.0.0)

### DIFF
--- a/cookbook/getting_started/17_agent_team.py
+++ b/cookbook/getting_started/17_agent_team.py
@@ -52,7 +52,6 @@ finance_agent = Agent(
         ExaTools(
             include_domains=["trendlyne.com"],
             text=False,
-            highlights=False,
             show_results=True,
         )
     ],

--- a/cookbook/tools/exa_tools.py
+++ b/cookbook/tools/exa_tools.py
@@ -24,7 +24,6 @@ agent_specific = Agent(
             include_domains=["cnbc.com", "reuters.com", "bloomberg.com"],
             show_results=True,
             text=False,
-            highlights=False,
         )
     ],
     markdown=True,
@@ -37,7 +36,6 @@ agent = Agent(
             include_domains=["cnbc.com", "reuters.com", "bloomberg.com"],
             show_results=True,
             text=False,
-            highlights=False,
         )
     ],
     markdown=True,

--- a/libs/agno/agno/tools/exa.py
+++ b/libs/agno/agno/tools/exa.py
@@ -27,7 +27,6 @@ class ExaTools(Toolkit):
         all (bool): Enable all tools. Overrides individual flags when True. Default is False.
         text (bool): Retrieve text content from results. Default is True.
         text_length_limit (int): Max length of text content per result. Default is 1000.
-        highlights (bool): Include highlighted snippets. Default is True.
         api_key (Optional[str]): Exa API key. Retrieved from `EXA_API_KEY` env variable if not provided.
         num_results (Optional[int]): Default number of search results. Overrides individual searches if set.
         start_crawl_date (Optional[str]): Include results crawled on/after this date (`YYYY-MM-DD`).
@@ -54,7 +53,6 @@ class ExaTools(Toolkit):
         all: bool = False,
         text: bool = True,
         text_length_limit: int = 1000,
-        highlights: bool = True,
         summary: bool = False,
         api_key: Optional[str] = None,
         num_results: Optional[int] = None,
@@ -84,7 +82,6 @@ class ExaTools(Toolkit):
 
         self.text: bool = text
         self.text_length_limit: int = text_length_limit
-        self.highlights: bool = highlights
         self.summary: bool = summary
         self.num_results: Optional[int] = num_results
         self.livecrawl: str = livecrawl
@@ -140,13 +137,6 @@ class ExaTools(Toolkit):
                 if self.text_length_limit:
                     _text = _text[: self.text_length_limit]
                 result_dict["text"] = _text
-            if self.highlights:
-                try:
-                    if result.highlights:  # type: ignore
-                        result_dict["highlights"] = result.highlights  # type: ignore
-                except Exception as e:
-                    log_debug(f"Failed to get highlights {e}")
-                    result_dict["highlights"] = f"Failed to get highlights {e}"
             exa_results_parsed.append(result_dict)
         return json.dumps(exa_results_parsed, indent=4, ensure_ascii=False)
 
@@ -168,7 +158,6 @@ class ExaTools(Toolkit):
                 log_info(f"Searching exa for: {query}")
             search_kwargs: Dict[str, Any] = {
                 "text": self.text,
-                "highlights": self.highlights,
                 "summary": self.summary,
                 "num_results": self.num_results or num_results,
                 "start_crawl_date": self.start_crawl_date,
@@ -212,7 +201,6 @@ class ExaTools(Toolkit):
 
         query_kwargs: Dict[str, Any] = {
             "text": self.text,
-            "highlights": self.highlights,
             "summary": self.summary,
         }
 
@@ -249,7 +237,6 @@ class ExaTools(Toolkit):
 
         query_kwargs: Dict[str, Any] = {
             "text": self.text,
-            "highlights": self.highlights,
             "summary": self.summary,
             "include_domains": self.include_domains,
             "exclude_domains": self.exclude_domains,

--- a/libs/agno/tests/unit/tools/test_exa.py
+++ b/libs/agno/tests/unit/tools/test_exa.py
@@ -34,7 +34,6 @@ def create_mock_search_result(
     author: str = None,
     published_date: str = None,
     text: str = None,
-    highlights: list = None,
 ):
     """Helper function to create mock search result."""
     result = Mock()
@@ -43,7 +42,6 @@ def create_mock_search_result(
     result.author = author
     result.published_date = published_date
     result.text = text
-    result.highlights = highlights
     return result
 
 
@@ -81,7 +79,6 @@ def test_search_exa_success(exa_tools, mock_exa_client):
             author="John Doe",
             published_date="2024-01-01",
             text="Sample text content",
-            highlights=["highlighted text"],
         )
     ]
 
@@ -95,7 +92,6 @@ def test_search_exa_success(exa_tools, mock_exa_client):
     assert result_data[0]["title"] == "Test Article"
     assert result_data[0]["author"] == "John Doe"
     assert result_data[0]["text"] == "Sample text content"
-    assert result_data[0]["highlights"] == ["highlighted text"]
 
 
 def test_get_contents_success(exa_tools, mock_exa_client):
@@ -187,7 +183,6 @@ def test_search_with_category(exa_tools, mock_exa_client):
     mock_exa_client.search_and_contents.assert_called_with(
         "research",
         text=True,
-        highlights=True,
         summary=False,
         num_results=5,
         category="research paper",


### PR DESCRIPTION
 ## Summary

  This PR fixes the "Invalid option: 'highlights'" error that occurs when using ExaTools with exa-py v2.0.0. The Exa API completely removed the `highlights` feature in v2.0.0
  (previously deprecated), but ExaTools was still attempting to pass this parameter to API calls.

  **Reference:** https://docs.exa.ai/changelog/sdk-major-version-changes

  (Fixes issue #5272)

  ## Type of change

  - [x] Bug fix
  - [ ] New feature
  - [ ] Breaking change
  - [ ] Improvement
  - [ ] Model update
  - [ ] Other:

  ---

  ## Checklist

  - [x] Code complies with style guidelines
  - [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
  - [x] Self-review completed
  - [x] Documentation updated (comments, docstrings)
  - [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
  - [ ] Tested in clean environment (dependency conflicts prevented full environment setup, but unit tests updated)
  - [x] Tests added/updated (if applicable)

  ---

  ## Additional Notes

  **Migration Guide for Users:**
  If you have code like this:
  ```python
  ExaTools(highlights=False)

  Simply remove the parameter:
  ExaTools()