### PR TITLE
feat: Support callable knowledge for dynamic per-user/tenant namespacing

### DIFF
--- a/cookbook/07_knowledge/README.md
+++ b/cookbook/07_knowledge/README.md
@@ -68,9 +68,37 @@ Add docs, manuals, and databases so agents can search and cite specific sources 
 - **[specify_reader.py](./basic_operations/specify_reader.py)** - Use specific document readers
 - **[async_speedup.py](./basic_operations/async_speedup.py)** - Async processing for performance
 
+### Dynamic Knowledge (Callable Knowledge)
+Create knowledge bases dynamically at runtime for per-user or per-tenant isolation:
+- **[01_user_namespaced_knowledge.py](./dynamic_knowledge/01_user_namespaced_knowledge.py)** - Per-user knowledge namespacing
+- **[02_multi_tenant_knowledge.py](./dynamic_knowledge/02_multi_tenant_knowledge.py)** - Multi-tenant SaaS architecture
+
+```python
+from agno.agent import Agent
+from agno.run import RunContext
+
+def get_user_knowledge(run_context: RunContext) -> Knowledge:
+    """Create user-specific knowledge at runtime."""
+    user_id = run_context.user_id
+    return Knowledge(
+        vector_db=ChromaDb(
+            collection=f"user_{user_id}_docs",
+            path=f"tmp/chromadb/users/{user_id}",
+        )
+    )
+
+# Pass the function, not the instance
+agent = Agent(knowledge=get_user_knowledge)
+
+# Knowledge is resolved per-run based on user_id
+agent.run("Search my docs", user_id="alice")
+```
+
 ### Other Topics
 - **[chunking/](./chunking/)** - Text chunking strategies
-- **[embedders/](./embedders/)** - Embedding model providers  
+- **[custom_retriever/](./custom_retriever/)** - Custom retrieval logic
+- **[dynamic_knowledge/](./dynamic_knowledge/)** - Runtime-resolved knowledge bases
+- **[embedders/](./embedders/)** - Embedding model providers
 - **[filters/](./filters/)** - Content filtering and access control
 - **[readers/](./readers/)** - Document format processors
 - **[search_type/](./search_type/)** - Search algorithm options

