### PR TITLE
fix: tool execution import

### DIFF
--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -1,6 +1,6 @@
 from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import Any, Dict, Optional
 
 from pydantic import BaseModel
 


### PR DESCRIPTION
## Summary

<img width="480" height="162" alt="image" src="https://github.com/user-attachments/assets/a7b730f6-38fc-4142-aa40-8ae8e3dd39fa" />

its because in `libs/agno/agno/run/base.py` we are importing

```python
if TYPE_CHECKING:
    from agno.models.response import ToolExecution
```
like this
but at run time its needed in the from_dict functions
```python
data["tool"] = ToolExecution.from_dict(tool)
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
