### PR TITLE
fix: Cache FastEmbed model and reset reader state between calls

### DIFF
--- a/libs/agno/agno/knowledge/embedder/fastembed.py
+++ b/libs/agno/agno/knowledge/embedder/fastembed.py
@@ -24,10 +24,16 @@ class FastEmbedEmbedder(Embedder):
 
     id: str = "BAAI/bge-small-en-v1.5"
     dimensions: Optional[int] = 384
+    fastembed_client: Optional[TextEmbedding] = None
+
+    @property
+    def client(self) -> TextEmbedding:
+        if self.fastembed_client is None:
+            self.fastembed_client = TextEmbedding(model_name=self.id)
+        return self.fastembed_client
 
     def get_embedding(self, text: str) -> List[float]:
-        model = TextEmbedding(model_name=self.id)
-        embeddings = model.embed(text)
+        embeddings = self.client.embed(text)
         embedding_list = list(embeddings)[0]
         if isinstance(embedding_list, np.ndarray):
             return embedding_list.tolist()

--- a/libs/agno/agno/knowledge/reader/web_search_reader.py
+++ b/libs/agno/agno/knowledge/reader/web_search_reader.py
@@ -208,6 +208,9 @@ class WebSearchReader(Reader):
 
     def read(self, query: str) -> List[Document]:
         """Read content for a given query by performing web search and fetching content"""
+        # Clear so URLs from previous queries aren't incorrectly skipped
+        self._visited_urls.clear()
+
         if not query:
             raise ValueError("Query cannot be empty")
 
@@ -259,6 +262,9 @@ class WebSearchReader(Reader):
 
     async def async_read(self, query: str) -> List[Document]:
         """Asynchronously read content for a given query"""
+        # Clear so URLs from previous queries aren't incorrectly skipped
+        self._visited_urls.clear()
+
         if not query:
             raise ValueError("Query cannot be empty")
 

--- a/libs/agno/agno/knowledge/reader/website_reader.py
+++ b/libs/agno/agno/knowledge/reader/website_reader.py
@@ -164,8 +164,10 @@ class WebsiteReader(Reader):
         num_links = 0
         crawler_result: Dict[str, str] = {}
         primary_domain = self._get_primary_domain(url)
-        # Add starting URL with its depth to the global list
-        self._urls_to_crawl.append((url, starting_depth))
+
+        # Clear state so URLs from previous crawls aren't incorrectly skipped (matches async_crawl)
+        self._visited = set()
+        self._urls_to_crawl = [(url, starting_depth)]
         while self._urls_to_crawl:
             # Unpack URL and depth from the global list
             current_url, current_depth = self._urls_to_crawl.pop(0)

--- a/libs/agno/tests/integration/embedder/test_fastembed_embedder.py
+++ b/libs/agno/tests/integration/embedder/test_fastembed_embedder.py
@@ -1,0 +1,44 @@
+import pytest
+
+pytest.importorskip("fastembed")
+
+from agno.knowledge.embedder.fastembed import FastEmbedEmbedder
+
+
+@pytest.fixture
+def embedder():
+    return FastEmbedEmbedder()
+
+
+def test_embedder_initialization(embedder):
+    assert embedder.id == "BAAI/bge-small-en-v1.5"
+    assert embedder.fastembed_client is None  # Lazy init, not created yet
+
+
+def test_get_embedding(embedder):
+    text = "The quick brown fox jumps over the lazy dog."
+    embeddings = embedder.get_embedding(text)
+
+    assert isinstance(embeddings, list)
+    assert len(embeddings) > 0
+    assert all(isinstance(x, float) for x in embeddings)
+
+
+def test_embedding_consistency(embedder):
+    text = "Consistency test"
+    embeddings1 = embedder.get_embedding(text)
+    embeddings2 = embedder.get_embedding(text)
+
+    assert len(embeddings1) == len(embeddings2)
+    assert all(abs(a - b) < 1e-6 for a, b in zip(embeddings1, embeddings2))
+
+
+def test_client_cached_after_first_use(embedder):
+    assert embedder.fastembed_client is None
+    embedder.get_embedding("trigger init")
+    assert embedder.fastembed_client is not None
+
+    # Second call should reuse the same client
+    client_ref = embedder.fastembed_client
+    embedder.get_embedding("second call")
+    assert embedder.fastembed_client is client_ref