--- a/cookbook/07_knowledge/dynamic_knowledge/01_user_namespaced_knowledge.py
+++ b/cookbook/07_knowledge/dynamic_knowledge/01_user_namespaced_knowledge.py
@@ -1,0 +1,166 @@
+"""
+User-Namespaced Knowledge with Callable Knowledge
+==================================================
+This example demonstrates how to create per-user knowledge bases using
+callable knowledge. Instead of passing a static Knowledge instance to the
+agent, you pass a function that creates the knowledge base at runtime.
+
+Why use callable knowledge?
+---------------------------
+- **Per-user isolation**: Each user gets their own namespace in the vector DB
+- **Simplified access control**: No need for metadata filtering across shared indexes
+- **Efficient auditing**: User data is partition-scoped, not scattered across indexes
+- **Clean deletion**: Removing a user's data is a simple partition drop
+
+Key concepts:
+- knowledge=callable: The function is called at runtime with run_context
+- run_context.user_id: Available to create user-specific namespaces
+- ChromaDb collections: Each user gets their own collection
+
+Example prompts to try:
+- Run as user "alice": "What documents do I have?"
+- Run as user "bob": "Search my knowledge base"
+"""
+
+from agno.agent import Agent
+from agno.knowledge.embedder.openai import OpenAIEmbedder
+from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIChat
+from agno.run import RunContext
+from agno.vectordb.chroma import ChromaDb
+
+# ============================================================================
+# Knowledge Factory Function
+# ============================================================================
+
+
+def get_user_knowledge(run_context: RunContext) -> Knowledge:
+    """Create a user-specific knowledge base at runtime.
+
+    This function is called when agent.run() or agent.arun() is invoked.
+    It receives the run_context which contains user_id, session_id, and
+    other runtime information.
+
+    Args:
+        run_context: Runtime context with user_id, session_id, etc.
+
+    Returns:
+        Knowledge instance configured for this specific user.
+    """
+    user_id = run_context.user_id or "anonymous"
+
+    # Sanitize user_id for use in collection/path names
+    safe_user_id = user_id.replace("@", "_").replace(".", "_")
+
+    print(f"Creating knowledge base for user: {user_id}")
+
+    # Each user gets their own ChromaDb collection
+    # This provides complete isolation at the vector DB level
+    return Knowledge(
+        name=f"Knowledge for {user_id}",
+        vector_db=ChromaDb(
+            name=f"user_{safe_user_id}_docs",
+            collection=f"user_{safe_user_id}_collection",
+            path=f"tmp/chromadb/users/{safe_user_id}",
+            persistent_client=True,
+            embedder=OpenAIEmbedder(id="text-embedding-3-small"),
+        ),
+        max_results=5,
+    )
+
+
+# ============================================================================
+# Create the Agent with Callable Knowledge
+# ============================================================================
+agent = Agent(
+    name="Personal Knowledge Assistant",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    # Pass the function, not a Knowledge instance
+    # The function will be called at runtime with run_context
+    knowledge=get_user_knowledge,
+    search_knowledge=True,
+    instructions="""\
+You are a personal knowledge assistant. You help users search and manage
+their personal knowledge base.
+
+When users ask questions:
+1. Search their knowledge base first
+2. If no relevant documents found, let them know
+3. Suggest they can add documents to their knowledge base
+""",
+    markdown=True,
+)
+
+
+# ============================================================================
+# Helper to Load User-Specific Content
+# ============================================================================
+
+
+def load_user_content(user_id: str, content_url: str, content_name: str):
+    """Load content into a user's knowledge base.
+
+    Since knowledge is created dynamically, we need to create the
+    knowledge instance manually when loading content outside of a run.
+    """
+    # Create a minimal run_context for the knowledge factory
+    run_context = RunContext(
+        run_id="load",
+        session_id="load",
+        user_id=user_id,
+    )
+
+    # Get the user's knowledge instance
+    knowledge = get_user_knowledge(run_context)
+
+    # Load the content
+    print(f"Loading '{content_name}' for user {user_id}...")
+    knowledge.insert(name=content_name, url=content_url)
+    print("Content loaded successfully")
+
+
+# ============================================================================
+# Main: Demonstrate User-Specific Knowledge
+# ============================================================================
+if __name__ == "__main__":
+    # Load different content for different users
+    load_user_content(
+        user_id="alice",
+        content_url="https://docs.agno.com/introduction.md",
+        content_name="Agno Introduction",
+    )
+
+    load_user_content(
+        user_id="bob",
+        content_url="https://docs.agno.com/agents/introduction.md",
+        content_name="Agno Agents Guide",
+    )
+
+    # Query as Alice - she only sees her documents
+    print("\n" + "=" * 60)
+    print("Querying as Alice:")
+    print("=" * 60)
+    agent.print_response(
+        "What is Agno?",
+        user_id="alice",
+        stream=True,
+    )
+
+    # Query as Bob - he only sees his documents
+    print("\n" + "=" * 60)
+    print("Querying as Bob:")
+    print("=" * 60)
+    agent.print_response(
+        "Tell me about agents",
+        user_id="bob",
+        stream=True,
+    )
+
+    # Query as anonymous user - separate namespace
+    print("\n" + "=" * 60)
+    print("Querying as anonymous (no user_id):")
+    print("=" * 60)
+    agent.print_response(
+        "What documents do I have?",
+        stream=True,
+    )

