### PR TITLE
[fix] Add response_usage propagation to model response

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1016,6 +1016,8 @@ class Model(ABC):
             model_response.extra.update(provider_response.extra)
         if provider_response.provider_data is not None:
             model_response.provider_data = provider_response.provider_data
+        if provider_response.response_usage is not None:
+            model_response.response_usage = provider_response.response_usage
 
     async def _aprocess_model_response(
         self,
@@ -1073,6 +1075,8 @@ class Model(ABC):
             model_response.extra.update(provider_response.extra)
         if provider_response.provider_data is not None:
             model_response.provider_data = provider_response.provider_data
+        if provider_response.response_usage is not None:
+            model_response.response_usage = provider_response.response_usage
 
     def _populate_assistant_message(
         self,


### PR DESCRIPTION
## Summary

This PR ensures that `response_usage` data from the provider response is properly propagated to the model response.

## Changes

- Added `response_usage` propagation in `_process_model_response()` method
- Added `response_usage` propagation in `_aprocess_model_response()` method (async version)

## Motivation

The `response_usage` field contains important usage metrics from the provider (like token counts) that should be included in the model response for tracking and debugging purposes. This fix ensures that this data is not lost during response processing.

## Testing

- Verified that response_usage is now properly included in the model response
- Both sync and async code paths have been updated consistently