### PR TITLE
fix: better handling for memories migrated from v1

### DIFF
--- a/libs/agno/agno/os/routers/memory/schemas.py
+++ b/libs/agno/agno/os/routers/memory/schemas.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
@@ -26,17 +27,23 @@ class UserMemorySchema(BaseModel):
             return None
 
         # Handle nested memory content (relevant for some memories migrated from v1)
-        if (memory := memory_dict["memory"].get("memory")) is not None:
-            memory_content = str(memory) if isinstance(memory, dict) else memory
+        if isinstance(memory_dict["memory"], dict):
+            if memory_dict["memory"].get("memory") is not None:
+                memory = str(memory_dict["memory"]["memory"])
+            else:
+                try:
+                    memory = json.dumps(memory_dict["memory"])
+                except json.JSONDecodeError:
+                    memory = str(memory_dict["memory"])
         else:
-            memory_content = str(memory_dict["memory"])
+            memory = memory_dict["memory"]
 
         return cls(
             memory_id=memory_dict["memory_id"],
             user_id=str(memory_dict["user_id"]),
             agent_id=memory_dict.get("agent_id"),
             team_id=memory_dict.get("team_id"),
-            memory=memory_content,
+            memory=memory,
             topics=memory_dict.get("topics", []),
             updated_at=memory_dict["updated_at"],
         )

--- a/libs/agno/tests/unit/os/test_schemas.py
+++ b/libs/agno/tests/unit/os/test_schemas.py
@@ -1,0 +1,56 @@
+"""Tests our API schemas handle all expected parsing."""
+
+import json
+
+from agno.os.routers.memory.schemas import UserMemorySchema
+
+
+def test_user_memory_schema():
+    """Test that our UserMemorySchema handle common memory objects."""
+    memory_dict = {
+        "memory_id": "123",
+        "memory": "This is a test memory",
+        "topics": ["test", "memory"],
+        "user_id": "456",
+        "agent_id": "789",
+        "team_id": "101",
+        "updated_at": 1719859200,
+        "created_at": 1719859200,
+    }
+    user_memory_schema = UserMemorySchema.from_dict(memory_dict)
+    assert user_memory_schema is not None
+    assert user_memory_schema.memory == "This is a test memory"
+    assert user_memory_schema.topics == ["test", "memory"]
+    assert user_memory_schema.user_id == "456"
+    assert user_memory_schema.agent_id == "789"
+    assert user_memory_schema.team_id == "101"
+
+
+def test_v1_migrated_user_memories():
+    """Test that our UserMemorySchema handles v1 migrated memories."""
+    memory_dict = {
+        "memory_id": "123",
+        "user_id": "456",
+        "memory": {"memory": "This is a test memory", "other": "other"},
+        "input": "This is a test input",
+        "updated_at": 1719859200,
+    }
+    user_memory_schema = UserMemorySchema.from_dict(memory_dict)
+    assert user_memory_schema is not None
+    assert user_memory_schema.memory == "This is a test memory"
+
+
+def test_user_memory_schema_complex_memory_content():
+    """Test that our UserMemorySchema handles custom, complex memory content."""
+    complex_content = {"user_mem": "This is a test memory", "score": "10", "other_fields": "other_fields"}
+    memory_dict = {
+        "memory_id": "123",
+        "user_id": "456",
+        "memory": complex_content,
+        "input": "This is a test input",
+        "updated_at": 1719859200,
+    }
+    user_memory_schema = UserMemorySchema.from_dict(memory_dict)
+    assert user_memory_schema is not None
+    assert json.loads(user_memory_schema.memory) == complex_content
+    assert user_memory_schema.user_id == "456"


### PR DESCRIPTION
Some memories migrated from v1 (depending on the specific version where they were generated) contain a JSON in the `memory` field where we now expect a simple string. This adds some parsing to better handle that case. 
