### PR TITLE
fix: Streaming agent crash in evals [SDK-363]

### DIFF
--- a/libs/agno/agno/eval/accuracy.py
+++ b/libs/agno/agno/eval/accuracy.py
@@ -282,7 +282,8 @@ Remember: You must only compare the agent_output to the expected_output. The exp
     ) -> Optional[AccuracyEvaluation]:
         """Orchestrate the evaluation process."""
         try:
-            accuracy_agent_response = evaluator_agent.run(evaluation_input).content
+            response = evaluator_agent.run(evaluation_input, stream=False)
+            accuracy_agent_response = response.content
             if accuracy_agent_response is None or not isinstance(accuracy_agent_response, AccuracyAgentResponse):
                 raise EvalError(f"Evaluator Agent returned an invalid response: {accuracy_agent_response}")
             return AccuracyEvaluation(
@@ -306,7 +307,7 @@ Remember: You must only compare the agent_output to the expected_output. The exp
     ) -> Optional[AccuracyEvaluation]:
         """Orchestrate the evaluation process asynchronously."""
         try:
-            response = await evaluator_agent.arun(evaluation_input)
+            response = await evaluator_agent.arun(evaluation_input, stream=False)
             accuracy_agent_response = response.content
             if accuracy_agent_response is None or not isinstance(accuracy_agent_response, AccuracyAgentResponse):
                 raise EvalError(f"Evaluator Agent returned an invalid response: {accuracy_agent_response}")
@@ -362,9 +363,11 @@ Remember: You must only compare the agent_output to the expected_output. The exp
                 agent_session_id = f"eval_{self.eval_id}_{i + 1}"
 
                 if self.agent is not None:
-                    output = self.agent.run(input=eval_input, session_id=agent_session_id).content
+                    agent_response = self.agent.run(input=eval_input, session_id=agent_session_id, stream=False)
+                    output = agent_response.content
                 elif self.team is not None:
-                    output = self.team.run(input=eval_input, session_id=agent_session_id).content
+                    team_response = self.team.run(input=eval_input, session_id=agent_session_id, stream=False)
+                    output = team_response.content
 
                 if not output:
                     logger.error(f"Failed to generate a valid answer on iteration {i + 1}: {output}")
@@ -505,11 +508,11 @@ Remember: You must only compare the agent_output to the expected_output. The exp
                 agent_session_id = f"eval_{self.eval_id}_{i + 1}"
 
                 if self.agent is not None:
-                    response = await self.agent.arun(input=eval_input, session_id=agent_session_id)
-                    output = response.content
+                    agent_response = await self.agent.arun(input=eval_input, session_id=agent_session_id, stream=False)
+                    output = agent_response.content
                 elif self.team is not None:
-                    response = await self.team.arun(input=eval_input, session_id=agent_session_id)  # type: ignore
-                    output = response.content
+                    team_response = await self.team.arun(input=eval_input, session_id=agent_session_id, stream=False)
+                    output = team_response.content
 
                 if not output:
                     logger.error(f"Failed to generate a valid answer on iteration {i + 1}: {output}")

--- a/libs/agno/agno/eval/agent_as_judge.py
+++ b/libs/agno/agno/eval/agent_as_judge.py
@@ -281,24 +281,25 @@ class AgentAsJudgeEval(BaseEval):
                 </output>
             """)
 
-            response = evaluator_agent.run(prompt).content
-            if not isinstance(response, (NumericJudgeResponse, BinaryJudgeResponse)):
-                raise EvalError(f"Invalid response: {response}")
+            response = evaluator_agent.run(prompt, stream=False)
+            judge_response = response.content
+            if not isinstance(judge_response, (NumericJudgeResponse, BinaryJudgeResponse)):
+                raise EvalError(f"Invalid response: {judge_response}")
 
             # Determine pass/fail based on scoring strategy and response type
-            if isinstance(response, NumericJudgeResponse):
-                score = response.score
+            if isinstance(judge_response, NumericJudgeResponse):
+                score = judge_response.score
                 passed = score >= self.threshold
             else:  # BinaryJudgeResponse
                 score = None
-                passed = response.passed
+                passed = judge_response.passed
 
             evaluation = AgentAsJudgeEvaluation(
                 input=input,
                 output=output,
                 criteria=self.criteria,
                 score=score,
-                reason=response.reason,
+                reason=judge_response.reason,
                 passed=passed,
             )
 
@@ -332,7 +333,7 @@ class AgentAsJudgeEval(BaseEval):
                 </output>
             """)
 
-            response = await evaluator_agent.arun(prompt)
+            response = await evaluator_agent.arun(prompt, stream=False)
             judge_response = response.content
             if not isinstance(judge_response, (NumericJudgeResponse, BinaryJudgeResponse)):
                 raise EvalError(f"Invalid response: {judge_response}")

--- a/libs/agno/agno/knowledge/embedder/openai.py
+++ b/libs/agno/agno/knowledge/embedder/openai.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from typing_extensions import Literal
 
 from agno.knowledge.embedder.base import Embedder
