### PR TITLE
fix: run output flag

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -1140,7 +1140,7 @@ class Agent:
         add_session_state_to_context: Optional[bool] = None,
         response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
         stream_events: bool = False,
-        yield_run_output: bool = False,
+        yield_run_output: Optional[bool] = None,
         debug_mode: Optional[bool] = None,
         **kwargs: Any,
     ) -> Iterator[Union[RunOutputEvent, RunOutput]]:
@@ -1491,7 +1491,7 @@ class Agent:
         add_session_state_to_context: Optional[bool] = None,
         dependencies: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
-        yield_run_response: bool = False,
+        yield_run_response: bool = False,  # To be deprecated: use yield_run_output instead
         yield_run_output: bool = False,
         debug_mode: Optional[bool] = None,
         **kwargs: Any,
@@ -1518,8 +1518,8 @@ class Agent:
         add_session_state_to_context: Optional[bool] = None,
         dependencies: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
-        yield_run_response: bool = False,
-        yield_run_output: bool = False,
+        yield_run_response: Optional[bool] = None,  # To be deprecated: use yield_run_output instead
+        yield_run_output: Optional[bool] = None,
         debug_mode: Optional[bool] = None,
         **kwargs: Any,
     ) -> Union[RunOutput, Iterator[Union[RunOutputEvent, RunOutput]]]:
@@ -1657,7 +1657,7 @@ class Agent:
         last_exception = None
         num_attempts = retries + 1
 
-        yield_run_output = yield_run_output or yield_run_response # For backwards compatibility
+        yield_run_output = yield_run_output or yield_run_response  # For backwards compatibility
 
         for attempt in range(num_attempts):
             try:
@@ -2013,7 +2013,7 @@ class Agent:
         add_session_state_to_context: Optional[bool] = None,
         response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
         stream_events: bool = False,
-        yield_run_output: bool = False,
+        yield_run_output: Optional[bool] = None,
         debug_mode: Optional[bool] = None,
         **kwargs: Any,
     ) -> AsyncIterator[Union[RunOutputEvent, RunOutput]]:
@@ -2412,8 +2412,8 @@ class Agent:
         add_session_state_to_context: Optional[bool] = None,
         dependencies: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
-        yield_run_response: Optional[bool] = None,
-        yield_run_output: bool = False,
+        yield_run_response: Optional[bool] = None,  # To be deprecated: use yield_run_output instead
+        yield_run_output: Optional[bool] = None,
         debug_mode: Optional[bool] = None,
         **kwargs: Any,
     ) -> AsyncIterator[Union[RunOutputEvent, RunOutput]]: ...
@@ -2439,7 +2439,7 @@ class Agent:
         add_session_state_to_context: Optional[bool] = None,
         dependencies: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
-        yield_run_response: Optional[bool] = None,
+        yield_run_response: Optional[bool] = None,  # To be deprecated: use yield_run_output instead
         yield_run_output: Optional[bool] = None,
         debug_mode: Optional[bool] = None,
         **kwargs: Any,
@@ -2565,7 +2565,7 @@ class Agent:
         last_exception = None
         num_attempts = retries + 1
 
-        yield_run_output = yield_run_output or yield_run_response # For backwards compatibility
+        yield_run_output = yield_run_output or yield_run_response  # For backwards compatibility
 
         for attempt in range(num_attempts):
             try:

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -1775,7 +1775,7 @@ class Team:
         dependencies: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         debug_mode: Optional[bool] = None,
-        yield_run_response: bool = False,
+        yield_run_response: bool = False,  # To be deprecated: use yield_run_output instead
         yield_run_output: bool = False,
         **kwargs: Any,
     ) -> Iterator[Union[RunOutputEvent, TeamRunOutputEvent]]: ...
@@ -1802,7 +1802,7 @@ class Team:
         dependencies: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         debug_mode: Optional[bool] = None,
-        yield_run_response: bool = False,
+        yield_run_response: bool = False,  # To be deprecated: use yield_run_output instead
         yield_run_output: bool = False,
         **kwargs: Any,
     ) -> Union[TeamRunOutput, Iterator[Union[RunOutputEvent, TeamRunOutputEvent]]]:
@@ -1947,7 +1947,7 @@ class Team:
         last_exception = None
         num_attempts = retries + 1
 
-        yield_run_output = yield_run_output or yield_run_response # For backwards compatibility
+        yield_run_output = yield_run_output or yield_run_response  # For backwards compatibility
 
         for attempt in range(num_attempts):
             # Initialize the current run
@@ -2632,7 +2632,7 @@ class Team:
         dependencies: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         debug_mode: Optional[bool] = None,
