### PR TITLE
fix: Team members inherit only primary model, not auxiliary model

### DIFF
--- a/cookbook/teams/other/team_model_inheritance.py
+++ b/cookbook/teams/other/team_model_inheritance.py
@@ -8,15 +8,13 @@ This is particularly useful when:
 
 Key behaviors:
 1. Primary model is always inherited by agents without explicit models
-2. Secondary models (output_model, parser_model, reasoning_model) are not inherited by default
-3. Use inherit_secondary_models parameter to opt-in to secondary model inheritance
-4. Agents with explicit models keep their own configuration
-5. Nested teams and their members inherit from their immediate parent team
+2. Members with explicit models keep their own configuration
+3. Nested team members inherit from their immediate parent team
 """
 
 from agno.agent import Agent
 from agno.models.openai import OpenAIChat
-from agno.team.team import SecondaryModelType, Team
+from agno.team.team import Team
 
 # These agents don't have models set
 researcher = Agent(
@@ -52,14 +50,10 @@ sub_team = Team(
 )
 
 
-# Main team with all members and secondary model inheritance
+# Main team with all members
 team = Team(
     name="Content Production Team",
     model=OpenAIChat(id="gpt-4o"),
-    output_model=OpenAIChat(id="gpt-4o-mini"),
-    parser_model=OpenAIChat(id="gpt-4o-mini"),
-    # Inherit only output_model (options: output_model, parser_model, reasoning_model)
-    inherit_secondary_models=[SecondaryModelType.output_model],
     members=[researcher, writer, editor, sub_team],
     instructions=[
         "Research the topic thoroughly",
@@ -72,27 +66,12 @@ team = Team(
 if __name__ == "__main__":
     team.initialize_team()
 
-    # researcher and writer inherit Claude Sonnet from team
+    # researcher and writer inherit gpt-4o from team
     print(f"Researcher model: {researcher.model.id}")
     print(f"Writer model: {writer.model.id}")
     # editor keeps its explicit model
     print(f"Editor model: {editor.model.id}")
-    # analyst inherits Claude Haiku from its sub-team
+    # analyst inherits gpt-4o-mini from its sub-team
     print(f"Analyst model: {analyst.model.id}")
-
-    # output_model is inherited because it's in inherit_secondary_models list
-    print(
-        f"Researcher output_model: {researcher.output_model.id if researcher.output_model else 'None'}"
-    )
-    print(
-        f"Writer output_model: {writer.output_model.id if writer.output_model else 'None'}"
-    )
-    # parser_model is not inherited because it's not in inherit_secondary_models list
-    print(
-        f"Researcher parser_model: {researcher.parser_model.id if researcher.parser_model else 'None (not inherited)'}"
-    )
-    print(
-        f"Writer parser_model: {writer.parser_model.id if writer.parser_model else 'None (not inherited)'}"
-    )
 
     team.print_response("Write a brief article about AI", stream=True)

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -4,7 +4,6 @@ import json
 from collections import ChainMap, deque
 from copy import copy
 from dataclasses import dataclass
-from enum import Enum
 from os import getenv
 from textwrap import dedent
 from typing import (
@@ -163,14 +162,6 @@ from agno.utils.team import (
     get_team_run_context_videos,
 )
 from agno.utils.timer import Timer
-
-
-class SecondaryModelType(str, Enum):
-    """Types of secondary models that can be inherited by team members"""
-
-    output_model = "output_model"
-    parser_model = "parser_model"
-    reasoning_model = "reasoning_model"
 
 
 @dataclass(init=False)
@@ -407,9 +398,6 @@ class Team:
     reasoning_min_steps: int = 1
     reasoning_max_steps: int = 10
 
-    # List of secondary models that should be inherited by members
-    inherit_secondary_models: Optional[List[SecondaryModelType]] = None
-
     # --- Team Streaming ---
     # Stream the response from the Team
     stream: Optional[bool] = None
@@ -533,7 +521,6 @@ class Team:
         reasoning_agent: Optional[Agent] = None,
         reasoning_min_steps: int = 1,
         reasoning_max_steps: int = 10,
-        inherit_secondary_models: Optional[List[SecondaryModelType]] = None,
         stream: Optional[bool] = None,
         stream_events: Optional[bool] = None,
         stream_intermediate_steps: Optional[bool] = None,
@@ -657,8 +644,6 @@ class Team:
         self.reasoning_agent = reasoning_agent
         self.reasoning_min_steps = reasoning_min_steps
         self.reasoning_max_steps = reasoning_max_steps
-
-        self.inherit_secondary_models = inherit_secondary_models
 
         self.stream = stream
         self.stream_events = stream_events or stream_intermediate_steps
@@ -821,15 +806,6 @@ class Team:
             if member.model is None and self.model is not None:
                 member.model = self.model
                 log_info(f"Agent '{member.name or member.id}' inheriting model from Team: {self.model.id}")
-
-            # Inherit secondary models only if specified in inherit_secondary_models
-            if self.inherit_secondary_models:
-                for model_type in self.inherit_secondary_models:
-                    if getattr(member, model_type) is None and getattr(self, model_type) is not None:
-                        setattr(member, model_type, getattr(self, model_type))
-                        log_info(
-                            f"Agent '{member.name or member.id}' inheriting {model_type.value} from Team: {getattr(self, model_type).id}"
-                        )
 
         elif isinstance(member, Team):
             member.parent_team_id = self.id

--- a/libs/agno/tests/unit/team/test_model_inheritance.py
+++ b/libs/agno/tests/unit/team/test_model_inheritance.py
@@ -1,7 +1,7 @@
 from agno.agent import Agent
 from agno.models.anthropic import Claude
 from agno.models.openai import OpenAIChat
-from agno.team.team import SecondaryModelType, Team
+from agno.team.team import Team
 
 
 def test_model_inheritance():
@@ -71,71 +71,6 @@ def test_nested_team_model_inheritance():
 
     assert isinstance(sub_agent2.model, Claude)
     assert sub_agent2.model.id == "claude-3-5-haiku-20241022"
-
-
-def test_secondary_models_not_inherited_by_default():
-    """Test that secondary models are not inherited by default."""
-    agent1 = Agent(name="Agent 1", role="Assistant")
-    agent2 = Agent(name="Agent 2", role="Helper", parser_model=OpenAIChat(id="gpt-3.5-turbo"))
-
-    team = Team(
-        name="Multi Model Team",
-        model=Claude(id="claude-3-5-sonnet-20241022"),
-        reasoning_model=OpenAIChat(id="o1"),
-        parser_model=OpenAIChat(id="gpt-4o-mini"),
-        output_model=OpenAIChat(id="gpt-4o-mini"),
-        members=[agent1, agent2],
-    )
-
-    team.initialize_team()
-
-    # Agent 1 should only inherit primary model, not secondary models
-    assert isinstance(agent1.model, Claude)
-    assert agent1.model.id == "claude-3-5-sonnet-20241022"
-    assert agent1.reasoning_model is None
-    assert agent1.parser_model is None
-    assert agent1.output_model is None
-
-    # Agent 2 should only inherit primary model, keep explicit parser_model
-    assert isinstance(agent2.model, Claude)
-    assert agent2.reasoning_model is None
-    assert agent2.output_model is None
-    assert agent2.parser_model.id == "gpt-3.5-turbo"
-
-
-def test_secondary_models_opt_in_inheritance():
-    """Test that secondary models can be inherited when explicitly specified."""
-    agent1 = Agent(name="Agent 1", role="Assistant")
-    agent2 = Agent(name="Agent 2", role="Helper", parser_model=OpenAIChat(id="gpt-3.5-turbo"))
-
-    team = Team(
-        name="Multi Model Team",
-        model=Claude(id="claude-3-5-sonnet-20241022"),
-        reasoning_model=OpenAIChat(id="o1"),
-        parser_model=OpenAIChat(id="gpt-4o-mini"),
-        output_model=OpenAIChat(id="gpt-4o-mini"),
-        inherit_secondary_models=[
-            SecondaryModelType.reasoning_model,
-            SecondaryModelType.parser_model,
-            SecondaryModelType.output_model,
-        ],
-        members=[agent1, agent2],
-    )
-
-    team.initialize_team()
-
-    # Agent 1 should inherit all model types
-    assert isinstance(agent1.model, Claude)
-    assert agent1.model.id == "claude-3-5-sonnet-20241022"
-    assert agent1.reasoning_model.id == "o1"
-    assert agent1.parser_model.id == "gpt-4o-mini"
-    assert agent1.output_model.id == "gpt-4o-mini"
-
-    # Agent 2 should inherit all except parser_model (has explicit)
-    assert isinstance(agent2.model, Claude)
-    assert agent2.reasoning_model.id == "o1"
-    assert agent2.output_model.id == "gpt-4o-mini"
-    assert agent2.parser_model.id == "gpt-3.5-turbo"
 
 
 def test_default_model():


### PR DESCRIPTION
## Summary

Fixes the bug where child agents were automatically inheriting all auxiliary models (`output_model`, `parser_model`, `reasoning_model`) from their Team, causing unwanted extra API calls

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

