### PR TITLE
Fix errors when invoking tools with empty or missing arguments

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -885,7 +885,10 @@ class FunctionCall(BaseModel):
                 execution_chain = self._build_nested_execution_chain(entrypoint_args=entrypoint_args)
                 result = execution_chain(self.function.name, self.function.entrypoint, self.arguments or {})
             else:
-                result = self.function.entrypoint(**entrypoint_args, **self.arguments)  # type: ignore
+                if self.arguments is None or self.arguments == {}:
+                    result = self.function.entrypoint(**entrypoint_args)
+                else:
+                    result = self.function.entrypoint(**entrypoint_args, **self.arguments)
 
             # Handle generator case
             if isgenerator(result):

--- a/libs/agno/agno/utils/functions.py
+++ b/libs/agno/agno/utils/functions.py
@@ -42,6 +42,10 @@ def get_function_call(
             )
             return function_call
 
+        # Handle empty array as no arguments (models may pass [] for no-param tools)
+        if isinstance(_arguments, list) and len(_arguments) == 0:
+            return function_call
+
         if not isinstance(_arguments, dict):
             log_error(f"Function arguments are not a valid JSON object: {arguments}")
             function_call.error = "Function arguments are not a valid JSON object.\n\n Please fix and retry."


### PR DESCRIPTION
## Summary
When a tool has no parameters, models may pass `None`, `null`, `{}`, or `[]` as arguments.

This fix makes the system handle these cases gracefully:

1. **Sync execution path (`function.py`)** Add the same `None` / empty-argument check that already exists in the async path, preventing a `TypeError` caused by unpacking `None` with `**`.

2. **`get_function_call` (`functions.py`)** Treat an empty array `[]` as “no arguments” instead of returning an error. Some models pass `[]` for tools that define no parameters.


## Type of change
- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)
