### PR TITLE
fix: Learning Machine async recall method

### DIFF
--- a/libs/agno/agno/learn/machine.py
+++ b/libs/agno/agno/learn/machine.py
@@ -645,12 +645,11 @@ class LearningMachine:
         for name, store in self.stores.items():
             try:
                 result = await store.arecall(**context)
-                if result is not None:
-                    results[name] = result
-                    try:
-                        log_debug(f"Recalled from {name}: {result}")
-                    except Exception:
-                        pass
+                results[name] = result
+                try:
+                    log_debug(f"Recalled from {name}: {result}")
+                except Exception:
+                    pass
             except Exception as e:
                 log_warning(f"Error recalling from {name}: {e}")
 


### PR DESCRIPTION
## Summary

Make the async `recall` method have the same behavior as the sync one: to also return empty results so that all stores appear in the dict. This is needed for `build_context` to insert relevant information about the configured stores.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)


