### PR TITLE
fix: get memory topics function for sqlite and postgres

### DIFF
--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -1114,7 +1114,7 @@ class AsyncSqliteDb(AsyncBaseDb):
 
             async with self.async_session_factory() as sess, sess.begin():
                 # Select topics from all results
-                stmt = select(func.json_array_elements_text(table.c.topics)).select_from(table)
+                stmt = select(table.c.topics)
                 result = (await sess.execute(stmt)).fetchall()
 
                 return list(set([record[0] for record in result]))

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -1109,9 +1109,8 @@ class SqliteDb(BaseDb):
 
             with self.Session() as sess, sess.begin():
                 # Select topics from all results
-                stmt = select(func.json_array_elements_text(table.c.topics)).select_from(table)
+                stmt = select(table.c.topics)
                 result = sess.execute(stmt).fetchall()
-
                 return list(set([record[0] for record in result]))
 
         except Exception as e:


### PR DESCRIPTION
- We were using `json_array_elements_text` in Postgres and AsyncPostgres, which doesn't work now that the relevant column is of type JSONB instead of JSON. This adds some logic to handle both cases.
- There were a similar bug in SQLite. We were using `json_array_elements_text` but it was not supported. 

Fixes https://github.com/agno-agi/agno/issues/5564