### PR TITLE
chore: os db requirement

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -179,8 +179,8 @@ class AgentOS:
             telemetry: Whether to enable telemetry
 
         """
-        if not agents and not workflows and not teams and not knowledge:
-            raise ValueError("Either agents, teams, workflows or knowledge bases must be provided.")
+        if not agents and not workflows and not teams and not knowledge and not db:
+            raise ValueError("Either agents, teams, workflows, knowledge bases or a database must be provided.")    
 
         self.config = load_yaml_config(config) if isinstance(config, str) else config
 


### PR DESCRIPTION
## Summary
- Allow AgentOS to be initialized with just a database, without requiring agents, teams, workflows, or knowledge bases
- This enables loading components from the database using the Agent-as-Config feature

## Changes
- Updated validation in `AgentOS.__init__` to accept `db` as a valid initialization option
- Updated error message to reflect the new valid options

## Test plan
- [ ] Verify AgentOS can be initialized with only a `db` parameter
- [ ] Verify existing initialization patterns still work (agents, teams, workflows, knowledge)

Generated with [Claude Code](https://claude.ai/code)