### PR TITLE
[fix] Fix AGUI input_content to store current user input instead of message history

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -23,7 +23,7 @@ from fastapi.responses import StreamingResponse
 from agno.agent import Agent, RemoteAgent
 from agno.os.interfaces.agui.utils import (
     async_stream_agno_response_as_agui_events,
-    convert_agui_messages_to_agno_messages,
+    extract_agui_user_input,
     validate_agui_state,
 )
 from agno.team.remote import RemoteTeam
@@ -35,8 +35,9 @@ async def run_agent(agent: Union[Agent, RemoteAgent], run_input: RunAgentInput) 
     run_id = run_input.run_id or str(uuid.uuid4())
 
     try:
-        # Preparing the input for the Agent and emitting the run started event
-        messages = convert_agui_messages_to_agno_messages(run_input.messages or [])
+        # AG-UI frontends send full conversation history every request.
+        # Extract only the last user message — agent manages history via session DB.
+        user_input = extract_agui_user_input(run_input.messages or [])
 
         yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id=run_input.thread_id, run_id=run_id)
 
@@ -50,7 +51,7 @@ async def run_agent(agent: Union[Agent, RemoteAgent], run_input: RunAgentInput) 
 
         # Request streaming response from agent
         response_stream = agent.arun(  # type: ignore
-            input=messages,
+            input=user_input,
             session_id=run_input.thread_id,
             stream=True,
             stream_events=True,
@@ -77,8 +78,9 @@ async def run_team(team: Union[Team, RemoteTeam], input: RunAgentInput) -> Async
     """Run the contextual Team, mapping AG-UI input messages to Agno format, and streaming the response in AG-UI format."""
     run_id = input.run_id or str(uuid.uuid4())
     try:
-        # Extract the last user message for team execution
-        messages = convert_agui_messages_to_agno_messages(input.messages or [])
+        # AG-UI frontends send full conversation history every request.
+        # Extract only the last user message — team manages history via session DB.
+        user_input = extract_agui_user_input(input.messages or [])
         yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id=input.thread_id, run_id=run_id)
 
         # Look for user_id in input.forwarded_props
