### PR TITLE
feat: add conventional A2A endpoints

### DIFF
--- a/libs/agno/agno/os/interfaces/a2a/router.py
+++ b/libs/agno/agno/os/interfaces/a2a/router.py
@@ -77,7 +77,7 @@ def attach_routes(
         warnings.warn("This endpoint is deprecated. Use /v1/message:send instead.")
 
         request_body = await request.json()
-        kwargs = await _get_request_kwargs(request, a2a_send_message)
+        kwargs = await get_request_kwargs(request, a2a_send_message)
 
         # 1. Get the Agent, Team, or Workflow to run
         agent_id = request_body.get("params", {}).get("message", {}).get("agentId") or request.headers.get("X-Agent-ID")
@@ -185,7 +185,7 @@ def attach_routes(
         warnings.warn("This endpoint is deprecated. Use /v1/message:stream instead.")
 
         request_body = await request.json()
-        kwargs = await _get_request_kwargs(request, a2a_stream_message)
+        kwargs = await get_request_kwargs(request, a2a_stream_message)
 
         # 1. Get the Agent, Team, or Workflow to run
         agent_id = request_body.get("params", {}).get("message", {}).get("agentId")


### PR DESCRIPTION
- Our A2A endpoints `/message/send` and `/message/stream` are not conventional
- Add a deprecation warning to them
- Add the conventional `v1/message:send` and `v1/message:stream`, as per the [latest protocol definition](https://a2a-protocol.org/v0.3.0/specification/#356-method-mapping-reference-table)

Note: merge together with the incoming new card endpoints