### PR TITLE
feat: support OpenRouter reasoning blocks

### DIFF
--- a/libs/agno/agno/models/openrouter/openrouter.py
+++ b/libs/agno/agno/models/openrouter/openrouter.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel
 
 from agno.exceptions import ModelAuthenticationError
 from agno.models.openai.like import OpenAILike
+from agno.models.message import Message
+from agno.models.response import ModelResponse
 from agno.run.agent import RunOutput
 
 
@@ -21,9 +23,11 @@ class OpenRouter(OpenAILike):
         api_key (Optional[str]): The API key.
         base_url (str): The base URL. Defaults to "https://openrouter.ai/api/v1".
         max_tokens (int): The maximum number of tokens. Defaults to 1024.
-        fallback_models (Optional[List[str]]): List of fallback model IDs to use if the primary model
+        models (Optional[List[str]]): List of fallback model IDs to use if the primary model
             fails due to rate limits, timeouts, or unavailability. OpenRouter will automatically try
             these models in order. Example: ["anthropic/claude-sonnet-4", "deepseek/deepseek-r1"]
+        preserve_reasoning (Optional[bool]): Preserve reasoning blocks for Gemini models.
+            See: https://openrouter.ai/docs/guides/best-practices/reasoning-tokens#preserving-reasoning-blocks
     """
 
     id: str = "gpt-4o"
@@ -34,6 +38,13 @@ class OpenRouter(OpenAILike):
     base_url: str = "https://openrouter.ai/api/v1"
     max_tokens: int = 1024
     models: Optional[List[str]] = None  # Dynamic model routing https://openrouter.ai/docs/features/model-routing
+    preserve_reasoning: Optional[bool] = None  # Auto-detect for Gemini models
+
+    def _should_preserve_reasoning(self) -> bool:
+        """Check if reasoning blocks should be preserved (auto-detect for Gemini models)."""
+        if self.preserve_reasoning is not None:
+            return self.preserve_reasoning
+        return bool(self.id and "gemini" in self.id.lower())
 
     def _get_client_params(self) -> Dict[str, Any]:
         """
@@ -60,26 +71,66 @@ class OpenRouter(OpenAILike):
         tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
         run_response: Optional[RunOutput] = None,
     ) -> Dict[str, Any]:
-        """
-        Returns keyword arguments for API requests, including fallback models configuration.
-
-        Returns:
-            Dict[str, Any]: A dictionary of keyword arguments for API requests.
-        """
-        # Get base request params from parent class
+        """Returns request params with fallback models and reasoning preservation."""
         request_params = super().get_request_params(
             response_format=response_format, tools=tools, tool_choice=tool_choice, run_response=run_response
         )
-
-        # Add fallback models to extra_body if specified
+        extra_body = request_params.get("extra_body") or {}
         if self.models:
-            # Get existing extra_body or create new dict
-            extra_body = request_params.get("extra_body") or {}
-
-            # Merge fallback models into extra_body
             extra_body["models"] = self.models
-
-            # Update request params
+        if self._should_preserve_reasoning():
+            extra_body["transforms"] = ["preserve_reasoning"]
+        if extra_body:
             request_params["extra_body"] = extra_body
-
         return request_params
