### PR TITLE
Froce Local mode for Qdrant/BM25 (hybrid search Knowledge Qdrant)

### DIFF
--- a/libs/agno/agno/vectordb/qdrant/qdrant.py
+++ b/libs/agno/agno/vectordb/qdrant/qdrant.py
@@ -148,7 +148,7 @@ class Qdrant(VectorDb):
             try:
                 from fastembed import SparseTextEmbedding  # type: ignore
 
-                default_kwargs = {"model_name": DEFAULT_SPARSE_MODEL}
+                default_kwargs = {"model_name": DEFAULT_SPARSE_MODEL, "local_files_only": True}
                 if fastembed_kwargs:
                     default_kwargs.update(fastembed_kwargs)
 


### PR DESCRIPTION
## Summary

Update to force the use of Qdrant/bm25 in the Hugging Face cache can be found here : `~/.cache/huggingface/hub` 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

First download Qdrant/bm25 in cache

Code to execute : 
```Python
from huggingface_hub import snapshot_download

snapshot_download(
    repo_id="Qdrant/bm25",
    repo_type="model",   # optionnel mais clair
)
```
