### PR TITLE
[fix] Correct json_contains_any syntax in Milvus _build_expr

### DIFF
--- a/libs/agno/agno/vectordb/milvus/milvus.py
+++ b/libs/agno/agno/vectordb/milvus/milvus.py
@@ -1099,7 +1099,7 @@ class Milvus(VectorDb):
             if isinstance(v, (list, tuple)):
                 # For array values, use json_contains_any
                 values_str = json.dumps(v)
-                expr = f'json_contains_any(meta_data, {values_str}, "{k}")'
+                expr = f'json_contains_any(meta_data["{k}"], {values_str})'
             elif isinstance(v, str):
                 # For string values
                 expr = f'meta_data["{k}"] == "{v}"'

--- a/libs/agno/tests/unit/vectordb/test_milvusdb.py
+++ b/libs/agno/tests/unit/vectordb/test_milvusdb.py
@@ -307,7 +307,7 @@ def test_build_expr(milvus_db):
 
     # Test with list value
     filters = {"tags": ["tag1", "tag2"]}
-    assert milvus_db._build_expr(filters) == 'json_contains_any(meta_data, ["tag1", "tag2"], "tags")'
+    assert milvus_db._build_expr(filters) == 'json_contains_any(meta_data["tags"], ["tag1", "tag2"])'
 
     # Test with None value
     filters = {"field": None}


### PR DESCRIPTION
## Summary

This PR fixes an incorrect construction of the `json_contains_any` filter expression in the Milvus VectorDB implementation.

Milvus requires the syntax:

    json_contains_any(meta_data["key"], ["value1", "value2"])

but agno previously generated:

    json_contains_any(meta_data, ["value1", "value2"], "key")

This caused Milvus query plan parsing failures such as:

`mismatched input ',' expecting ')': invalid parameter`

The `_build_expr()` function now correctly builds two-parameter JSON filter expressions, and the unit tests have been updated accordingly.

Fixes #5536

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran `./scripts/format.sh` and `./scripts/validate.sh`
- [x] Tests updated
- [x] All local tests pass