-from agno.utils.log import log_warning, log_info
+from agno.utils.log import log_info, log_warning
 
 try:
     from openai import AsyncOpenAI

--- a/libs/agno/agno/os/routers/evals/utils.py
+++ b/libs/agno/agno/os/routers/evals/utils.py
@@ -66,14 +66,14 @@ async def run_agent_as_judge_eval(
 
     # Run agent/team to get output
     if agent:
-        agent_response = await agent.arun(eval_run_input.input)
+        agent_response = await agent.arun(eval_run_input.input, stream=False)
         output = str(agent_response.content) if agent_response.content else ""
         model_id = agent.model.id if agent and agent.model else None
         model_provider = agent.model.provider if agent and agent.model else None
         agent_id = agent.id
         team_id = None
     elif team:
-        team_response = await team.arun(eval_run_input.input)
+        team_response = await team.arun(eval_run_input.input, stream=False)
         output = str(team_response.content) if team_response.content else ""
         model_id = team.model.id if team and team.model else None
         model_provider = team.model.provider if team and team.model else None
@@ -125,39 +125,21 @@ async def run_performance_eval(
     default_model: Optional[Model] = None,
 ) -> EvalSchema:
     """Run a performance evaluation for the given agent or team"""
-    # Create sync or async function based on DB type
-    if isinstance(db, AsyncBaseDb):
-        if agent:
+    if agent:
 
-            async def run_component():  # type: ignore
-                return await agent.arun(eval_run_input.input)
+        async def run_component():  # type: ignore
+            return await agent.arun(eval_run_input.input, stream=False)
 
-            model_id = agent.model.id if agent and agent.model else None
-            model_provider = agent.model.provider if agent and agent.model else None
+        model_id = agent.model.id if agent and agent.model else None
+        model_provider = agent.model.provider if agent and agent.model else None
 
-        elif team:
+    elif team:
 
-            async def run_component():  # type: ignore
-                return await team.arun(eval_run_input.input)
+        async def run_component():  # type: ignore
+            return await team.arun(eval_run_input.input, stream=False)
 
-            model_id = team.model.id if team and team.model else None
-            model_provider = team.model.provider if team and team.model else None
-    else:
-        if agent:
-
-            def run_component():  # type: ignore
-                return agent.run(eval_run_input.input)
-
-            model_id = agent.model.id if agent and agent.model else None
-            model_provider = agent.model.provider if agent and agent.model else None
-
-        elif team:
-
-            def run_component():
-                return team.run(eval_run_input.input)
-
-            model_id = team.model.id if team and team.model else None
-            model_provider = team.model.provider if team and team.model else None
+        model_id = team.model.id if team and team.model else None
+        model_provider = team.model.provider if team and team.model else None
 
     performance_eval = PerformanceEval(
         db=db,
@@ -171,11 +153,7 @@ async def run_performance_eval(
         model_provider=model_provider,
     )
 
-    # PerformanceEval needs sync/async check because it wraps a function
-    if isinstance(db, AsyncBaseDb):
-        result = await performance_eval.arun(print_results=False, print_summary=False)
-    else:
-        result = performance_eval.run(print_results=False, print_summary=False)
+    result = await performance_eval.arun(print_results=False, print_summary=False)
     if not result:
         raise HTTPException(status_code=500, detail="Failed to run performance evaluation")
 
@@ -210,7 +188,7 @@ async def run_reliability_eval(
         raise HTTPException(status_code=400, detail="expected_tool_calls is required for reliability evaluations")
 
     if agent:
-        agent_response = await agent.arun(eval_run_input.input)
+        agent_response = await agent.arun(eval_run_input.input, stream=False)
         reliability_eval = ReliabilityEval(
             db=db,
             name=eval_run_input.name,
@@ -221,7 +199,7 @@ async def run_reliability_eval(
         model_provider = agent.model.provider if agent and agent.model else None
 
     elif team:
-        team_response = await team.arun(eval_run_input.input)
+        team_response = await team.arun(eval_run_input.input, stream=False)
         reliability_eval = ReliabilityEval(
             db=db,
             name=eval_run_input.name,

--- a/libs/agno/agno/vectordb/pgvector/pgvector.py
+++ b/libs/agno/agno/vectordb/pgvector/pgvector.py
@@ -28,7 +28,7 @@ from agno.filters import FilterExpr
 from agno.knowledge.document import Document
 from agno.knowledge.embedder import Embedder
 from agno.knowledge.reranker.base import Reranker
-from agno.utils.log import log_debug, log_info, log_error, log_warning
+from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.vectordb.base import VectorDb
 from agno.vectordb.distance import Distance
 from agno.vectordb.pgvector.index import HNSW, Ivfflat


### PR DESCRIPTION
## Summary

 When running evals, we get an error `AttributeError: 'generator' object has no attribute 'content'` if the agent being has `stream=True` enabled.

Added `stream=False` to all agent/team/evaluator runs in evals

(If applicable, issue number: #5659)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
