### PR TITLE
refactor: rename RegistryContentType to RegistryResourceType

### DIFF
--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -629,8 +629,8 @@ class ConfigUpdate(BaseModel):
     links: Optional[List[Dict[str, Any]]] = None
 
 
-class RegistryContentType(str, Enum):
-    """Types of components that can be stored in a registry."""
+class RegistryResourceType(str, Enum):
+    """Types of resources that can be stored in a registry."""
 
     TOOL = "tool"
     MODEL = "model"
@@ -727,6 +727,6 @@ RegistryMetadata = Union[
 
 class RegistryContentResponse(BaseModel):
     name: str
-    type: RegistryContentType
+    type: RegistryResourceType
     description: Optional[str] = None
     metadata: Optional[Dict[str, Any]] = None

--- a/libs/agno/tests/unit/os/routers/test_registry_router.py
+++ b/libs/agno/tests/unit/os/routers/test_registry_router.py
@@ -369,7 +369,7 @@ class TestListRegistryFiltering:
     """Tests for GET /registry endpoint filtering."""
 
     def test_list_registry_filter_by_type(self, settings):
-        """Test list_registry filters by component_type."""
+        """Test list_registry filters by resource_type."""
 
         def my_tool():
             pass
@@ -386,7 +386,7 @@ class TestListRegistryFiltering:
         app.include_router(router)
         client = TestClient(app)
 
-        response = client.get("/registry?component_type=db")
+        response = client.get("/registry?resource_type=db")
 
         assert response.status_code == 200
         data = response.json()


### PR DESCRIPTION
## Summary

- Rename `RegistryContentType` enum to `RegistryResourceType` in schema
- Rename `component_type` query parameter to `resource_type` in registry router
- Update internal function and variable names for consistency

This differentiates the registry router from the components router:
- **Components router**: manages agents/teams/workflows, uses `component_type`
- **Registry router**: exposes tools/models/dbs/etc., now uses `resource_type`

## Type of change

- [x] Refactor (non-breaking change that improves code quality)

## Checklist

- [x] Formatted and validated: `./scripts/format.sh && ./scripts/validate.sh`
- [x] No new dependencies added
- [x] Existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)