### PR TITLE
[fix] Correct AWS credential validation in Bedrock Claude model

### DIFF
--- a/libs/agno/agno/models/aws/claude.py
+++ b/libs/agno/agno/models/aws/claude.py
@@ -82,7 +82,7 @@ class Claude(AnthropicClaude):
 
             if not (self.api_key or (self.aws_access_key and self.aws_secret_key)):
                 log_warning(
-                    "AWS credentials not found. Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables or provide a boto3 session."
+                    "AWS credentials not found. Please set AWS_BEDROCK_API_KEY or AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables or provide a boto3 session."
                 )
 
         if self.timeout is not None:


### PR DESCRIPTION
## Summary
Fixes #5612

The AWS Bedrock Claude model was emitting spurious `ERROR` logs even when credentials were available via the standard AWS credential chain.

## Root Causes Fixed
1. **Wrong env var names**: Code read `AWS_ACCESS_KEY`/`AWS_SECRET_KEY` instead of standard `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`
2. **Broken validation logic**: `if not (self.aws_access_key or (self.aws_access_key and self.aws_secret_key))` was logically equivalent to `if not self.aws_access_key`
3. **Validation ran unconditionally**: Even when `session` or `api_key` paths were used

## Changes
- Use standard AWS SDK env var names with fallback to legacy names for backward compatibility
- Fix validation logic (`or` → `and`) to properly check both credentials
- Move validation inside `else` block so it only triggers for the explicit credentials path
- Change `log_error` → `log_warning` since boto3 credential chain may still resolve credentials

## Backward Compatibility
Users who set the old (non-standard) env var names will continue to work via fallback.