### PR TITLE
fix: add pagination limit validation to prevent 500 error on /sessions endpoint

### DIFF
--- a/libs/agno/agno/os/routers/session/session.py
+++ b/libs/agno/agno/os/routers/session/session.py
@@ -34,6 +34,9 @@ from agno.session import AgentSession, TeamSession, WorkflowSession
 
 logger = logging.getLogger(__name__)
 
+# Maximum number of items per page for pagination
+MAX_PAGE_SIZE = 100
+
 
 def get_session_router(
     dbs: dict[str, list[Union[BaseDb, AsyncBaseDb, RemoteDb]]], settings: AgnoAPISettings = AgnoAPISettings()
@@ -107,7 +110,9 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
         ),
         user_id: Optional[str] = Query(default=None, description="Filter sessions by user ID"),
         session_name: Optional[str] = Query(default=None, description="Filter sessions by name (partial match)"),
-        limit: Optional[int] = Query(default=20, description="Number of sessions to return per page"),
+        limit: Optional[int] = Query(
+            default=20, description=f"Number of sessions to return per page (max: {MAX_PAGE_SIZE})", le=MAX_PAGE_SIZE, ge=1
+        ),
         page: Optional[int] = Query(default=1, description="Page number for pagination"),
         sort_by: Optional[str] = Query(default="created_at", description="Field to sort sessions by"),
         sort_order: Optional[SortOrder] = Query(default="desc", description="Sort order (asc or desc)"),


### PR DESCRIPTION
## Description

### Problem
Calling `GET /sessions?limit=XXX` with a limit value greater than 100 results in a **500 Internal Server Error** instead of a proper validation response. This happens because:

1. The endpoint accepts any integer value for the `limit` parameter
2. The `PaginationInfo` Pydantic model has a constraint `le=100` on the `limit` field
3. When limit > 100, Pydantic validation fails during response construction, causing an unhandled validation error

**Error trace:**
```python
pydantic_core._pydantic_core.ValidationError: 1 validation error for PaginationInfo
limit
  Input should be less than or equal to 100 [type=less_than_equal, input_value=120, input_type=int]
```

### Solution
Implemented **explicit request validation** at the endpoint level using FastAPI's Query parameter validation:

- Added `MAX_PAGE_SIZE = 100` constant as single source of truth
- Added `le=MAX_PAGE_SIZE, ge=1` constraints to the `limit` Query parameter
- Updated API documentation to indicate the maximum page size
- FastAPI now returns a proper **422 Validation Error** with clear error message

This approach provides:
- Proper HTTP semantics: 422 for validation errors instead of 500 for server errors
- Clear error messages: Users know exactly what went wrong
- Defense in depth: Validation at both request level (FastAPI) and response level (Pydantic)
- Maintainability: Single constant for max page size
- API documentation: Constraints visible in OpenAPI spec

### Changes Made

**File: `libs/agno/agno/os/routers/session/session.py`**

1. Added `MAX_PAGE_SIZE = 100` constant (line 38)
2. Added validation constraints to `limit` parameter: `le=MAX_PAGE_SIZE, ge=1` (line 114)
3. Updated query parameter documentation to show max limit

### Before vs After

**Before:**
```bash
GET /sessions?limit=120
→ 500 Internal Server Error
{
  "detail": "Internal server error"
}
```

**After:**
```bash
GET /sessions?limit=120
→ 422 Unprocessable Entity
{
  "detail": [
    {
      "type": "less_than_equal",
      "loc": ["query", "limit"],
      "msg": "Input should be less than or equal to 100",
      "input": "120"
    }
  ]
}
```

### Testing
- Test with `limit=150`: Should return **422** with validation error
- Test with `limit=0`: Should return **422** (must be >= 1)
- Test with `limit=100`: Should return **200** with data
- Test with `limit=50`: Should return **200** with data
- Existing tests continue to pass
- No breaking changes to valid API usage

### API Contract
- Valid range: `1 <= limit <= 100`
- Default: `20`
- Invalid requests now properly return 422 instead of 500

Fixes #5855

---

**Design Notes:**
- This follows REST best practices: 422 for client validation errors, not 500
- The OpenAPI spec now documents these constraints automatically
- Alternative approach (graceful clamping) was considered but rejected in favor of explicit validation for clearer API contracts