### PR TITLE
fix: AgentOS resync /docs

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -245,16 +245,18 @@ class AgentOS:
         ]
 
         # Clear all previously existing routes
-        app.router.routes = [route for route in app.router.routes if route.path in ["/docs", "/redoc", "/openapi.json", "/docs/oauth2-redirect"]]
-        
+        app.router.routes = [
+            route
+            for route in app.router.routes
+            if hasattr(route, "path") and route.path in ["/docs", "/redoc", "/openapi.json", "/docs/oauth2-redirect"]  # type: ignore
+        ]
 
         # Add the built-in routes
         self._add_built_in_routes(app=app)
-        
+
         # Add the updated routes
         for router in updated_routers:
             self._add_router(app, router)
-
 
     def _add_built_in_routes(self, app: FastAPI) -> None:
         """Add all AgentOSbuilt-in routes to the given app."""


### PR DESCRIPTION
## Summary

/docs endpoints got removed during resync. This fixes that issue

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
