### PR TITLE
fix: Update cookbook examples to use `insert()`

### DIFF
--- a/cookbook/08_knowledge/README.md
+++ b/cookbook/08_knowledge/README.md
@@ -43,7 +43,7 @@ knowledge = Knowledge(
 )
 
 # Add content from URL
-knowledge.add_content(
+knowledge.insert(
     url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf"
 )
 

--- a/cookbook/08_knowledge/chunking/README.md
+++ b/cookbook/08_knowledge/chunking/README.md
@@ -19,16 +19,31 @@ export OPENAI_API_KEY=your_api_key
 Chunking strategies integrate with readers to process documents:
 
 ```python
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.knowledge.knowledge import Knowledge
+from agno.vectordb.pgvector import PgVector
 from agno.knowledge.reader.pdf_reader import PDFReader
 from agno.knowledge.chunking.semantic import SemanticChunking
 
+# Create knowledge base
+knowledge = Knowledge(
+    vector_db=PgVector(
+        table_name="docs",
+        db_url="postgresql+psycopg://ai:ai@localhost:5532/ai"
+    )
+)
+
+# Add content with chunking strategy
 reader = PDFReader(
     chunking_strategy=SemanticChunking()
 )
-knowledge.add_content(url="document.pdf", reader=reader)
+knowledge.insert(path="document.pdf", reader=reader)
 
+# Create agent
 agent = Agent(
-    knowledge=knowledge_base,
+    model=OpenAIChat(id="gpt-4o"),
+    knowledge=knowledge,
     search_knowledge=True,
 )
 
@@ -47,6 +62,7 @@ See the [custom strategy example](./custom_strategy_example.py) for a complete w
 ## Supported Chunking Strategies
 
 - **[Agentic Chunking](./agentic_chunking.py)** - AI-powered intelligent chunk boundaries
+- **[Code Chunking](./code_chunking.py)** - Split code into chunks based on code structure
 - **[CSV Row Chunking](./csv_row_chunking.py)** - Each CSV row as a separate chunk
 - **[Document Chunking](./document_chunking.py)** - Treat entire document as single chunk
 - **[Fixed Size Chunking](./fixed_size_chunking.py)** - Fixed character/token length chunks

--- a/cookbook/08_knowledge/chunking/code_chunking.py
+++ b/cookbook/08_knowledge/chunking/code_chunking.py
@@ -11,7 +11,7 @@ knowledge = Knowledge(
 )
 
 # Add code with CodeChunking
-knowledge.add_content(
+knowledge.insert(
     url="https://raw.githubusercontent.com/agno-agi/agno/main/libs/agno/agno/session/workflow.py",
     reader=TextReader(
         chunking_strategy=CodeChunking(

--- a/cookbook/08_knowledge/chunking/code_chunking_custom_tokenizer.py
+++ b/cookbook/08_knowledge/chunking/code_chunking_custom_tokenizer.py
@@ -52,7 +52,7 @@ knowledge = Knowledge(
     vector_db=PgVector(table_name="code_custom_tokenizer", db_url=db_url),
 )
 
-knowledge.add_content(
+knowledge.insert(
     url="https://raw.githubusercontent.com/agno-agi/agno/main/libs/agno/agno/session/workflow.py",
     reader=TextReader(
         chunking_strategy=CodeChunking(

--- a/cookbook/08_knowledge/filters/README.md
+++ b/cookbook/08_knowledge/filters/README.md
@@ -22,7 +22,7 @@ from agno.knowledge.knowledge import Knowledge
 from agno.vectordb.lancedb import LanceDb
 
 knowledge = Knowledge(vector_db=LanceDb(table_name="docs", uri="tmp/lancedb"))
-knowledge.add_content(path="data.csv", metadata={"type": "sales", "quarter": "Q1"})
+knowledge.insert(path="data.csv", metadata={"type": "sales", "quarter": "Q1"})
 
 results = knowledge.search(
     query="revenue trends",

--- a/cookbook/08_knowledge/readers/README.md
+++ b/cookbook/08_knowledge/readers/README.md
@@ -7,19 +7,37 @@ Readers transform raw data into structured, searchable knowledge for your agents
 Readers integrate with the Knowledge system to process different data sources:
 
 ```python
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
 from agno.knowledge.knowledge import Knowledge
+from agno.vectordb.pgvector import PgVector
 from agno.knowledge.reader.pdf_reader import PDFReader
 
-knowledge = Knowledge(vector_db=your_vector_db)
-knowledge.add_content(
+# Create knowledge base
+knowledge = Knowledge(
+    vector_db=PgVector(
+        table_name="docs",
+        db_url="postgresql+psycopg://ai:ai@localhost:5532/ai"
+    )
+)
+
+# Add documents with specific reader
+knowledge.insert(
     path="documents/",
     reader=PDFReader(),
     metadata={"source": "docs"}
 )
 
+# Create agent
 agent = Agent(
+    model=OpenAIChat(id="gpt-4o"),
     knowledge=knowledge,
     search_knowledge=True,
+)
+
+agent.print_response(
+    "What are the key concepts covered in this document?",
+    markdown=True
 )
 ```
 


### PR DESCRIPTION
## Summary

Updates cookbooks and READMEs to use `insert()` instead of deprecated `add_content()` and fixes incomplete code examples with missing imports.

(If applicable, pr number: #5982)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
