### PR TITLE
feat: add is_component flag to agent, team, and workflow responses

### DIFF
--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -589,7 +589,7 @@ def get_agent_router(
                 if isinstance(agent, RemoteAgent):
                     agents.append(await agent.get_agent_config())
                 else:
-                    agent_response = await AgentResponse.from_agent(agent=agent)
+                    agent_response = await AgentResponse.from_agent(agent=agent, is_component=False)
                     agents.append(agent_response)
 
         if os.db and isinstance(os.db, BaseDb):
@@ -598,7 +598,7 @@ def get_agent_router(
             db_agents = get_agents(db=os.db, registry=registry)
             if db_agents:
                 for db_agent in db_agents:
-                    agent_response = await AgentResponse.from_agent(agent=db_agent)
+                    agent_response = await AgentResponse.from_agent(agent=db_agent, is_component=True)
                     agents.append(agent_response)
 
         return agents

--- a/libs/agno/agno/os/routers/agents/schema.py
+++ b/libs/agno/agno/os/routers/agents/schema.py
@@ -35,9 +35,10 @@ class AgentResponse(BaseModel):
     streaming: Optional[Dict[str, Any]] = None
     metadata: Optional[Dict[str, Any]] = None
     input_schema: Optional[Dict[str, Any]] = None
+    is_component: bool = False
 
     @classmethod
-    async def from_agent(cls, agent: Agent) -> "AgentResponse":
+    async def from_agent(cls, agent: Agent, is_component: bool = False) -> "AgentResponse":
         def filter_meaningful_config(d: Dict[str, Any], defaults: Dict[str, Any]) -> Optional[Dict[str, Any]]:
             """Filter out fields that match their default values, keeping only meaningful user configurations"""
             filtered = {}
@@ -285,4 +286,5 @@ class AgentResponse(BaseModel):
             introduction=agent.introduction,
             metadata=agent.metadata,
             input_schema=input_schema_dict,
+            is_component=is_component,
         )

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -438,7 +438,7 @@ def get_team_router(
             if isinstance(team, RemoteTeam):
                 teams.append(await team.get_team_config())
             else:
-                team_response = await TeamResponse.from_team(team=team)
+                team_response = await TeamResponse.from_team(team=team, is_component=False)
                 teams.append(team_response)
 
         # Also load teams from database
@@ -447,7 +447,7 @@ def get_team_router(
 
             db_teams = get_teams(db=os.db, registry=registry)
             for db_team in db_teams:
-                team_response = await TeamResponse.from_team(team=db_team)
+                team_response = await TeamResponse.from_team(team=db_team, is_component=True)
                 teams.append(team_response)
 
         return teams

--- a/libs/agno/agno/os/routers/teams/schema.py
+++ b/libs/agno/agno/os/routers/teams/schema.py
@@ -36,9 +36,10 @@ class TeamResponse(BaseModel):
     members: Optional[List[Union[AgentResponse, "TeamResponse"]]] = None
     metadata: Optional[Dict[str, Any]] = None
     input_schema: Optional[Dict[str, Any]] = None
+    is_component: bool = False
 
     @classmethod
-    async def from_team(cls, team: Team) -> "TeamResponse":
+    async def from_team(cls, team: Team, is_component: bool = False) -> "TeamResponse":
         def filter_meaningful_config(d: Dict[str, Any], defaults: Dict[str, Any]) -> Optional[Dict[str, Any]]:
             """Filter out fields that match their default values, keeping only meaningful user configurations"""
             filtered = {}
@@ -277,4 +278,5 @@ class TeamResponse(BaseModel):
             members=members if members else None,
             metadata=team.metadata,
             input_schema=input_schema_dict,
+            is_component=is_component,
         )

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -547,7 +547,7 @@ def get_workflow_router(
         workflows: List[WorkflowSummaryResponse] = []
         if accessible_workflows:
             for workflow in accessible_workflows:
-                workflows.append(WorkflowSummaryResponse.from_workflow(workflow=workflow))
+                workflows.append(WorkflowSummaryResponse.from_workflow(workflow=workflow, is_component=False))
 
         if os.db and isinstance(os.db, BaseDb):
             from agno.workflow.workflow import get_workflows
@@ -555,7 +555,7 @@ def get_workflow_router(
             db_workflows = get_workflows(db=os.db, registry=os.registry)
             if db_workflows:
                 for db_workflow in db_workflows:
-                    workflows.append(WorkflowSummaryResponse.from_workflow(workflow=db_workflow))
+                    workflows.append(WorkflowSummaryResponse.from_workflow(workflow=db_workflow, is_component=True))
 
         return workflows
 

--- a/libs/agno/agno/os/routers/workflows/schema.py
+++ b/libs/agno/agno/os/routers/workflows/schema.py
@@ -84,6 +84,7 @@ class WorkflowResponse(BaseModel):
     team: Optional[TeamResponse] = Field(None, description="Team configuration if used")
     metadata: Optional[Dict[str, Any]] = Field(None, description="Additional metadata")
     workflow_agent: bool = Field(False, description="Whether this workflow uses a WorkflowAgent")
+    is_component: bool = Field(False, description="Whether this workflow was created via Builder")
 
     @classmethod
     async def _resolve_agents_and_teams_recursively(cls, steps: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
@@ -120,7 +121,7 @@ class WorkflowResponse(BaseModel):
         return steps
 
     @classmethod
-    async def from_workflow(cls, workflow: Workflow) -> "WorkflowResponse":
+    async def from_workflow(cls, workflow: Workflow, is_component: bool = False) -> "WorkflowResponse":
         workflow_dict = workflow.to_dict_for_steps()
         steps = workflow_dict.get("steps")
 
@@ -136,4 +137,5 @@ class WorkflowResponse(BaseModel):
             input_schema=get_workflow_input_schema_dict(workflow),
             metadata=workflow.metadata,
             workflow_agent=isinstance(workflow.agent, WorkflowAgent) if workflow.agent else False,
+            is_component=is_component,
         )

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -124,15 +124,19 @@ class WorkflowSummaryResponse(BaseModel):
     name: Optional[str] = Field(None, description="Name of the workflow")
     description: Optional[str] = Field(None, description="Description of the workflow")
     db_id: Optional[str] = Field(None, description="Database identifier")
+    is_component: bool = Field(False, description="Whether this workflow was created via Builder")
 
     @classmethod
-    def from_workflow(cls, workflow: Union[Workflow, RemoteWorkflow]) -> "WorkflowSummaryResponse":
+    def from_workflow(
+        cls, workflow: Union[Workflow, RemoteWorkflow], is_component: bool = False
+    ) -> "WorkflowSummaryResponse":
         db_id = workflow.db.id if workflow.db else None
         return cls(
             id=workflow.id,
             name=workflow.name,
             description=workflow.description,
             db_id=db_id,
+            is_component=is_component,
         )
 
 


### PR DESCRIPTION
## Summary

Adds an `is_component` boolean field to Agent, Team, and Workflow API responses so the frontend can differentiate between code-defined resources and those created via Builder (DB-stored).

- Code-defined resources: `is_component = false`
- Builder/DB-created resources: `is_component = true`

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Files changed:
- `agents/schema.py` + `agents/router.py`
- `teams/schema.py` + `teams/router.py`
- `workflows/schema.py` + `workflows/router.py`
- `os/schema.py` (WorkflowSummaryResponse)