### PR TITLE
[feat] Add multi-block system message caching for Claude

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -526,7 +526,7 @@ class Claude(Model):
 
     def _prepare_request_kwargs(
         self,
-        system_message: str,
+        system_message: Union[str, List[Dict[str, Any]]],
         tools: Optional[List[Dict[str, Any]]] = None,
         response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
     ) -> Dict[str, Any]:
@@ -534,7 +534,9 @@ class Claude(Model):
         Prepare the request keyword arguments for the API call.
 
         Args:
-            system_message (str): The concatenated system messages.
+            system_message: The system messages, either as:
+                - A concatenated string (legacy format)
+                - A list of structured blocks with optional cache_control (multi-block format)
             tools: Optional list of tools
             response_format: Optional response format (Pydantic model or dict)
 
@@ -547,7 +549,11 @@ class Claude(Model):
         # Pass response_format and tools to get_request_params for beta header handling
         request_kwargs = self.get_request_params(response_format=response_format, tools=tools).copy()
         if system_message:
-            if self.cache_system_prompt:
+            if isinstance(system_message, list):
+                # Multi-block format with per-message cache_control from format_messages()
+                request_kwargs["system"] = system_message
+            elif self.cache_system_prompt:
+                # Legacy string format with model-level cache settings
                 cache_control = (
                     {"type": "ephemeral", "ttl": "1h"}
                     if self.extended_cache_time is not None and self.extended_cache_time is True

--- a/libs/agno/agno/models/aws/claude.py
+++ b/libs/agno/agno/models/aws/claude.py
@@ -198,7 +198,7 @@ class Claude(AnthropicClaude):
 
     def _prepare_request_kwargs(
         self,
-        system_message: str,
+        system_message: Union[str, List[Dict[str, Any]]],
         tools: Optional[List[Dict[str, Any]]] = None,
         response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
     ) -> Dict[str, Any]:
@@ -206,7 +206,9 @@ class Claude(AnthropicClaude):
         Prepare the request keyword arguments for the API call.
 
         Args:
-            system_message (str): The concatenated system messages.
+            system_message: The system messages, either as:
+                - A concatenated string (legacy format)
+                - A list of structured blocks with optional cache_control (multi-block format)
             tools: Optional list of tools
             response_format: Optional response format (Pydantic model or dict)
 
@@ -216,7 +218,11 @@ class Claude(AnthropicClaude):
         # Pass response_format and tools to get_request_params for beta header handling
         request_kwargs = self.get_request_params(response_format=response_format, tools=tools).copy()
         if system_message:
-            if self.cache_system_prompt:
+            if isinstance(system_message, list):
+                # Multi-block format with per-message cache_control from format_messages()
+                request_kwargs["system"] = system_message
+            elif self.cache_system_prompt:
+                # Legacy string format with model-level cache settings
                 cache_control = (
                     {"type": "ephemeral", "ttl": "1h"}
                     if self.extended_cache_time is not None and self.extended_cache_time is True

--- a/libs/agno/agno/models/vertexai/claude.py
+++ b/libs/agno/agno/models/vertexai/claude.py
@@ -153,7 +153,7 @@ class Claude(AnthropicClaude):
 
     def _prepare_request_kwargs(
         self,
-        system_message: str,
+        system_message: Union[str, List[Dict[str, Any]]],
         tools: Optional[List[Dict[str, Any]]] = None,
         response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
     ) -> Dict[str, Any]:
@@ -161,7 +161,9 @@ class Claude(AnthropicClaude):
         Prepare the request keyword arguments for the API call.
 
         Args:
-            system_message (str): The concatenated system messages.
+            system_message: The system messages, either as:
+                - A concatenated string (legacy format)
+                - A list of structured blocks with optional cache_control (multi-block format)
             tools: Optional list of tools
             response_format: Optional response format (Pydantic model or dict)
 
@@ -171,7 +173,11 @@ class Claude(AnthropicClaude):
         # Pass response_format and tools to get_request_params for beta header handling
         request_kwargs = self.get_request_params(response_format=response_format, tools=tools).copy()
         if system_message:
-            if self.cache_system_prompt:
+            if isinstance(system_message, list):
+                # Multi-block format with per-message cache_control from format_messages()
+                request_kwargs["system"] = system_message
+            elif self.cache_system_prompt:
+                # Legacy string format with model-level cache settings
                 cache_control = (
                     {"type": "ephemeral", "ttl": "1h"}
                     if self.extended_cache_time is not None and self.extended_cache_time is True

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -221,9 +221,13 @@ def _format_file_for_message(file: File) -> Optional[Dict[str, Any]]:
     return None
 
 
+# Type alias for system message return value
+SystemMessageResult = Union[str, List[Dict[str, Any]]]
+
+
 def format_messages(
     messages: List[Message], compress_tool_results: bool = False
-) -> Tuple[List[Dict[str, Union[str, list]]], str]:
+) -> Tuple[List[Dict[str, Union[str, list]]], SystemMessageResult]:
     """
     Process the list of messages and separate them into API messages and system messages.
 
@@ -232,17 +236,26 @@ def format_messages(
         compress_tool_results: Whether to compress tool results.
 
     Returns:
-        Tuple[List[Dict[str, Union[str, list]]], str]: A tuple containing the list of API messages and the concatenated system messages.
+        Tuple containing:
+        - List of API messages
+        - System messages as either:
+          - A concatenated string (default, backwards compatible)
+          - A list of structured blocks if any system message has provider_data.cache_control
+
+    Note:
+        When any system message has `provider_data={"cache_control": {...}}`, the function
+        returns a list of structured blocks to enable per-block cache control in Claude API.
+        This allows caching static instructions while keeping dynamic context uncached.
     """
     chat_messages: List[Dict[str, Union[str, list]]] = []
-    system_messages: List[str] = []
+    system_messages: List[Message] = []  # Keep full Message objects for cache_control access
 
     for message in messages:
         content = message.content or ""
         # Both "system" and "developer" roles should be extracted as system messages
         if message.role in ("system", "developer"):
             if content is not None:
-                system_messages.append(content)  # type: ignore
+                system_messages.append(message)  # Keep full message for provider_data
             continue
         elif message.role == "user":
             if isinstance(content, str):
@@ -321,7 +334,23 @@ def format_messages(
             continue
 
         chat_messages.append({"role": ROLE_MAP[message.role], "content": content})  # type: ignore
-    return chat_messages, " ".join(system_messages)
+
+    # Check if any system message has cache_control in provider_data
+    has_cache_control = any(m.provider_data and "cache_control" in m.provider_data for m in system_messages)
+
+    if has_cache_control:
+        # Return structured blocks with per-message cache_control
+        system_blocks: List[Dict[str, Any]] = []
+        for m in system_messages:
+            block: Dict[str, Any] = {"type": "text", "text": m.content}
+            if m.provider_data and "cache_control" in m.provider_data:
+                block["cache_control"] = m.provider_data["cache_control"]
+            system_blocks.append(block)
+        return chat_messages, system_blocks
+    else:
+        # Backwards compatible: return concatenated string
+        system_contents = [str(m.content) for m in system_messages if m.content]
+        return chat_messages, " ".join(system_contents)
 
 
 def format_tools_for_model(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:

--- a/libs/agno/tests/unit/utils/test_claude.py
+++ b/libs/agno/tests/unit/utils/test_claude.py
@@ -1,0 +1,237 @@
+"""
+Unit tests for Claude utility functions.
+
+Tests multi-block system message caching functionality.
+"""
+
+from agno.models.message import Message
+from agno.utils.models.claude import format_messages
+
+
+class TestFormatMessagesWithCacheControl:
+    """Tests for multi-block system message caching in format_messages()."""
+
+    def test_no_cache_control_returns_string(self):
+        """Without cache_control, returns concatenated string (backwards compatible)."""
+        messages = [
+            Message(role="system", content="You are helpful."),
+            Message(role="system", content="Be concise."),
+            Message(role="user", content="Hello"),
+        ]
+        chat_messages, system_message = format_messages(messages)
+
+        assert isinstance(system_message, str)
+        assert system_message == "You are helpful. Be concise."
+        assert len(chat_messages) == 1
+        assert chat_messages[0]["role"] == "user"
+
+    def test_with_cache_control_returns_list(self):
+        """With cache_control on any message, returns list of structured blocks."""
+        messages = [
+            Message(
+                role="system",
+                content="Static instructions",
+                provider_data={"cache_control": {"type": "ephemeral"}},
+            ),
+            Message(role="system", content="Dynamic context"),
+            Message(role="user", content="Hello"),
+        ]
+        chat_messages, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert len(system_message) == 2
+
+        # First block has cache_control
+        assert system_message[0]["type"] == "text"
+        assert system_message[0]["text"] == "Static instructions"
+        assert system_message[0]["cache_control"] == {"type": "ephemeral"}
+
+        # Second block has no cache_control
+        assert system_message[1]["type"] == "text"
+        assert system_message[1]["text"] == "Dynamic context"
+        assert "cache_control" not in system_message[1]
+
+    def test_cache_control_with_extended_ttl(self):
+        """Cache control with extended TTL is preserved."""
+        messages = [
+            Message(
+                role="system",
+                content="Instructions",
+                provider_data={"cache_control": {"type": "ephemeral", "ttl": "1h"}},
+            ),
+        ]
+        chat_messages, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert system_message[0]["cache_control"]["type"] == "ephemeral"
+        assert system_message[0]["cache_control"]["ttl"] == "1h"
+
+    def test_developer_role_treated_as_system(self):
+        """Developer role messages are treated as system messages."""
+        messages = [
+            Message(
+                role="developer",
+                content="Developer instructions",
+                provider_data={"cache_control": {"type": "ephemeral"}},
+            ),
+            Message(role="user", content="Hello"),
+        ]
+        chat_messages, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert len(system_message) == 1
+        assert system_message[0]["text"] == "Developer instructions"
+
+    def test_empty_system_messages_returns_empty_string(self):
+        """No system messages returns empty string."""
+        messages = [
+            Message(role="user", content="Hello"),
+        ]
+        chat_messages, system_message = format_messages(messages)
+
+        assert system_message == ""
+
+    def test_mixed_system_and_developer_with_cache_control(self):
+        """Mixed system and developer roles with cache_control."""
+        messages = [
+            Message(
+                role="system",
+                content="System instructions",
+                provider_data={"cache_control": {"type": "ephemeral"}},
+            ),
+            Message(role="developer", content="Developer context"),
+            Message(role="user", content="Hello"),
+        ]
+        chat_messages, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert len(system_message) == 2
+        assert system_message[0]["text"] == "System instructions"
+        assert "cache_control" in system_message[0]
+        assert system_message[1]["text"] == "Developer context"
+        assert "cache_control" not in system_message[1]
+
+    def test_provider_data_without_cache_control_returns_string(self):
+        """provider_data without cache_control key returns string format."""
+        messages = [
+            Message(
+                role="system",
+                content="Instructions",
+                provider_data={"other_key": "value"},
+            ),
+        ]
+        chat_messages, system_message = format_messages(messages)
+
+        assert isinstance(system_message, str)
+        assert system_message == "Instructions"
+
+    def test_cache_control_on_last_message_only(self):
+        """Cache control on last system message triggers list format for all."""
+        messages = [
+            Message(role="system", content="First"),
+            Message(role="system", content="Second"),
+            Message(
+                role="system",
+                content="Third with cache",
+                provider_data={"cache_control": {"type": "ephemeral"}},
+            ),
+            Message(role="user", content="Hello"),
+        ]
+        chat_messages, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert len(system_message) == 3
+        # First two have no cache_control
+        assert "cache_control" not in system_message[0]
+        assert "cache_control" not in system_message[1]
+        # Third has cache_control
+        assert system_message[2]["cache_control"] == {"type": "ephemeral"}
+
+    def test_multiple_cache_control_blocks(self):
+        """Multiple blocks can have cache_control."""
+        messages = [
+            Message(
+                role="system",
+                content="Static A",
+                provider_data={"cache_control": {"type": "ephemeral"}},
+            ),
+            Message(role="system", content="Dynamic"),
+            Message(
+                role="system",
+                content="Static B",
+                provider_data={"cache_control": {"type": "ephemeral", "ttl": "1h"}},
+            ),
+            Message(role="user", content="Hello"),
+        ]
+        chat_messages, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert len(system_message) == 3
+        assert system_message[0]["cache_control"] == {"type": "ephemeral"}
+        assert "cache_control" not in system_message[1]
+        assert system_message[2]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+    def test_system_messages_order_preserved(self):
+        """System messages maintain their order in list format."""
+        messages = [
+            Message(
+                role="system",
+                content="First",
+                provider_data={"cache_control": {"type": "ephemeral"}},
+            ),
+            Message(role="system", content="Second"),
+            Message(role="system", content="Third"),
+            Message(role="user", content="Hello"),
+        ]
+        chat_messages, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert [b["text"] for b in system_message] == ["First", "Second", "Third"]
+
+    def test_chat_messages_unaffected_by_cache_control(self):
+        """User and assistant messages are unaffected by system cache_control."""
+        messages = [
+            Message(
+                role="system",
+                content="System",
+                provider_data={"cache_control": {"type": "ephemeral"}},
+            ),
+            Message(role="user", content="User question"),
+            Message(role="assistant", content="Assistant response"),
+            Message(role="user", content="Follow up"),
+        ]
+        chat_messages, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert len(chat_messages) == 3
+        assert chat_messages[0]["role"] == "user"
+        assert chat_messages[1]["role"] == "assistant"
+        assert chat_messages[2]["role"] == "user"
+
+    def test_single_system_message_without_cache_control(self):
+        """Single system message without cache_control returns string."""
+        messages = [
+            Message(role="system", content="Single instruction"),
+            Message(role="user", content="Hello"),
+        ]
+        chat_messages, system_message = format_messages(messages)
+
+        assert isinstance(system_message, str)
+        assert system_message == "Single instruction"
+
+    def test_single_system_message_with_cache_control(self):
+        """Single system message with cache_control returns list."""
+        messages = [
+            Message(
+                role="system",
+                content="Single instruction",
+                provider_data={"cache_control": {"type": "ephemeral"}},
+            ),
+            Message(role="user", content="Hello"),
+        ]
+        chat_messages, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert len(system_message) == 1
+        assert system_message[0]["text"] == "Single instruction"
+        assert system_message[0]["cache_control"] == {"type": "ephemeral"}


### PR DESCRIPTION
## Summary

Adds support for multi-block system message caching for Claude models.

This allows users to cache static parts of their system prompt (like base instructions) while keeping dynamic parts (like tenant context) uncached, enabling effective prompt caching in multi-tenant applications.

Fixes #6280

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

### How it works

The existing `Message.provider_data` field is used to carry cache control hints:

```python
Message(
    role="system",
    content="Static instructions...",
    provider_data={"cache_control": {"type": "ephemeral"}}
)
```

When `format_messages()` detects any system message with `provider_data.cache_control`, it returns a list of structured blocks instead of a concatenated string.

### Backwards Compatibility

- If no messages have `provider_data.cache_control`, behavior is unchanged
- Existing `cache_system_prompt=True` on the model still works for single-block caching
- Works for both direct Anthropic API and AWS Bedrock

### Use Case

Multi-tenant SaaS applications where base instructions (10k+ tokens) are identical across all tenants, but tenant-specific context varies per request.