### PR TITLE
fix: propagate create_table_if_not_found in async Postgres _get_table

### DIFF
--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -257,7 +257,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                 self.session_table = await self._get_or_create_table(
                     table_name=self.session_table_name,
                     table_type="sessions",
-                    create_table_if_not_found=create_table_if_not_found
+                    create_table_if_not_found=create_table_if_not_found,
                 )
             return self.session_table
 
@@ -266,7 +266,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                 self.memory_table = await self._get_or_create_table(
                     table_name=self.memory_table_name,
                     table_type="memories",
-                    create_table_if_not_found=create_table_if_not_found
+                    create_table_if_not_found=create_table_if_not_found,
                 )
             return self.memory_table
 
@@ -275,7 +275,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                 self.metrics_table = await self._get_or_create_table(
                     table_name=self.metrics_table_name,
                     table_type="metrics",
-                    create_table_if_not_found=create_table_if_not_found
+                    create_table_if_not_found=create_table_if_not_found,
                 )
             return self.metrics_table
 
@@ -284,7 +284,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                 self.eval_table = await self._get_or_create_table(
                     table_name=self.eval_table_name,
                     table_type="evals",
-                    create_table_if_not_found=create_table_if_not_found
+                    create_table_if_not_found=create_table_if_not_found,
                 )
             return self.eval_table
 
@@ -293,7 +293,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                 self.knowledge_table = await self._get_or_create_table(
                     table_name=self.knowledge_table_name,
                     table_type="knowledge",
-                    create_table_if_not_found=create_table_if_not_found
+                    create_table_if_not_found=create_table_if_not_found,
                 )
             return self.knowledge_table
 
@@ -302,7 +302,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                 self.culture_table = await self._get_or_create_table(
                     table_name=self.culture_table_name,
                     table_type="culture",
-                    create_table_if_not_found=create_table_if_not_found
+                    create_table_if_not_found=create_table_if_not_found,
                 )
             return self.culture_table
 
@@ -311,7 +311,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                 self.versions_table = await self._get_or_create_table(
                     table_name=self.versions_table_name,
                     table_type="versions",
-                    create_table_if_not_found=create_table_if_not_found
+                    create_table_if_not_found=create_table_if_not_found,
                 )
             return self.versions_table
 

--- a/libs/agno/tests/integration/models/groq/test_tool_use.py
+++ b/libs/agno/tests/integration/models/groq/test_tool_use.py
@@ -51,6 +51,7 @@ def test_tool_use_stream():
     assert len(responses) > 0
     assert tool_call_seen, "No tool calls observed in stream"
 
+
 @pytest.mark.asyncio
 @pytest.mark.skip(reason="This test fails often on CI for Groq")
 async def test_async_tool_use():


### PR DESCRIPTION
## Summary

Ensures auto-creation by forwarding the flag for all table 

(If applicable, issue number: #5599)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
