### PR TITLE
fix: allow empty string passwords for encrypted PDFs

### DIFF
--- a/libs/agno/agno/knowledge/reader/pdf_reader.py
+++ b/libs/agno/agno/knowledge/reader/pdf_reader.py
@@ -232,8 +232,9 @@ class BasePDFReader(Reader):
             return True
 
         # Use provided password or fall back to instance password
-        pdf_password = password or self.password
-        if not pdf_password:
+        # Use explicit None check to allow empty string passwords (e.g., PDFs with blank user passwords)
+        pdf_password = self.password if password is None else password
+        if pdf_password is None:
             log_error(f'PDF file "{doc_name}" is password protected but no password provided')
             return False
 


### PR DESCRIPTION
The previous code used `password or self.password` which treated empty string passwords as falsy, falling back to self.password. PDFs with blank user passwords (but non-empty owner passwords) require empty string to decrypt.

Changed to explicit None check: `self.password if password is None else password`

Fixes #6051

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
