### PR TITLE
fix: remove unused variable in test_seltz to fix CI

### DIFF
--- a/libs/agno/tests/unit/tools/test_seltz.py
+++ b/libs/agno/tests/unit/tools/test_seltz.py
@@ -119,7 +119,7 @@ def test_search_empty_query(seltz_tools):
 
 def test_search_without_api_key():
     """Test search without API key returns error."""
-    with patch("agno.tools.seltz.Seltz") as mock_seltz:
+    with patch("agno.tools.seltz.Seltz"):
         with patch.dict("os.environ", {"SELTZ_API_KEY": ""}, clear=False):
             with patch.object(SeltzTools, "__init__", lambda self, **kwargs: None):
                 tools = SeltzTools()


### PR DESCRIPTION
## Summary

Remove unused `mock_seltz` variable assignment to fix ruff failing the style-check-agno CI job.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