@@ -91,7 +93,7 @@ async def run_team(team: Union[Team, RemoteTeam], input: RunAgentInput) -> Async
 
         # Request streaming response from team
         response_stream = team.arun(  # type: ignore
-            input=messages,
+            input=user_input,
             session_id=input.thread_id,
             stream=True,
             stream_steps=True,

--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -177,56 +177,6 @@ def extract_agui_user_input(messages: List[AGUIMessage]) -> str:
     return ""
 
 
-def convert_agui_messages_to_agno_messages(messages: List[AGUIMessage]) -> List[Message]:
-    """Convert AG-UI messages to Agno messages."""
-    # First pass: collect all tool_call_ids that have results
-    tool_call_ids_with_results: Set[str] = set()
-    for msg in messages:
-        if msg.role == "tool" and msg.tool_call_id:
-            tool_call_ids_with_results.add(msg.tool_call_id)
-
-    # Second pass: convert messages
-    result: List[Message] = []
-    seen_tool_call_ids: Set[str] = set()
-
-    for msg in messages:
-        if msg.role == "tool":
-            # Deduplicate tool results - keep only first occurrence
-            if msg.tool_call_id in seen_tool_call_ids:
-                log_debug(f"Skipping duplicate AGUI tool result: {msg.tool_call_id}")
-                continue
-            seen_tool_call_ids.add(msg.tool_call_id)
-            result.append(Message(id=msg.id, role="tool", tool_call_id=msg.tool_call_id, content=msg.content))
-
-        elif msg.role == "assistant":
-            tool_calls = None
-            if msg.tool_calls:
-                # Filter tool_calls to only those with results in this message sequence
-                filtered_calls = [call for call in msg.tool_calls if call.id in tool_call_ids_with_results]
-                if filtered_calls:
-                    tool_calls = [call.model_dump() for call in filtered_calls]
-            result.append(Message(id=msg.id, role="assistant", content=msg.content, tool_calls=tool_calls))
-
-        elif msg.role == "user":
-            # UserMessage.content is Union[str, List[InputContent]]
-            if isinstance(msg.content, str):
-                content = msg.content
-            elif isinstance(msg.content, list):
-                text_parts = [p.text for p in msg.content if hasattr(p, "type") and p.type == "text" and hasattr(p, "text")]
-                content = "\n".join(text_parts) if text_parts else ""
-            else:
-                content = ""
-            result.append(Message(id=msg.id, role="user", content=content))
-
-        elif msg.role == "system":
-            pass  # Skip - agent builds its own system message from configuration
-
-        else:
-            log_warning(f"Unknown AGUI message role: {msg.role}")
-
-    return result
-
-
 def extract_team_response_chunk_content(response: TeamRunContentEvent) -> str:
     """Given a response stream chunk, find and extract the content."""
 

--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -27,7 +27,6 @@ from ag_ui.core import (
 from ag_ui.core.types import Message as AGUIMessage
 from pydantic import BaseModel
 
-from agno.models.message import Message
 from agno.reasoning.step import ReasoningStep
 from agno.run.agent import ReasoningCompletedEvent as AgentReasoningCompletedEvent
 from agno.run.agent import ReasoningContentDeltaEvent as AgentReasoningContentDeltaEvent
@@ -40,7 +39,7 @@ from agno.run.team import ReasoningStartedEvent as TeamReasoningStartedEvent
 from agno.run.team import ReasoningStepEvent as TeamReasoningStepEvent
 from agno.run.team import RunContentEvent as TeamRunContentEvent
 from agno.run.team import TeamRunEvent, TeamRunOutputEvent
-from agno.utils.log import log_debug, log_warning
+from agno.utils.log import log_warning
 from agno.utils.message import get_text_from_message
 
 

--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -114,6 +114,29 @@ class EventBuffer:
         self.pending_tool_calls_parent_id = ""
 
 
+def extract_agui_user_input(messages: List[AGUIMessage]) -> str:
+    """Extract the last user message content from AG-UI messages.
+
+    AG-UI frontends send the full conversation history on every request.
+    The agent manages its own history via session DB, so we only need the
+    latest user message as input — matching the REST API pattern.
+    """
+    for msg in reversed(messages):
+        if msg.role == "user" and msg.content is not None:
+            # UserMessage.content is Union[str, List[InputContent]]
+            if isinstance(msg.content, str):
+                return msg.content
+            # Multimodal: extract text parts
+            if isinstance(msg.content, list):
+                text_parts = []
+                for part in msg.content:
+                    if hasattr(part, "type") and part.type == "text" and hasattr(part, "text"):
+                        text_parts.append(part.text)
+                if text_parts:
+                    return "\n".join(text_parts)
+    return ""
+
+
 def convert_agui_messages_to_agno_messages(messages: List[AGUIMessage]) -> List[Message]:
     """Convert AG-UI messages to Agno messages."""
     # First pass: collect all tool_call_ids that have results
@@ -133,7 +156,7 @@ def convert_agui_messages_to_agno_messages(messages: List[AGUIMessage]) -> List[
                 log_debug(f"Skipping duplicate AGUI tool result: {msg.tool_call_id}")
                 continue
             seen_tool_call_ids.add(msg.tool_call_id)
-            result.append(Message(role="tool", tool_call_id=msg.tool_call_id, content=msg.content))
+            result.append(Message(id=msg.id, role="tool", tool_call_id=msg.tool_call_id, content=msg.content))
 
         elif msg.role == "assistant":
             tool_calls = None
@@ -142,10 +165,18 @@ def convert_agui_messages_to_agno_messages(messages: List[AGUIMessage]) -> List[
                 filtered_calls = [call for call in msg.tool_calls if call.id in tool_call_ids_with_results]
                 if filtered_calls:
                     tool_calls = [call.model_dump() for call in filtered_calls]
-            result.append(Message(role="assistant", content=msg.content, tool_calls=tool_calls))
+            result.append(Message(id=msg.id, role="assistant", content=msg.content, tool_calls=tool_calls))
 
         elif msg.role == "user":
-            result.append(Message(role="user", content=msg.content))
+            # UserMessage.content is Union[str, List[InputContent]]
+            if isinstance(msg.content, str):
+                content = msg.content
+            elif isinstance(msg.content, list):
+                text_parts = [p.text for p in msg.content if hasattr(p, "type") and p.type == "text" and hasattr(p, "text")]
+                content = "\n".join(text_parts) if text_parts else ""
+            else:
+                content = ""
+            result.append(Message(id=msg.id, role="user", content=content))
 
         elif msg.role == "system":
             pass  # Skip - agent builds its own system message from configuration

--- a/libs/agno/tests/unit/app/test_agui_app.py
+++ b/libs/agno/tests/unit/app/test_agui_app.py
@@ -2,12 +2,11 @@ from unittest.mock import MagicMock
 
 import pytest
 from ag_ui.core import EventType
-from ag_ui.core.types import AssistantMessage, SystemMessage, TextInputContent, ToolMessage, UserMessage
+from ag_ui.core.types import AssistantMessage, SystemMessage, TextInputContent, UserMessage
 
 from agno.os.interfaces.agui.utils import (
     EventBuffer,
     async_stream_agno_response_as_agui_events,
-    convert_agui_messages_to_agno_messages,
     extract_agui_user_input,
 )
 from agno.run.agent import RunContentEvent, ToolCallCompletedEvent, ToolCallStartedEvent
@@ -1503,31 +1502,3 @@ def test_extract_agui_user_input_multimodal_content():
     result = extract_agui_user_input(messages)
 
     assert result == "describe this image"
-
-
-def test_convert_preserves_user_and_assistant_ids():
-    """Test that AG-UI message IDs are preserved through conversion, not replaced with random UUIDs."""
-    messages = [
-        UserMessage(id="agui-user-1", content="hello"),
-        AssistantMessage(id="agui-asst-1", content="hi there"),
-    ]
-
-    result = convert_agui_messages_to_agno_messages(messages)
-
-    assert result[0].id == "agui-user-1"
-    assert result[0].role == "user"
-    assert result[1].id == "agui-asst-1"
-    assert result[1].role == "assistant"
-
-
-def test_convert_preserves_tool_message_id():
-    """Test that tool message IDs and tool_call_ids are preserved through conversion."""
-    messages = [
-        ToolMessage(id="agui-tool-1", content="result data", tool_call_id="tc-1"),
-    ]
-
-    result = convert_agui_messages_to_agno_messages(messages)
-
-    assert result[0].id == "agui-tool-1"
-    assert result[0].tool_call_id == "tc-1"
-    assert result[0].role == "tool"

--- a/libs/agno/tests/unit/app/test_agui_app.py
+++ b/libs/agno/tests/unit/app/test_agui_app.py
@@ -2,8 +2,14 @@ from unittest.mock import MagicMock
 
 import pytest
 from ag_ui.core import EventType
+from ag_ui.core.types import AssistantMessage, SystemMessage, TextInputContent, ToolMessage, UserMessage
 
-from agno.os.interfaces.agui.utils import EventBuffer, async_stream_agno_response_as_agui_events
+from agno.os.interfaces.agui.utils import (
+    EventBuffer,
+    async_stream_agno_response_as_agui_events,
+    convert_agui_messages_to_agno_messages,
+    extract_agui_user_input,
+)
 from agno.run.agent import RunContentEvent, ToolCallCompletedEvent, ToolCallStartedEvent
 
 
@@ -1358,3 +1364,82 @@ def test_validate_agui_state_with_invalid_to_dict():
     obj = TestClass()
     result = validate_agui_state(obj, "test_thread")
     assert result is None
+
+
+def test_extract_agui_user_input_from_full_history():
+    """Test extracting last user message from a CopilotKit-style full conversation history."""
+    messages = [
+        UserMessage(id="u1", content="hello 1"),
+        AssistantMessage(id="a1", content="response 1"),
+        UserMessage(id="u2", content="hello 2"),
+    ]
+
+    result = extract_agui_user_input(messages)
+
+    # Should extract only the last user message, not the first
+    assert result == "hello 2"
+
+
+def test_extract_agui_user_input_single_message():
+    """Test extraction when only one user message is present."""
+    messages = [UserMessage(id="u1", content="just one")]
+
+    result = extract_agui_user_input(messages)
+
+    assert result == "just one"
+
+
+def test_extract_agui_user_input_empty_list():
+    """Test extraction from empty message list returns empty string."""
+    assert extract_agui_user_input([]) == ""
+
+
+def test_extract_agui_user_input_no_user_messages():
+    """Test extraction when no user messages exist returns empty string."""
+    messages = [
+        AssistantMessage(id="a1", content="hello"),
+        SystemMessage(id="s1", content="you are helpful"),
+    ]
+
+    result = extract_agui_user_input(messages)
+
+    assert result == ""
+
+
+def test_extract_agui_user_input_multimodal_content():
+    """Test extraction handles multimodal UserMessage.content (List[InputContent])."""
+    messages = [
+        UserMessage(id="u1", content=[TextInputContent(text="describe this image")]),
+    ]
+
+    result = extract_agui_user_input(messages)
+
+    assert result == "describe this image"
+
+
+def test_convert_preserves_user_and_assistant_ids():
+    """Test that AG-UI message IDs are preserved through conversion, not replaced with random UUIDs."""
+    messages = [
+        UserMessage(id="agui-user-1", content="hello"),
+        AssistantMessage(id="agui-asst-1", content="hi there"),
+    ]
+
+    result = convert_agui_messages_to_agno_messages(messages)
+
+    assert result[0].id == "agui-user-1"
+    assert result[0].role == "user"
+    assert result[1].id == "agui-asst-1"
+    assert result[1].role == "assistant"
+
+
+def test_convert_preserves_tool_message_id():
+    """Test that tool message IDs and tool_call_ids are preserved through conversion."""
+    messages = [
+        ToolMessage(id="agui-tool-1", content="result data", tool_call_id="tc-1"),
+    ]
+
+    result = convert_agui_messages_to_agno_messages(messages)
+
+    assert result[0].id == "agui-tool-1"
+    assert result[0].tool_call_id == "tc-1"
+    assert result[0].role == "tool"


### PR DESCRIPTION
## Summary

Fixes the AG-UI interface to correctly handle CopilotKit and other AG-UI frontends that send the full conversation history on every request (per AG-UI protocol spec). The router now extracts only the last user message and passes it as a string to `agent.arun()`, matching the REST API pattern.

**Fixes #5813**

---

## The Bug

### What the AG-UI protocol does
CopilotKit, Mastra, and other AG-UI frontends send the **full conversation history** on every request. On turn 3, the frontend sends:
```
messages: [user:"hello 1", asst:"hi", user:"hello 2", asst:"hey", user:"hello 3"]
```

### What the old code did
The router called `convert_agui_messages_to_agno_messages()` which converted ALL messages into Agno `Message` objects, then passed the list to `agent.arun(input=List[Message])`.

This triggered the `List[Message]` code path in `get_run_messages()` (`_messages.py:1329-1348`) which appended ALL messages as `extra_messages` per run. The agent also loads its own history from session DB via `add_history_to_context`. Result: **every message appeared twice**.

### Three bugs from this

1. **N+(N+1) message growth in DB:** Each run stored the entire AG-UI history as new messages. After 5 turns, the DB had 15 user messages instead of 5. Token growth was quadratic, not linear.

2. **Wrong display in Agent UI:** `RunInput.input_content` stored the full message list. `stringify_input_content()` returned the first message's content, so every run showed "hello 1" instead of the actual per-turn input.

3. **Doubled context:** With `add_history_to_context=True`, the model saw both DB history AND the full AG-UI history -- every message appeared twice in the model's context window.

### Code path trace

```
OLD: CopilotKit sends [msg1, msg2, msg3]
  -> convert_agui_messages_to_agno_messages() -> List[Message] with 3 items
  -> agent.arun(input=[3 Messages])
  -> get_run_messages() step 5 (line 1329): appends ALL 3 as extra_messages
  -> DB stores all 3 as part of this run
  -> Next turn: DB history has msgs from previous runs + frontend re-sends them
  -> DUPLICATION

NEW: CopilotKit sends [msg1, msg2, msg3]
  -> extract_agui_user_input() -> "hello 3" (last user message as string)
  -> agent.arun(input="hello 3")
  -> get_run_messages() step 4 (line 1278): creates ONE user message
  -> DB stores 1 user message for this run
  -> Next turn: DB history has clean per-run messages, no duplication
```

### REST API parity

The REST API router (`os/routers/agents/router.py:84`) has always passed a plain `message: str` from the form data. It never had this bug because it never hit the `List[Message]` code path. This fix aligns AG-UI with that same pattern.

---

## Changes

### `libs/agno/agno/os/interfaces/agui/router.py` (+9/-7)
- `run_agent()` and `run_team()` now call `extract_agui_user_input()` and pass the string result to `arun(input=user_input)` instead of `arun(input=messages_list)`.

### `libs/agno/agno/os/interfaces/agui/utils.py` (+21/-48)
- **Added** `extract_agui_user_input()` -- walks AG-UI messages backward, returns the last user message content as a string. Handles multimodal `UserMessage.content` (`Union[str, List[InputContent]]`).
- **Removed** `convert_agui_messages_to_agno_messages()` -- see justification below.
- **Removed** unused imports (`Message`, `log_debug`) that were only used by the deleted function.

### `libs/agno/tests/unit/app/test_agui_app.py` (+55/-2)
- 5 new tests for `extract_agui_user_input`: full history extraction, single message, empty list, no user messages, multimodal content.
- Removed 2 tests for the deleted function.

---

## Why `convert_agui_messages_to_agno_messages` was removed

### It's a footgun
The function's output type (`List[Message]`) feeds directly into the code path that caused the bug (`get_run_messages()` line 1329). Keeping it invites the bug to return -- anyone who imports it and passes the result to `arun()` will hit the same duplication.

### Not a public API
`agno.os.interfaces.agui.__init__.py` only exports `AGUI`. The function was an importable symbol in `utils.py`, not a documented or supported API. No external callers exist.

### Already lossy and opinionated
The function skipped system messages, filtered assistant tool calls, deduplicated tool results, and flattened multimodal content. It was not a faithful "AG-UI to Agno transcript converter." If a future feature needs full-history processing, it should get a purpose-built helper with an explicit contract, not reuse this function.

### Only the router called it
The router was the only production caller. With the router switched to `extract_agui_user_input`, the function has zero callers. Keeping dead code in a critical interface path creates confusion about which function to use.

### Codex second opinion
Independent review confirmed: "The helper itself is a footgun because the obvious usage is the wrong usage. In a critical interface, that is enough reason to remove it."

---

## Behavior Change

AG-UI now matches the REST API pattern: **the agent manages its own history via session DB**.

Users with `add_history_to_context=False` (the default) who were previously getting accidental multi-turn context through the AG-UI message list will need to set `add_history_to_context=True` for multi-turn conversations. This is the same requirement as REST API users -- the agent developer explicitly opts into history, and the transport layer (REST vs AG-UI) doesn't change agent behavior.

---

## What This Does NOT Change

- **Agent core** (`_messages.py`, `_run.py`) -- no modifications
- **REST API** -- already passes string input, unaffected
- **Session storage** -- `upsert_run()` works correctly with string `input_content`
- **Event streaming** -- all AG-UI event types are unaffected. The entire output pipeline (`_create_events_from_chunk`, `EventBuffer`, `REASONING_*`, `TOOL_CALL_*`, `TEXT_MESSAGE_*`, `RUN_*`) is untouched. `convert_agui_messages_to_agno_messages` was only about the INPUT path (what goes into the agent), not the OUTPUT path (what streams back to the frontend)
- **Existing cookbooks** -- all 7 AG-UI cookbooks work unchanged

---

## Before / After

```
BEFORE (bug):                          AFTER (fix):
Run 1: input_content=[list...]         Run 1: input_content='hello 1'
Run 2: input_content=[list...]         Run 2: input_content='hello 2'
Run 3: input_content=[list...]         Run 3: input_content='hello 3'
Agent UI: "hello 1, hello 1, hello 1"  Agent UI: "hello 1, hello 2, hello 3"
Total user msgs: 6 (growing)           Total user msgs: 3 (constant)
Token growth: quadratic (59->140->300) Token growth: linear (59->81->100)
```

---

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Tests added/updated (40/40 pass)
- [x] Codex independent review confirms the approach

---

## Testing

### Unit Tests
- 40/40 unit tests pass (35 existing + 5 new extraction tests)
- All event imports verified (Agent + Team reasoning, tool call, text message, run events)

### E2E: curl -- no DB (stateless)
3-turn CopilotKit simulation:
- Turn 1: "reply-1" -> correct response
- Turn 2: CopilotKit sends full history -> "reply-2" (not "reply-1" repeated)
- Turn 3: CopilotKit sends full history -> "reply-3" (correct per-turn)

### E2E: curl -- DB + `add_history_to_context=True` (issue #5813 config)
3-turn CopilotKit simulation with PostgreSQL session storage:
- Turn 1: "What is 2+2?" -> "4"
- Turn 2: "Multiply by 10" -> "40"
- Turn 3: "What were my previous questions?" -> correctly listed both prior questions (proves history works via session DB)

**DB verification:**

| Check | Expected | Actual |
|-------|----------|--------|
| Runs count | 3 | 3 |
| Messages per run | 3 (system+user+assistant) | 3, 3, 3 |
| Total messages | 9 | 9 |
| Run 1 input_content | "What is 2+2?..." | Correct |
| Run 2 input_content | "Now multiply..." | Correct |
| Run 3 input_content | "What were my..." | Correct |
| additional_input (extra_messages) | null for all runs | null for all runs |
| Token growth | Linear | 59 -> 81 -> 100 |

### E2E: AG-UI Dojo (CopilotKit frontend)
All 4 Agno demos tested against local Dojo (localhost:3000) with worktree code:

| Demo | Events | Errors | Result |
|------|--------|--------|--------|
| Agentic Chat (multi-turn + tools) | 200+ | 0 | Multi-turn chat, YFinance tool calls, frontend tool execution (`change_background`), sonnet generation -- all working |
| Backend Tool Rendering | OK | 0 | Weather tool rendered correctly |
| Human in the Loop | OK | 0 | Task steps generated with external execution |
| Tool Based Generative UI | OK | 0 | Haiku generated with bilingual output |

**Event types verified streaming correctly:**
- `RUN_STARTED` / `RUN_FINISHED`
- `TEXT_MESSAGE_START` / `TEXT_MESSAGE_CONTENT` / `TEXT_MESSAGE_END`
- `TOOL_CALL_START` / `TOOL_CALL_ARGS` / `TOOL_CALL_END` / `TOOL_CALL_RESULT`

### E2E: Reasoning agent (o4-mini)
- Reasoning agent cookbook tested via AG-UI endpoint
- Text streaming events work correctly
- Reasoning event pipeline (`_create_events_from_chunk`) is in the OUTPUT path and completely untouched by this change

---

Co-authored-by: RowanLane <jstd000@proton.me>