### PR TITLE
fix: Workflow session summary

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -5764,6 +5764,7 @@ class Agent:
             return self.db.get_session(session_id=session_id, session_type=session_type)  # type: ignore
         except Exception as e:
             import traceback
+
             traceback.print_exc(limit=3)
             log_warning(f"Error getting session from db: {e}")
             return None
@@ -5775,9 +5776,10 @@ class Agent:
         try:
             if not self.db:
                 raise ValueError("Db not initialized")
-            return await self.db.get_session(session_id=session_id, session_type=SessionType.AGENT)  # type: ignore
+            return await self.db.get_session(session_id=session_id, session_type=session_type)  # type: ignore
         except Exception as e:
             import traceback
+
             traceback.print_exc(limit=3)
             log_warning(f"Error getting session from db: {e}")
             return None
@@ -5791,6 +5793,7 @@ class Agent:
             return self.db.upsert_session(session=session)  # type: ignore
         except Exception as e:
             import traceback
+
             traceback.print_exc(limit=3)
             log_warning(f"Error upserting session into db: {e}")
             return None
@@ -5803,6 +5806,7 @@ class Agent:
             return await self.db.upsert_session(session=session)  # type: ignore
         except Exception as e:
             import traceback
+
             traceback.print_exc(limit=3)
             log_warning(f"Error upserting session into db: {e}")
             return None

--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -703,6 +703,7 @@ class RunOutput:
             else:
                 # Use the factory from response.py for agent events
                 from agno.run.team import team_run_output_event_from_dict
+
                 event = team_run_output_event_from_dict(event)
             final_events.append(event)
         events = final_events

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -7520,6 +7520,7 @@ class Team:
             return session  # type: ignore
         except Exception as e:
             import traceback
+
             traceback.print_exc(limit=3)
             log_warning(f"Error getting session from db: {e}")
             return None
@@ -7536,6 +7537,7 @@ class Team:
             return session  # type: ignore
         except Exception as e:
             import traceback
+
             traceback.print_exc(limit=3)
             log_warning(f"Error getting session from db: {e}")
             return None
@@ -7549,6 +7551,7 @@ class Team:
             return self.db.upsert_session(session=session)  # type: ignore
         except Exception as e:
             import traceback
+
             traceback.print_exc(limit=3)
             log_warning(f"Error upserting session into db: {e}")
         return None
@@ -7562,6 +7565,7 @@ class Team:
             return await self.db.upsert_session(session=session)  # type: ignore
         except Exception as e:
             import traceback
+
             traceback.print_exc(limit=3)
             log_warning(f"Error upserting session into db: {e}")
         return None


### PR DESCRIPTION
## Summary

Fixes session history retrieval bug for agents inside workflows with AsyncPostgresDb and other async databases.

Root Cause:
`_aread_session()` had a hardcoded SessionType.AGENT that ignored the `session_type` parameter

Deserialize `WorkflowRunOutput` as RunOutput → format mismatch → errors

Fixes - #5157 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)