-        yield_run_response: bool = False,
+        yield_run_response: bool = False,  # To be deprecated: use yield_run_output instead
         yield_run_output: bool = False,
         **kwargs: Any,
     ) -> AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent]]: ...
@@ -2659,7 +2659,7 @@ class Team:
         dependencies: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         debug_mode: Optional[bool] = None,
-        yield_run_response: bool = False,
+        yield_run_response: bool = False,  # To be deprecated: use yield_run_output instead
         yield_run_output: bool = False,
         **kwargs: Any,
     ) -> Union[TeamRunOutput, AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent]]]:
@@ -2786,7 +2786,7 @@ class Team:
         last_exception = None
         num_attempts = retries + 1
 
-        yield_run_output = yield_run_output or yield_run_response # For backwards compatibility
+        yield_run_output = yield_run_output or yield_run_response  # For backwards compatibility
 
         for attempt in range(num_attempts):
             # Run the team

--- a/libs/agno/tests/integration/models/openai/responses/test_structured_response.py
+++ b/libs/agno/tests/integration/models/openai/responses/test_structured_response.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Literal
 
 import pytest
 from pydantic import BaseModel, Field
+
 from agno.agent import Agent, RunOutput  # noqa
 from agno.models.openai import OpenAIResponses
 from agno.tools.duckduckgo import DuckDuckGoTools

--- a/libs/agno/tests/integration/test_basic.py
+++ b/libs/agno/tests/integration/test_basic.py
@@ -1,11 +1,12 @@
-
 import pytest
+
 from agno.agent.agent import Agent
-from agno.team.team import Team
 from agno.knowledge.knowledge import Knowledge
 from agno.models.openai import OpenAIChat
 from agno.run.agent import RunOutput
+from agno.team.team import Team
 from agno.vectordb.chroma import ChromaDb
+
 
 @pytest.fixture
 def vector_db():
@@ -21,24 +22,10 @@ def test_basic_with_no_import_errors(shared_db, vector_db):
         vector_db=vector_db,
         contents_db=shared_db,
     )
-    agent = Agent(
-        model=OpenAIChat(id="gpt-4o-mini"), 
-        knowledge=knowledge,
-        db=shared_db,
-        markdown=True, 
-        telemetry=False
-    )
-    team = Team(
-        members=[agent],
-        model=OpenAIChat(id="gpt-4o-mini"),
-        db=shared_db,
-        markdown=True,
-        telemetry=False
-    )
+    agent = Agent(model=OpenAIChat(id="gpt-4o-mini"), knowledge=knowledge, db=shared_db, markdown=True, telemetry=False)
+    team = Team(members=[agent], model=OpenAIChat(id="gpt-4o-mini"), db=shared_db, markdown=True, telemetry=False)
 
     # Simple test to ensure that we can run agents/team without any import errors
     response: RunOutput = team.run("Share a 2 sentence horror story")
 
     assert response.content is not None
-
-

--- a/libs/agno/tests/integration/test_os_basic.py
+++ b/libs/agno/tests/integration/test_os_basic.py
@@ -1,11 +1,12 @@
-
 import pytest
+from fastapi.testclient import TestClient
+
 from agno.agent.agent import Agent
 from agno.knowledge.knowledge import Knowledge
 from agno.models.openai import OpenAIChat
-from agno.vectordb.chroma import ChromaDb
 from agno.os import AgentOS
-from fastapi.testclient import TestClient
+from agno.vectordb.chroma import ChromaDb
+
 
 @pytest.fixture
 def vector_db():
@@ -15,6 +16,7 @@ def vector_db():
     # Clean up after test
     vector_db.drop()
 
+
 @pytest.fixture
 def agent(shared_db, vector_db):
     """Create a test agent with SQLite database."""
@@ -22,14 +24,9 @@ def agent(shared_db, vector_db):
         vector_db=vector_db,
         contents_db=shared_db,
     )
-    agent = Agent(
-        model=OpenAIChat(id="gpt-4o-mini"), 
-        knowledge=knowledge,
-        db=shared_db,
-        markdown=True, 
-        telemetry=False
-    )
+    agent = Agent(model=OpenAIChat(id="gpt-4o-mini"), knowledge=knowledge, db=shared_db, markdown=True, telemetry=False)
     return agent
+
 
 @pytest.fixture
 def test_os_client(agent: Agent):
@@ -39,14 +36,10 @@ def test_os_client(agent: Agent):
     return TestClient(app)
 
 
-
 def test_basic_with_no_import_errors(test_os_client, agent):
-    
     response = test_os_client.post(
         f"/agents/{agent.id}/runs",
         data={"message": "Hello, world!"},
         headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
     assert response.status_code == 200
-
-


### PR DESCRIPTION
## Summary

Adds a `yield_run_output` flag for the run and arun functions

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
