### PR TITLE
fix: avoid content pollution when condition steps are skipped

### DIFF
--- a/libs/agno/agno/workflow/condition.py
+++ b/libs/agno/agno/workflow/condition.py
@@ -462,13 +462,14 @@ class Condition:
                 branch = CONDITION_BRANCH_ELSE
                 log_debug(f"Condition {self.name} not met, executing {len(steps_to_execute)} else_steps (else branch)")
             else:
-                # No else_steps provided, return "not met" message
+                # No else_steps provided, skip the condition
                 log_debug(f"Condition {self.name} not met, skipping {len(self.steps)} steps")
                 return StepOutput(
                     step_name=self.name,
                     step_id=conditional_step_id,
                     step_type=StepType.CONDITION,
-                    content=f"Condition {self.name} not met - skipped {len(self.steps)} steps",
+                    # Use None content to avoid polluting previous_step_content for subsequent steps
+                    content=None,
                     success=True,
                 )
 
@@ -846,13 +847,14 @@ class Condition:
                 branch = CONDITION_BRANCH_ELSE
                 log_debug(f"Condition {self.name} not met, executing {len(steps_to_execute)} else_steps (else branch)")
             else:
-                # No else_steps provided, return "not met" message
+                # No else_steps provided, skip the condition
                 log_debug(f"Condition {self.name} not met, skipping {len(self.steps)} steps")
                 return StepOutput(
                     step_name=self.name,
                     step_id=conditional_step_id,
                     step_type=StepType.CONDITION,
-                    content=f"Condition {self.name} not met - skipped {len(self.steps)} steps",
+                    # Use None content to avoid polluting previous_step_content for subsequent steps
+                    content=None,
                     success=True,
                 )
 


### PR DESCRIPTION
## Summary

When a `Condition` evaluates to `False` and steps are skipped (no `else_steps` provided), the returned `StepOutput` was setting `content` to a descriptive skip message string. This polluted `previous_step_content` for subsequent steps in the workflow, causing downstream steps to receive the skip message instead of the actual content from prior steps.

Changed `content` to `None` for skipped conditions in both `execute()` and `aexecute()` methods, which preserves the actual `previous_step_content` for downstream processing.

Fixes #6039

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

The fix is minimal: two lines changed from `content=f"Condition ... not met - skipped ..."` to `content=None` in the `else` branch (no else_steps) of both `execute()` and `aexecute()`. The streaming variants (`execute_stream`, `aexecute_stream`) already handle this correctly by simply returning without yielding a `StepOutput`.