### PR TITLE
ci: simplify Claude workflow to trigger only on @claude mentions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,8 +1,6 @@
 name: Claude Code
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -14,9 +12,7 @@ on:
 
 jobs:
   claude:
-    # Run on PR events (for code review) OR @claude mentions (for assistant)
     if: |
-      (github.event_name == 'pull_request' && !github.event.pull_request.draft) ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
@@ -27,65 +23,13 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
-      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
-      # Automated code review - runs on PR events only
-      - name: Run Claude Code Review
-        if: github.event_name == 'pull_request'
+      - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          track_progress: true
-          prompt: |
-            REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
-
-            Perform a comprehensive code review with the following focus areas:
-
-            1. **Code Quality**
-               - Clean code principles and best practices
-               - Proper error handling and edge cases
-               - Code readability and maintainability
-
-            2. **Security**
-               - Check for potential security vulnerabilities
-               - Validate input sanitization
-               - Review authentication/authorization logic
-
-            3. **Performance**
-               - Identify potential performance bottlenecks
-               - Review database queries for efficiency
-               - Check for memory leaks or resource issues
-
-            4. **Testing**
-               - Verify adequate test coverage
-               - Review test quality and edge cases
-               - Check for missing test scenarios
-
-            5. **Documentation**
-               - Ensure code is properly documented
-               - Verify README updates for new features
-               - Check API documentation accuracy
-
-            Provide detailed feedback using inline comments for specific issues.
-            Use top-level comments for general observations or praise.
-          claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
-
-      # Interactive assistant - runs on @claude mentions only
-      - name: Run Claude Code Assistant
-        if: |
-          github.event_name == 'issue_comment' ||
-          github.event_name == 'pull_request_review_comment' ||
-          github.event_name == 'pull_request_review' ||
-          github.event_name == 'issues'
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          additional_permissions: |
-            actions: read


### PR DESCRIPTION
## Summary

- Remove automatic code review on every PR open/sync
- Keep only `@claude` mention-triggered functionality
- Simplify from 92 lines to 35 lines

## Why

The automatic review on every PR was noisy and not always useful. This change makes Claude opt-in - reviewers can tag `@claude` when they want its input.

## How to use

- Comment `@claude please review this PR` on any PR
- Comment `@claude what does this function do?` on any issue
- Tag Claude in PR review comments for inline discussions

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change (automatic PR reviews will no longer happen)
- [ ] Documentation update
- [ ] Refactoring
- [x] Infrastructure/CI change

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated the documentation accordingly