### PR TITLE
fix: workflow run not saving to DB with status RUNNING

### DIFF
--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -2569,6 +2569,8 @@ class Workflow:
                 else:
                     # Update status to RUNNING and save
                     workflow_run_response.status = RunStatus.running
+
+                    workflow_session.upsert_run(run=workflow_run_response)
                     if self._has_async_db():
                         await self.asave_session(session=workflow_session)
                     else:


### PR DESCRIPTION
## Summary

- somehow we removed the logic to upsert the wf run in DB right when it starts so that it can be queried.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