--- a/libs/agno/tests/unit/knowledge/test_reader_embedder_state.py
+++ b/libs/agno/tests/unit/knowledge/test_reader_embedder_state.py
@@ -1,0 +1,146 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agno.knowledge.reader.web_search_reader import WebSearchReader
+from agno.knowledge.reader.website_reader import WebsiteReader
+
+# --- FastEmbedEmbedder caching tests ---
+
+
+def test_fastembed_embedder_caches_client():
+    import numpy as np
+
+    mock_text_embedding_class = MagicMock()
+    mock_client_instance = MagicMock()
+    mock_client_instance.embed.return_value = [np.array([0.1, 0.2, 0.3])]
+    mock_text_embedding_class.return_value = mock_client_instance
+
+    with patch.dict("sys.modules", {"fastembed": MagicMock(TextEmbedding=mock_text_embedding_class)}):
+        with patch("agno.knowledge.embedder.fastembed.TextEmbedding", mock_text_embedding_class):
+            from agno.knowledge.embedder.fastembed import FastEmbedEmbedder
+
+            embedder = FastEmbedEmbedder()
+
+            embedder.get_embedding("text 1")
+            embedder.get_embedding("text 2")
+            embedder.get_embedding("text 3")
+
+            # Client constructor should only be called once (lazy on first use)
+            assert mock_text_embedding_class.call_count == 1
+            assert mock_client_instance.embed.call_count == 3
+
+
+def test_fastembed_embedder_accepts_injected_client():
+    import numpy as np
+
+    mock_client = MagicMock()
+    mock_client.embed.return_value = [np.array([0.1, 0.2, 0.3])]
+
+    mock_text_embedding_class = MagicMock()
+
+    with patch.dict("sys.modules", {"fastembed": MagicMock(TextEmbedding=mock_text_embedding_class)}):
+        with patch("agno.knowledge.embedder.fastembed.TextEmbedding", mock_text_embedding_class):
+            from agno.knowledge.embedder.fastembed import FastEmbedEmbedder
+
+            embedder = FastEmbedEmbedder(fastembed_client=mock_client)
+
+            assert embedder.fastembed_client is mock_client
+
+            result = embedder.get_embedding("test")
+            mock_client.embed.assert_called_once_with("test")
+            assert result == [0.1, 0.2, 0.3]
+
+
+# --- WebSearchReader state tests ---
+
+
+def test_web_search_reader_visited_urls_cleared_between_reads():
+    reader = WebSearchReader()
+
+    reader._visited_urls.add("https://example.com")
+    reader._visited_urls.add("https://test.com")
+    assert len(reader._visited_urls) == 2
+
+    with patch.object(reader, "_perform_web_search", return_value=[]):
+        reader.read("test query")
+
+    assert len(reader._visited_urls) == 0
+
+
+def test_web_search_reader_urls_not_skipped_on_second_read():
+    reader = WebSearchReader()
+
+    reader._visited_urls.add("https://example.com")
+
+    with patch.object(reader, "_perform_web_search", return_value=[]):
+        reader.read("second query")
+
+    assert "https://example.com" not in reader._visited_urls
+
+
+@pytest.mark.asyncio
+async def test_web_search_reader_async_read_clears_state():
+    reader = WebSearchReader()
+
+    reader._visited_urls.add("https://example.com")
+    reader._visited_urls.add("https://test.com")
+    assert len(reader._visited_urls) == 2
+
+    with patch.object(reader, "_perform_web_search", return_value=[]):
+        await reader.async_read("test query")
+
+    assert len(reader._visited_urls) == 0
+
+
+# --- WebsiteReader state tests ---
+
+
+@pytest.fixture
+def mock_http_response():
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b"<html><body>Test content</body></html>"
+    mock_response.raise_for_status = MagicMock()
+    return mock_response
+
+
+def test_website_reader_sync_crawl_resets_visited(mock_http_response):
+    reader = WebsiteReader(max_depth=1, max_links=1)
+
+    reader._visited.add("https://old-site.com")
+    reader._visited.add("https://old-site.com/page1")
+    assert len(reader._visited) == 2
+
+    with patch("httpx.get", return_value=mock_http_response):
+        reader.crawl("https://new-site.com")
+
+    assert "https://old-site.com" not in reader._visited
+    assert "https://old-site.com/page1" not in reader._visited
+
+
+def test_website_reader_sync_crawl_resets_urls_to_crawl(mock_http_response):
+    reader = WebsiteReader(max_depth=1, max_links=1)
+
+    reader._urls_to_crawl = [("https://leftover.com", 1), ("https://leftover2.com", 2)]
+
+    with patch("httpx.get", return_value=mock_http_response):
+        reader.crawl("https://new-site.com")
+
+    remaining_urls = [url for url, _ in reader._urls_to_crawl]
+    assert "https://leftover.com" not in remaining_urls
+    assert "https://leftover2.com" not in remaining_urls
+
+
+def test_website_reader_sync_and_async_have_same_reset_behavior():
+    import inspect
+
+    reader = WebsiteReader()
+
+    sync_source = inspect.getsource(reader.crawl)
+    async_source = inspect.getsource(reader.async_crawl)
+
+    assert "self._visited = set()" in sync_source
+    assert "self._visited = set()" in async_source
+    assert "self._urls_to_crawl = [" in sync_source
+    assert "self._urls_to_crawl = [" in async_source


### PR DESCRIPTION
## Summary

Fixes three state management bugs in the Knowledge system that cause incorrect behavior when readers/embedders are reused:

- **FastEmbedEmbedder memory leak**: Model was recreated on every `get_embedding()` call (~100MB ONNX model per call) instead of being cached. Now uses `@property` lazy init matching other embedders (OpenAI, Cohere, etc.)
- **WebSearchReader state pollution**: URLs visited in query 1 were incorrectly skipped in query 2. Both `read()` and `async_read()` now clear `_visited_urls` at entry.
- **WebsiteReader sync/async inconsistency**: Sync `crawl()` didn't reset state like `async_crawl()` did (original day-1 oversight from commit 1f595c912).

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

## Additional Notes

**Rebased clean on main** — the original branch had 50+ commits with merge noise from v2.4.0. Now a single clean commit.

| Component | Bug | Impact if unfixed |
|-----------|-----|-------------------|
| FastEmbedEmbedder | ~100MB model loaded per call | OOM in long-running agents |
| WebSearchReader | URLs from query 1 skipped in query 2 | Missing search results |
| WebsiteReader | sync crawl() didn't reset state | Stale/incomplete crawl results |

**Tests:** Unit tests (mock-based, no external deps) + integration tests (with `pytest.importorskip` for fastembed).