### PR TITLE
feat: Ability to publish draft config without setting it as current (active)

### DIFF
--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -694,13 +694,14 @@ class BaseDb(ABC):
         stage: Optional[str] = None,
         notes: Optional[str] = None,
         links: Optional[List[Dict[str, Any]]] = None,
+        set_current: bool = True,
     ) -> Dict[str, Any]:
         """Create or update a config version for a component.
 
         Rules:
             - Draft configs can be edited freely
             - Published configs are immutable
-            - Publishing a config automatically sets it as current_version
+            - Publishing a config sets it as current_version if set_current is True
 
         Args:
             component_id: The component ID.
@@ -710,6 +711,8 @@ class BaseDb(ABC):
             stage: "draft" or "published". Defaults to "draft" for new configs.
             notes: Optional notes.
             links: Optional list of links. Each link must have child_version set.
+            set_current: If True (default), publishing sets the config as current.
+                        If False, config is published but current_version is not updated.
 
         Returns:
             Created/updated config dictionary.

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -2996,6 +2996,7 @@ class AsyncPostgresDb(AsyncBaseDb):
         stage: Optional[str] = None,
         notes: Optional[str] = None,
         links: Optional[List[Dict[str, Any]]] = None,
+        set_current: bool = True,
     ) -> Dict[str, Any]:
         raise NotImplementedError("Component methods not yet supported for async databases")
 

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -3665,6 +3665,7 @@ class PostgresDb(BaseDb):
         stage: Optional[str] = None,
         notes: Optional[str] = None,
         links: Optional[List[Dict[str, Any]]] = None,
+        set_current: bool = True,
     ) -> Dict[str, Any]:
         """Create or update a config version for a component.
 
@@ -3825,7 +3826,7 @@ class PostgresDb(BaseDb):
                 # Determine final stage (could be from update or create)
                 final_stage = stage if stage is not None else (existing["stage"] if version is not None else "draft")
 
-                if final_stage == "published":
+                if final_stage == "published" and set_current:
                     sess.execute(
                         components_table.update()
                         .where(components_table.c.component_id == component_id)

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -3225,6 +3225,7 @@ class AsyncSqliteDb(AsyncBaseDb):
         stage: Optional[str] = None,
         notes: Optional[str] = None,
         links: Optional[List[Dict[str, Any]]] = None,
+        set_current: bool = True,
     ) -> Dict[str, Any]:
         raise NotImplementedError("Component methods not yet supported for async databases")
 

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -3547,6 +3547,7 @@ class SqliteDb(BaseDb):
         stage: Optional[str] = None,
         notes: Optional[str] = None,
         links: Optional[List[Dict[str, Any]]] = None,
+        set_current: bool = True,
     ) -> Dict[str, Any]:
         """Create or update a config version for a component.
 
@@ -3703,7 +3704,7 @@ class SqliteDb(BaseDb):
                 # Determine final stage (could be from update or create)
                 final_stage = stage if stage is not None else (existing.stage if version is not None else "draft")
 
-                if final_stage == "published":
+                if final_stage == "published" and set_current:
                     sess.execute(
                         components_table.update()
                         .where(components_table.c.component_id == component_id)

--- a/libs/agno/agno/os/routers/components/components.py
+++ b/libs/agno/agno/os/routers/components/components.py
@@ -322,6 +322,7 @@ def attach_routes(
                 stage=body.stage,
                 notes=body.notes,
                 links=body.links,
+                set_current=body.set_current,
             )
             return ComponentConfigResponse(**config)
         except ValueError as e:
@@ -358,6 +359,7 @@ def attach_routes(
                 stage=body.stage,
                 notes=body.notes,
                 links=body.links,
+                set_current=body.set_current,
             )
             return ComponentConfigResponse(**config)
         except ValueError as e:

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -626,3 +626,4 @@ class ConfigUpdate(BaseModel):
     stage: Optional[str] = None
     notes: Optional[str] = None
     links: Optional[List[Dict[str, Any]]] = None
+    set_current: bool = Field(True, description="Set as current version when publishing")

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -626,4 +626,6 @@ class ConfigUpdate(BaseModel):
     stage: Optional[str] = None
     notes: Optional[str] = None
     links: Optional[List[Dict[str, Any]]] = None
-    set_current: bool = Field(True, description="Set as current version when publishing")
+    set_current: bool = Field(True, 
+    description="Set as current version when publishing. Set to False to publish a config without activating it (useful for staged rollouts or testing). Default is True."
+    )

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -626,6 +626,7 @@ class ConfigUpdate(BaseModel):
     stage: Optional[str] = None
     notes: Optional[str] = None
     links: Optional[List[Dict[str, Any]]] = None
-    set_current: bool = Field(True, 
-    description="Set as current version when publishing. Set to False to publish a config without activating it (useful for staged rollouts or testing). Default is True."
+    set_current: bool = Field(
+        True,
+        description="Set as current version when publishing. Set to False to publish a config without activating it (useful for staged rollouts or testing). Default is True.",
     )


### PR DESCRIPTION
## Summary

Introduces a new `set_current` parameter to the config versioning methods across various database implementations. This parameter controls whether publishing a config sets it as the current version.

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
