### PR TITLE
[feat] Add direct file attachment support for OpenAI Responses API

### DIFF
--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -516,8 +516,10 @@ class OpenAIResponses(Model):
                             mime_type = file.mime_type
                             if not mime_type and file.filepath:
                                 mime_type = mimetypes.guess_type(str(file.filepath))[0]
-                            if not mime_type and (file.filename or file.name):
-                                mime_type = mimetypes.guess_type(file.filename or file.name)[0]
+                            if not mime_type:
+                                filename = file.filename or file.name
+                                if filename:
+                                    mime_type = mimetypes.guess_type(filename)[0]
                             mime_type = mime_type or "application/octet-stream"
 
                             message_dict["content"].append(


### PR DESCRIPTION
## Summary

- Add `_get_file_content_base64` method to encode file content for direct attachment
- Add direct file attachment via `input_file` type in message content
- Implement proper MIME type detection from file properties, filepath, or filename
- Only upload files to vector stores when `file_search` tool is present (optimization)
- Fall back to `application/octet-stream` for unknown file types

This enables attaching files directly to messages without requiring the `file_search` tool, allowing the model to read file contents directly in context.

## Background

Previously, file attachments in OpenAI Responses API were only supported through vector stores (requiring the `file_search` tool). This PR adds support for direct file attachment using the `input_file` content type, which:

1. Sends file content directly in the message (base64 encoded)
2. Allows the model to read file contents in its context window
3. Works independently of the vector store/file_search mechanism

The two mechanisms can coexist:
- **Vector Store + file_search tool**: For RAG-style semantic search through files
- **Direct Attachment (input_file)**: For the model to read files directly in context

## Test plan

- [ ] Test attaching PDF files with explicit `mime_type` set
- [ ] Test attaching non-PDF files (txt, json, csv) and verify MIME type detection from filepath
- [ ] Test attaching files with only filename (no filepath) and verify MIME type detection
- [ ] Test attaching files with unknown extension and verify fallback to `application/octet-stream`
- [ ] Test that file_search tool still works with vector stores when enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)