--- a/cookbook/07_knowledge/dynamic_knowledge/02_multi_tenant_knowledge.py
+++ b/cookbook/07_knowledge/dynamic_knowledge/02_multi_tenant_knowledge.py
@@ -1,0 +1,223 @@
+"""
+Multi-Tenant Knowledge with Callable Knowledge
+==============================================
+This example demonstrates a multi-tenant architecture where each organization
+(tenant) has completely isolated knowledge bases. This pattern is essential
+for SaaS applications where data isolation is critical.
+
+Architecture:
+------------
+- Each tenant gets their own vector database namespace
+- Users within a tenant share the same knowledge base
+- Tenant ID comes from session_state or dependencies at runtime
+- Complete data isolation between tenants
+
+Benefits over metadata filtering:
+--------------------------------
+1. **Security**: Physical isolation, not just query-time filtering
+2. **Performance**: Smaller indexes per tenant = faster queries
+3. **Compliance**: Easy to demonstrate data isolation for audits
+4. **Data lifecycle**: Simple tenant offboarding (drop partition)
+
+Example usage:
+- Organization "acme" has their internal docs
+- Organization "globex" has different docs
+- Each org's users only see their org's documents
+"""
+
+from typing import Any, Dict
+
+from agno.agent import Agent
+from agno.knowledge.embedder.openai import OpenAIEmbedder
+from agno.knowledge.knowledge import Knowledge
+from agno.models.openai import OpenAIChat
+from agno.run import RunContext
+from agno.vectordb.chroma import ChromaDb
+
+# ============================================================================
+# Multi-Tenant Knowledge Factory
+# ============================================================================
+
+
+def get_tenant_knowledge(
+    agent: Agent,
+    session_state: Dict[str, Any],
+    run_context: RunContext,
+) -> Knowledge:
+    """Create a tenant-specific knowledge base at runtime.
+
+    This function demonstrates accessing multiple sources of context:
+    - agent: The agent instance (for accessing agent config)
+    - session_state: Persistent state across the session
+    - run_context: Runtime context with user_id, dependencies, etc.
+
+    Tenant ID resolution priority:
+    1. From dependencies (passed at runtime)
+    2. From session_state (persisted across runs)
+    3. Default to "public" tenant
+
+    Args:
+        agent: The Agent instance.
+        session_state: Current session state dictionary.
+        run_context: Runtime context with dependencies, user_id, etc.
+
+    Returns:
+        Knowledge instance configured for this tenant.
+    """
+    # Try to get tenant_id from various sources
+    tenant_id = None
+
+    # 1. Check dependencies (highest priority - explicitly passed)
+    if run_context.dependencies:
+        tenant_id = run_context.dependencies.get("tenant_id")
+
+    # 2. Check session_state (persisted from previous runs)
+    if not tenant_id and session_state:
+        tenant_id = session_state.get("tenant_id")
+
+    # 3. Default to public tenant
+    if not tenant_id:
+        tenant_id = "public"
+
+    # Sanitize for use in paths/collection names
+    safe_tenant_id = tenant_id.lower().replace(" ", "_").replace("-", "_")
+
+    print(f"Resolving knowledge for tenant: {tenant_id}")
+    print(f"  - User: {run_context.user_id or 'anonymous'}")
+    print(f"  - Session: {run_context.session_id}")
+
+    # Create tenant-isolated knowledge base
+    return Knowledge(
+        name=f"{tenant_id} Knowledge Base",
+        vector_db=ChromaDb(
+            name=f"tenant_{safe_tenant_id}",
+            collection=f"tenant_{safe_tenant_id}_docs",
+            path=f"tmp/chromadb/tenants/{safe_tenant_id}",
+            persistent_client=True,
+            embedder=OpenAIEmbedder(id="text-embedding-3-small"),
+        ),
+        max_results=5,
+    )
+
+
+# ============================================================================
+# Create the Multi-Tenant Agent
+# ============================================================================
+agent = Agent(
+    name="Enterprise Knowledge Assistant",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    # Callable knowledge - resolved per-run based on tenant context
+    knowledge=get_tenant_knowledge,
+    search_knowledge=True,
+    instructions="""\
+You are an enterprise knowledge assistant serving multiple organizations.
+Each organization has their own isolated knowledge base.
+
+Guidelines:
+1. Search the organization's knowledge base to answer questions
+2. Never reference or hint at other organizations' data
+3. If information isn't found, suggest contacting the admin
+4. Be professional and context-aware
+""",
+    markdown=True,
+)
+
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+
+def load_tenant_content(tenant_id: str, content_url: str, content_name: str):
+    """Load content into a tenant's knowledge base."""
+    run_context = RunContext(
+        run_id="load",
+        session_id="load",
+        user_id="system",
+        dependencies={"tenant_id": tenant_id},
+    )
+
+    knowledge = get_tenant_knowledge(
+        agent=agent,
+        session_state={},
+        run_context=run_context,
+    )
+
+    print(f"Loading '{content_name}' for tenant '{tenant_id}'...")
+    knowledge.insert(name=content_name, url=content_url)
+    print("Content loaded successfully\n")
+
+
+def query_as_tenant(tenant_id: str, user_id: str, query: str):
+    """Query the agent as a user from a specific tenant."""
+    print("\n" + "=" * 60)
+    print(f"Tenant: {tenant_id} | User: {user_id}")
+    print(f"Query: {query}")
+    print("=" * 60)
+
+    agent.print_response(
+        query,
+        user_id=user_id,
+        dependencies={"tenant_id": tenant_id},
+        stream=True,
+    )
+
+
+# ============================================================================
+# Main: Demonstrate Multi-Tenant Isolation
+# ============================================================================
+if __name__ == "__main__":
+    # Setup: Load different content for different tenants
+    print("Setting up tenant knowledge bases...\n")
+
+    load_tenant_content(
+        tenant_id="acme",
+        content_url="https://docs.agno.com/introduction.md",
+        content_name="ACME Internal Docs",
+    )
+
+    load_tenant_content(
+        tenant_id="globex",
+        content_url="https://docs.agno.com/agents/introduction.md",
+        content_name="Globex Agent Guidelines",
+    )
+
+    # Demonstrate tenant isolation
+    print("\n" + "#" * 60)
+    print("# DEMONSTRATING TENANT ISOLATION")
+    print("#" * 60)
+
+    # ACME user queries - sees only ACME docs
+    query_as_tenant(
+        tenant_id="acme",
+        user_id="alice@acme.com",
+        query="What can you tell me about our documentation?",
+    )
+
+    # Globex user queries - sees only Globex docs
+    query_as_tenant(
+        tenant_id="globex",
+        user_id="bob@globex.com",
+        query="What are the guidelines for agents?",
+    )
+
+    # ACME user asking about agents - won't find Globex content
+    query_as_tenant(
+        tenant_id="acme",
+        user_id="alice@acme.com",
+        query="What are the agent guidelines?",
+    )
+
+    print("\n" + "#" * 60)
+    print("# USING SESSION STATE FOR TENANT CONTEXT")
+    print("#" * 60)
+
+    # Alternative: Pass tenant via session_state
+    # Useful when tenant is determined once per session
+    print("\nQuerying with tenant_id in session_state:")
+    agent.print_response(
+        "What documentation do we have?",
+        user_id="charlie@acme.com",
+        session_state={"tenant_id": "acme"},
+        stream=True,
+    )

