### PR TITLE
ci: use single job with conditional steps for cleaner CI display

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,35 +13,10 @@ on:
     types: [submitted]
 
 jobs:
-  # Automated code review on all PRs
-  code-review:
+  claude:
+    # Run on PR events (for code review) OR @claude mentions (for assistant)
     if: |
-      github.event_name == 'pull_request' &&
-      !github.event.pull_request.draft
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: read
-      issues: read
-      id-token: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code Review
-        id: claude-review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-
-  # Interactive assistant when @claude is mentioned
-  assistant:
-    if: |
+      (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
@@ -59,8 +34,23 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: Run Claude Code
-        id: claude
+      # Automated code review - runs on PR events only
+      - name: Run Claude Code Review
+        if: github.event_name == 'pull_request'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+
+      # Interactive assistant - runs on @claude mentions only
+      - name: Run Claude Code Assistant
+        if: |
+          github.event_name == 'issue_comment' ||
+          github.event_name == 'pull_request_review_comment' ||
+          github.event_name == 'pull_request_review' ||
+          github.event_name == 'issues'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Simplifies the Claude Code workflow from two jobs to one job with conditional steps.

## Before
```
Claude Code / code-review (pull_request) ✅
Claude Code / assistant (pull_request) ⏭️ Skipped
```

## After (expected)
```
Claude Code (pull_request) ✅
```

## Changes

- Single `claude` job instead of `code-review` + `assistant` jobs
- Step-level `if:` conditions determine which action runs
- Code review step: runs on `pull_request` events
- Assistant step: runs on `@claude` mention events

## Testing

- [ ] PR opened → Shows single "Claude Code" entry (not two)
- [ ] Code review runs successfully
- [ ] No "skipped" job entries visible

🤖 Generated with [Claude Code](https://claude.ai/code)