### PR TITLE
fix: handle None model_response.content before string concatenation

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -750,7 +750,10 @@ class Model(ABC):
                                 ModelResponseEvent.tool_call_completed.value,
                             ]:
                                 if function_call_response.content:
-                                    model_response.content += function_call_response.content  # type: ignore
+                                    if model_response.content is None:
+                                        model_response.content = function_call_response.content
+                                    else:
+                                        model_response.content += function_call_response.content
 
                     # Add a function call for each successful execution
                     function_call_count += len(function_call_results)
@@ -954,7 +957,10 @@ class Model(ABC):
                                 ModelResponseEvent.tool_call_completed.value,
                             ]:
                                 if function_call_response.content:
-                                    model_response.content += function_call_response.content  # type: ignore
+                                    if model_response.content is None:
+                                        model_response.content = function_call_response.content
+                                    else:
+                                        model_response.content += function_call_response.content
 
                     # Add a function call for each successful execution
                     function_call_count += len(function_call_results)


### PR DESCRIPTION
## Summary

Fixes #6219 - Handle `None` value for `model_response.content` before string concatenation.

When using certain models through OpenRouter (e.g., `moonshotai/kimi-k2.5:nitro`), a `TypeError` is raised because `model_response.content` defaults to `None` and the code attempts `+=` without checking for `None` first.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

### Root Cause

In `agno/models/base.py`, lines 753 and 957:

```python
if function_call_response.content:
    model_response.content += function_call_response.content  # type: ignore
```

The `# type: ignore` was masking the fact that `model_response.content` can be `None` (its default in `ModelResponse`).

### Fix

```python
if function_call_response.content:
    if model_response.content is None:
        model_response.content = function_call_response.content
    else:
        model_response.content += function_call_response.content
```

Applied at both sync (line 753) and async (line 957) code paths.