### PR TITLE
fix: preserve LightRAG references in search response [SDK-404]

### DIFF
--- a/cookbook/07_knowledge/vector_db/lightrag/lightrag.py
+++ b/cookbook/07_knowledge/vector_db/lightrag/lightrag.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from os import getenv
 
 from agno.agent import Agent
@@ -7,12 +8,13 @@ from agno.knowledge.reader.wikipedia_reader import WikipediaReader
 from agno.vectordb.lightrag import LightRag
 
 vector_db = LightRag(
+    server_url=getenv("LIGHTRAG_SERVER_URL", "http://localhost:9621"),
     api_key=getenv("LIGHTRAG_API_KEY"),
 )
 
 knowledge = Knowledge(
-    name="My Pinecone Knowledge Base",
-    description="This is a knowledge base that uses a Pinecone Vector DB",
+    name="LightRAG Knowledge Base",
+    description="Knowledge base using LightRAG for graph-based retrieval",
     vector_db=vector_db,
 )
 
@@ -36,10 +38,12 @@ asyncio.run(
 asyncio.run(
     knowledge.ainsert(
         name="Recipes",
-        url="https://en.wikipedia.org/wiki/Manchester_United_F.C.",
+        path="cookbook/07_knowledge/testing_resources/cv_2.pdf",
     )
 )
 
+# Wait for LightRAG to index documents
+time.sleep(60)
 
 agent = Agent(
     knowledge=knowledge,
@@ -57,3 +61,9 @@ asyncio.run(
         "In what year did Manchester United change their name?", markdown=True
     )
 )
+
+# Search results include references to source documents
+results = asyncio.run(vector_db.async_search("What skills does Jordan Mitchell have?"))
+if results:
+    doc = results[0]
+    print(f"References: {doc.meta_data.get('references', [])}")

--- a/libs/agno/agno/vectordb/lightrag/lightrag.py
+++ b/libs/agno/agno/vectordb/lightrag/lightrag.py
@@ -109,7 +109,7 @@ class LightRag(VectorDb):
             async with httpx.AsyncClient(timeout=30.0) as client:
                 response = await client.post(
                     f"{self.server_url}/query",
-                    json={"query": query, "mode": "hybrid"},
+                    json={"query": query, "mode": "hybrid", "include_references": True},
                     headers=self._get_headers(),
                 )
 
@@ -322,7 +322,7 @@ class LightRag(VectorDb):
             async with httpx.AsyncClient(timeout=30.0) as client:
                 response = await client.post(
                     f"{self.server_url}/query",
-                    json={"query": query, "mode": "hybrid"},
+                    json={"query": query, "mode": "hybrid", "include_references": True},
                     headers=self._get_headers(),
                 )
 
@@ -349,10 +349,11 @@ class LightRag(VectorDb):
         # LightRAG server returns a dict with 'response' key, but we expect a list of documents
         # Convert the response to the expected format
         if isinstance(result, dict) and "response" in result:
-            # Wrap the response in a Document object
-            return [
-                Document(content=result["response"], meta_data={"source": "lightrag", "query": query, "mode": mode})
-            ]
+            meta_data = {"source": "lightrag", "query": query, "mode": mode}
+            # Preserve references from LightRAG response for document citations
+            if "references" in result:
+                meta_data["references"] = result["references"]
+            return [Document(content=result["response"], meta_data=meta_data)]
         elif isinstance(result, list):
             # Convert list items to Document objects
             documents = []

--- a/libs/agno/tests/unit/vectordb/test_lightrag.py
+++ b/libs/agno/tests/unit/vectordb/test_lightrag.py
@@ -1,0 +1,146 @@
+import pytest
+
+from agno.vectordb.lightrag import LightRag
+
+TEST_SERVER_URL = "http://localhost:9621"
+TEST_API_KEY = "test_api_key"
+
+
+@pytest.fixture
+def lightrag_db():
+    """Fixture to create a LightRag instance"""
+    db = LightRag(
+        server_url=TEST_SERVER_URL,
+        api_key=TEST_API_KEY,
+    )
+    yield db
+
+
+def test_initialization():
+    """Test basic initialization with defaults"""
+    db = LightRag()
+
+    assert db.server_url == "http://localhost:9621"
+    assert db.api_key is None
+
+
+def test_initialization_with_params():
+    """Test initialization with custom parameters"""
+    db = LightRag(
+        server_url="http://custom:8080",
+        api_key="secret",
+        name="test_db",
+        description="Test database",
+    )
+
+    assert db.server_url == "http://custom:8080"
+    assert db.api_key == "secret"
+    assert db.name == "test_db"
+    assert db.description == "Test database"
+
+
+def test_get_headers_with_api_key(lightrag_db):
+    """Test headers include API key when configured"""
+    headers = lightrag_db._get_headers()
+
+    assert headers["Content-Type"] == "application/json"
+    assert headers["X-API-KEY"] == TEST_API_KEY
+
+
+def test_get_headers_without_api_key():
+    """Test headers without API key"""
+    db = LightRag(server_url=TEST_SERVER_URL)
+    headers = db._get_headers()
+
+    assert headers["Content-Type"] == "application/json"
+    assert "X-API-KEY" not in headers
+
+
+def test_get_auth_headers(lightrag_db):
+    """Test auth headers for file uploads"""
+    headers = lightrag_db._get_auth_headers()
+
+    assert "Content-Type" not in headers
+    assert headers["X-API-KEY"] == TEST_API_KEY
+
+
+def test_custom_auth_header_format():
+    """Test custom auth header name and format"""
+    db = LightRag(
+        server_url=TEST_SERVER_URL,
+        api_key="my_key",
+        auth_header_name="Authorization",
+        auth_header_format="Bearer {api_key}",
+    )
+    headers = db._get_headers()
+
+    assert headers["Authorization"] == "Bearer my_key"
+
+
+def test_format_response_with_references(lightrag_db):
+    """Test that references are preserved in meta_data"""
+    result = {
+        "response": "Jordan Mitchell has skills in Python and JavaScript.",
+        "references": [
+            {"reference_id": "1", "file_path": "cv_1.pdf", "content": None},
+            {"reference_id": "2", "file_path": "cv_2.pdf", "content": None},
+        ],
+    }
+
+    documents = lightrag_db._format_lightrag_response(result, "What skills?", "hybrid")
+
+    assert len(documents) == 1
+    assert documents[0].content == "Jordan Mitchell has skills in Python and JavaScript."
+    assert documents[0].meta_data["source"] == "lightrag"
+    assert documents[0].meta_data["query"] == "What skills?"
+    assert documents[0].meta_data["mode"] == "hybrid"
+    assert "references" in documents[0].meta_data
+    assert len(documents[0].meta_data["references"]) == 2
+    assert documents[0].meta_data["references"][0]["file_path"] == "cv_1.pdf"
+
+
+def test_format_response_without_references(lightrag_db):
+    """Test backward compatibility when no references in response"""
+    result = {"response": "Some content without references."}
+
+    documents = lightrag_db._format_lightrag_response(result, "query", "local")
+
+    assert len(documents) == 1
+    assert documents[0].content == "Some content without references."
+    assert "references" not in documents[0].meta_data
+
+
+def test_format_response_list_with_content(lightrag_db):
+    """Test formatting list response with content field"""
+    result = [
+        {"content": "First document", "metadata": {"source": "custom"}},
+        {"content": "Second document"},
+    ]
+
+    documents = lightrag_db._format_lightrag_response(result, "query", "global")
+
+    assert len(documents) == 2
+    assert documents[0].content == "First document"
+    assert documents[0].meta_data["source"] == "custom"
+
+
+def test_format_response_list_plain_strings(lightrag_db):
+    """Test formatting list response with plain strings"""
+    result = ["plain text item 1", "plain text item 2"]
+
+    documents = lightrag_db._format_lightrag_response(result, "query", "hybrid")
+
+    assert len(documents) == 2
+    assert documents[0].content == "plain text item 1"
+    assert documents[0].meta_data["source"] == "lightrag"
+
+
+def test_format_response_string(lightrag_db):
+    """Test formatting plain string response"""
+    result = "Just a plain string response"
+
+    documents = lightrag_db._format_lightrag_response(result, "query", "hybrid")
+
+    assert len(documents) == 1
+    assert documents[0].content == "Just a plain string response"
+    assert documents[0].meta_data["source"] == "lightrag"


### PR DESCRIPTION
## Summary

  ## Summary                                                                                                                       
  - Fix `_format_lightrag_response()` to preserve the `references` array from LightRAG API responses in document `meta_data`       
  - Add `include_references: True` parameter to query requests                                                                     
  - Add unit tests for LightRAG vectordb 
(If applicable, issue number: #5630)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
