### PR TITLE
fix: explicitly show <scripts>none</scripts> in skills system prompt

### DIFF
--- a/libs/agno/agno/skills/agent_skills.py
+++ b/libs/agno/agno/skills/agent_skills.py
@@ -120,6 +120,8 @@ class Skills:
             "3. **Reference**: Use `get_skill_reference` to access specific documentation as needed",
             "4. **Scripts**: Use `get_skill_script` to read or execute scripts from a skill",
             "",
+            "**IMPORTANT**: References are documentation files (NOT executable). Only use `get_skill_script` when `<scripts>` lists actual script files. If `<scripts>none</scripts>`, do NOT call `get_skill_script`.",
+            "",
             "This approach ensures you only load detailed instructions when actually needed.",
             "",
             "## Available Skills",
@@ -131,6 +133,9 @@ class Skills:
             if skill.scripts:
                 script_names = [s["name"] if isinstance(s, dict) else s for s in skill.scripts]
                 lines.append(f"  <scripts>{', '.join(script_names)}</scripts>")
+            else:
+                # Explicitly indicate no scripts to prevent model confusion
+                lines.append("  <scripts>none</scripts>")
             if skill.references:
                 ref_names = [r["name"] if isinstance(r, dict) else r for r in skill.references]
                 lines.append(f"  <references>{', '.join(ref_names)}</references>")

--- a/libs/agno/tests/unit/skills/test_agent_skills.py
+++ b/libs/agno/tests/unit/skills/test_agent_skills.py
@@ -217,6 +217,16 @@ def test_get_system_prompt_includes_scripts(mock_loader: MockSkillLoader) -> Non
     assert "helper.py" in snippet
 
 
+def test_get_system_prompt_shows_none_when_no_scripts(minimal_skill: Skill) -> None:
+    """Test that system prompt shows <scripts>none</scripts> when skill has no scripts."""
+    loader = MockSkillLoader([minimal_skill])
+    skills = Skills(loaders=[loader])
+    snippet = skills.get_system_prompt_snippet()
+
+    # Should explicitly show "none" instead of omitting the tag
+    assert "<scripts>none</scripts>" in snippet
+
+
 def test_get_system_prompt_includes_references(mock_loader: MockSkillLoader) -> None:
     """Test that system prompt includes references list."""
     skills = Skills(loaders=[mock_loader])


### PR DESCRIPTION
## Summary

Fixes #6304

When a skill has no scripts, the system prompt now explicitly shows `<scripts>none</scripts>` instead of omitting the tag entirely. This prevents less capable models from confusing reference files with scripts.

### Problem

When using skills with certain models (e.g., Qwen3-30B-A3B-Instruct-2507), the agent would incorrectly call `get_skill_script` with a reference file path (like `run_task.md`) when the skill had no actual scripts. This happened because:

1. The `<scripts>` tag was simply **omitted** when a skill had no scripts
2. Models had to **infer** from the missing tag that no scripts existed
3. Less capable models saw reference files and mistakenly tried to use them as scripts

### Solution

1. **Explicit indication**: Now shows `<scripts>none</scripts>` instead of omitting the tag
2. **Clear instruction**: Added guidance that references are NOT executable and `get_skill_script` should not be called when scripts is "none"

### Before

```xml
<skill>
  <name>my-skill</name>
  <description>A documentation-only skill</description>
  <references>run_task.md</references>
</skill>
```

### After

```xml
<skill>
  <name>my-skill</name>
  <description>A documentation-only skill</description>
  <scripts>none</scripts>
  <references>run_task.md</references>
</skill>
```

Plus added instruction:
> **IMPORTANT**: References are documentation files (NOT executable). Only use `get_skill_script` when `<scripts>` lists actual script files. If `<scripts>none</scripts>`, do NOT call `get_skill_script`.

### Testing

- Reproduced the issue with Qwen3-30B-A3B-Instruct-2507 via OpenRouter
- Verified fix prevents model from confusing references with scripts
- Added unit test `test_get_system_prompt_shows_none_when_no_scripts`
- All 44 skills tests pass

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Formatted and linted (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Added tests that prove the fix is effective
- [x] Existing tests pass locally

---

🤖 Generated with [Claude Code](https://claude.ai/code)