### PR TITLE
fix: GoogleBigQueryTools SQL statements parsing

### DIFF
--- a/libs/agno/agno/tools/google_bigquery.py
+++ b/libs/agno/agno/tools/google_bigquery.py
@@ -17,7 +17,7 @@ def _clean_sql(sql: str) -> str:
     Replaces newlines with spaces (not empty strings) to prevent line comments
     from swallowing subsequent SQL statements.
     """
-    return sql.replace("\\n", " ").replace("\n", " ").replace("\\", "")
+    return sql.replace("\\n", " ").replace("\n", " ")
 
 
 class GoogleBigQueryTools(Toolkit):
@@ -120,7 +120,7 @@ class GoogleBigQueryTools(Toolkit):
             query_job = self.client.query(cleaned_query, job_config)
             results = query_job.result()
             results_str = str([dict(row) for row in results])
-            return results_str.replace("\\", "").replace("\n", "")
+            return results_str.replace("\n", " ")
         except Exception as e:
             logger.error(f"Error while executing SQL: {e}")
             return ""

--- a/libs/agno/tests/unit/tools/test_google_bigquery.py
+++ b/libs/agno/tests/unit/tools/test_google_bigquery.py
@@ -134,8 +134,8 @@ def test_clean_sql_handles_escaped_newlines():
     assert cleaned == "SELECT * FROM table"
 
 
-def test_clean_sql_removes_backslashes():
-    """Test that _clean_sql removes backslash characters."""
-    sql = "SELECT * FROM table WHERE name = 'test\\value'"
+def test_clean_sql_preserves_backslashes_in_string_literals():
+    """Test that _clean_sql preserves backslashes (e.g., regex patterns in strings)."""
+    sql = r"SELECT * FROM table WHERE regex = 'word\s+'"
     cleaned = _clean_sql(sql)
-    assert cleaned == "SELECT * FROM table WHERE name = 'testvalue'"
+    assert cleaned == r"SELECT * FROM table WHERE regex = 'word\s+'"


### PR DESCRIPTION
We had some SQL statement cleanup logic in GoogleBigQueryTools that was breaking when receiving SQL statements with comments. This fixes the parsing logic and adds some brief testing.