+
+    def _format_message(self, message: Message, compress_tool_results: bool = False) -> Dict[str, Any]:
+        """Format message, preserving reasoning_details for Gemini function calling."""
+        message_dict = super()._format_message(message, compress_tool_results=compress_tool_results)
+        # Preserve reasoning_details in assistant messages with tool calls
+        if self._should_preserve_reasoning() and message.role == "assistant" and message.tool_calls:
+            if message.provider_data and message.provider_data.get("reasoning_details"):
+                message_dict["reasoning_details"] = message.provider_data["reasoning_details"]
+        return message_dict
+
+    def _extract_reasoning_from_obj(self, obj: Any) -> tuple[Any, Optional[str]]:
+        """Extract reasoning_details and reasoning text from a response object."""
+        reasoning_details = getattr(obj, 'reasoning_details', None)
+        if not reasoning_details and hasattr(obj, 'model_extra') and obj.model_extra:
+            reasoning_details = obj.model_extra.get('reasoning_details')
+        reasoning_text = getattr(obj, 'reasoning', None)
+        if not reasoning_text and hasattr(obj, 'model_extra') and obj.model_extra:
+            reasoning_text = obj.model_extra.get('reasoning')
+        return reasoning_details, reasoning_text
+
+    def _apply_reasoning_to_response(self, model_response: ModelResponse, obj: Any) -> None:
+        """Apply extracted reasoning data to model response."""
+        reasoning_details, reasoning_text = self._extract_reasoning_from_obj(obj)
+        if reasoning_details:
+            if model_response.provider_data is None:
+                model_response.provider_data = {}
+            model_response.provider_data["reasoning_details"] = reasoning_details
+        if reasoning_text and model_response.reasoning_content is None:
+            model_response.reasoning_content = reasoning_text
+
+    def _parse_provider_response(
+        self,
+        response: Any,
+        response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
+    ) -> ModelResponse:
+        """Parse response, extracting reasoning_details for Gemini models."""
+        model_response = super()._parse_provider_response(response, response_format=response_format)
+        if self._should_preserve_reasoning() and hasattr(response, 'choices') and response.choices:
+            message = getattr(response.choices[0], 'message', None)
+            if message:
+                self._apply_reasoning_to_response(model_response, message)
+        return model_response
+
+    def _parse_provider_response_delta(self, response_delta: Any) -> ModelResponse:
+        """Parse streaming delta, extracting reasoning_details."""
+        model_response = super()._parse_provider_response_delta(response_delta)
+        if self._should_preserve_reasoning() and hasattr(response_delta, 'choices') and response_delta.choices:
+            delta = getattr(response_delta.choices[0], 'delta', None)
+            if delta:
+                self._apply_reasoning_to_response(model_response, delta)
+        return model_response

--- a/libs/agno/tests/integration/models/openrouter/test_tool_use.py
+++ b/libs/agno/tests/integration/models/openrouter/test_tool_use.py
@@ -8,10 +8,14 @@ from agno.tools.duckduckgo import DuckDuckGoTools
 from agno.tools.exa import ExaTools
 from agno.tools.yfinance import YFinanceTools
 
+# Test both OpenAI and Gemini models to verify reasoning blocks preservation
+MODEL_IDS = ["gpt-4o", "google/gemini-3-flash-preview"]
 
