### PR TITLE
chore: pass instructions as is without xml tags

### DIFF
--- a/cookbook/03_agents/context_management/instruction_tags.py
+++ b/cookbook/03_agents/context_management/instruction_tags.py
@@ -1,7 +1,7 @@
-"""Example demonstrating the add_instruction_tags parameter.
+"""Example demonstrating the use_instruction_tags parameter.
 
 By default, instructions are added directly to the system message without XML tags.
-Set add_instruction_tags=True to wrap instructions in <instructions> tags for
+Set use_instruction_tags=True to wrap instructions in <instructions> tags for
 models that respond better to structured prompts.
 
 Run: `pip install openai agno` to install the dependencies
@@ -30,7 +30,7 @@ agent_with_tags = Agent(
         "Always be concise and clear.",
         "Use bullet points when listing items.",
     ],
-    add_instruction_tags=True,
+    use_instruction_tags=True,
 )
 
 print("=== Agent without instruction tags (default) ===")

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -342,7 +342,7 @@ class Agent:
     # List of instructions for the agent.
     instructions: Optional[Union[str, List[str], Callable]] = None
     # If True, wrap instructions in <instructions> tags. Default is False.
-    add_instruction_tags: bool = False
+    use_instruction_tags: bool = False
     # Provide the expected output from the Agent.
     expected_output: Optional[str] = None
     # Additional context added to the end of the system message.
@@ -525,7 +525,7 @@ class Agent:
         build_context: bool = True,
         description: Optional[str] = None,
         instructions: Optional[Union[str, List[str], Callable]] = None,
-        add_instruction_tags: bool = False,
+        use_instruction_tags: bool = False,
         expected_output: Optional[str] = None,
         additional_context: Optional[str] = None,
         markdown: bool = False,
@@ -655,7 +655,7 @@ class Agent:
         self.build_context = build_context
         self.description = description
         self.instructions = instructions
-        self.add_instruction_tags = add_instruction_tags
+        self.use_instruction_tags = use_instruction_tags
         self.expected_output = expected_output
         self.additional_context = additional_context
         self.markdown = markdown
@@ -8069,7 +8069,7 @@ class Agent:
             system_message_content += f"\n<your_role>\n{self.role}\n</your_role>\n\n"
         # 3.3.3 Then add instructions for the Agent
         if len(instructions) > 0:
-            if self.add_instruction_tags:
+            if self.use_instruction_tags:
                 system_message_content += "<instructions>"
                 if len(instructions) > 1:
                     for _upi in instructions:
@@ -8423,7 +8423,7 @@ class Agent:
             system_message_content += f"\n<your_role>\n{self.role}\n</your_role>\n\n"
         # 3.3.3 Then add instructions for the Agent
         if len(instructions) > 0:
-            if self.add_instruction_tags:
+            if self.use_instruction_tags:
                 system_message_content += "<instructions>"
                 if len(instructions) > 1:
                     for _upi in instructions:

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -266,7 +266,7 @@ class Team:
     # List of instructions for the team.
     instructions: Optional[Union[str, List[str], Callable]] = None
     # If True, wrap instructions in <instructions> tags. Default is False.
-    add_instruction_tags: bool = False
+    use_instruction_tags: bool = False
     # Provide the expected output from the Team.
     expected_output: Optional[str] = None
     # Additional context added to the end of the system message.
@@ -496,7 +496,7 @@ class Team:
         num_history_sessions: Optional[int] = None,
         description: Optional[str] = None,
         instructions: Optional[Union[str, List[str], Callable]] = None,
-        add_instruction_tags: bool = False,
+        use_instruction_tags: bool = False,
         expected_output: Optional[str] = None,
         additional_context: Optional[str] = None,
         markdown: bool = False,
@@ -615,7 +615,7 @@ class Team:
 
         self.description = description
         self.instructions = instructions
-        self.add_instruction_tags = add_instruction_tags
+        self.use_instruction_tags = use_instruction_tags
         self.expected_output = expected_output
         self.additional_context = additional_context
         self.markdown = markdown
@@ -5641,7 +5641,7 @@ class Team:
 
         # 3.3.5 Then add instructions for the Team
         if len(instructions) > 0:
-            if self.add_instruction_tags:
+            if self.use_instruction_tags:
                 system_message_content += "<instructions>"
                 if len(instructions) > 1:
                     for _upi in instructions:
@@ -5953,7 +5953,7 @@ class Team:
 
         # 3.3.5 Then add instructions for the Team
         if len(instructions) > 0:
-            if self.add_instruction_tags:
+            if self.use_instruction_tags:
                 system_message_content += "<instructions>"
                 if len(instructions) > 1:
                     for _upi in instructions:


### PR DESCRIPTION
## Summary

- **Agent & Team**: Instructions are now added directly to the system message without `<instructions>` tags by default
- **New parameter**: Added `add_instruction_tags=True` option to restore the previous behavior for users who prefer structured prompts
- **Removed description from system message**: The description field is now for API/display purposes only

Before:
```
<instructions>
- instruction 1
- instruction 2
</instructions>
```
After (default):
```
- instruction 1
- instruction 2
```

After (with `add_instruction_tags=True`):
```
<instructions>
- instruction 1
- instruction 2
</instructions>
```

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
