### PR TITLE
Add optional session parameter to yfinance Ticker calls

### DIFF
--- a/cookbook/tools/yfinance_tools.py
+++ b/cookbook/tools/yfinance_tools.py
@@ -12,7 +12,6 @@ from agno.agent import Agent
 from agno.tools.yfinance import YFinanceTools
 from curl_cffi.requests import Session
 
-
 # Example 1: All financial functions available (default behavior)
 agent_full = Agent(
     tools=[YFinanceTools()],  # All functions enabled by default

--- a/libs/agno/agno/tools/yfinance.py
+++ b/libs/agno/agno/tools/yfinance.py
@@ -9,6 +9,7 @@ try:
 except ImportError:
     raise ImportError("`yfinance` not installed. Please install using `pip install yfinance`.")
 
+
 class YFinanceTools(Toolkit):
     """
     YFinanceTools is a toolkit for getting financial data from Yahoo Finance.


### PR DESCRIPTION
This update adds support for an optional `session` parameter in `yf.Ticker`, allowing users to override the default session configuration. This is particularly useful when SSL verification needs to be disabled or when using a custom session setup.

**Example usage:**

```python
from curl_cffi.requests import Session
session=Session()
session.verify = False  # Disable SSL verification (use with caution)

tools = [
    YFinanceTools(
        include_tools=["get_current_stock_price", "get_analyst_recommendations"],
        session=session
    )
]
```

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