-def test_tool_use():
+
+@pytest.mark.parametrize("model_id", MODEL_IDS)
+def test_tool_use(model_id):
     agent = Agent(
-        model=OpenRouter(id="gpt-4o"),
+        model=OpenRouter(id=model_id),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -26,9 +30,10 @@ def test_tool_use():
     assert "TSLA" in response.content
 
 
-def test_tool_use_stream():
+@pytest.mark.parametrize("model_id", MODEL_IDS)
+def test_tool_use_stream(model_id):
     agent = Agent(
-        model=OpenRouter(id="gpt-4o"),
+        model=OpenRouter(id=model_id),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -51,9 +56,10 @@ def test_tool_use_stream():
 
 
 @pytest.mark.asyncio
-async def test_async_tool_use():
+@pytest.mark.parametrize("model_id", MODEL_IDS)
+async def test_async_tool_use(model_id):
     agent = Agent(
-        model=OpenRouter(id="gpt-4o"),
+        model=OpenRouter(id=model_id),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -69,9 +75,10 @@ async def test_async_tool_use():
 
 
 @pytest.mark.asyncio
-async def test_async_tool_use_stream():
+@pytest.mark.parametrize("model_id", MODEL_IDS)
+async def test_async_tool_use_stream(model_id):
     agent = Agent(
-        model=OpenRouter(id="gpt-4o"),
+        model=OpenRouter(id=model_id),
         tools=[YFinanceTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -93,9 +100,10 @@ async def test_async_tool_use_stream():
         full_content += r.content or "" or ""
 
 
-def test_multiple_tool_calls():
+@pytest.mark.parametrize("model_id", MODEL_IDS)
+def test_multiple_tool_calls(model_id):
     agent = Agent(
-        model=OpenRouter(id="gpt-4o"),
+        model=OpenRouter(id=model_id),
         tools=[YFinanceTools(cache_results=True), DuckDuckGoTools(cache_results=True)],
         markdown=True,
         telemetry=False,
@@ -114,7 +122,8 @@ def test_multiple_tool_calls():
     assert "TSLA" in response.content and "latest news" in response.content.lower()
 
 
-def test_tool_call_custom_tool_no_parameters():
+@pytest.mark.parametrize("model_id", MODEL_IDS)
+def test_tool_call_custom_tool_no_parameters(model_id):
     def get_the_weather_in_tokyo():
         """
         Get the weather in Tokyo
@@ -122,7 +131,7 @@ def test_tool_call_custom_tool_no_parameters():
         return "It is currently 70 degrees and cloudy in Tokyo"
 
     agent = Agent(
-        model=OpenRouter(id="gpt-4o"),
+        model=OpenRouter(id=model_id),
         tools=[get_the_weather_in_tokyo],
         markdown=True,
         telemetry=False,
@@ -137,7 +146,8 @@ def test_tool_call_custom_tool_no_parameters():
     assert "70" in response.content
 
 
-def test_tool_call_custom_tool_optional_parameters():
+@pytest.mark.parametrize("model_id", MODEL_IDS)
+def test_tool_call_custom_tool_optional_parameters(model_id):
     def get_the_weather(city: Optional[str] = None):
         """
         Get the weather in a city
@@ -151,7 +161,7 @@ def test_tool_call_custom_tool_optional_parameters():
             return f"It is currently 70 degrees and cloudy in {city}"
 
     agent = Agent(
-        model=OpenRouter(id="gpt-4o"),
+        model=OpenRouter(id=model_id),
         tools=[get_the_weather],
         markdown=True,
         telemetry=False,


### PR DESCRIPTION
## Summary

Fix OpenRouter Gemini models failing when using function calling due to missing reasoning blocks preservation.

When using Gemini models (e.g., `google/gemini-3-flash-preview`) via OpenRouter with tools/function calling, the API requires preserving `reasoning_details` in subsequent requests. Without this, the model fails with errors after tool execution.

**Changes:**
- Added `preserve_reasoning` parameter with auto-detection for Gemini models
- Added `transforms: ["preserve_reasoning"]` to request params for Gemini models
- Extract and store `reasoning_details` from API responses in `provider_data`
- Preserve `reasoning_details` in assistant messages when formatting for subsequent requests
- Updated integration tests to cover both `gpt-4o` and `google/gemini-3-flash-preview`

**Reference:** 
- [OpenRouter - Preserving Reasoning Blocks](https://openrouter.ai/docs/guides/best-practices/reasoning-tokens#preserving-reasoning-blocks)
- Related PR: https://github.com/agno-agi/agno/pull/5454

Fixes https://github.com/agno-agi/agno/issues/5329

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

**Files changed:**
- `libs/agno/agno/models/openrouter/openrouter.py` - Core implementation
- `libs/agno/tests/integration/models/openrouter/test_tool_use.py` - Added Gemini model coverage

**New attribute:**
```python
OpenRouter(
    id="google/gemini-3-flash-preview",
    preserve_reasoning=True  # Auto-detected for Gemini models, can be explicitly set
)
```

**Backward compatible:** Yes. The feature auto-enables for Gemini models and has no effect on other models like GPT-4o.
