### PR TITLE
feat: Add shebang parsing and Windows command building for script execution

### DIFF
--- a/libs/agno/agno/skills/utils.py
+++ b/libs/agno/agno/skills/utils.py
@@ -72,8 +72,6 @@ def parse_shebang(script_path: Path) -> Optional[str]:
         return None
 
     parts = shebang.split()
-    if not parts:
-        return None
 
     # Handle /usr/bin/env style shebangs
     if Path(parts[0]).name == "env":


### PR DESCRIPTION

## Summary

On Windows, shebang lines (#!/usr/bin/env python3) are not processed by the OS, causing script execution to fail. This PR adds platform detection and shebang parsing so that on Windows, scripts are executed with the appropriate interpreter explicitly specified.
fixes: #6240

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
