### PR TITLE
fix: remove all break statement and add comments in streaming for team run

### DIFF
--- a/cookbook/teams/async_flows/03_async_respond_directly.py
+++ b/cookbook/teams/async_flows/03_async_respond_directly.py
@@ -70,7 +70,6 @@ multi_language_team = Team(
         "For unsupported languages like Italian, respond in English with the above message.",
     ],
     show_members_responses=True,
-    debug_mode=True,
 )
 
 

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -7135,7 +7135,6 @@ class Team:
                         member_agent_run_response = member_agent_run_response_event  # type: ignore
                         continue # Don't yield TeamRunOutput or RunOutput, only yield events
 
-
                     # Check if the run is cancelled
                     check_if_run_cancelled(member_agent_run_response_event)
 


### PR DESCRIPTION
## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #5385)

## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [X] Code complies with style guidelines
- [X] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [X] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [X] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes
**Before removing the break statement**
<img width="1450" height="995" alt="Screenshot 2025-11-11 at 7 03 39 PM" src="https://github.com/user-attachments/assets/4781ca68-15f8-4d86-949c-3c46ac765504" />

**After removing the break statement**
<img width="1450" height="952" alt="Screenshot 2025-11-11 at 7 03 31 PM" src="https://github.com/user-attachments/assets/8a02ef22-1edf-4a50-8fd4-1adafc87c402" />

Add any important context (deployment instructions, screenshots, security considerations, etc.)
