### PR TITLE
chore: add tests for streaming and db persistence with hooks

### DIFF
--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -136,7 +136,7 @@ class BaseRunOutputEvent:
             _dict["session_summary"] = self.session_summary.to_dict()
 
         if hasattr(self, "run_input") and self.run_input is not None:
-            _dict["run_input"] = self.run_input if isinstance(self.run_input, str) else self.run_input.to_dict()
+            _dict["run_input"] = self.run_input.to_dict()
 
         return _dict
 


### PR DESCRIPTION
- ~~Add missing `to_dict` logic for the `PreHookStartedEvent ` and `PreHookCompletedEvent ` classes~~
- Add tests for streaming and db persistence scenarios with hooks

Fixes: https://github.com/agno-agi/agno/issues/5581