### PR TITLE
[fix] Cast session_name to TEXT in PostgresDb.rename_session()

### DIFF
--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -709,7 +709,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                             func.jsonb_set(
                                 func.cast(table.c.session_data, postgresql.JSONB),
                                 text("'{session_name}'"),
-                                func.to_jsonb(sanitized_session_name),
+                                func.to_jsonb(func.cast(sanitized_session_name, postgresql.TEXT)),
                             ),
                             postgresql.JSON,
                         )

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -861,7 +861,7 @@ class PostgresDb(BaseDb):
                             func.jsonb_set(
                                 func.cast(table.c.session_data, postgresql.JSONB),
                                 text("'{session_name}'"),
-                                func.to_jsonb(sanitized_session_name),
+                                func.to_jsonb(func.cast(sanitized_session_name, postgresql.TEXT)),
                             ),
                             postgresql.JSON,
                         )


### PR DESCRIPTION
## Description

This PR fixes issue #6161 where `PostgresDb.rename_session()` fails with a `sqlalchemy.exc.ProgrammingError: could not determine polymorphic type because input has type unknown` error.

## Root Cause

The `to_jsonb()` function in SQLAlchemy was receiving a string parameter (`sanitized_session_name`) without explicit type casting, causing PostgreSQL to infer it as an "unknown" type, which led to the polymorphic type determination error.

## Solution

Added explicit type casting to `postgresql.TEXT` for the `sanitized_session_name` parameter before passing it to `to_jsonb()`:

```python
func.to_jsonb(func.cast(sanitized_session_name, postgresql.TEXT))
```

## Changes Made

- Modified `libs/agno/agno/db/postgres/postgres.py` - Added TEXT cast in `rename_session()` method
- Modified `libs/agno/agno/db/postgres/async_postgres.py` - Added TEXT cast in `rename_session()` method (async version)

## Testing

Existing tests in `tests/integration/db/postgres/test_session.py` cover the `rename_session()` functionality:
- `test_rename_agent_session()`
- `test_rename_team_session()`
- `test_rename_session_without_deserialize()`

The fix ensures these tests will pass without the datatype mismatch error.

## Checklist

- [x] Code follows project formatting standards (ran `.\scripts\format.bat`)
- [x] Changes applied to both sync and async implementations
- [x] Commit message follows `[type] description` format
- [x] PR description links to the issue using `fixes #6161`

Fixes #6161
