### PR TITLE
fix: resolve BaseEval circular import [SDK-387]

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -9,7 +9,6 @@ from inspect import iscoroutinefunction
 from os import getenv
 from textwrap import dedent
 from typing import (
-    TYPE_CHECKING,
     Any,
     AsyncIterator,
     Callable,
@@ -31,13 +30,11 @@ from uuid import uuid4
 
 from pydantic import BaseModel
 
-if TYPE_CHECKING:
-    from agno.eval.base import BaseEval
-
 from agno.compression.manager import CompressionManager
 from agno.culture.manager import CultureManager
 from agno.db.base import AsyncBaseDb, BaseDb, SessionType, UserMemory
 from agno.db.schemas.culture import CulturalKnowledge
+from agno.eval.base import BaseEval
 from agno.exceptions import (
     InputCheckError,
     OutputCheckError,
@@ -280,9 +277,9 @@ class Agent:
 
     # --- Agent Hooks ---
     # Functions called right after agent-session is loaded, before processing starts
-    pre_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, "BaseEval"]]] = None
+    pre_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, BaseEval]]] = None
     # Functions called after output is generated but before the response is returned
-    post_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, "BaseEval"]]] = None
+    post_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, BaseEval]]] = None
     # If True, run hooks as FastAPI background tasks (non-blocking). Set by AgentOS.
     _run_hooks_in_background: Optional[bool] = None
 
@@ -487,8 +484,8 @@ class Agent:
         tool_call_limit: Optional[int] = None,
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         tool_hooks: Optional[List[Callable]] = None,
-        pre_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, "BaseEval"]]] = None,
-        post_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, "BaseEval"]]] = None,
+        pre_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, BaseEval]]] = None,
+        post_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, BaseEval]]] = None,
         reasoning: bool = False,
         reasoning_model: Optional[Union[Model, str]] = None,
         reasoning_agent: Optional[Agent] = None,

--- a/libs/agno/agno/eval/__init__.py
+++ b/libs/agno/agno/eval/__init__.py
@@ -1,12 +1,4 @@
-from agno.eval.accuracy import AccuracyAgentResponse, AccuracyEval, AccuracyEvaluation, AccuracyResult
-from agno.eval.agent_as_judge import (
-    AgentAsJudgeEval,
-    AgentAsJudgeEvaluation,
-    AgentAsJudgeResult,
-)
 from agno.eval.base import BaseEval
-from agno.eval.performance import PerformanceEval, PerformanceResult
-from agno.eval.reliability import ReliabilityEval, ReliabilityResult
 
 __all__ = [
     "AccuracyAgentResponse",
@@ -22,3 +14,24 @@ __all__ = [
     "ReliabilityEval",
     "ReliabilityResult",
 ]
+
+
+def __getattr__(name: str):
+    """Lazy import for eval implementations to avoid circular imports with Agent."""
+    if name in ("AccuracyAgentResponse", "AccuracyEval", "AccuracyEvaluation", "AccuracyResult"):
+        from agno.eval import accuracy
+
+        return getattr(accuracy, name)
+    elif name in ("AgentAsJudgeEval", "AgentAsJudgeEvaluation", "AgentAsJudgeResult"):
+        from agno.eval import agent_as_judge
+
+        return getattr(agent_as_judge, name)
+    elif name in ("PerformanceEval", "PerformanceResult"):
+        from agno.eval import performance
+
+        return getattr(performance, name)
+    elif name in ("ReliabilityEval", "ReliabilityResult"):
+        from agno.eval import reliability
+
+        return getattr(reliability, name)
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass
 from os import getenv
 from textwrap import dedent
 from typing import (
-    TYPE_CHECKING,
     Any,
     AsyncIterator,
     Callable,
@@ -33,12 +32,10 @@ from uuid import uuid4
 
 from pydantic import BaseModel
 
-if TYPE_CHECKING:
-    from agno.eval.base import BaseEval
-
 from agno.agent import Agent
 from agno.compression.manager import CompressionManager
 from agno.db.base import AsyncBaseDb, BaseDb, SessionType, UserMemory
+from agno.eval.base import BaseEval
 from agno.exceptions import (
     InputCheckError,
     OutputCheckError,
@@ -354,9 +351,9 @@ class Team:
 
     # --- Team Hooks ---
     # Functions called right after team session is loaded, before processing starts
-    pre_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, "BaseEval"]]] = None
+    pre_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, BaseEval]]] = None
     # Functions called after output is generated but before the response is returned
-    post_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, "BaseEval"]]] = None
+    post_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, BaseEval]]] = None
     # If True, run hooks as FastAPI background tasks (non-blocking). Set by AgentOS.
     _run_hooks_in_background: Optional[bool] = None
 
@@ -525,8 +522,8 @@ class Team:
         tool_call_limit: Optional[int] = None,
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         tool_hooks: Optional[List[Callable]] = None,
-        pre_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, "BaseEval"]]] = None,
-        post_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, "BaseEval"]]] = None,
+        pre_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, BaseEval]]] = None,
+        post_hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, BaseEval]]] = None,
         input_schema: Optional[Type[BaseModel]] = None,
         output_schema: Optional[Type[BaseModel]] = None,
         parser_model: Optional[Union[Model, str]] = None,

--- a/libs/agno/agno/utils/hooks.py
+++ b/libs/agno/agno/utils/hooks.py
@@ -1,9 +1,7 @@
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
-if TYPE_CHECKING:
-    from agno.eval.base import BaseEval
-
+from agno.eval.base import BaseEval
 from agno.guardrails.base import BaseGuardrail
 from agno.hooks.decorator import HOOK_RUN_IN_BACKGROUND_ATTR
 from agno.utils.log import log_warning
@@ -57,7 +55,7 @@ def should_run_hook_in_background(hook: Callable[..., Any]) -> bool:
 
 
 def normalize_pre_hooks(
-    hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, "BaseEval"]]],
+    hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, BaseEval]]],
     async_mode: bool = False,
 ) -> Optional[List[Callable[..., Any]]]:
     """Normalize pre-hooks to a list format.
@@ -66,8 +64,6 @@ def normalize_pre_hooks(
         hooks: List of hook functions, guardrails, or eval instances
         async_mode: Whether to use async versions of methods
     """
-    from agno.eval.base import BaseEval
-
     result_hooks: List[Callable[..., Any]] = []
 
     if hooks is not None:
@@ -102,7 +98,7 @@ def normalize_pre_hooks(
 
 
 def normalize_post_hooks(
-    hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, "BaseEval"]]],
+    hooks: Optional[List[Union[Callable[..., Any], BaseGuardrail, BaseEval]]],
     async_mode: bool = False,
 ) -> Optional[List[Callable[..., Any]]]:
     """Normalize post-hooks to a list format.
@@ -111,8 +107,6 @@ def normalize_post_hooks(
         hooks: List of hook functions, guardrails, or eval instances
         async_mode: Whether to use async versions of methods
     """
-    from agno.eval.base import BaseEval
-
     result_hooks: List[Callable[..., Any]] = []
 
     if hooks is not None:


### PR DESCRIPTION
## Summary

Tools with agent: Agent param were failing because Pydantic couldn't find BaseEval at runtime. Fixed by making eval imports lazy to break the circular import chain.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
