### PR TITLE
feat: Add httpx client support to MCP tools for SSL verification control (#5812)

### DIFF
--- a/cookbook/14_tools/mcp/mcp_toolbox_demo/pyproject.toml
+++ b/cookbook/14_tools/mcp/mcp_toolbox_demo/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 dependencies = [
     "agno",
     "fastapi>=0.116.1",
-    "mcp>=1.12.2",
+    "mcp>=1.25.0",
     "openai>=1.97.1",
     "sqlalchemy>=2.0.43",
     "toolbox-core>=0.4.0",

--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -55,7 +55,7 @@ class MCPTools(Toolkit):
             command: The command to run to start the server. Should be used in conjunction with env.
             url: The URL endpoint for SSE or Streamable HTTP connection when transport is "sse" or "streamable-http".
             env: The environment variables to pass to the server. Should be used in conjunction with command.
-            client: The underlying MCP client (optional, used to prevent garbage collection)
+            client: Custom httpx AsyncClient for Streamable HTTP connections (optional, allows SSL verification control)
             timeout_seconds: Read timeout in seconds for the MCP client
             include_tools: Optional list of tool names to include (if None, includes all)
             exclude_tools: Optional list of tool names to exclude (if None, excludes none)
@@ -199,27 +199,27 @@ class MCPTools(Toolkit):
             streamable_http_params = {}
             if self.server_params is not None:
                 # Temporarily remove http_client to avoid pickle issues with asdict
-                http_client = getattr(self.server_params, 'http_client', None)
+                http_client = getattr(self.server_params, "http_client", None)
                 if http_client is not None:
                     self.server_params.http_client = None
-                
+
                 streamable_http_params = asdict(self.server_params)  # type: ignore
-                
+
                 # Restore and add http_client
                 if http_client is not None:
                     self.server_params.http_client = http_client
                     streamable_http_params["http_client"] = http_client
-                
+
                 # Remove deprecated parameters not accepted by streamable_http_client
                 streamable_http_params.pop("headers", None)
                 streamable_http_params.pop("timeout", None)
                 streamable_http_params.pop("sse_read_timeout", None)
-                
+
                 if "url" not in streamable_http_params:
                     streamable_http_params["url"] = self.url
             else:
                 streamable_http_params["url"] = self.url
-            
+
             self._context = streamable_http_client(**streamable_http_params)  # type: ignore
             client_timeout = self.timeout_seconds
 

--- a/libs/agno/agno/tools/mcp/multi_mcp.py
+++ b/libs/agno/agno/tools/mcp/multi_mcp.py
@@ -239,22 +239,22 @@ class MultiMCPTools(Toolkit):
                 # Handle Streamable HTTP connections
                 elif isinstance(server_params, StreamableHTTPClientParams):
                     # Temporarily remove http_client to avoid pickle issues with asdict
-                    http_client = getattr(server_params, 'http_client', None)
+                    http_client = getattr(server_params, "http_client", None)
                     if http_client is not None:
                         server_params.http_client = None
-                    
+
                     streamable_http_params = asdict(server_params)
-                    
+
                     # Restore and add http_client
                     if http_client is not None:
                         server_params.http_client = http_client
                         streamable_http_params["http_client"] = http_client
-                    
+
                     # Remove deprecated parameters not accepted by streamable_http_client
                     streamable_http_params.pop("headers", None)
                     streamable_http_params.pop("timeout", None)
                     streamable_http_params.pop("sse_read_timeout", None)
-                    
+
                     client_connection = await self._async_exit_stack.enter_async_context(
                         streamable_http_client(**streamable_http_params)
                     )

--- a/libs/agno/agno/tools/mcp/params.py
+++ b/libs/agno/agno/tools/mcp/params.py
@@ -1,4 +1,4 @@
-﻿from dataclasses import dataclass
+from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, Dict, Optional
 

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -117,7 +117,7 @@ gmail = ["google-api-python-client", "google-auth-httplib2", "google-auth-oauthl
 google_bigquery = ["google-cloud-bigquery"]
 googlemaps = ["googlemaps", "google-maps-places"]
 matplotlib = ["matplotlib"]
-mcp = ["mcp>=1.9.2"]
+mcp = ["mcp>=1.25.0"]
 mem0 = ["mem0ai"]
 memori = ["memorisdk==3.0.5"]
 newspaper = ["newspaper4k", "lxml_html_clean"]


### PR DESCRIPTION
## Summary

This PR addresses issue #5812 by adding support for passing custom httpx clients to MCP tools, enabling SSL verification control (e.g., `verify=False` for self-signed certificates). The implementation is updated for MCP 1.25.0 compatibility with the new `streamable_http_client`.

Issue number: #5812

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

The changes include:
- Added `http_client` field to `StreamableHTTPClientParams`
- Modified `MCPTools` to accept and use the `client` parameter
- Fixed import typo for `streamable_http_client` (MCP 1.25.0)
- Updated connection logic to handle `http_client` properly
- Updated MCP version requirements to >=1.25.0

Usage example:
```python
import httpx
from agno.tools.mcp import MCPTools

client = httpx.AsyncClient(verify=False)
async with MCPTools(url="https://example.com/mcp", transport="streamable-http", client=client) as mcp:
    pass