--- a/cookbook/07_knowledge/dynamic_knowledge/__init__.py
+++ b/cookbook/07_knowledge/dynamic_knowledge/__init__.py
@@ -1,0 +1,5 @@
+# Dynamic Knowledge Examples
+#
+# This folder contains examples of using callable knowledge for runtime-resolved
+# knowledge bases. This enables per-user or per-tenant namespacing at the vector
+# database level.

--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -26,6 +26,8 @@ class RunContext:
     metadata: Optional[Dict[str, Any]] = None
     session_state: Optional[Dict[str, Any]] = None
     output_schema: Optional[Union[Type[BaseModel], Dict[str, Any]]] = None
+    # Resolved knowledge instance (when knowledge is provided as a callable)
+    knowledge: Optional[Any] = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary

Add support for passing a callable to Agent's `knowledge` parameter. When a callable is provided, it's resolved at runtime with access to `agent`, `session_state`, and `run_context`. This enables:

- **Per-user knowledge namespacing**: Each user gets an isolated vector DB partition
- **Multi-tenant architectures**: Organizations have completely separate knowledge bases
- **Dynamic knowledge creation**: Knowledge bases created based on runtime context

### Why callable knowledge?

Metadata filtering at query time handles the happy path but breaks down when you need to audit or revoke access. If a user gets reassigned, you're scanning every document to find what had `user_id=john` attached.

With callable knowledge, you get separate namespaces per tenant at the vector DB level. Deletion and access audits become partition-scoped instead of full-index scans.

### Example usage

```python
from agno.agent import Agent
from agno.run import RunContext
from agno.knowledge.knowledge import Knowledge
from agno.vectordb.chroma import ChromaDb

def get_user_knowledge(run_context: RunContext) -> Knowledge:
    """Create user-specific knowledge at runtime."""
    return Knowledge(
        vector_db=ChromaDb(
            collection=f"user_{run_context.user_id}_docs",
            path=f"./chromadb/users/{run_context.user_id}"
        )
    )

agent = Agent(
    knowledge=get_user_knowledge,  # Callable, not instance
    search_knowledge=True,
)

# Knowledge resolved per-run based on user_id
agent.run("Search my docs", user_id="alice")  # Uses alice's namespace
agent.run("Search my docs", user_id="bob")    # Uses bob's namespace
```

### Changes

**Core implementation:**
- Add `knowledge` field to `RunContext` for storing resolved knowledge
- Add `resolve_knowledge()` and `aresolve_knowledge()` utility functions in `utils/agent.py`
- Update Agent to resolve callable knowledge at start of `run()`/`arun()`/`continue_run()`/`acontinue_run()`
- Add `_get_knowledge(run_context)` helper method for accessing resolved knowledge
- Update ~30 `self.knowledge` access points to use the helper
- Add `_create_add_to_knowledge_tool()` factory to capture resolved knowledge for update_knowledge tool

**Cookbooks:**
- `cookbook/07_knowledge/dynamic_knowledge/01_user_namespaced_knowledge.py` - Per-user isolation
- `cookbook/07_knowledge/dynamic_knowledge/02_multi_tenant_knowledge.py` - Multi-tenant SaaS pattern

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

The callable receives these parameters based on its signature (inspected at runtime):
- `agent`: The Agent instance
- `session_state`: Current session state dict
- `run_context`: Full RunContext with `user_id`, `session_id`, `dependencies`, etc.

This follows the same pattern as callable `instructions` and `system_message`.

🤖 Generated with [Claude Code](https://claude.ai/code)