### PR TITLE
feat: Add cron-like scheduler for AgentOS

### DIFF
--- a/cookbook/05_agent_os/scheduler/01_basic_scheduler.py
+++ b/cookbook/05_agent_os/scheduler/01_basic_scheduler.py
@@ -1,0 +1,52 @@
+"""
+Basic Scheduler Example
+
+This example shows how to enable the scheduler in AgentOS.
+The scheduler polls for due schedules and executes them automatically.
+
+Requirements:
+    pip install agno[scheduler]
+
+Run:
+    python cookbook/05_agent_os/scheduler/01_basic_scheduler.py
+
+Then create a schedule via API:
+    curl -X POST http://localhost:7777/v1/schedules \
+      -H "Content-Type: application/json" \
+      -d '{
+        "name": "test-schedule",
+        "endpoint": "/v1/agents/hello-agent/runs",
+        "method": "POST",
+        "payload": {"message": "Hello from scheduler!"},
+        "cron_expr": "* * * * *"
+      }'
+"""
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+
+# Create a simple agent
+agent = Agent(
+    id="hello-agent",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    instructions="You are a friendly assistant. Respond with a brief greeting.",
+)
+
+# Create a SQLite database for persistence
+db = SqliteDb(db_file="scheduler_example.db")
+
+# Create AgentOS with scheduler enabled
+agent_os = AgentOS(
+    agents=[agent],
+    db=db,
+    enable_scheduler=True,  # Enable the built-in scheduler
+    scheduler_poll_interval=10,  # Check for due schedules every 10 seconds
+)
+
+if __name__ == "__main__":
+    print("Starting AgentOS with scheduler enabled...")
+    print("Create schedules via POST /v1/schedules")
+    print("List schedules via GET /v1/schedules")
+    agent_os.run(port=7777)

--- a/cookbook/05_agent_os/scheduler/02_schedule_agent_runs.py
+++ b/cookbook/05_agent_os/scheduler/02_schedule_agent_runs.py
@@ -1,0 +1,104 @@
+"""
+Schedule Agent Runs Example
+
+This example demonstrates scheduling regular agent runs.
+The scheduler will automatically run the agent at specified times.
+
+Requirements:
+    pip install agno[scheduler]
+
+Run:
+    python cookbook/05_agent_os/scheduler/02_schedule_agent_runs.py
+"""
+
+import httpx
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+
+# Create a daily report agent
+report_agent = Agent(
+    id="daily-reporter",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    instructions="""You are a daily report generator.
+    Generate a brief summary of the current date and a motivational quote.""",
+)
+
+# Create a weather agent
+weather_agent = Agent(
+    id="weather-checker",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    instructions="""You are a weather information assistant.
+    Provide a brief weather forecast (you can make up plausible weather).""",
+)
+
+# Create database and AgentOS
+db = SqliteDb(db_file="scheduled_agents.db")
+agent_os = AgentOS(
+    agents=[report_agent, weather_agent],
+    db=db,
+    enable_scheduler=True,
+    scheduler_poll_interval=10,
+)
+
+
+def create_schedules():
+    """Create sample schedules after server starts."""
+    base_url = "http://localhost:7777"
+
+    schedules = [
+        {
+            "name": "daily-morning-report",
+            "description": "Generate a daily morning report",
+            "endpoint": "/v1/agents/daily-reporter/runs",
+            "method": "POST",
+            "payload": {"message": "Generate the morning report for today."},
+            "cron_expr": "0 8 * * *",  # Every day at 8 AM
+            "timezone": "UTC",
+        },
+        {
+            "name": "hourly-weather-check",
+            "description": "Check weather every hour",
+            "endpoint": "/v1/agents/weather-checker/runs",
+            "method": "POST",
+            "payload": {"message": "What's the weather forecast?"},
+            "cron_expr": "0 * * * *",  # Every hour
+            "timezone": "UTC",
+        },
+    ]
+
+    print("\nCreating schedules...")
+    for schedule in schedules:
+        try:
+            response = httpx.post(
+                f"{base_url}/v1/schedules",
+                json=schedule,
+                timeout=10.0,
+            )
+            if response.status_code == 201:
+                data = response.json()
+                print(
+                    f"  Created: {data['name']} (next run: {data.get('next_run_at')})"
+                )
+            elif response.status_code == 400:
+                # Schedule might already exist
+                print(f"  Skipped: {schedule['name']} (already exists)")
+            else:
+                print(f"  Error creating {schedule['name']}: {response.text}")
+        except Exception as e:
+            print(f"  Error: {e}")
+
+
+if __name__ == "__main__":
+    print("Starting AgentOS with scheduled agents...")
+    print("\nAvailable agents:")
+    print("  - daily-reporter: Generates daily reports")
+    print("  - weather-checker: Provides weather forecasts")
+
+    # Note: In a real application, you would create schedules via API
+    # after the server starts. This is shown for demonstration.
+    print("\nServer starting on http://localhost:7777")
+    print("Create schedules via: POST /v1/schedules")
+
+    agent_os.run(port=7777)

--- a/cookbook/05_agent_os/scheduler/03_schedule_workflow.py
+++ b/cookbook/05_agent_os/scheduler/03_schedule_workflow.py
@@ -1,0 +1,77 @@
+"""
+Schedule Workflow Example
+
+This example demonstrates scheduling workflow executions.
+Workflows can be scheduled just like agents.
+
+Requirements:
+    pip install agno[scheduler]
+
+Run:
+    python cookbook/05_agent_os/scheduler/03_schedule_workflow.py
+"""
+
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+from agno.workflow import Workflow
+
+
+class ReportWorkflow(Workflow):
+    """A workflow that generates a multi-step report."""
+
+    id: str = "report-workflow"
+    description: str = "Generate a comprehensive report with multiple steps"
+
+    # Define agents used in the workflow
+    researcher: Agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        instructions="You are a researcher. Gather key facts about the given topic.",
+    )
+
+    writer: Agent = Agent(
+        model=OpenAIChat(id="gpt-4o-mini"),
+        instructions="You are a report writer. Write a clear summary based on research.",
+    )
+
+    def run(self, topic: str = "AI trends") -> str:
+        """Run the report generation workflow."""
+        # Step 1: Research
+        research = self.researcher.run(f"Research key facts about: {topic}")
+
+        # Step 2: Write report
+        report = self.writer.run(
+            f"Write a brief report based on this research:\n{research.content}"
+        )
+
+        return report.content
+
+
+# Create database and AgentOS
+db = SqliteDb(db_file="scheduled_workflow.db")
+agent_os = AgentOS(
+    workflows=[ReportWorkflow()],
+    db=db,
+    enable_scheduler=True,
+    scheduler_poll_interval=10,
+)
+
+if __name__ == "__main__":
+    print("Starting AgentOS with scheduled workflow...")
+    print("\nAvailable workflow:")
+    print("  - report-workflow: Generates research-based reports")
+    print("\nCreate a schedule to run the workflow:")
+    print("""
+    curl -X POST http://localhost:7777/v1/schedules \\
+      -H "Content-Type: application/json" \\
+      -d '{
+        "name": "weekly-ai-report",
+        "endpoint": "/v1/workflows/report-workflow/runs",
+        "method": "POST",
+        "payload": {"topic": "Latest AI developments"},
+        "cron_expr": "0 9 * * 1"
+      }'
+    """)
+
+    agent_os.run(port=7777)

--- a/cookbook/05_agent_os/scheduler/04_async_scheduler.py
+++ b/cookbook/05_agent_os/scheduler/04_async_scheduler.py
@@ -1,0 +1,45 @@
+"""
+Async Scheduler Example
+
+This example demonstrates using the scheduler with an async database.
+Async databases provide non-blocking database operations which is
+important for high-throughput scenarios.
+
+Requirements:
+    pip install agno[scheduler] aiosqlite
+
+Run:
+    python cookbook/05_agent_os/scheduler/04_async_scheduler.py
+"""
+
+from agno.agent import Agent
+from agno.db.sqlite import AsyncSqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+
+# Create a simple agent
+agent = Agent(
+    id="async-agent",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    instructions="You are a helpful assistant. Be concise.",
+)
+
+# Create an async SQLite database
+# The scheduler will automatically use async methods when available
+async_db = AsyncSqliteDb(db_file="async_scheduler.db")
+
+# Create AgentOS with scheduler enabled
+agent_os = AgentOS(
+    agents=[agent],
+    db=async_db,  # Async database
+    enable_scheduler=True,
+    scheduler_poll_interval=10,
+)
+
+if __name__ == "__main__":
+    print("Starting AgentOS with async scheduler...")
+    print("\nUsing AsyncSqliteDb for non-blocking database operations.")
+    print("The scheduler poller and executor will use async methods.")
+    print("\nCreate schedules via POST /v1/schedules")
+
+    agent_os.run(port=7777)

--- a/cookbook/05_agent_os/scheduler/05_manual_trigger.py
+++ b/cookbook/05_agent_os/scheduler/05_manual_trigger.py
@@ -1,0 +1,159 @@
+"""
+Manual Trigger Example
+
+This example demonstrates how to manually trigger schedules.
+Manual triggers bypass the normal cron timing and execute immediately.
+
+This is useful for:
+- Testing schedules before their scheduled time
+- On-demand execution of recurring tasks
+- Integration with external event systems
+
+Requirements:
+    pip install agno[scheduler]
+
+Run:
+    python cookbook/05_agent_os/scheduler/05_manual_trigger.py
+
+Then:
+    1. Create a schedule (see output for curl command)
+    2. Trigger it manually (see output for curl command)
+"""
+
+import time
+
+import httpx
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+
+# Create an agent that can be triggered on demand
+notification_agent = Agent(
+    id="notification-agent",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    instructions="""You are a notification assistant.
+    Generate a brief notification message based on the input.""",
+)
+
+# Create database and AgentOS
+db = SqliteDb(db_file="manual_trigger.db")
+agent_os = AgentOS(
+    agents=[notification_agent],
+    db=db,
+    enable_scheduler=True,
+    scheduler_poll_interval=30,  # Longer interval since we'll trigger manually
+)
+
+
+def demo_manual_trigger():
+    """Demonstrate creating and manually triggering a schedule."""
+    base_url = "http://localhost:7777"
+
+    # Wait for server to start
+    time.sleep(2)
+
+    print("\n" + "=" * 60)
+    print("Manual Trigger Demo")
+    print("=" * 60)
+
+    # Step 1: Create a schedule (set to run far in the future)
+    print("\n1. Creating a schedule (runs daily at midnight)...")
+    schedule_data = {
+        "name": "daily-notification",
+        "description": "Send daily notification",
+        "endpoint": "/v1/agents/notification-agent/runs",
+        "method": "POST",
+        "payload": {"message": "Generate a notification for the team."},
+        "cron_expr": "0 0 * * *",  # Midnight - won't run automatically soon
+        "timezone": "UTC",
+    }
+
+    try:
+        response = httpx.post(
+            f"{base_url}/v1/schedules",
+            json=schedule_data,
+            timeout=10.0,
+        )
+        if response.status_code == 201:
+            schedule = response.json()
+            schedule_id = schedule["id"]
+            print(f"   Created schedule: {schedule['name']} (ID: {schedule_id})")
+            print(f"   Next scheduled run: {schedule.get('next_run_at')}")
+
+            # Step 2: Manually trigger the schedule
+            print("\n2. Manually triggering the schedule...")
+            trigger_response = httpx.post(
+                f"{base_url}/v1/schedules/{schedule_id}/trigger",
+                timeout=30.0,
+            )
+            if trigger_response.status_code == 200:
+                print("   Schedule triggered successfully!")
+                print(f"   Response: {trigger_response.json()}")
+            else:
+                print(f"   Trigger failed: {trigger_response.text}")
+
+            # Step 3: Check run history
+            print("\n3. Checking run history...")
+            time.sleep(5)  # Wait for execution
+            runs_response = httpx.get(
+                f"{base_url}/v1/schedules/{schedule_id}/runs",
+                timeout=10.0,
+            )
+            if runs_response.status_code == 200:
+                runs = runs_response.json()
+                print(f"   Total runs: {runs['total']}")
+                for run in runs["runs"]:
+                    print(f"   - Run {run['id']}: {run['status']}")
+
+        elif response.status_code == 400:
+            print("   Schedule already exists, fetching it...")
+            # Get existing schedule
+            list_response = httpx.get(f"{base_url}/v1/schedules", timeout=10.0)
+            if list_response.status_code == 200:
+                schedules = list_response.json()["schedules"]
+                for s in schedules:
+                    if s["name"] == "daily-notification":
+                        schedule_id = s["id"]
+                        print(f"   Found: {s['name']} (ID: {schedule_id})")
+
+                        # Trigger it
+                        print("\n   Triggering existing schedule...")
+                        trigger_response = httpx.post(
+                            f"{base_url}/v1/schedules/{schedule_id}/trigger",
+                            timeout=30.0,
+                        )
+                        if trigger_response.status_code == 200:
+                            print("   Triggered successfully!")
+                        break
+
+    except Exception as e:
+        print(f"   Error: {e}")
+
+    print("\n" + "=" * 60)
+
+
+if __name__ == "__main__":
+    print("Starting AgentOS with manual trigger demo...")
+    print("\nAPI Commands:")
+    print("\n  Create schedule:")
+    print("""    curl -X POST http://localhost:7777/v1/schedules \\
+      -H "Content-Type: application/json" \\
+      -d '{
+        "name": "my-schedule",
+        "endpoint": "/v1/agents/notification-agent/runs",
+        "cron_expr": "0 0 * * *"
+      }'""")
+
+    print("\n  Trigger manually:")
+    print("    curl -X POST http://localhost:7777/v1/schedules/{id}/trigger")
+
+    print("\n  View runs:")
+    print("    curl http://localhost:7777/v1/schedules/{id}/runs")
+
+    # Run the demo in background after server starts
+    import threading
+
+    threading.Timer(3.0, demo_manual_trigger).start()
+
+    agent_os.run(port=7777)

--- a/cookbook/05_agent_os/scheduler/README.md
+++ b/cookbook/05_agent_os/scheduler/README.md
@@ -1,0 +1,113 @@
+# AgentOS Scheduler
+
+The AgentOS scheduler provides cron-based task scheduling for agents, teams, workflows, and arbitrary endpoints.
+
+## Features
+
+- **Cron-based scheduling**: Schedule tasks using standard cron expressions
+- **Timezone support**: Configure schedules in any timezone
+- **Distributed locking**: Safe execution in multi-container deployments (PostgreSQL)
+- **Retry logic**: Configurable retry attempts with delay
+- **Manual triggers**: Trigger schedules on-demand via API
+- **Execution tracking**: Track run history, status, and errors
+- **SSE streaming**: Non-blocking execution with real-time status tracking
+
+## Quick Start
+
+```python
+from agno.agent import Agent
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIChat
+from agno.os import AgentOS
+
+# Create an agent
+agent = Agent(
+    id="daily-reporter",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    instructions="Generate a daily report.",
+)
+
+# Create AgentOS with scheduler enabled
+db = SqliteDb(db_file="scheduler.db")
+agent_os = AgentOS(
+    agents=[agent],
+    db=db,
+    enable_scheduler=True,  # Enable the scheduler
+    scheduler_poll_interval=30,  # Check for due schedules every 30 seconds
+)
+
+# Run the server
+agent_os.run(port=7777)
+```
+
+## Creating Schedules via API
+
+Once the server is running, create schedules using the REST API:
+
+```bash
+# Create a schedule that runs an agent daily at 3 AM
+curl -X POST http://localhost:7777/v1/schedules \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "daily-report",
+    "endpoint": "/v1/agents/daily-reporter/runs",
+    "method": "POST",
+    "payload": {"message": "Generate the daily report"},
+    "cron_expr": "0 3 * * *",
+    "timezone": "America/New_York"
+  }'
+```
+
+## Cron Expression Reference
+
+| Expression | Description |
+|------------|-------------|
+| `* * * * *` | Every minute |
+| `0 * * * *` | Every hour |
+| `0 0 * * *` | Every day at midnight |
+| `0 3 * * *` | Every day at 3 AM |
+| `0 0 * * 0` | Every Sunday at midnight |
+| `0 0 1 * *` | First day of every month |
+| `*/5 * * * *` | Every 5 minutes |
+| `0 9-17 * * 1-5` | Every hour 9 AM-5 PM, Mon-Fri |
+
+## API Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/v1/schedules` | List all schedules |
+| POST | `/v1/schedules` | Create a new schedule |
+| GET | `/v1/schedules/{id}` | Get a specific schedule |
+| PATCH | `/v1/schedules/{id}` | Update a schedule |
+| DELETE | `/v1/schedules/{id}` | Delete a schedule |
+| POST | `/v1/schedules/{id}/enable` | Enable a schedule |
+| POST | `/v1/schedules/{id}/disable` | Disable a schedule |
+| POST | `/v1/schedules/{id}/trigger` | Manually trigger a schedule |
+| GET | `/v1/schedules/{id}/runs` | Get run history |
+| GET | `/v1/schedules/{id}/runs/{run_id}` | Get a specific run |
+
+## Examples
+
+- `01_basic_scheduler.py` - Basic scheduler setup with SQLite
+- `02_schedule_agent_runs.py` - Schedule agent executions
+- `03_schedule_workflow.py` - Schedule workflow executions
+- `04_async_scheduler.py` - Async database support
+- `05_manual_trigger.py` - Manually trigger schedules via API
+
+## Requirements
+
+Install the scheduler dependencies:
+
+```bash
+pip install agno[scheduler]
+```
+
+This installs the `croniter` package required for cron expression parsing.
+
+## Production Considerations
+
+1. **Use PostgreSQL**: For multi-container deployments, use PostgreSQL which supports `SELECT FOR UPDATE SKIP LOCKED` for atomic schedule claiming.
+
+2. **External Scheduler**: For high-availability, consider using external schedulers (Kubernetes CronJobs, AWS EventBridge) that call the AgentOS trigger endpoint.
+
+3. **Authentication**: The scheduler uses an internal service token. For production, use security key authentication (not JWT mode).

--- a/cookbook/05_agent_os/scheduler/__init__.py
+++ b/cookbook/05_agent_os/scheduler/__init__.py
@@ -1,0 +1,1 @@
+# Scheduler cookbook examples

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -25,6 +25,7 @@ from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
+from agno.db.schemas.scheduler import Schedule, ScheduleRun
 from agno.session import AgentSession, Session, TeamSession, WorkflowSession
 from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.string import sanitize_postgres_string, sanitize_postgres_strings
@@ -58,6 +59,8 @@ class AsyncPostgresDb(AsyncBaseDb):
         spans_table: Optional[str] = None,
         versions_table: Optional[str] = None,
         learnings_table: Optional[str] = None,
+        schedule_table: Optional[str] = None,
+        schedule_runs_table: Optional[str] = None,
         create_schema: bool = True,
     ):
         """
@@ -92,6 +95,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             spans_table (Optional[str]): Name of the table to store span events.
             versions_table (Optional[str]): Name of the table to store schema versions.
             learnings_table (Optional[str]): Name of the table to store learnings.
+            schedule_table (Optional[str]): Name of the table to store schedules.
+            schedule_runs_table (Optional[str]): Name of the table to store schedule runs.
             create_schema (bool): Whether to automatically create the database schema if it doesn't exist.
                 Set to False if schema is managed externally (e.g., via migrations). Defaults to True.
 
@@ -112,6 +117,8 @@ class AsyncPostgresDb(AsyncBaseDb):
             spans_table=spans_table,
             versions_table=versions_table,
             learnings_table=learnings_table,
+            schedule_table=schedule_table,
+            schedule_runs_table=schedule_runs_table,
         )
 
         _engine: Optional[AsyncEngine] = db_engine
@@ -3042,3 +3049,389 @@ class AsyncPostgresDb(AsyncBaseDb):
         label: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         raise NotImplementedError("Component methods not yet supported for async databases")
+
+    # --- Scheduler Methods ---
+    async def _get_schedule_table(self) -> Optional[Table]:
+        """Get or create the schedules table."""
+        return await self._aget_table(table_type="schedules", create_table_if_not_found=True)
+
+    async def _get_schedule_runs_table(self) -> Optional[Table]:
+        """Get or create the schedule runs table."""
+        return await self._aget_table(table_type="schedule_runs", create_table_if_not_found=True)
+
+    async def get_schedule(self, schedule_id: str) -> Optional[Schedule]:
+        """Get a schedule by ID."""
+        try:
+            table = await self._get_schedule_table()
+            if table is None:
+                return None
+
+            async with self.async_session_factory() as sess:
+                stmt = select(table).where(table.c.id == schedule_id)
+                result = await sess.execute(stmt)
+                row = result.fetchone()
+                if row is None:
+                    return None
+                return Schedule.from_dict(dict(row._mapping))
+        except Exception as e:
+            log_error(f"Error getting schedule: {e}")
+            return None
+
+    async def get_schedule_by_name(self, name: str) -> Optional[Schedule]:
+        """Get a schedule by name."""
+        try:
+            table = await self._get_schedule_table()
+            if table is None:
+                return None
+
+            async with self.async_session_factory() as sess:
+                stmt = select(table).where(table.c.name == name)
+                result = await sess.execute(stmt)
+                row = result.fetchone()
+                if row is None:
+                    return None
+                return Schedule.from_dict(dict(row._mapping))
+        except Exception as e:
+            log_error(f"Error getting schedule by name: {e}")
+            return None
+
+    async def get_schedules(
+        self,
+        enabled: Optional[bool] = None,
+        limit: Optional[int] = 100,
+        offset: Optional[int] = None,
+    ) -> Tuple[List[Schedule], int]:
+        """Get all schedules with optional filtering."""
+        try:
+            table = await self._get_schedule_table()
+            if table is None:
+                return [], 0
+
+            async with self.async_session_factory() as sess:
+                # Build query
+                stmt = select(table)
+                count_stmt = select(func.count()).select_from(table)
+
+                if enabled is not None:
+                    stmt = stmt.where(table.c.enabled == enabled)
+                    count_stmt = count_stmt.where(table.c.enabled == enabled)
+
+                # Get total count
+                count_result = await sess.execute(count_stmt)
+                total = count_result.scalar() or 0
+
+                # Apply pagination
+                stmt = stmt.order_by(table.c.created_at.desc())
+                if limit:
+                    stmt = stmt.limit(limit)
+                if offset:
+                    stmt = stmt.offset(offset)
+
+                result = await sess.execute(stmt)
+                rows = result.fetchall()
+
+                schedules = [Schedule.from_dict(dict(row._mapping)) for row in rows]
+                return schedules, total
+        except Exception as e:
+            log_error(f"Error getting schedules: {e}")
+            return [], 0
+
+    async def create_schedule(self, schedule: Schedule) -> Schedule:
+        """Create a new schedule."""
+        try:
+            table = await self._get_schedule_table()
+            if table is None:
+                raise ValueError("Could not create schedules table")
+
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    stmt = postgresql.insert(table).values(
+                        id=schedule.id,
+                        name=schedule.name,
+                        description=schedule.description,
+                        method=schedule.method,
+                        endpoint=schedule.endpoint,
+                        payload=schedule.payload,
+                        cron_expr=schedule.cron_expr,
+                        timezone=schedule.timezone,
+                        timeout_seconds=schedule.timeout_seconds,
+                        max_retries=schedule.max_retries,
+                        retry_delay_seconds=schedule.retry_delay_seconds,
+                        enabled=schedule.enabled,
+                        next_run_at=schedule.next_run_at,
+                        locked_by=schedule.locked_by,
+                        locked_at=schedule.locked_at,
+                        created_at=schedule.created_at,
+                        updated_at=schedule.updated_at,
+                    )
+                    await sess.execute(stmt)
+
+            return schedule
+        except Exception as e:
+            log_error(f"Error creating schedule: {e}")
+            raise
+
+    async def update_schedule(self, schedule: Schedule) -> Schedule:
+        """Update an existing schedule."""
+        try:
+            table = await self._get_schedule_table()
+            if table is None:
+                raise ValueError("Could not get schedules table")
+
+            current_time = int(time.time())
+            schedule.updated_at = current_time
+
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    stmt = (
+                        update(table)
+                        .where(table.c.id == schedule.id)
+                        .values(
+                            name=schedule.name,
+                            description=schedule.description,
+                            method=schedule.method,
+                            endpoint=schedule.endpoint,
+                            payload=schedule.payload,
+                            cron_expr=schedule.cron_expr,
+                            timezone=schedule.timezone,
+                            timeout_seconds=schedule.timeout_seconds,
+                            max_retries=schedule.max_retries,
+                            retry_delay_seconds=schedule.retry_delay_seconds,
+                            enabled=schedule.enabled,
+                            next_run_at=schedule.next_run_at,
+                            locked_by=schedule.locked_by,
+                            locked_at=schedule.locked_at,
+                            updated_at=current_time,
+                        )
+                    )
+                    await sess.execute(stmt)
+
+            return schedule
+        except Exception as e:
+            log_error(f"Error updating schedule: {e}")
+            raise
+
+    async def delete_schedule(self, schedule_id: str) -> bool:
+        """Delete a schedule by ID."""
+        try:
+            table = await self._get_schedule_table()
+            if table is None:
+                return False
+
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    from sqlalchemy import delete
+
+                    stmt = delete(table).where(table.c.id == schedule_id)
+                    result = await sess.execute(stmt)
+                    return result.rowcount > 0
+        except Exception as e:
+            log_error(f"Error deleting schedule: {e}")
+            return False
+
+    async def claim_due_schedule(
+        self,
+        container_id: str,
+        lock_grace_seconds: int = 60,
+    ) -> Optional[Schedule]:
+        """Atomically claim one due schedule for execution using SKIP LOCKED.
+
+        This ensures exactly-once execution in multi-container deployments.
+
+        Args:
+            container_id: The ID of the container claiming the schedule.
+            lock_grace_seconds: Grace period in seconds after timeout before
+                considering a lock stale (default: 60).
+
+        Returns:
+            The claimed schedule, or None if no schedules are due.
+        """
+        try:
+            table = await self._get_schedule_table()
+            if table is None:
+                return None
+
+            current_time = int(time.time())
+
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    # Use raw SQL for SKIP LOCKED which SQLAlchemy doesn't support directly
+                    claim_sql = text(f"""
+                        UPDATE {self.db_schema}.{self.schedule_table_name}
+                        SET
+                            locked_by = :container_id,
+                            locked_at = :current_time
+                        WHERE id = (
+                            SELECT id FROM {self.db_schema}.{self.schedule_table_name}
+                            WHERE enabled = true
+                              AND next_run_at <= :current_time
+                              AND (
+                                  locked_by IS NULL
+                                  OR locked_at < :current_time - timeout_seconds - :lock_grace_seconds
+                              )
+                            ORDER BY next_run_at
+                            FOR UPDATE SKIP LOCKED
+                            LIMIT 1
+                        )
+                        RETURNING *
+                    """)
+
+                    result = await sess.execute(
+                        claim_sql,
+                        {
+                            "container_id": container_id,
+                            "current_time": current_time,
+                            "lock_grace_seconds": lock_grace_seconds,
+                        },
+                    )
+                    row = result.fetchone()
+
+                    if not row:
+                        return None
+
+                    return Schedule.from_dict(dict(row._mapping))
+        except Exception as e:
+            log_error(f"Error claiming schedule: {e}")
+            return None
+
+    async def release_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: int,
+    ) -> None:
+        """Release a schedule lock and set the next run time."""
+        try:
+            table = await self._get_schedule_table()
+            if table is None:
+                return
+
+            current_time = int(time.time())
+
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    stmt = (
+                        update(table)
+                        .where(table.c.id == schedule_id)
+                        .values(
+                            locked_by=None,
+                            locked_at=None,
+                            next_run_at=next_run_at,
+                            updated_at=current_time,
+                        )
+                    )
+                    await sess.execute(stmt)
+        except Exception as e:
+            log_error(f"Error releasing schedule: {e}")
+
+    # --- Schedule Runs ---
+    async def create_schedule_run(self, run: ScheduleRun) -> ScheduleRun:
+        """Create a schedule run record."""
+        try:
+            table = await self._get_schedule_runs_table()
+            if table is None:
+                raise ValueError("Could not create schedule_runs table")
+
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    current_time = int(time.time())
+                    stmt = postgresql.insert(table).values(
+                        id=run.id,
+                        schedule_id=run.schedule_id,
+                        attempt=run.attempt,
+                        triggered_at=run.triggered_at or current_time,
+                        completed_at=run.completed_at,
+                        status=run.status,
+                        status_code=run.status_code,
+                        run_id=run.run_id,
+                        session_id=run.session_id,
+                        error=run.error,
+                        created_at=run.created_at or current_time,
+                    )
+                    await sess.execute(stmt)
+
+            return run
+        except Exception as e:
+            log_error(f"Error creating schedule run: {e}")
+            raise
+
+    async def update_schedule_run(self, run: ScheduleRun) -> ScheduleRun:
+        """Update a schedule run record."""
+        try:
+            table = await self._get_schedule_runs_table()
+            if table is None:
+                raise ValueError("Could not get schedule_runs table")
+
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    stmt = (
+                        update(table)
+                        .where(table.c.id == run.id)
+                        .values(
+                            attempt=run.attempt,
+                            triggered_at=run.triggered_at,
+                            completed_at=run.completed_at,
+                            status=run.status,
+                            status_code=run.status_code,
+                            run_id=run.run_id,
+                            session_id=run.session_id,
+                            error=run.error,
+                        )
+                    )
+                    await sess.execute(stmt)
+
+            return run
+        except Exception as e:
+            log_error(f"Error updating schedule run: {e}")
+            raise
+
+    async def get_schedule_runs(
+        self,
+        schedule_id: str,
+        limit: Optional[int] = 100,
+        offset: Optional[int] = None,
+    ) -> Tuple[List[ScheduleRun], int]:
+        """Get runs for a schedule."""
+        try:
+            table = await self._get_schedule_runs_table()
+            if table is None:
+                return [], 0
+
+            async with self.async_session_factory() as sess:
+                # Get total count
+                count_stmt = select(func.count()).select_from(table).where(table.c.schedule_id == schedule_id)
+                count_result = await sess.execute(count_stmt)
+                total = count_result.scalar() or 0
+
+                # Get runs
+                stmt = select(table).where(table.c.schedule_id == schedule_id).order_by(table.c.created_at.desc())
+                if limit:
+                    stmt = stmt.limit(limit)
+                if offset:
+                    stmt = stmt.offset(offset)
+
+                result = await sess.execute(stmt)
+                rows = result.fetchall()
+
+                runs = [ScheduleRun.from_dict(dict(row._mapping)) for row in rows]
+                return runs, total
+        except Exception as e:
+            log_error(f"Error getting schedule runs: {e}")
+            return [], 0
+
+    async def get_schedule_run(self, run_id: str) -> Optional[ScheduleRun]:
+        """Get a specific schedule run by ID."""
+        try:
+            table = await self._get_schedule_runs_table()
+            if table is None:
+                return None
+
+            async with self.async_session_factory() as sess:
+                stmt = select(table).where(table.c.id == run_id)
+                result = await sess.execute(stmt)
+                row = result.fetchone()
+                if row is None:
+                    return None
+                return ScheduleRun.from_dict(dict(row._mapping))
+        except Exception as e:
+            log_error(f"Error getting schedule run: {e}")
+            return None

--- a/libs/agno/agno/db/postgres/schemas.py
+++ b/libs/agno/agno/db/postgres/schemas.py
@@ -230,6 +230,57 @@ LEARNINGS_TABLE_SCHEMA = {
     "updated_at": {"type": BigInteger, "nullable": True},
 }
 
+SCHEDULE_TABLE_SCHEMA = {
+    # Identity
+    "id": {"type": String, "primary_key": True, "nullable": False},
+    "name": {"type": String, "nullable": False},
+    "description": {"type": Text, "nullable": True},
+    # What to call (HTTP request)
+    "method": {"type": String, "nullable": False, "default": "POST"},
+    "endpoint": {"type": String, "nullable": False},
+    "payload": {"type": JSONB, "nullable": True},
+    # When to run
+    "cron_expr": {"type": String, "nullable": False},
+    "timezone": {"type": String, "nullable": False, "default": "UTC"},
+    # Execution settings
+    "timeout_seconds": {"type": Integer, "nullable": False, "default": 3600},
+    "max_retries": {"type": Integer, "nullable": False, "default": 0},
+    "retry_delay_seconds": {"type": Integer, "nullable": False, "default": 60},
+    # State
+    "enabled": {"type": Boolean, "nullable": False, "default": True},
+    "next_run_at": {"type": BigInteger, "nullable": True, "index": True},
+    # Distributed locking (for multi-container)
+    "locked_by": {"type": String, "nullable": True},
+    "locked_at": {"type": BigInteger, "nullable": True},
+    # Metadata
+    "created_at": {"type": BigInteger, "nullable": False, "index": True},
+    "updated_at": {"type": BigInteger, "nullable": True},
+    "_unique_constraints": [
+        {
+            "name": "uq_schedule_name",
+            "columns": ["name"],
+        },
+    ],
+}
+
+SCHEDULE_RUNS_TABLE_SCHEMA = {
+    "id": {"type": String, "primary_key": True, "nullable": False},
+    "schedule_id": {"type": String, "nullable": False, "index": True},
+    # Attempt tracking
+    "attempt": {"type": Integer, "nullable": False, "default": 1},
+    # Timing
+    "triggered_at": {"type": BigInteger, "nullable": False},
+    "completed_at": {"type": BigInteger, "nullable": True},
+    # Result
+    "status": {"type": String, "nullable": False, "default": "running", "index": True},
+    "status_code": {"type": Integer, "nullable": True},
+    "run_id": {"type": String, "nullable": True},
+    "session_id": {"type": String, "nullable": True},
+    "error": {"type": Text, "nullable": True},
+    # Metadata
+    "created_at": {"type": BigInteger, "nullable": False, "index": True},
+}
+
 
 def get_table_schema_definition(
     table_type: str, traces_table_name: str = "agno_traces", db_schema: str = "agno"
@@ -262,6 +313,8 @@ def get_table_schema_definition(
         "component_configs": COMPONENT_CONFIGS_TABLE_SCHEMA,
         "component_links": COMPONENT_LINKS_TABLE_SCHEMA,
         "learnings": LEARNINGS_TABLE_SCHEMA,
+        "schedules": SCHEDULE_TABLE_SCHEMA,
+        "schedule_runs": SCHEDULE_RUNS_TABLE_SCHEMA,
     }
 
     schema = schemas.get(table_type, {})

--- a/libs/agno/agno/db/schemas/__init__.py
+++ b/libs/agno/agno/db/schemas/__init__.py
@@ -1,4 +1,5 @@
 from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.memory import UserMemory
+from agno.db.schemas.scheduler import Schedule, ScheduleRun
 
-__all__ = ["CulturalKnowledge", "UserMemory"]
+__all__ = ["CulturalKnowledge", "UserMemory", "Schedule", "ScheduleRun"]

--- a/libs/agno/agno/db/schemas/scheduler.py
+++ b/libs/agno/agno/db/schemas/scheduler.py
@@ -1,0 +1,191 @@
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from agno.utils.dttm import now_epoch_s, to_epoch_s
+
+
+@dataclass
+class Schedule:
+    """Model for scheduled tasks."""
+
+    # Identity
+    id: str
+    name: str
+    description: Optional[str] = None
+
+    # What to call (HTTP request)
+    method: str = "POST"
+    endpoint: str = ""  # e.g., '/v1/agents/daily-reporter/runs'
+    payload: Optional[Dict[str, Any]] = None
+
+    # When to run
+    cron_expr: str = ""  # e.g., '0 3 * * *' (3 AM daily)
+    timezone: str = "UTC"
+
+    # Execution settings
+    timeout_seconds: int = 3600  # Max time for a single run
+    max_retries: int = 0  # Retry on failure
+    retry_delay_seconds: int = 60
+
+    # State
+    enabled: bool = True
+    next_run_at: Optional[int] = None  # Epoch seconds
+
+    # Distributed locking (for multi-container)
+    locked_by: Optional[str] = None  # Container ID that claimed this
+    locked_at: Optional[int] = None  # When it was claimed
+
+    # Metadata
+    created_at: Optional[int] = None
+    updated_at: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        """Automatically set/normalize created_at and updated_at."""
+        self.created_at = now_epoch_s() if self.created_at is None else to_epoch_s(self.created_at)
+        if self.updated_at is not None:
+            self.updated_at = to_epoch_s(self.updated_at)
+        if self.next_run_at is not None:
+            self.next_run_at = to_epoch_s(self.next_run_at)
+        if self.locked_at is not None:
+            self.locked_at = to_epoch_s(self.locked_at)
+
+    def to_dict(self) -> Dict[str, Any]:
+        _dict = {
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "method": self.method,
+            "endpoint": self.endpoint,
+            "payload": self.payload,
+            "cron_expr": self.cron_expr,
+            "timezone": self.timezone,
+            "timeout_seconds": self.timeout_seconds,
+            "max_retries": self.max_retries,
+            "retry_delay_seconds": self.retry_delay_seconds,
+            "enabled": self.enabled,
+            "next_run_at": self.next_run_at,
+            "locked_by": self.locked_by,
+            "locked_at": self.locked_at,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+        return {k: v for k, v in _dict.items() if v is not None}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Schedule":
+        data = dict(data)
+
+        # Preserve 0 and None explicitly; only process if key exists
+        if "created_at" in data and data["created_at"] is not None:
+            data["created_at"] = to_epoch_s(data["created_at"])
+        if "updated_at" in data and data["updated_at"] is not None:
+            data["updated_at"] = to_epoch_s(data["updated_at"])
+        if "next_run_at" in data and data["next_run_at"] is not None:
+            data["next_run_at"] = to_epoch_s(data["next_run_at"])
+        if "locked_at" in data and data["locked_at"] is not None:
+            data["locked_at"] = to_epoch_s(data["locked_at"])
+
+        # Filter out unknown keys
+        valid_keys = {
+            "id",
+            "name",
+            "description",
+            "method",
+            "endpoint",
+            "payload",
+            "cron_expr",
+            "timezone",
+            "timeout_seconds",
+            "max_retries",
+            "retry_delay_seconds",
+            "enabled",
+            "next_run_at",
+            "locked_by",
+            "locked_at",
+            "created_at",
+            "updated_at",
+        }
+        data = {k: v for k, v in data.items() if k in valid_keys}
+
+        return cls(**data)
+
+
+@dataclass
+class ScheduleRun:
+    """Model for schedule execution history."""
+
+    id: str
+    schedule_id: str
+
+    # Attempt tracking
+    attempt: int = 1
+
+    # Timing
+    triggered_at: Optional[int] = None  # When we started the call
+    completed_at: Optional[int] = None  # When it finished
+
+    # Result
+    status: str = "running"  # running, success, failed, timeout
+    status_code: Optional[int] = None  # HTTP status code
+    run_id: Optional[str] = None  # Run ID from agent/workflow response
+    session_id: Optional[str] = None  # Session ID from response
+    error: Optional[str] = None  # Error message if failed
+
+    # Metadata
+    created_at: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        """Automatically set/normalize timestamps."""
+        self.created_at = now_epoch_s() if self.created_at is None else to_epoch_s(self.created_at)
+        if self.triggered_at is None:
+            self.triggered_at = self.created_at
+        else:
+            self.triggered_at = to_epoch_s(self.triggered_at)
+        if self.completed_at is not None:
+            self.completed_at = to_epoch_s(self.completed_at)
+
+    def to_dict(self) -> Dict[str, Any]:
+        _dict = {
+            "id": self.id,
+            "schedule_id": self.schedule_id,
+            "attempt": self.attempt,
+            "triggered_at": self.triggered_at,
+            "completed_at": self.completed_at,
+            "status": self.status,
+            "status_code": self.status_code,
+            "run_id": self.run_id,
+            "session_id": self.session_id,
+            "error": self.error,
+            "created_at": self.created_at,
+        }
+        return {k: v for k, v in _dict.items() if v is not None}
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ScheduleRun":
+        data = dict(data)
+
+        # Preserve 0 and None explicitly; only process if key exists
+        if "created_at" in data and data["created_at"] is not None:
+            data["created_at"] = to_epoch_s(data["created_at"])
+        if "triggered_at" in data and data["triggered_at"] is not None:
+            data["triggered_at"] = to_epoch_s(data["triggered_at"])
+        if "completed_at" in data and data["completed_at"] is not None:
+            data["completed_at"] = to_epoch_s(data["completed_at"])
+
+        # Filter out unknown keys
+        valid_keys = {
+            "id",
+            "schedule_id",
+            "attempt",
+            "triggered_at",
+            "completed_at",
+            "status",
+            "status_code",
+            "run_id",
+            "session_id",
+            "error",
+            "created_at",
+        }
+        data = {k: v for k, v in data.items() if k in valid_keys}
+
+        return cls(**data)

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -13,6 +13,7 @@ from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
+from agno.db.schemas.scheduler import Schedule, ScheduleRun
 from agno.db.sqlite.schemas import get_table_schema_definition
 from agno.db.sqlite.utils import (
     abulk_upsert_metrics,
@@ -55,6 +56,8 @@ class AsyncSqliteDb(AsyncBaseDb):
         spans_table: Optional[str] = None,
         versions_table: Optional[str] = None,
         learnings_table: Optional[str] = None,
+        schedule_table: Optional[str] = None,
+        schedule_runs_table: Optional[str] = None,
         id: Optional[str] = None,
     ):
         """
@@ -101,6 +104,8 @@ class AsyncSqliteDb(AsyncBaseDb):
             spans_table=spans_table,
             versions_table=versions_table,
             learnings_table=learnings_table,
+            schedule_table=schedule_table,
+            schedule_runs_table=schedule_runs_table,
         )
 
         _engine: Optional[AsyncEngine] = db_engine
@@ -344,6 +349,25 @@ class AsyncSqliteDb(AsyncBaseDb):
                 create_table_if_not_found=create_table_if_not_found,
             )
             return self.learnings_table
+
+        elif table_type == "schedules":
+            self.schedule_table = await self._get_or_create_table(
+                table_name=self.schedule_table_name,
+                table_type="schedules",
+                create_table_if_not_found=create_table_if_not_found,
+            )
+            return self.schedule_table
+
+        elif table_type == "schedule_runs":
+            # Ensure schedules table exists first (runs has FK to schedules)
+            if create_table_if_not_found:
+                await self._get_table(table_type="schedules", create_table_if_not_found=True)
+            self.schedule_runs_table = await self._get_or_create_table(
+                table_name=self.schedule_runs_table_name,
+                table_type="schedule_runs",
+                create_table_if_not_found=create_table_if_not_found,
+            )
+            return self.schedule_runs_table
 
         else:
             raise ValueError(f"Unknown table type: '{table_type}'")
@@ -3271,3 +3295,486 @@ class AsyncSqliteDb(AsyncBaseDb):
         label: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         raise NotImplementedError("Component methods not yet supported for async databases")
+
+    # --- Scheduler Methods ---
+    async def aget_schedule(self, schedule_id: str) -> Optional[Schedule]:
+        """Get a schedule by ID.
+
+        Args:
+            schedule_id: The schedule ID.
+
+        Returns:
+            Schedule or None if not found.
+        """
+        try:
+            table = await self._get_table(table_type="schedules")
+            if table is None:
+                return None
+
+            async with self.async_session_factory() as sess:
+                stmt = select(table).where(table.c.id == schedule_id)
+                result = await sess.execute(stmt)
+                row = result.fetchone()
+                if not row:
+                    return None
+                return Schedule.from_dict(dict(row._mapping))
+
+        except Exception as e:
+            log_error(f"Error getting schedule: {e}")
+            return None
+
+    async def aget_schedule_by_name(self, name: str) -> Optional[Schedule]:
+        """Get a schedule by name.
+
+        Args:
+            name: The schedule name.
+
+        Returns:
+            Schedule or None if not found.
+        """
+        try:
+            table = await self._get_table(table_type="schedules")
+            if table is None:
+                return None
+
+            async with self.async_session_factory() as sess:
+                stmt = select(table).where(table.c.name == name)
+                result = await sess.execute(stmt)
+                row = result.fetchone()
+                if not row:
+                    return None
+                return Schedule.from_dict(dict(row._mapping))
+
+        except Exception as e:
+            log_error(f"Error getting schedule by name: {e}")
+            return None
+
+    async def aget_schedules(
+        self,
+        enabled: Optional[bool] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> Tuple[List[Schedule], int]:
+        """Get schedules with optional filtering.
+
+        Args:
+            enabled: Filter by enabled status.
+            limit: Maximum number of schedules to return.
+            offset: Number of schedules to skip.
+
+        Returns:
+            Tuple of (list of schedules, total count).
+        """
+        try:
+            table = await self._get_table(table_type="schedules")
+            if table is None:
+                return [], 0
+
+            async with self.async_session_factory() as sess:
+                # Count query
+                count_stmt = select(func.count()).select_from(table)
+                if enabled is not None:
+                    count_stmt = count_stmt.where(table.c.enabled == enabled)
+                count_result = await sess.execute(count_stmt)
+                total_count = count_result.scalar() or 0
+
+                # Data query
+                stmt = select(table)
+                if enabled is not None:
+                    stmt = stmt.where(table.c.enabled == enabled)
+                stmt = stmt.order_by(table.c.created_at.desc())
+
+                if offset is not None:
+                    stmt = stmt.offset(offset)
+                if limit is not None:
+                    stmt = stmt.limit(limit)
+
+                result = await sess.execute(stmt)
+                rows = result.fetchall()
+                schedules = [Schedule.from_dict(dict(row._mapping)) for row in rows]
+                return schedules, total_count
+
+        except Exception as e:
+            log_error(f"Error getting schedules: {e}")
+            return [], 0
+
+    async def acreate_schedule(self, schedule: Schedule) -> Schedule:
+        """Create a new schedule.
+
+        Args:
+            schedule: The schedule to create.
+
+        Returns:
+            The created schedule.
+        """
+        try:
+            table = await self._get_table(table_type="schedules", create_table_if_not_found=True)
+            if table is None:
+                raise ValueError("Could not create schedules table")
+
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    current_time = int(time.time())
+
+                    stmt = sqlite.insert(table).values(
+                        id=schedule.id,
+                        name=schedule.name,
+                        description=schedule.description,
+                        method=schedule.method,
+                        endpoint=schedule.endpoint,
+                        payload=schedule.payload,
+                        cron_expr=schedule.cron_expr,
+                        timezone=schedule.timezone,
+                        timeout_seconds=schedule.timeout_seconds,
+                        max_retries=schedule.max_retries,
+                        retry_delay_seconds=schedule.retry_delay_seconds,
+                        enabled=schedule.enabled,
+                        next_run_at=schedule.next_run_at,
+                        locked_by=schedule.locked_by,
+                        locked_at=schedule.locked_at,
+                        created_at=schedule.created_at or current_time,
+                        updated_at=schedule.updated_at or current_time,
+                    )
+                    await sess.execute(stmt)
+
+            return schedule
+
+        except Exception as e:
+            log_error(f"Error creating schedule: {e}")
+            raise
+
+    async def aupdate_schedule(self, schedule: Schedule) -> Schedule:
+        """Update an existing schedule.
+
+        Args:
+            schedule: The schedule to update.
+
+        Returns:
+            The updated schedule.
+        """
+        try:
+            from sqlalchemy import update
+
+            table = await self._get_table(table_type="schedules")
+            if table is None:
+                raise ValueError("Schedules table not found")
+
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    current_time = int(time.time())
+
+                    stmt = (
+                        update(table)
+                        .where(table.c.id == schedule.id)
+                        .values(
+                            name=schedule.name,
+                            description=schedule.description,
+                            method=schedule.method,
+                            endpoint=schedule.endpoint,
+                            payload=schedule.payload,
+                            cron_expr=schedule.cron_expr,
+                            timezone=schedule.timezone,
+                            timeout_seconds=schedule.timeout_seconds,
+                            max_retries=schedule.max_retries,
+                            retry_delay_seconds=schedule.retry_delay_seconds,
+                            enabled=schedule.enabled,
+                            next_run_at=schedule.next_run_at,
+                            locked_by=schedule.locked_by,
+                            locked_at=schedule.locked_at,
+                            updated_at=current_time,
+                        )
+                    )
+                    await sess.execute(stmt)
+
+            schedule.updated_at = current_time
+            return schedule
+
+        except Exception as e:
+            log_error(f"Error updating schedule: {e}")
+            raise
+
+    async def adelete_schedule(self, schedule_id: str) -> bool:
+        """Delete a schedule.
+
+        Args:
+            schedule_id: The schedule ID to delete.
+
+        Returns:
+            True if deleted, False if not found.
+        """
+        try:
+            from sqlalchemy import delete
+
+            table = await self._get_table(table_type="schedules")
+            if table is None:
+                return False
+
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    stmt = delete(table).where(table.c.id == schedule_id)
+                    result = await sess.execute(stmt)
+                    return result.rowcount > 0
+
+        except Exception as e:
+            log_error(f"Error deleting schedule: {e}")
+            return False
+
+    async def aclaim_due_schedule(
+        self,
+        container_id: str,
+        lock_grace_seconds: int = 60,
+    ) -> Optional[Schedule]:
+        """Atomically claim one due schedule for execution.
+
+        WARNING: SQLite does not support SKIP LOCKED. In multi-process deployments,
+        there is a potential race condition where two processes could claim the same
+        schedule. For production multi-container deployments, use PostgreSQL instead.
+
+        This implementation is suitable for:
+        - Single-container deployments
+        - Development and testing
+        - Simple single-process applications
+
+        Args:
+            container_id: The ID of the container claiming the schedule.
+            lock_grace_seconds: Grace period in seconds after timeout before
+                considering a lock stale (default: 60).
+
+        Returns:
+            The claimed schedule, or None if no schedules are due.
+        """
+        try:
+            from sqlalchemy import update
+
+            table = await self._get_table(table_type="schedules")
+            if table is None:
+                return None
+
+            current_time = int(time.time())
+
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    # Find a due schedule that's not locked (or has an expired lock)
+                    stmt = (
+                        select(table)
+                        .where(table.c.enabled == True)  # noqa: E712
+                        .where(table.c.next_run_at <= current_time)
+                        .where(
+                            (table.c.locked_by == None)  # noqa: E711
+                            | (table.c.locked_at < current_time - table.c.timeout_seconds - lock_grace_seconds)
+                        )
+                        .order_by(table.c.next_run_at)
+                        .limit(1)
+                    )
+                    result = await sess.execute(stmt)
+                    row = result.fetchone()
+
+                    if not row:
+                        return None
+
+                    schedule_data = dict(row._mapping)
+                    schedule_id = schedule_data["id"]
+
+                    # Claim it by setting locked_by and locked_at
+                    update_stmt = (
+                        update(table)
+                        .where(table.c.id == schedule_id)
+                        .values(locked_by=container_id, locked_at=current_time)
+                    )
+                    await sess.execute(update_stmt)
+
+                    schedule_data["locked_by"] = container_id
+                    schedule_data["locked_at"] = current_time
+                    return Schedule.from_dict(schedule_data)
+
+        except Exception as e:
+            log_error(f"Error claiming schedule: {e}")
+            return None
+
+    async def arelease_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: int,
+    ) -> None:
+        """Release a schedule lock and set the next run time.
+
+        Args:
+            schedule_id: The schedule ID.
+            next_run_at: Epoch seconds for the next run.
+        """
+        try:
+            from sqlalchemy import update
+
+            table = await self._get_table(table_type="schedules")
+            if table is None:
+                return
+
+            current_time = int(time.time())
+
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    stmt = (
+                        update(table)
+                        .where(table.c.id == schedule_id)
+                        .values(
+                            locked_by=None,
+                            locked_at=None,
+                            next_run_at=next_run_at,
+                            updated_at=current_time,
+                        )
+                    )
+                    await sess.execute(stmt)
+
+        except Exception as e:
+            log_error(f"Error releasing schedule: {e}")
+
+    # --- Schedule Runs ---
+    async def acreate_schedule_run(self, run: ScheduleRun) -> ScheduleRun:
+        """Create a schedule run record.
+
+        Args:
+            run: The schedule run to create.
+
+        Returns:
+            The created schedule run.
+        """
+        try:
+            table = await self._get_table(table_type="schedule_runs", create_table_if_not_found=True)
+            if table is None:
+                raise ValueError("Could not create schedule_runs table")
+
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    current_time = int(time.time())
+
+                    stmt = sqlite.insert(table).values(
+                        id=run.id,
+                        schedule_id=run.schedule_id,
+                        attempt=run.attempt,
+                        triggered_at=run.triggered_at or current_time,
+                        completed_at=run.completed_at,
+                        status=run.status,
+                        status_code=run.status_code,
+                        run_id=run.run_id,
+                        session_id=run.session_id,
+                        error=run.error,
+                        created_at=run.created_at or current_time,
+                    )
+                    await sess.execute(stmt)
+
+            return run
+
+        except Exception as e:
+            log_error(f"Error creating schedule run: {e}")
+            raise
+
+    async def aupdate_schedule_run(self, run: ScheduleRun) -> ScheduleRun:
+        """Update a schedule run record.
+
+        Args:
+            run: The schedule run to update.
+
+        Returns:
+            The updated schedule run.
+        """
+        try:
+            from sqlalchemy import update
+
+            table = await self._get_table(table_type="schedule_runs")
+            if table is None:
+                raise ValueError("Schedule runs table not found")
+
+            async with self.async_session_factory() as sess:
+                async with sess.begin():
+                    stmt = (
+                        update(table)
+                        .where(table.c.id == run.id)
+                        .values(
+                            attempt=run.attempt,
+                            triggered_at=run.triggered_at,
+                            completed_at=run.completed_at,
+                            status=run.status,
+                            status_code=run.status_code,
+                            run_id=run.run_id,
+                            session_id=run.session_id,
+                            error=run.error,
+                        )
+                    )
+                    await sess.execute(stmt)
+
+            return run
+
+        except Exception as e:
+            log_error(f"Error updating schedule run: {e}")
+            raise
+
+    async def aget_schedule_runs(
+        self,
+        schedule_id: str,
+        limit: Optional[int] = 100,
+        offset: Optional[int] = None,
+    ) -> Tuple[List[ScheduleRun], int]:
+        """Get execution history for a schedule.
+
+        Args:
+            schedule_id: The schedule ID.
+            limit: Maximum number of runs to return.
+            offset: Number of runs to skip.
+
+        Returns:
+            Tuple of (list of schedule runs, total count).
+        """
+        try:
+            table = await self._get_table(table_type="schedule_runs")
+            if table is None:
+                return [], 0
+
+            async with self.async_session_factory() as sess:
+                # Count query
+                count_stmt = select(func.count()).select_from(table).where(table.c.schedule_id == schedule_id)
+                count_result = await sess.execute(count_stmt)
+                total_count = count_result.scalar() or 0
+
+                # Data query
+                stmt = select(table).where(table.c.schedule_id == schedule_id)
+                stmt = stmt.order_by(table.c.created_at.desc())
+
+                if offset is not None:
+                    stmt = stmt.offset(offset)
+                if limit is not None:
+                    stmt = stmt.limit(limit)
+
+                result = await sess.execute(stmt)
+                rows = result.fetchall()
+                runs = [ScheduleRun.from_dict(dict(row._mapping)) for row in rows]
+                return runs, total_count
+
+        except Exception as e:
+            log_error(f"Error getting schedule runs: {e}")
+            return [], 0
+
+    async def aget_schedule_run(self, run_id: str) -> Optional[ScheduleRun]:
+        """Get a specific schedule run.
+
+        Args:
+            run_id: The run ID.
+
+        Returns:
+            ScheduleRun or None if not found.
+        """
+        try:
+            table = await self._get_table(table_type="schedule_runs")
+            if table is None:
+                return None
+
+            async with self.async_session_factory() as sess:
+                stmt = select(table).where(table.c.id == run_id)
+                result = await sess.execute(stmt)
+                row = result.fetchone()
+                if not row:
+                    return None
+                return ScheduleRun.from_dict(dict(row._mapping))
+
+        except Exception as e:
+            log_error(f"Error getting schedule run: {e}")
+            return None

--- a/libs/agno/agno/db/sqlite/schemas.py
+++ b/libs/agno/agno/db/sqlite/schemas.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 try:
-    from sqlalchemy.types import JSON, BigInteger, Boolean, Date, String
+    from sqlalchemy.types import JSON, BigInteger, Boolean, Date, Integer, String
 except ImportError:
     raise ImportError("`sqlalchemy` not installed. Please install it using `pip install sqlalchemy`")
 
@@ -227,6 +227,57 @@ LEARNINGS_TABLE_SCHEMA = {
     "updated_at": {"type": BigInteger, "nullable": True},
 }
 
+SCHEDULE_TABLE_SCHEMA = {
+    # Identity
+    "id": {"type": String, "primary_key": True, "nullable": False},
+    "name": {"type": String, "nullable": False},
+    "description": {"type": String, "nullable": True},
+    # What to call (HTTP request)
+    "method": {"type": String, "nullable": False, "default": "POST"},
+    "endpoint": {"type": String, "nullable": False},
+    "payload": {"type": JSON, "nullable": True},
+    # When to run
+    "cron_expr": {"type": String, "nullable": False},
+    "timezone": {"type": String, "nullable": False, "default": "UTC"},
+    # Execution settings
+    "timeout_seconds": {"type": Integer, "nullable": False, "default": 3600},
+    "max_retries": {"type": Integer, "nullable": False, "default": 0},
+    "retry_delay_seconds": {"type": Integer, "nullable": False, "default": 60},
+    # State
+    "enabled": {"type": Boolean, "nullable": False, "default": True},
+    "next_run_at": {"type": BigInteger, "nullable": True, "index": True},
+    # Distributed locking (for multi-container)
+    "locked_by": {"type": String, "nullable": True},
+    "locked_at": {"type": BigInteger, "nullable": True},
+    # Metadata
+    "created_at": {"type": BigInteger, "nullable": False, "index": True},
+    "updated_at": {"type": BigInteger, "nullable": True},
+    "_unique_constraints": [
+        {
+            "name": "uq_schedule_name",
+            "columns": ["name"],
+        },
+    ],
+}
+
+SCHEDULE_RUNS_TABLE_SCHEMA = {
+    "id": {"type": String, "primary_key": True, "nullable": False},
+    "schedule_id": {"type": String, "nullable": False, "index": True},
+    # Attempt tracking
+    "attempt": {"type": Integer, "nullable": False, "default": 1},
+    # Timing
+    "triggered_at": {"type": BigInteger, "nullable": False},
+    "completed_at": {"type": BigInteger, "nullable": True},
+    # Result
+    "status": {"type": String, "nullable": False, "default": "running", "index": True},
+    "status_code": {"type": Integer, "nullable": True},
+    "run_id": {"type": String, "nullable": True},
+    "session_id": {"type": String, "nullable": True},
+    "error": {"type": String, "nullable": True},
+    # Metadata
+    "created_at": {"type": BigInteger, "nullable": False, "index": True},
+}
+
 
 def get_table_schema_definition(table_type: str, traces_table_name: str = "agno_traces") -> dict[str, Any]:
     """
@@ -256,6 +307,8 @@ def get_table_schema_definition(table_type: str, traces_table_name: str = "agno_
         "component_configs": COMPONENT_CONFIGS_TABLE_SCHEMA,
         "component_links": COMPONENT_LINKS_TABLE_SCHEMA,
         "learnings": LEARNINGS_TABLE_SCHEMA,
+        "schedules": SCHEDULE_TABLE_SCHEMA,
+        "schedule_runs": SCHEDULE_RUNS_TABLE_SCHEMA,
     }
     schema = schemas.get(table_type, {})
 

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -13,6 +13,7 @@ from agno.db.schemas.culture import CulturalKnowledge
 from agno.db.schemas.evals import EvalFilterType, EvalRunRecord, EvalType
 from agno.db.schemas.knowledge import KnowledgeRow
 from agno.db.schemas.memory import UserMemory
+from agno.db.schemas.scheduler import Schedule, ScheduleRun
 from agno.db.sqlite.schemas import get_table_schema_definition
 from agno.db.sqlite.utils import (
     apply_sorting,
@@ -59,6 +60,8 @@ class SqliteDb(BaseDb):
         component_configs_table: Optional[str] = None,
         component_links_table: Optional[str] = None,
         learnings_table: Optional[str] = None,
+        schedule_table: Optional[str] = None,
+        schedule_runs_table: Optional[str] = None,
         id: Optional[str] = None,
     ):
         """
@@ -111,6 +114,8 @@ class SqliteDb(BaseDb):
             component_configs_table=component_configs_table,
             component_links_table=component_links_table,
             learnings_table=learnings_table,
+            schedule_table=schedule_table,
+            schedule_runs_table=schedule_runs_table,
         )
 
         _engine: Optional[Engine] = db_engine
@@ -166,6 +171,8 @@ class SqliteDb(BaseDb):
             components_table=data.get("components_table"),
             component_configs_table=data.get("component_configs_table"),
             component_links_table=data.get("component_links_table"),
+            schedule_table=data.get("schedule_table"),
+            schedule_runs_table=data.get("schedule_runs_table"),
             id=data.get("id"),
         )
 
@@ -204,6 +211,8 @@ class SqliteDb(BaseDb):
             (self.component_configs_table_name, "component_configs"),
             (self.component_links_table_name, "component_links"),
             (self.learnings_table_name, "learnings"),
+            (self.schedule_table_name, "schedules"),
+            (self.schedule_runs_table_name, "schedule_runs"),
         ]
 
         for table_name, table_type in tables_to_create:
@@ -4324,3 +4333,469 @@ class SqliteDb(BaseDb):
         except Exception as e:
             log_debug(f"Error getting learnings: {e}")
             return []
+
+    # --- Schedules ---
+    def get_schedule(self, schedule_id: str) -> Optional[Schedule]:
+        """Get a schedule by ID.
+
+        Args:
+            schedule_id: The schedule ID.
+
+        Returns:
+            Schedule or None if not found.
+        """
+        try:
+            table = self._get_table(table_type="schedules")
+            if table is None:
+                return None
+
+            with self.Session() as sess:
+                stmt = select(table).where(table.c.id == schedule_id)
+                result = sess.execute(stmt).fetchone()
+                if not result:
+                    return None
+                return Schedule.from_dict(dict(result._mapping))
+
+        except Exception as e:
+            log_error(f"Error getting schedule: {e}")
+            return None
+
+    def get_schedule_by_name(self, name: str) -> Optional[Schedule]:
+        """Get a schedule by name.
+
+        Args:
+            name: The schedule name.
+
+        Returns:
+            Schedule or None if not found.
+        """
+        try:
+            table = self._get_table(table_type="schedules")
+            if table is None:
+                return None
+
+            with self.Session() as sess:
+                stmt = select(table).where(table.c.name == name)
+                result = sess.execute(stmt).fetchone()
+                if not result:
+                    return None
+                return Schedule.from_dict(dict(result._mapping))
+
+        except Exception as e:
+            log_error(f"Error getting schedule by name: {e}")
+            return None
+
+    def get_schedules(
+        self,
+        enabled: Optional[bool] = None,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
+    ) -> Tuple[List[Schedule], int]:
+        """Get schedules with optional filtering.
+
+        Args:
+            enabled: Filter by enabled status.
+            limit: Maximum number of schedules to return.
+            offset: Number of schedules to skip.
+
+        Returns:
+            Tuple of (list of schedules, total count).
+        """
+        try:
+            table = self._get_table(table_type="schedules")
+            if table is None:
+                return [], 0
+
+            with self.Session() as sess:
+                # Count query
+                count_stmt = select(func.count()).select_from(table)
+                if enabled is not None:
+                    count_stmt = count_stmt.where(table.c.enabled == enabled)
+                total_count = sess.execute(count_stmt).scalar() or 0
+
+                # Data query
+                stmt = select(table)
+                if enabled is not None:
+                    stmt = stmt.where(table.c.enabled == enabled)
+                stmt = stmt.order_by(table.c.created_at.desc())
+
+                if offset is not None:
+                    stmt = stmt.offset(offset)
+                if limit is not None:
+                    stmt = stmt.limit(limit)
+
+                results = sess.execute(stmt).fetchall()
+                schedules = [Schedule.from_dict(dict(row._mapping)) for row in results]
+                return schedules, total_count
+
+        except Exception as e:
+            log_error(f"Error getting schedules: {e}")
+            return [], 0
+
+    def create_schedule(self, schedule: Schedule) -> Schedule:
+        """Create a new schedule.
+
+        Args:
+            schedule: The schedule to create.
+
+        Returns:
+            The created schedule.
+        """
+        try:
+            table = self._get_table(table_type="schedules", create_table_if_not_found=True)
+            if table is None:
+                raise ValueError("Could not create schedules table")
+
+            with self.Session() as sess, sess.begin():
+                current_time = int(time.time())
+
+                stmt = sqlite.insert(table).values(
+                    id=schedule.id,
+                    name=schedule.name,
+                    description=schedule.description,
+                    method=schedule.method,
+                    endpoint=schedule.endpoint,
+                    payload=schedule.payload,
+                    cron_expr=schedule.cron_expr,
+                    timezone=schedule.timezone,
+                    timeout_seconds=schedule.timeout_seconds,
+                    max_retries=schedule.max_retries,
+                    retry_delay_seconds=schedule.retry_delay_seconds,
+                    enabled=schedule.enabled,
+                    next_run_at=schedule.next_run_at,
+                    locked_by=schedule.locked_by,
+                    locked_at=schedule.locked_at,
+                    created_at=schedule.created_at or current_time,
+                    updated_at=schedule.updated_at or current_time,
+                )
+                sess.execute(stmt)
+
+            return schedule
+
+        except Exception as e:
+            log_error(f"Error creating schedule: {e}")
+            raise e
+
+    def update_schedule(self, schedule: Schedule) -> Schedule:
+        """Update an existing schedule.
+
+        Args:
+            schedule: The schedule to update.
+
+        Returns:
+            The updated schedule.
+        """
+        try:
+            from sqlalchemy import update
+
+            table = self._get_table(table_type="schedules")
+            if table is None:
+                raise ValueError("Schedules table not found")
+
+            with self.Session() as sess, sess.begin():
+                current_time = int(time.time())
+
+                stmt = (
+                    update(table)
+                    .where(table.c.id == schedule.id)
+                    .values(
+                        name=schedule.name,
+                        description=schedule.description,
+                        method=schedule.method,
+                        endpoint=schedule.endpoint,
+                        payload=schedule.payload,
+                        cron_expr=schedule.cron_expr,
+                        timezone=schedule.timezone,
+                        timeout_seconds=schedule.timeout_seconds,
+                        max_retries=schedule.max_retries,
+                        retry_delay_seconds=schedule.retry_delay_seconds,
+                        enabled=schedule.enabled,
+                        next_run_at=schedule.next_run_at,
+                        locked_by=schedule.locked_by,
+                        locked_at=schedule.locked_at,
+                        updated_at=current_time,
+                    )
+                )
+                sess.execute(stmt)
+
+            schedule.updated_at = current_time
+            return schedule
+
+        except Exception as e:
+            log_error(f"Error updating schedule: {e}")
+            raise e
+
+    def delete_schedule(self, schedule_id: str) -> bool:
+        """Delete a schedule.
+
+        Args:
+            schedule_id: The schedule ID to delete.
+
+        Returns:
+            True if deleted, False if not found.
+        """
+        try:
+            table = self._get_table(table_type="schedules")
+            if table is None:
+                return False
+
+            with self.Session() as sess, sess.begin():
+                stmt = table.delete().where(table.c.id == schedule_id)
+                result = sess.execute(stmt)
+                return result.rowcount > 0
+
+        except Exception as e:
+            log_error(f"Error deleting schedule: {e}")
+            return False
+
+    def claim_due_schedule(
+        self,
+        container_id: str,
+        lock_grace_seconds: int = 60,
+    ) -> Optional[Schedule]:
+        """Atomically claim one due schedule for execution.
+
+        WARNING: SQLite does not support SKIP LOCKED. In multi-process deployments,
+        there is a potential race condition where two processes could claim the same
+        schedule. For production multi-container deployments, use PostgreSQL instead.
+
+        This implementation is suitable for:
+        - Single-container deployments
+        - Development and testing
+        - Simple single-process applications
+
+        Args:
+            container_id: The ID of the container claiming the schedule.
+            lock_grace_seconds: Grace period in seconds after timeout before
+                considering a lock stale (default: 60).
+
+        Returns:
+            The claimed schedule, or None if no schedules are due.
+        """
+        try:
+            from sqlalchemy import update
+
+            table = self._get_table(table_type="schedules")
+            if table is None:
+                return None
+
+            current_time = int(time.time())
+
+            with self.Session() as sess, sess.begin():
+                # Find a due schedule that's not locked (or has an expired lock)
+                stmt = (
+                    select(table)
+                    .where(table.c.enabled == True)  # noqa: E712
+                    .where(table.c.next_run_at <= current_time)
+                    .where(
+                        (table.c.locked_by == None)  # noqa: E711
+                        | (table.c.locked_at < current_time - table.c.timeout_seconds - lock_grace_seconds)
+                    )
+                    .order_by(table.c.next_run_at)
+                    .limit(1)
+                )
+                result = sess.execute(stmt).fetchone()
+
+                if not result:
+                    return None
+
+                schedule_data = dict(result._mapping)
+                schedule_id = schedule_data["id"]
+
+                # Claim it by setting locked_by and locked_at
+                update_stmt = (
+                    update(table)
+                    .where(table.c.id == schedule_id)
+                    .values(locked_by=container_id, locked_at=current_time)
+                )
+                sess.execute(update_stmt)
+
+                schedule_data["locked_by"] = container_id
+                schedule_data["locked_at"] = current_time
+                return Schedule.from_dict(schedule_data)
+
+        except Exception as e:
+            log_error(f"Error claiming schedule: {e}")
+            return None
+
+    def release_schedule(
+        self,
+        schedule_id: str,
+        next_run_at: int,
+    ) -> None:
+        """Release a schedule lock and set the next run time.
+
+        Args:
+            schedule_id: The schedule ID.
+            next_run_at: Epoch seconds for the next run.
+        """
+        try:
+            from sqlalchemy import update
+
+            table = self._get_table(table_type="schedules")
+            if table is None:
+                return
+
+            current_time = int(time.time())
+
+            with self.Session() as sess, sess.begin():
+                stmt = (
+                    update(table)
+                    .where(table.c.id == schedule_id)
+                    .values(
+                        locked_by=None,
+                        locked_at=None,
+                        next_run_at=next_run_at,
+                        updated_at=current_time,
+                    )
+                )
+                sess.execute(stmt)
+
+        except Exception as e:
+            log_error(f"Error releasing schedule: {e}")
+
+    # --- Schedule Runs ---
+    def create_schedule_run(self, run: ScheduleRun) -> ScheduleRun:
+        """Create a schedule run record.
+
+        Args:
+            run: The schedule run to create.
+
+        Returns:
+            The created schedule run.
+        """
+        try:
+            table = self._get_table(table_type="schedule_runs", create_table_if_not_found=True)
+            if table is None:
+                raise ValueError("Could not create schedule_runs table")
+
+            with self.Session() as sess, sess.begin():
+                current_time = int(time.time())
+
+                stmt = sqlite.insert(table).values(
+                    id=run.id,
+                    schedule_id=run.schedule_id,
+                    attempt=run.attempt,
+                    triggered_at=run.triggered_at or current_time,
+                    completed_at=run.completed_at,
+                    status=run.status,
+                    status_code=run.status_code,
+                    run_id=run.run_id,
+                    session_id=run.session_id,
+                    error=run.error,
+                    created_at=run.created_at or current_time,
+                )
+                sess.execute(stmt)
+
+            return run
+
+        except Exception as e:
+            log_error(f"Error creating schedule run: {e}")
+            raise e
+
+    def update_schedule_run(self, run: ScheduleRun) -> ScheduleRun:
+        """Update a schedule run record.
+
+        Args:
+            run: The schedule run to update.
+
+        Returns:
+            The updated schedule run.
+        """
+        try:
+            from sqlalchemy import update
+
+            table = self._get_table(table_type="schedule_runs")
+            if table is None:
+                raise ValueError("Schedule runs table not found")
+
+            with self.Session() as sess, sess.begin():
+                stmt = (
+                    update(table)
+                    .where(table.c.id == run.id)
+                    .values(
+                        attempt=run.attempt,
+                        triggered_at=run.triggered_at,
+                        completed_at=run.completed_at,
+                        status=run.status,
+                        status_code=run.status_code,
+                        run_id=run.run_id,
+                        session_id=run.session_id,
+                        error=run.error,
+                    )
+                )
+                sess.execute(stmt)
+
+            return run
+
+        except Exception as e:
+            log_error(f"Error updating schedule run: {e}")
+            raise e
+
+    def get_schedule_runs(
+        self,
+        schedule_id: str,
+        limit: Optional[int] = 100,
+        offset: Optional[int] = None,
+    ) -> Tuple[List[ScheduleRun], int]:
+        """Get execution history for a schedule.
+
+        Args:
+            schedule_id: The schedule ID.
+            limit: Maximum number of runs to return.
+            offset: Number of runs to skip.
+
+        Returns:
+            Tuple of (list of schedule runs, total count).
+        """
+        try:
+            table = self._get_table(table_type="schedule_runs")
+            if table is None:
+                return [], 0
+
+            with self.Session() as sess:
+                # Count query
+                count_stmt = select(func.count()).select_from(table).where(table.c.schedule_id == schedule_id)
+                total_count = sess.execute(count_stmt).scalar() or 0
+
+                # Data query
+                stmt = select(table).where(table.c.schedule_id == schedule_id)
+                stmt = stmt.order_by(table.c.created_at.desc())
+
+                if offset is not None:
+                    stmt = stmt.offset(offset)
+                if limit is not None:
+                    stmt = stmt.limit(limit)
+
+                results = sess.execute(stmt).fetchall()
+                runs = [ScheduleRun.from_dict(dict(row._mapping)) for row in results]
+                return runs, total_count
+
+        except Exception as e:
+            log_error(f"Error getting schedule runs: {e}")
+            return [], 0
+
+    def get_schedule_run(self, run_id: str) -> Optional[ScheduleRun]:
+        """Get a specific schedule run.
+
+        Args:
+            run_id: The run ID.
+
+        Returns:
+            ScheduleRun or None if not found.
+        """
+        try:
+            table = self._get_table(table_type="schedule_runs")
+            if table is None:
+                return None
+
+            with self.Session() as sess:
+                stmt = select(table).where(table.c.id == run_id)
+                result = sess.execute(stmt).fetchone()
+                if not result:
+                    return None
+                return ScheduleRun.from_dict(dict(result._mapping))
+
+        except Exception as e:
+            log_error(f"Error getting schedule run: {e}")
+            return None

--- a/libs/agno/agno/os/routers/schedules/__init__.py
+++ b/libs/agno/agno/os/routers/schedules/__init__.py
@@ -1,0 +1,3 @@
+from agno.os.routers.schedules.router import get_schedule_router
+
+__all__ = ["get_schedule_router"]

--- a/libs/agno/agno/os/routers/schedules/router.py
+++ b/libs/agno/agno/os/routers/schedules/router.py
@@ -1,0 +1,497 @@
+"""FastAPI router for Schedule management endpoints."""
+
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from agno.db.base import AsyncBaseDb, BaseDb
+from agno.db.schemas.scheduler import Schedule, ScheduleRun
+from agno.os.routers.schedules.schema import (
+    ScheduleCreateRequest,
+    ScheduleListResponse,
+    ScheduleResponse,
+    ScheduleRunListResponse,
+    ScheduleRunResponse,
+    ScheduleUpdateRequest,
+    TriggerResponse,
+)
+from agno.os.schema import (
+    BadRequestResponse,
+    InternalServerErrorResponse,
+    NotFoundResponse,
+    UnauthorizedResponse,
+    ValidationErrorResponse,
+)
+from agno.os.settings import AgnoAPISettings
+from agno.scheduler.cron import calculate_next_run, validate_cron_expr
+from agno.utils.log import log_error
+
+if TYPE_CHECKING:
+    from agno.scheduler.poller import SchedulePoller
+
+
+async def get_db(
+    dbs: Dict[str, List[Union[BaseDb, AsyncBaseDb, "RemoteDb"]]],  # noqa: F821
+    db_id: Optional[str] = None,
+) -> Optional[Union[BaseDb, AsyncBaseDb]]:
+    """Get a database instance from the dbs dictionary.
+
+    Returns sync (BaseDb) or async (AsyncBaseDb) database.
+    Prefers sync database if both are available.
+    """
+    # Try to find a sync database first
+    for db_list in dbs.values():
+        for db in db_list:
+            if isinstance(db, BaseDb):
+                if db_id is None or db.id == db_id:
+                    return db
+    # Fall back to async database
+    for db_list in dbs.values():
+        for db in db_list:
+            if isinstance(db, AsyncBaseDb):
+                if db_id is None or db.id == db_id:
+                    return db
+    return None
+
+
+def _is_async_db(db: Union[BaseDb, AsyncBaseDb]) -> bool:
+    """Check if the database is async."""
+    return isinstance(db, AsyncBaseDb) or hasattr(db, "aget_schedule")
+
+
+async def _get_schedule(db: Union[BaseDb, AsyncBaseDb], schedule_id: str) -> Optional[Schedule]:
+    """Get a schedule by ID (supports both sync and async db)."""
+    if _is_async_db(db):
+        return await db.aget_schedule(schedule_id)  # type: ignore
+    return db.get_schedule(schedule_id)  # type: ignore
+
+
+async def _get_schedule_by_name(db: Union[BaseDb, AsyncBaseDb], name: str) -> Optional[Schedule]:
+    """Get a schedule by name (supports both sync and async db)."""
+    if _is_async_db(db):
+        return await db.aget_schedule_by_name(name)  # type: ignore
+    return db.get_schedule_by_name(name)  # type: ignore
+
+
+async def _get_schedules(
+    db: Union[BaseDb, AsyncBaseDb],
+    enabled: Optional[bool],
+    limit: Optional[int],
+    offset: Optional[int],
+) -> Tuple[List[Schedule], int]:
+    """Get schedules (supports both sync and async db)."""
+    if _is_async_db(db):
+        return await db.aget_schedules(enabled=enabled, limit=limit, offset=offset)  # type: ignore
+    return db.get_schedules(enabled=enabled, limit=limit, offset=offset)  # type: ignore
+
+
+async def _create_schedule(db: Union[BaseDb, AsyncBaseDb], schedule: Schedule) -> Schedule:
+    """Create a schedule (supports both sync and async db)."""
+    if _is_async_db(db):
+        return await db.acreate_schedule(schedule)  # type: ignore
+    return db.create_schedule(schedule)  # type: ignore
+
+
+async def _update_schedule(db: Union[BaseDb, AsyncBaseDb], schedule: Schedule) -> Schedule:
+    """Update a schedule (supports both sync and async db)."""
+    if _is_async_db(db):
+        return await db.aupdate_schedule(schedule)  # type: ignore
+    return db.update_schedule(schedule)  # type: ignore
+
+
+async def _delete_schedule(db: Union[BaseDb, AsyncBaseDb], schedule_id: str) -> bool:
+    """Delete a schedule (supports both sync and async db)."""
+    if _is_async_db(db):
+        return await db.adelete_schedule(schedule_id)  # type: ignore
+    return db.delete_schedule(schedule_id)  # type: ignore
+
+
+async def _get_schedule_runs(
+    db: Union[BaseDb, AsyncBaseDb],
+    schedule_id: str,
+    limit: Optional[int],
+    offset: Optional[int],
+) -> Tuple[List[ScheduleRun], int]:
+    """Get schedule runs (supports both sync and async db)."""
+    if _is_async_db(db):
+        return await db.aget_schedule_runs(schedule_id, limit=limit, offset=offset)  # type: ignore
+    return db.get_schedule_runs(schedule_id, limit=limit, offset=offset)  # type: ignore
+
+
+async def _get_schedule_run(db: Union[BaseDb, AsyncBaseDb], run_id: str) -> Optional[ScheduleRun]:
+    """Get a schedule run (supports both sync and async db)."""
+    if _is_async_db(db):
+        return await db.aget_schedule_run(run_id)  # type: ignore
+    return db.get_schedule_run(run_id)  # type: ignore
+
+
+def get_schedule_router(
+    dbs: Dict[str, List[Union[BaseDb, AsyncBaseDb]]],
+    settings: AgnoAPISettings = AgnoAPISettings(),
+    poller: Optional["SchedulePoller"] = None,
+) -> APIRouter:
+    """Create the schedule management router.
+
+    Args:
+        dbs: Dictionary of database instances (supports both sync and async).
+        settings: API settings for authentication.
+        poller: Optional schedule poller for manual triggers.
+
+    Returns:
+        FastAPI router with schedule endpoints.
+    """
+    from agno.os.utils import get_authentication_dependency
+
+    router = APIRouter(
+        prefix="/v1/schedules",
+        tags=["Schedules"],
+        dependencies=[Depends(get_authentication_dependency(settings))],
+        responses={
+            400: {"description": "Bad Request", "model": BadRequestResponse},
+            401: {"description": "Unauthorized", "model": UnauthorizedResponse},
+            404: {"description": "Not Found", "model": NotFoundResponse},
+            422: {"description": "Validation Error", "model": ValidationErrorResponse},
+            500: {"description": "Internal Server Error", "model": InternalServerErrorResponse},
+        },
+    )
+
+    @router.get(
+        "",
+        operation_id="list_schedules",
+        summary="List Schedules",
+        description="Get a list of all schedules with optional filtering.",
+        response_model=ScheduleListResponse,
+    )
+    async def list_schedules(
+        enabled: Optional[bool] = Query(None, description="Filter by enabled status"),
+        limit: int = Query(20, ge=1, le=100, description="Maximum number of schedules to return"),
+        offset: int = Query(0, ge=0, description="Number of schedules to skip"),
+    ) -> ScheduleListResponse:
+        db = await get_db(dbs)
+        if db is None:
+            raise HTTPException(status_code=500, detail="No database available")
+
+        schedules, total = await _get_schedules(db, enabled=enabled, limit=limit, offset=offset)
+
+        return ScheduleListResponse(
+            schedules=[_schedule_to_response(s) for s in schedules],
+            total=total,
+            limit=limit,
+            offset=offset,
+        )
+
+    @router.post(
+        "",
+        operation_id="create_schedule",
+        summary="Create Schedule",
+        description="Create a new schedule for running agents, workflows, or other endpoints on a recurring basis.",
+        response_model=ScheduleResponse,
+        status_code=201,
+    )
+    async def create_schedule(request: ScheduleCreateRequest) -> ScheduleResponse:
+        db = await get_db(dbs)
+        if db is None:
+            raise HTTPException(status_code=500, detail="No database available")
+
+        # Validate cron expression
+        if not validate_cron_expr(request.cron_expr):
+            raise HTTPException(status_code=400, detail=f"Invalid cron expression: {request.cron_expr}")
+
+        # Check for duplicate name
+        existing = await _get_schedule_by_name(db, request.name)
+        if existing:
+            raise HTTPException(status_code=400, detail=f"Schedule with name '{request.name}' already exists")
+
+        # Calculate next run time
+        try:
+            next_run_at = calculate_next_run(request.cron_expr, request.timezone)
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=str(e))
+
+        schedule = Schedule(
+            id=str(uuid4()),
+            name=request.name,
+            description=request.description,
+            endpoint=request.endpoint,
+            method=request.method,
+            payload=request.payload,
+            cron_expr=request.cron_expr,
+            timezone=request.timezone,
+            timeout_seconds=request.timeout_seconds,
+            max_retries=request.max_retries,
+            retry_delay_seconds=request.retry_delay_seconds,
+            enabled=request.enabled,
+            next_run_at=next_run_at,
+        )
+
+        try:
+            created = await _create_schedule(db, schedule)
+            return _schedule_to_response(created)
+        except Exception as e:
+            log_error(f"Error creating schedule: {e}")
+            raise HTTPException(status_code=500, detail="Failed to create schedule")
+
+    @router.get(
+        "/{schedule_id}",
+        operation_id="get_schedule",
+        summary="Get Schedule",
+        description="Get details of a specific schedule.",
+        response_model=ScheduleResponse,
+    )
+    async def get_schedule_endpoint(schedule_id: str) -> ScheduleResponse:
+        db = await get_db(dbs)
+        if db is None:
+            raise HTTPException(status_code=500, detail="No database available")
+
+        schedule = await _get_schedule(db, schedule_id)
+        if schedule is None:
+            raise HTTPException(status_code=404, detail=f"Schedule '{schedule_id}' not found")
+
+        return _schedule_to_response(schedule)
+
+    @router.patch(
+        "/{schedule_id}",
+        operation_id="update_schedule",
+        summary="Update Schedule",
+        description="Update an existing schedule's configuration.",
+        response_model=ScheduleResponse,
+    )
+    async def update_schedule_endpoint(schedule_id: str, request: ScheduleUpdateRequest) -> ScheduleResponse:
+        db = await get_db(dbs)
+        if db is None:
+            raise HTTPException(status_code=500, detail="No database available")
+
+        schedule = await _get_schedule(db, schedule_id)
+        if schedule is None:
+            raise HTTPException(status_code=404, detail=f"Schedule '{schedule_id}' not found")
+
+        # Update fields if provided
+        if request.name is not None:
+            # Check for duplicate name
+            if request.name != schedule.name:
+                existing = await _get_schedule_by_name(db, request.name)
+                if existing:
+                    raise HTTPException(status_code=400, detail=f"Schedule with name '{request.name}' already exists")
+            schedule.name = request.name
+
+        if request.description is not None:
+            schedule.description = request.description
+        if request.endpoint is not None:
+            schedule.endpoint = request.endpoint
+        if request.method is not None:
+            schedule.method = request.method
+        if request.payload is not None:
+            schedule.payload = request.payload
+        if request.timeout_seconds is not None:
+            schedule.timeout_seconds = request.timeout_seconds
+        if request.max_retries is not None:
+            schedule.max_retries = request.max_retries
+        if request.retry_delay_seconds is not None:
+            schedule.retry_delay_seconds = request.retry_delay_seconds
+        if request.enabled is not None:
+            schedule.enabled = request.enabled
+
+        # Handle cron/timezone updates
+        cron_changed = request.cron_expr is not None or request.timezone is not None
+        if cron_changed:
+            cron_expr = request.cron_expr or schedule.cron_expr
+            timezone = request.timezone or schedule.timezone
+
+            if not validate_cron_expr(cron_expr):
+                raise HTTPException(status_code=400, detail=f"Invalid cron expression: {cron_expr}")
+
+            schedule.cron_expr = cron_expr
+            schedule.timezone = timezone
+
+            # Recalculate next run time
+            try:
+                schedule.next_run_at = calculate_next_run(cron_expr, timezone)
+            except Exception as e:
+                raise HTTPException(status_code=400, detail=str(e))
+
+        try:
+            updated = await _update_schedule(db, schedule)
+            return _schedule_to_response(updated)
+        except Exception as e:
+            log_error(f"Error updating schedule: {e}")
+            raise HTTPException(status_code=500, detail="Failed to update schedule")
+
+    @router.delete(
+        "/{schedule_id}",
+        operation_id="delete_schedule",
+        summary="Delete Schedule",
+        description="Delete a schedule.",
+        status_code=204,
+    )
+    async def delete_schedule_endpoint(schedule_id: str) -> None:
+        db = await get_db(dbs)
+        if db is None:
+            raise HTTPException(status_code=500, detail="No database available")
+
+        deleted = await _delete_schedule(db, schedule_id)
+        if not deleted:
+            raise HTTPException(status_code=404, detail=f"Schedule '{schedule_id}' not found")
+
+    @router.post(
+        "/{schedule_id}/enable",
+        operation_id="enable_schedule",
+        summary="Enable Schedule",
+        description="Enable a disabled schedule.",
+        response_model=ScheduleResponse,
+    )
+    async def enable_schedule(schedule_id: str) -> ScheduleResponse:
+        db = await get_db(dbs)
+        if db is None:
+            raise HTTPException(status_code=500, detail="No database available")
+
+        schedule = await _get_schedule(db, schedule_id)
+        if schedule is None:
+            raise HTTPException(status_code=404, detail=f"Schedule '{schedule_id}' not found")
+
+        schedule.enabled = True
+        # Recalculate next run time when enabling
+        schedule.next_run_at = calculate_next_run(schedule.cron_expr, schedule.timezone)
+
+        updated = await _update_schedule(db, schedule)
+        return _schedule_to_response(updated)
+
+    @router.post(
+        "/{schedule_id}/disable",
+        operation_id="disable_schedule",
+        summary="Disable Schedule",
+        description="Disable a schedule without deleting it.",
+        response_model=ScheduleResponse,
+    )
+    async def disable_schedule(schedule_id: str) -> ScheduleResponse:
+        db = await get_db(dbs)
+        if db is None:
+            raise HTTPException(status_code=500, detail="No database available")
+
+        schedule = await _get_schedule(db, schedule_id)
+        if schedule is None:
+            raise HTTPException(status_code=404, detail=f"Schedule '{schedule_id}' not found")
+
+        schedule.enabled = False
+        updated = await _update_schedule(db, schedule)
+        return _schedule_to_response(updated)
+
+    @router.post(
+        "/{schedule_id}/trigger",
+        operation_id="trigger_schedule",
+        summary="Trigger Schedule",
+        description="Manually trigger a schedule to run immediately, bypassing the cron timing.",
+        response_model=TriggerResponse,
+    )
+    async def trigger_schedule(schedule_id: str) -> TriggerResponse:
+        db = await get_db(dbs)
+        if db is None:
+            raise HTTPException(status_code=500, detail="No database available")
+
+        schedule = await _get_schedule(db, schedule_id)
+        if schedule is None:
+            raise HTTPException(status_code=404, detail=f"Schedule '{schedule_id}' not found")
+
+        if poller is None:
+            raise HTTPException(
+                status_code=503,
+                detail="Scheduler is not enabled. Enable it with enable_scheduler=True in AgentOS configuration.",
+            )
+
+        triggered = await poller.trigger_schedule(schedule_id)
+        if not triggered:
+            raise HTTPException(status_code=500, detail="Failed to trigger schedule")
+
+        return TriggerResponse(
+            message="Schedule triggered successfully",
+            schedule_id=schedule_id,
+        )
+
+    # --- Schedule Runs ---
+    @router.get(
+        "/{schedule_id}/runs",
+        operation_id="list_schedule_runs",
+        summary="List Schedule Runs",
+        description="Get the execution history for a schedule.",
+        response_model=ScheduleRunListResponse,
+    )
+    async def list_schedule_runs(
+        schedule_id: str,
+        limit: int = Query(20, ge=1, le=100, description="Maximum number of runs to return"),
+        offset: int = Query(0, ge=0, description="Number of runs to skip"),
+    ) -> ScheduleRunListResponse:
+        db = await get_db(dbs)
+        if db is None:
+            raise HTTPException(status_code=500, detail="No database available")
+
+        # Verify schedule exists
+        schedule = await _get_schedule(db, schedule_id)
+        if schedule is None:
+            raise HTTPException(status_code=404, detail=f"Schedule '{schedule_id}' not found")
+
+        runs, total = await _get_schedule_runs(db, schedule_id, limit=limit, offset=offset)
+
+        return ScheduleRunListResponse(
+            runs=[_run_to_response(r) for r in runs],
+            total=total,
+            limit=limit,
+            offset=offset,
+        )
+
+    @router.get(
+        "/{schedule_id}/runs/{run_id}",
+        operation_id="get_schedule_run",
+        summary="Get Schedule Run",
+        description="Get details of a specific schedule run.",
+        response_model=ScheduleRunResponse,
+    )
+    async def get_schedule_run_endpoint(schedule_id: str, run_id: str) -> ScheduleRunResponse:
+        db = await get_db(dbs)
+        if db is None:
+            raise HTTPException(status_code=500, detail="No database available")
+
+        run = await _get_schedule_run(db, run_id)
+        if run is None or run.schedule_id != schedule_id:
+            raise HTTPException(status_code=404, detail=f"Run '{run_id}' not found")
+
+        return _run_to_response(run)
+
+    return router
+
+
+def _schedule_to_response(schedule: Schedule) -> ScheduleResponse:
+    """Convert a Schedule domain object to a response model."""
+    return ScheduleResponse(
+        id=schedule.id,
+        name=schedule.name,
+        description=schedule.description,
+        endpoint=schedule.endpoint,
+        method=schedule.method,
+        payload=schedule.payload,
+        cron_expr=schedule.cron_expr,
+        timezone=schedule.timezone,
+        timeout_seconds=schedule.timeout_seconds,
+        max_retries=schedule.max_retries,
+        retry_delay_seconds=schedule.retry_delay_seconds,
+        enabled=schedule.enabled,
+        next_run_at=schedule.next_run_at,
+        created_at=schedule.created_at,
+        updated_at=schedule.updated_at,
+    )
+
+
+def _run_to_response(run: ScheduleRun) -> ScheduleRunResponse:
+    """Convert a ScheduleRun domain object to a response model."""
+    return ScheduleRunResponse(
+        id=run.id,
+        schedule_id=run.schedule_id,
+        attempt=run.attempt,
+        triggered_at=run.triggered_at,
+        completed_at=run.completed_at,
+        status=run.status,
+        status_code=run.status_code,
+        run_id=run.run_id,
+        session_id=run.session_id,
+        error=run.error,
+        created_at=run.created_at,
+    )

--- a/libs/agno/agno/os/routers/schedules/schema.py
+++ b/libs/agno/agno/os/routers/schedules/schema.py
@@ -1,0 +1,173 @@
+"""Pydantic models for Schedule API requests and responses."""
+
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ScheduleCreateRequest(BaseModel):
+    """Request model for creating a schedule."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "name": "daily-report",
+                "description": "Generate daily metrics report",
+                "endpoint": "/v1/agents/report-generator/runs",
+                "method": "POST",
+                "payload": {"message": "Generate the daily report"},
+                "cron_expr": "0 3 * * *",
+                "timezone": "America/New_York",
+                "max_retries": 2,
+                "timeout_seconds": 1800,
+            }
+        }
+    )
+
+    name: str = Field(..., description="Unique name for the schedule")
+    description: Optional[str] = Field(None, description="Description of what this schedule does")
+    endpoint: str = Field(..., description="The AgentOS endpoint to call (e.g., '/v1/agents/my-agent/runs')")
+    method: str = Field(default="POST", description="HTTP method to use (GET, POST, PUT, DELETE)")
+    payload: Optional[Dict[str, Any]] = Field(None, description="Request body/payload to send")
+    cron_expr: str = Field(..., description="Cron expression (e.g., '0 3 * * *' for 3 AM daily)")
+    timezone: str = Field(default="UTC", description="Timezone for the cron expression")
+    timeout_seconds: int = Field(default=3600, ge=1, le=86400, description="Max execution time in seconds")
+    max_retries: int = Field(default=0, ge=0, le=10, description="Number of retry attempts on failure")
+    retry_delay_seconds: int = Field(default=60, ge=1, le=3600, description="Delay between retries in seconds")
+    enabled: bool = Field(default=True, description="Whether the schedule is active")
+
+
+class ScheduleUpdateRequest(BaseModel):
+    """Request model for updating a schedule."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "description": "Updated description",
+                "cron_expr": "0 4 * * *",
+                "enabled": False,
+            }
+        }
+    )
+
+    name: Optional[str] = Field(None, description="Unique name for the schedule")
+    description: Optional[str] = Field(None, description="Description of what this schedule does")
+    endpoint: Optional[str] = Field(None, description="The AgentOS endpoint to call")
+    method: Optional[str] = Field(None, description="HTTP method to use")
+    payload: Optional[Dict[str, Any]] = Field(None, description="Request body/payload to send")
+    cron_expr: Optional[str] = Field(None, description="Cron expression")
+    timezone: Optional[str] = Field(None, description="Timezone for the cron expression")
+    timeout_seconds: Optional[int] = Field(None, ge=1, le=86400, description="Max execution time in seconds")
+    max_retries: Optional[int] = Field(None, ge=0, le=10, description="Number of retry attempts on failure")
+    retry_delay_seconds: Optional[int] = Field(None, ge=1, le=3600, description="Delay between retries in seconds")
+    enabled: Optional[bool] = Field(None, description="Whether the schedule is active")
+
+
+class ScheduleResponse(BaseModel):
+    """Response model for a schedule."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": "550e8400-e29b-41d4-a716-446655440000",
+                "name": "daily-report",
+                "description": "Generate daily metrics report",
+                "endpoint": "/v1/agents/report-generator/runs",
+                "method": "POST",
+                "payload": {"message": "Generate the daily report"},
+                "cron_expr": "0 3 * * *",
+                "timezone": "America/New_York",
+                "timeout_seconds": 1800,
+                "max_retries": 2,
+                "retry_delay_seconds": 60,
+                "enabled": True,
+                "next_run_at": 1706850000,
+                "created_at": 1706763600,
+                "updated_at": 1706763600,
+            }
+        }
+    )
+
+    id: str = Field(..., description="Unique identifier for the schedule")
+    name: str = Field(..., description="Schedule name")
+    description: Optional[str] = Field(None, description="Schedule description")
+    endpoint: str = Field(..., description="Target endpoint")
+    method: str = Field(..., description="HTTP method")
+    payload: Optional[Dict[str, Any]] = Field(None, description="Request payload")
+    cron_expr: str = Field(..., description="Cron expression")
+    timezone: str = Field(..., description="Timezone")
+    timeout_seconds: int = Field(..., description="Execution timeout")
+    max_retries: int = Field(..., description="Max retry attempts")
+    retry_delay_seconds: int = Field(..., description="Retry delay")
+    enabled: bool = Field(..., description="Whether active")
+    next_run_at: Optional[int] = Field(None, description="Next scheduled run (epoch seconds)")
+    created_at: Optional[int] = Field(None, description="Created timestamp (epoch seconds)")
+    updated_at: Optional[int] = Field(None, description="Updated timestamp (epoch seconds)")
+
+
+class ScheduleListResponse(BaseModel):
+    """Response model for listing schedules."""
+
+    schedules: List[ScheduleResponse] = Field(..., description="List of schedules")
+    total: int = Field(..., description="Total number of schedules")
+    limit: int = Field(..., description="Page size limit")
+    offset: int = Field(..., description="Offset from start")
+
+
+class ScheduleRunResponse(BaseModel):
+    """Response model for a schedule run."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": "run-123",
+                "schedule_id": "550e8400-e29b-41d4-a716-446655440000",
+                "attempt": 1,
+                "triggered_at": 1706850000,
+                "completed_at": 1706850120,
+                "status": "success",
+                "status_code": 200,
+                "run_id": "agent-run-456",
+                "session_id": "session-789",
+                "error": None,
+                "created_at": 1706850000,
+            }
+        }
+    )
+
+    id: str = Field(..., description="Unique identifier for the run")
+    schedule_id: str = Field(..., description="Associated schedule ID")
+    attempt: int = Field(..., description="Attempt number (1 = first try)")
+    triggered_at: Optional[int] = Field(None, description="When execution started (epoch seconds)")
+    completed_at: Optional[int] = Field(None, description="When execution finished (epoch seconds)")
+    status: str = Field(..., description="Run status (running, success, failed, timeout)")
+    status_code: Optional[int] = Field(None, description="HTTP status code from endpoint")
+    run_id: Optional[str] = Field(None, description="Run ID from agent/workflow response")
+    session_id: Optional[str] = Field(None, description="Session ID from response")
+    error: Optional[str] = Field(None, description="Error message if failed")
+    created_at: Optional[int] = Field(None, description="Created timestamp (epoch seconds)")
+
+
+class ScheduleRunListResponse(BaseModel):
+    """Response model for listing schedule runs."""
+
+    runs: List[ScheduleRunResponse] = Field(..., description="List of runs")
+    total: int = Field(..., description="Total number of runs")
+    limit: int = Field(..., description="Page size limit")
+    offset: int = Field(..., description="Offset from start")
+
+
+class TriggerResponse(BaseModel):
+    """Response model for manual trigger."""
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "message": "Schedule triggered successfully",
+                "schedule_id": "550e8400-e29b-41d4-a716-446655440000",
+            }
+        }
+    )
+
+    message: str = Field(..., description="Status message")
+    schedule_id: str = Field(..., description="ID of the triggered schedule")

--- a/libs/agno/agno/scheduler/__init__.py
+++ b/libs/agno/agno/scheduler/__init__.py
@@ -1,0 +1,10 @@
+from agno.scheduler.cron import calculate_next_run, validate_cron_expr
+from agno.scheduler.executor import ScheduleExecutor
+from agno.scheduler.poller import SchedulePoller
+
+__all__ = [
+    "SchedulePoller",
+    "ScheduleExecutor",
+    "calculate_next_run",
+    "validate_cron_expr",
+]

--- a/libs/agno/agno/scheduler/cron.py
+++ b/libs/agno/agno/scheduler/cron.py
@@ -1,0 +1,167 @@
+"""Cron utilities for schedule management.
+
+This module provides utilities for working with cron expressions,
+including validation and calculating next run times.
+
+Requires the 'croniter' package: pip install croniter
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from agno.utils.log import log_error
+
+
+def _get_croniter():
+    """Lazily import croniter to avoid import errors if not installed."""
+    try:
+        from croniter import croniter
+
+        return croniter
+    except ImportError:
+        raise ImportError(
+            "croniter is required for scheduler functionality. Install it with: pip install agno[scheduler]"
+        )
+
+
+def validate_cron_expr(cron_expr: str) -> bool:
+    """Validate a cron expression.
+
+    Args:
+        cron_expr: The cron expression to validate (e.g., '0 3 * * *').
+
+    Returns:
+        True if the expression is valid, False otherwise.
+    """
+    try:
+        croniter = _get_croniter()
+        croniter(cron_expr)
+        return True
+    except (ValueError, KeyError):
+        return False
+
+
+def calculate_next_run(
+    cron_expr: str,
+    tz: str = "UTC",
+    base_time: Optional[datetime] = None,
+) -> int:
+    """Calculate the next run time for a cron expression.
+
+    Args:
+        cron_expr: The cron expression (e.g., '0 3 * * *' for 3 AM daily).
+        tz: The timezone name (e.g., 'America/New_York', 'UTC').
+        base_time: The base time to calculate from. Defaults to now.
+
+    Returns:
+        Epoch seconds for the next run time.
+
+    Raises:
+        ValueError: If the cron expression is invalid.
+        ImportError: If croniter is not installed.
+    """
+    try:
+        import pytz
+    except ImportError:
+        pytz = None
+
+    croniter = _get_croniter()
+
+    # Get the base time in the specified timezone
+    if base_time is None:
+        base_time = datetime.now(timezone.utc)
+
+    # Convert to the specified timezone if pytz is available
+    if pytz is not None and tz != "UTC":
+        try:
+            target_tz = pytz.timezone(tz)
+            base_time = base_time.astimezone(target_tz)
+        except Exception as e:
+            log_error(f"Invalid timezone '{tz}', using UTC: {e}")
+            base_time = base_time.astimezone(timezone.utc)
+    else:
+        base_time = base_time.astimezone(timezone.utc)
+
+    try:
+        cron = croniter(cron_expr, base_time)
+        next_run = cron.get_next(datetime)
+
+        # Convert to UTC and return as epoch seconds
+        if next_run.tzinfo is None:
+            next_run = next_run.replace(tzinfo=timezone.utc)
+        else:
+            next_run = next_run.astimezone(timezone.utc)
+
+        return int(next_run.timestamp())
+
+    except Exception as e:
+        raise ValueError(f"Invalid cron expression '{cron_expr}': {e}")
+
+
+def get_cron_description(cron_expr: str) -> str:
+    """Get a human-readable description of a cron expression.
+
+    Args:
+        cron_expr: The cron expression.
+
+    Returns:
+        A human-readable description.
+    """
+    # Common patterns
+    patterns = {
+        "* * * * *": "Every minute",
+        "0 * * * *": "Every hour",
+        "0 0 * * *": "Every day at midnight",
+        "0 0 * * 0": "Every Sunday at midnight",
+        "0 0 1 * *": "First day of every month at midnight",
+    }
+
+    if cron_expr in patterns:
+        return patterns[cron_expr]
+
+    parts = cron_expr.split()
+    if len(parts) != 5:
+        return cron_expr
+
+    minute, hour, day, month, weekday = parts
+
+    desc_parts = []
+
+    # Minute
+    if minute == "*":
+        desc_parts.append("every minute")
+    elif minute == "0":
+        pass  # Will be covered by hour
+    else:
+        desc_parts.append(f"at minute {minute}")
+
+    # Hour
+    if hour == "*":
+        if minute != "*":
+            desc_parts.append("every hour")
+    elif hour != "*":
+        desc_parts.append(f"at {hour}:{'00' if minute == '0' else minute}")
+
+    # Day of month
+    if day != "*":
+        desc_parts.append(f"on day {day}")
+
+    # Month
+    if month != "*":
+        months = ["", "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+        try:
+            month_name = months[int(month)]
+            desc_parts.append(f"in {month_name}")
+        except (ValueError, IndexError):
+            desc_parts.append(f"in month {month}")
+
+    # Day of week
+    if weekday != "*":
+        days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+        try:
+            day_name = days[int(weekday)]
+            desc_parts.append(f"on {day_name}")
+        except (ValueError, IndexError):
+            desc_parts.append(f"on weekday {weekday}")
+
+    return " ".join(desc_parts) if desc_parts else cron_expr

--- a/libs/agno/agno/scheduler/executor.py
+++ b/libs/agno/agno/scheduler/executor.py
@@ -1,0 +1,308 @@
+"""Schedule executor for running scheduled tasks.
+
+This module handles the execution of scheduled tasks by making HTTP calls
+to AgentOS endpoints and tracking the results.
+"""
+
+import json
+import time
+from typing import TYPE_CHECKING, Union
+from uuid import uuid4
+
+from agno.db.schemas.scheduler import Schedule, ScheduleRun
+from agno.scheduler.cron import calculate_next_run
+from agno.utils.log import log_debug, log_error, log_info
+
+if TYPE_CHECKING:
+    from agno.db.base import AsyncBaseDb, BaseDb
+
+try:
+    import httpx
+except ImportError:
+    httpx = None  # type: ignore
+
+
+class ScheduleExecutor:
+    """Executes scheduled tasks by making HTTP calls to AgentOS endpoints.
+
+    This executor supports both sync and async database adapters. When using
+    an async adapter (AsyncBaseDb), database calls are non-blocking. When using
+    a sync adapter (BaseDb), database calls will briefly block the event loop.
+
+    The executor uses an internal service token for authentication. This token
+    is not validated by JWT middleware, so the scheduler is not compatible with
+    JWT authorization mode. Use security key authentication instead, or disable
+    authentication for internal endpoints.
+    """
+
+    def __init__(
+        self,
+        db: Union["BaseDb", "AsyncBaseDb"],
+        base_url: str,
+        token: str,
+    ):
+        """Initialize the executor.
+
+        Args:
+            db: Database instance for tracking runs (supports both sync and async).
+            base_url: Base URL for AgentOS endpoints (e.g., 'http://localhost:7777').
+            token: Internal service token for authentication.
+        """
+        self.db = db
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        # Check if db has async methods
+        self._is_async_db = hasattr(db, "acreate_schedule_run")
+
+    async def _create_schedule_run(self, run: ScheduleRun) -> ScheduleRun:
+        """Create a schedule run record (async-aware)."""
+        if self._is_async_db:
+            return await self.db.acreate_schedule_run(run)  # type: ignore
+        return self.db.create_schedule_run(run)
+
+    async def _update_schedule_run(self, run: ScheduleRun) -> ScheduleRun:
+        """Update a schedule run record (async-aware)."""
+        if self._is_async_db:
+            return await self.db.aupdate_schedule_run(run)  # type: ignore
+        return self.db.update_schedule_run(run)
+
+    async def _release_schedule(self, schedule_id: str, next_run_at: int) -> None:
+        """Release a schedule lock (async-aware)."""
+        if self._is_async_db:
+            await self.db.arelease_schedule(schedule_id, next_run_at)  # type: ignore
+        else:
+            self.db.release_schedule(schedule_id, next_run_at)
+
+    async def execute(self, schedule: Schedule) -> None:
+        """Execute a schedule and track the result.
+
+        Args:
+            schedule: The schedule to execute.
+        """
+        if httpx is None:
+            raise ImportError("httpx is required for scheduler execution")
+
+        # Create a run record
+        run = ScheduleRun(
+            id=str(uuid4()),
+            schedule_id=schedule.id,
+            attempt=1,
+            status="running",
+        )
+
+        try:
+            await self._create_schedule_run(run)
+            await self._execute_and_track(schedule, run)
+        except Exception as e:
+            log_error(f"Error executing schedule '{schedule.name}': {e}")
+            await self._mark_failed(schedule, run, str(e))
+
+    async def _execute_and_track(self, schedule: Schedule, run: ScheduleRun) -> None:
+        """Execute the schedule and consume SSE stream until completion.
+
+        Args:
+            schedule: The schedule being executed.
+            run: The run record to update.
+        """
+        url = f"{self.base_url}{schedule.endpoint}"
+        log_info(f"Executing schedule '{schedule.name}': {schedule.method} {url}")
+
+        timeout = httpx.Timeout(
+            connect=10.0,
+            read=float(schedule.timeout_seconds),
+            write=10.0,
+            pool=10.0,
+        )
+
+        # Prepare the request
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+        }
+
+        # Determine if we should stream based on the endpoint
+        # Agent/team/workflow runs typically support streaming
+        should_stream = any(x in schedule.endpoint for x in ["/runs", "/agents/", "/teams/", "/workflows/"])
+
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            if should_stream and schedule.method.upper() == "POST":
+                # For agent/team/workflow runs, use streaming to track completion
+                await self._execute_streaming(client, schedule, run, url, headers)
+            else:
+                # For other endpoints, use simple request/response
+                await self._execute_simple(client, schedule, run, url, headers)
+
+    async def _execute_streaming(
+        self,
+        client: httpx.AsyncClient,
+        schedule: Schedule,
+        run: ScheduleRun,
+        url: str,
+        headers: dict,
+    ) -> None:
+        """Execute a streaming request and consume SSE events.
+
+        Args:
+            client: HTTP client.
+            schedule: The schedule being executed.
+            run: The run record to update.
+            url: The URL to call.
+            headers: Request headers.
+        """
+        # Add stream parameter to payload
+        payload = dict(schedule.payload or {})
+        payload["stream"] = True
+
+        headers["Content-Type"] = "application/x-www-form-urlencoded"
+
+        try:
+            async with client.stream(
+                method=schedule.method,
+                url=url,
+                data=payload,
+                headers=headers,
+            ) as response:
+                if response.status_code >= 400:
+                    error_text = await response.aread()
+                    await self._mark_failed(schedule, run, f"HTTP {response.status_code}: {error_text.decode()}")
+                    return
+
+                # Update run with status code
+                run.status_code = response.status_code
+
+                async for line in response.aiter_lines():
+                    if not line.startswith("data:"):
+                        continue
+
+                    try:
+                        data = json.loads(line[5:].strip())
+                        event = data.get("event", "")
+
+                        # Capture run info from first event
+                        if data.get("run_id") and not run.run_id:
+                            run.run_id = data.get("run_id")
+                            run.session_id = data.get("session_id")
+                            await self._update_schedule_run(run)
+
+                        # Check for terminal events
+                        if event == "RunCompleted":
+                            await self._mark_success(schedule, run)
+                            return
+                        elif event == "RunError":
+                            await self._mark_failed(schedule, run, data.get("content", "Unknown error"))
+                            return
+
+                    except json.JSONDecodeError:
+                        continue
+
+            # Stream ended without completion event
+            await self._mark_failed(schedule, run, "Stream ended unexpectedly")
+
+        except httpx.TimeoutException:
+            await self._mark_failed(schedule, run, "Request timed out")
+        except Exception as e:
+            await self._mark_failed(schedule, run, str(e))
+
+    async def _execute_simple(
+        self,
+        client: httpx.AsyncClient,
+        schedule: Schedule,
+        run: ScheduleRun,
+        url: str,
+        headers: dict,
+    ) -> None:
+        """Execute a simple (non-streaming) request.
+
+        Args:
+            client: HTTP client.
+            schedule: The schedule being executed.
+            run: The run record to update.
+            url: The URL to call.
+            headers: Request headers.
+        """
+        try:
+            if schedule.method.upper() == "GET":
+                response = await client.get(url, headers=headers)
+            elif schedule.method.upper() == "POST":
+                headers["Content-Type"] = "application/json"
+                response = await client.post(url, json=schedule.payload or {}, headers=headers)
+            elif schedule.method.upper() == "PUT":
+                headers["Content-Type"] = "application/json"
+                response = await client.put(url, json=schedule.payload or {}, headers=headers)
+            elif schedule.method.upper() == "DELETE":
+                response = await client.delete(url, headers=headers)
+            else:
+                await self._mark_failed(schedule, run, f"Unsupported method: {schedule.method}")
+                return
+
+            run.status_code = response.status_code
+
+            if response.status_code >= 400:
+                await self._mark_failed(schedule, run, f"HTTP {response.status_code}: {response.text}")
+            else:
+                # Try to extract run_id from response
+                try:
+                    data = response.json()
+                    if isinstance(data, dict):
+                        run.run_id = data.get("run_id")
+                        run.session_id = data.get("session_id")
+                except (json.JSONDecodeError, ValueError):
+                    pass
+
+                await self._mark_success(schedule, run)
+
+        except httpx.TimeoutException:
+            await self._mark_failed(schedule, run, "Request timed out")
+        except Exception as e:
+            await self._mark_failed(schedule, run, str(e))
+
+    async def _mark_success(self, schedule: Schedule, run: ScheduleRun) -> None:
+        """Mark a run as successful and release the schedule.
+
+        Args:
+            schedule: The schedule that was executed.
+            run: The run record to update.
+        """
+        run.status = "success"
+        run.completed_at = int(time.time())
+        await self._update_schedule_run(run)
+
+        # Calculate next run time and release the schedule
+        next_run_at = calculate_next_run(schedule.cron_expr, schedule.timezone)
+        await self._release_schedule(schedule.id, next_run_at)
+
+        log_info(f"Schedule '{schedule.name}' completed successfully")
+
+    async def _mark_failed(self, schedule: Schedule, run: ScheduleRun, error: str) -> None:
+        """Mark a run as failed and handle retry logic.
+
+        Args:
+            schedule: The schedule that was executed.
+            run: The run record to update.
+            error: The error message.
+        """
+        run.status = "failed"
+        run.error = error
+        run.completed_at = int(time.time())
+        await self._update_schedule_run(run)
+
+        log_error(f"Schedule '{schedule.name}' failed: {error}")
+
+        # Check if we should retry
+        if run.attempt < schedule.max_retries:
+            # Schedule a retry
+            retry_run = ScheduleRun(
+                id=str(uuid4()),
+                schedule_id=schedule.id,
+                attempt=run.attempt + 1,
+                status="pending",
+                triggered_at=int(time.time()) + schedule.retry_delay_seconds,
+            )
+            await self._create_schedule_run(retry_run)
+            log_debug(
+                f"Scheduling retry {run.attempt + 1}/{schedule.max_retries} "
+                f"for '{schedule.name}' in {schedule.retry_delay_seconds}s"
+            )
+        else:
+            # All retries exhausted, release the schedule
+            next_run_at = calculate_next_run(schedule.cron_expr, schedule.timezone)
+            await self._release_schedule(schedule.id, next_run_at)

--- a/libs/agno/agno/scheduler/poller.py
+++ b/libs/agno/agno/scheduler/poller.py
@@ -1,0 +1,252 @@
+"""Schedule poller for checking and executing due schedules.
+
+This module implements the polling loop that periodically checks for
+due schedules and spawns execution tasks.
+"""
+
+import asyncio
+from typing import TYPE_CHECKING, Optional, Set, Union
+from uuid import uuid4
+
+from agno.db.schemas.scheduler import Schedule
+from agno.scheduler.executor import ScheduleExecutor
+from agno.utils.log import log_debug, log_error, log_info
+
+if TYPE_CHECKING:
+    from agno.db.base import AsyncBaseDb, BaseDb
+
+
+class SchedulePoller:
+    """Polls for due schedules and spawns execution tasks.
+
+    This poller runs as an asyncio task within the FastAPI process.
+    It periodically checks for due schedules, claims them atomically,
+    and spawns execution tasks.
+
+    This poller supports both sync and async database adapters. When using
+    an async adapter (AsyncBaseDb), database calls are non-blocking. When using
+    a sync adapter (BaseDb), database calls will briefly block the event loop.
+    For production deployments with high throughput, use an async database adapter.
+    """
+
+    def __init__(
+        self,
+        db: Union["BaseDb", "AsyncBaseDb"],
+        base_url: str,
+        token: str,
+        poll_interval: int = 30,
+        lock_grace_seconds: int = 60,
+        container_id: Optional[str] = None,
+    ):
+        """Initialize the poller.
+
+        Args:
+            db: Database instance for schedule operations (supports both sync and async).
+            base_url: Base URL for AgentOS endpoints.
+            token: Internal service token for authentication.
+            poll_interval: Seconds between claim attempts (default: 30).
+            lock_grace_seconds: Grace period in seconds after timeout before
+                considering a lock stale (default: 60).
+            container_id: Unique ID for this container instance.
+        """
+        self.db = db
+        self.executor = ScheduleExecutor(db, base_url, token)
+        self.poll_interval = poll_interval
+        self.lock_grace_seconds = lock_grace_seconds
+        self.container_id = container_id or str(uuid4())
+        self._running = False
+        self._active_tasks: Set[asyncio.Task] = set()
+        self._poll_task: Optional[asyncio.Task] = None
+        # Check if db has async methods
+        self._is_async_db = hasattr(db, "aclaim_due_schedule")
+
+    async def _claim_due_schedule(self) -> Optional[Schedule]:
+        """Claim a due schedule (async-aware)."""
+        if self._is_async_db:
+            return await self.db.aclaim_due_schedule(  # type: ignore
+                self.container_id,
+                lock_grace_seconds=self.lock_grace_seconds,
+            )
+        return self.db.claim_due_schedule(
+            self.container_id,
+            lock_grace_seconds=self.lock_grace_seconds,
+        )
+
+    async def _get_schedule(self, schedule_id: str) -> Optional[Schedule]:
+        """Get a schedule by ID (async-aware)."""
+        if self._is_async_db:
+            return await self.db.aget_schedule(schedule_id)  # type: ignore
+        return self.db.get_schedule(schedule_id)
+
+    @property
+    def is_running(self) -> bool:
+        """Check if the poller is currently running."""
+        return self._running
+
+    @property
+    def active_task_count(self) -> int:
+        """Get the number of currently executing schedules."""
+        return len(self._active_tasks)
+
+    async def start(self) -> None:
+        """Start the polling loop.
+
+        This method runs until stop() is called or an unrecoverable
+        error occurs.
+        """
+        if self._running:
+            log_debug("Poller is already running")
+            return
+
+        self._running = True
+        log_info(f"Starting schedule poller (container_id={self.container_id})")
+
+        while self._running:
+            try:
+                schedule = await self._claim_due_schedule()
+
+                if schedule:
+                    log_debug(f"Claimed schedule: {schedule.name}")
+
+                    # Spawn execution task
+                    task = asyncio.create_task(
+                        self.executor.execute(schedule),
+                        name=f"schedule-{schedule.name}",
+                    )
+                    self._active_tasks.add(task)
+                    task.add_done_callback(self._task_done_callback)
+
+            except Exception as e:
+                log_error(f"Scheduler polling error: {e}")
+
+            # Wait before next poll
+            await asyncio.sleep(self.poll_interval)
+
+        log_info("Schedule poller stopped")
+
+    def _task_done_callback(self, task: asyncio.Task) -> None:
+        """Handle task completion.
+
+        Args:
+            task: The completed task.
+        """
+        self._active_tasks.discard(task)
+
+        # Log any exceptions
+        if task.done() and not task.cancelled():
+            try:
+                exc = task.exception()
+                if exc:
+                    log_error(f"Schedule execution error: {exc}")
+            except asyncio.CancelledError:
+                pass
+
+    async def stop(self, timeout: float = 30.0) -> None:
+        """Gracefully stop the poller.
+
+        Args:
+            timeout: Maximum time to wait for active tasks (default: 30s).
+        """
+        if not self._running:
+            return
+
+        log_info("Stopping schedule poller...")
+        self._running = False
+
+        # Wait for active tasks to complete
+        if self._active_tasks:
+            log_info(f"Waiting for {len(self._active_tasks)} active tasks...")
+
+            done, pending = await asyncio.wait(
+                self._active_tasks,
+                timeout=timeout,
+            )
+
+            # Cancel any still pending
+            for task in pending:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+        log_info("Schedule poller stopped")
+
+    async def trigger_schedule(self, schedule_id: str) -> bool:
+        """Manually trigger a schedule execution.
+
+        This bypasses the normal cron timing and executes the schedule
+        immediately.
+
+        Args:
+            schedule_id: The ID of the schedule to trigger.
+
+        Returns:
+            True if the schedule was triggered, False if not found.
+        """
+        schedule = await self._get_schedule(schedule_id)
+        if not schedule:
+            return False
+
+        log_info(f"Manually triggering schedule: {schedule.name}")
+
+        # Spawn execution task
+        task = asyncio.create_task(
+            self.executor.execute(schedule),
+            name=f"schedule-{schedule.name}-manual",
+        )
+        self._active_tasks.add(task)
+        task.add_done_callback(self._task_done_callback)
+
+        return True
+
+
+async def create_scheduler_lifespan(
+    db: Union["BaseDb", "AsyncBaseDb"],
+    base_url: str,
+    token: str,
+    poll_interval: int = 30,
+    lock_grace_seconds: int = 60,
+    enabled: bool = False,
+):
+    """Create a context manager for scheduler lifespan.
+
+    This can be used with FastAPI's lifespan parameter.
+
+    Args:
+        db: Database instance (supports both sync and async).
+        base_url: Base URL for AgentOS endpoints.
+        token: Internal service token.
+        poll_interval: Seconds between polls.
+        lock_grace_seconds: Grace period for stale lock detection.
+        enabled: Whether the scheduler is enabled.
+
+    Yields:
+        SchedulePoller instance if enabled, None otherwise.
+    """
+    poller = None
+
+    if enabled:
+        poller = SchedulePoller(
+            db=db,
+            base_url=base_url,
+            token=token,
+            poll_interval=poll_interval,
+            lock_grace_seconds=lock_grace_seconds,
+        )
+
+        # Start polling in background
+        poll_task = asyncio.create_task(poller.start(), name="scheduler-poller")
+
+        try:
+            yield poller
+        finally:
+            # Graceful shutdown
+            await poller.stop()
+            poll_task.cancel()
+            try:
+                await poll_task
+            except asyncio.CancelledError:
+                pass
+    else:
+        yield None

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -144,6 +144,9 @@ oxylabs = ["oxylabs"]
 trafilatura = ["trafilatura"]
 neo4j = ["neo4j"]
 
+# Dependencies for Scheduler
+scheduler = ["croniter>=2.0.0"]
+
 # Dependencies for Storage
 sql = ["sqlalchemy"]
 postgres = ["psycopg-binary"]
@@ -560,6 +563,7 @@ module = [
   "surrealdb.*",
   "trafilatura.*",
   "xlrd.*",
-  "celpy.*"
+  "celpy.*",
+  "croniter.*"
 ]
 ignore_missing_imports = true

--- a/libs/agno/tests/integration/scheduler/__init__.py
+++ b/libs/agno/tests/integration/scheduler/__init__.py
@@ -1,0 +1,1 @@
+# Scheduler integration tests

--- a/libs/agno/tests/integration/scheduler/test_sqlite_scheduler.py
+++ b/libs/agno/tests/integration/scheduler/test_sqlite_scheduler.py
@@ -1,0 +1,256 @@
+"""Integration tests for scheduler SQLite database operations."""
+
+import tempfile
+import time
+
+import pytest
+
+
+@pytest.fixture
+def temp_db_file():
+    """Create a temporary database file."""
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        yield f.name
+    # Cleanup happens automatically when test ends
+
+
+@pytest.fixture
+def sqlite_db(temp_db_file):
+    """Create a SQLite database instance for testing."""
+    from agno.db.sqlite import SqliteDb
+
+    return SqliteDb(db_file=temp_db_file)
+
+
+@pytest.fixture
+def sample_schedule():
+    """Create a sample schedule for testing."""
+    from agno.db.schemas.scheduler import Schedule
+
+    return Schedule(
+        id="schedule-1",
+        name="test-schedule",
+        description="A test schedule",
+        method="POST",
+        endpoint="/v1/agents/test-agent/runs",
+        payload={"message": "Hello from scheduler"},
+        cron_expr="0 3 * * *",
+        timezone="UTC",
+        timeout_seconds=3600,
+        max_retries=2,
+        retry_delay_seconds=60,
+        enabled=True,
+        next_run_at=int(time.time()) + 3600,
+    )
+
+
+class TestSqliteScheduleCRUD:
+    """Tests for schedule CRUD operations in SQLite."""
+
+    def test_create_schedule(self, sqlite_db, sample_schedule):
+        """Test creating a schedule."""
+        created = sqlite_db.create_schedule(sample_schedule)
+
+        assert created.id == sample_schedule.id
+        assert created.name == sample_schedule.name
+        assert created.cron_expr == sample_schedule.cron_expr
+
+    def test_get_schedule(self, sqlite_db, sample_schedule):
+        """Test getting a schedule by ID."""
+        sqlite_db.create_schedule(sample_schedule)
+
+        retrieved = sqlite_db.get_schedule(sample_schedule.id)
+
+        assert retrieved is not None
+        assert retrieved.id == sample_schedule.id
+        assert retrieved.name == sample_schedule.name
+
+    def test_get_schedule_not_found(self, sqlite_db):
+        """Test getting a non-existent schedule."""
+        result = sqlite_db.get_schedule("nonexistent")
+        assert result is None
+
+    def test_get_schedule_by_name(self, sqlite_db, sample_schedule):
+        """Test getting a schedule by name."""
+        sqlite_db.create_schedule(sample_schedule)
+
+        retrieved = sqlite_db.get_schedule_by_name(sample_schedule.name)
+
+        assert retrieved is not None
+        assert retrieved.id == sample_schedule.id
+
+    def test_get_schedules(self, sqlite_db, sample_schedule):
+        """Test listing schedules."""
+        sqlite_db.create_schedule(sample_schedule)
+
+        schedules, total = sqlite_db.get_schedules()
+
+        assert total >= 1
+        assert any(s.id == sample_schedule.id for s in schedules)
+
+    def test_get_schedules_with_enabled_filter(self, sqlite_db, sample_schedule):
+        """Test listing schedules with enabled filter."""
+        sqlite_db.create_schedule(sample_schedule)
+
+        # Get enabled schedules
+        enabled, _ = sqlite_db.get_schedules(enabled=True)
+        assert any(s.id == sample_schedule.id for s in enabled)
+
+        # Get disabled schedules
+        disabled, _ = sqlite_db.get_schedules(enabled=False)
+        assert not any(s.id == sample_schedule.id for s in disabled)
+
+    def test_update_schedule(self, sqlite_db, sample_schedule):
+        """Test updating a schedule."""
+        sqlite_db.create_schedule(sample_schedule)
+
+        sample_schedule.description = "Updated description"
+        sample_schedule.enabled = False
+
+        updated = sqlite_db.update_schedule(sample_schedule)
+
+        assert updated.description == "Updated description"
+        assert updated.enabled is False
+        assert updated.updated_at is not None
+
+    def test_delete_schedule(self, sqlite_db, sample_schedule):
+        """Test deleting a schedule."""
+        sqlite_db.create_schedule(sample_schedule)
+
+        deleted = sqlite_db.delete_schedule(sample_schedule.id)
+        assert deleted is True
+
+        # Verify it's gone
+        result = sqlite_db.get_schedule(sample_schedule.id)
+        assert result is None
+
+    def test_delete_nonexistent_schedule(self, sqlite_db):
+        """Test deleting a non-existent schedule."""
+        deleted = sqlite_db.delete_schedule("nonexistent")
+        assert deleted is False
+
+
+class TestSqliteScheduleLocking:
+    """Tests for schedule locking operations in SQLite."""
+
+    def test_claim_due_schedule(self, sqlite_db, sample_schedule):
+        """Test claiming a due schedule."""
+        # Set next_run_at to past to make it due
+        sample_schedule.next_run_at = int(time.time()) - 60
+        sqlite_db.create_schedule(sample_schedule)
+
+        claimed = sqlite_db.claim_due_schedule("container-1")
+
+        assert claimed is not None
+        assert claimed.id == sample_schedule.id
+        assert claimed.locked_by == "container-1"
+        assert claimed.locked_at is not None
+
+    def test_claim_due_schedule_none_due(self, sqlite_db, sample_schedule):
+        """Test claim when no schedules are due."""
+        # Set next_run_at to future
+        sample_schedule.next_run_at = int(time.time()) + 3600
+        sqlite_db.create_schedule(sample_schedule)
+
+        claimed = sqlite_db.claim_due_schedule("container-1")
+
+        assert claimed is None
+
+    def test_claim_due_schedule_disabled(self, sqlite_db, sample_schedule):
+        """Test that disabled schedules are not claimed."""
+        sample_schedule.next_run_at = int(time.time()) - 60
+        sample_schedule.enabled = False
+        sqlite_db.create_schedule(sample_schedule)
+
+        claimed = sqlite_db.claim_due_schedule("container-1")
+
+        assert claimed is None
+
+    def test_claim_due_schedule_already_locked(self, sqlite_db, sample_schedule):
+        """Test that locked schedules are not claimed (unless expired)."""
+        sample_schedule.next_run_at = int(time.time()) - 60
+        sample_schedule.locked_by = "container-2"
+        sample_schedule.locked_at = int(time.time())
+        sqlite_db.create_schedule(sample_schedule)
+
+        # Should not be claimed because lock is fresh
+        claimed = sqlite_db.claim_due_schedule("container-1")
+
+        assert claimed is None
+
+    def test_release_schedule(self, sqlite_db, sample_schedule):
+        """Test releasing a schedule lock."""
+        sample_schedule.next_run_at = int(time.time()) - 60
+        sqlite_db.create_schedule(sample_schedule)
+
+        # Claim it
+        sqlite_db.claim_due_schedule("container-1")
+
+        # Release it
+        new_next_run = int(time.time()) + 3600
+        sqlite_db.release_schedule(sample_schedule.id, new_next_run)
+
+        # Verify it's released
+        schedule = sqlite_db.get_schedule(sample_schedule.id)
+        assert schedule.locked_by is None
+        assert schedule.locked_at is None
+        assert schedule.next_run_at == new_next_run
+
+
+class TestSqliteScheduleRuns:
+    """Tests for schedule run operations in SQLite."""
+
+    @pytest.fixture
+    def sample_run(self, sample_schedule):
+        """Create a sample schedule run."""
+        from agno.db.schemas.scheduler import ScheduleRun
+
+        return ScheduleRun(
+            id="run-1",
+            schedule_id=sample_schedule.id,
+            attempt=1,
+            status="running",
+        )
+
+    def test_create_schedule_run(self, sqlite_db, sample_schedule, sample_run):
+        """Test creating a schedule run."""
+        sqlite_db.create_schedule(sample_schedule)
+
+        created = sqlite_db.create_schedule_run(sample_run)
+
+        assert created.id == sample_run.id
+        assert created.schedule_id == sample_schedule.id
+
+    def test_update_schedule_run(self, sqlite_db, sample_schedule, sample_run):
+        """Test updating a schedule run."""
+        sqlite_db.create_schedule(sample_schedule)
+        sqlite_db.create_schedule_run(sample_run)
+
+        sample_run.status = "success"
+        sample_run.status_code = 200
+        sample_run.completed_at = int(time.time())
+
+        updated = sqlite_db.update_schedule_run(sample_run)
+
+        assert updated.status == "success"
+        assert updated.status_code == 200
+
+    def test_get_schedule_runs(self, sqlite_db, sample_schedule, sample_run):
+        """Test getting runs for a schedule."""
+        sqlite_db.create_schedule(sample_schedule)
+        sqlite_db.create_schedule_run(sample_run)
+
+        runs, total = sqlite_db.get_schedule_runs(sample_schedule.id)
+
+        assert total >= 1
+        assert any(r.id == sample_run.id for r in runs)
+
+    def test_get_schedule_run(self, sqlite_db, sample_schedule, sample_run):
+        """Test getting a specific run."""
+        sqlite_db.create_schedule(sample_schedule)
+        sqlite_db.create_schedule_run(sample_run)
+
+        run = sqlite_db.get_schedule_run(sample_run.id)
+
+        assert run is not None
+        assert run.id == sample_run.id

--- a/libs/agno/tests/unit/scheduler/__init__.py
+++ b/libs/agno/tests/unit/scheduler/__init__.py
@@ -1,0 +1,1 @@
+# Scheduler unit tests

--- a/libs/agno/tests/unit/scheduler/test_cron.py
+++ b/libs/agno/tests/unit/scheduler/test_cron.py
@@ -1,0 +1,148 @@
+"""Unit tests for cron utilities."""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+
+class TestValidateCronExpr:
+    """Tests for validate_cron_expr function."""
+
+    def test_validate_valid_cron_expressions(self):
+        """Test validation of valid cron expressions."""
+        from agno.scheduler.cron import validate_cron_expr
+
+        valid_expressions = [
+            "* * * * *",  # Every minute
+            "0 * * * *",  # Every hour
+            "0 0 * * *",  # Every day at midnight
+            "0 3 * * *",  # Every day at 3 AM
+            "0 0 * * 0",  # Every Sunday at midnight
+            "0 0 1 * *",  # First day of every month
+            "*/5 * * * *",  # Every 5 minutes
+            "0 9-17 * * 1-5",  # 9 AM to 5 PM, Monday to Friday
+            "30 4 1,15 * *",  # 4:30 AM on 1st and 15th
+        ]
+
+        for expr in valid_expressions:
+            assert validate_cron_expr(expr) is True, f"Expected '{expr}' to be valid"
+
+    def test_validate_invalid_cron_expressions(self):
+        """Test validation of invalid cron expressions."""
+        from agno.scheduler.cron import validate_cron_expr
+
+        invalid_expressions = [
+            "",  # Empty
+            "invalid",  # Not a cron expression
+            "* * *",  # Too few fields
+            "* * * * * *",  # Too many fields (standard cron has 5)
+            "60 * * * *",  # Invalid minute (0-59)
+            "* 24 * * *",  # Invalid hour (0-23)
+            "* * 32 * *",  # Invalid day of month (1-31)
+            "* * * 13 *",  # Invalid month (1-12)
+            "* * * * 8",  # Invalid day of week (0-7)
+        ]
+
+        for expr in invalid_expressions:
+            assert validate_cron_expr(expr) is False, f"Expected '{expr}' to be invalid"
+
+    def test_validate_croniter_not_installed(self):
+        """Test behavior when croniter is not installed."""
+        from agno.scheduler.cron import validate_cron_expr
+
+        with patch("agno.scheduler.cron._get_croniter") as mock_get:
+            mock_get.side_effect = ImportError("croniter not installed")
+
+            with pytest.raises(ImportError, match="croniter"):
+                validate_cron_expr("* * * * *")
+
+
+class TestCalculateNextRun:
+    """Tests for calculate_next_run function."""
+
+    def test_calculate_next_run_basic(self):
+        """Test basic next run calculation."""
+        from agno.scheduler.cron import calculate_next_run
+
+        # Get next run for every minute
+        next_run = calculate_next_run("* * * * *")
+
+        # Should be within the next 60 seconds
+        now = int(datetime.now(timezone.utc).timestamp())
+        assert next_run > now
+        assert next_run <= now + 60
+
+    def test_calculate_next_run_with_base_time(self):
+        """Test next run calculation with specific base time."""
+        from agno.scheduler.cron import calculate_next_run
+
+        # Base time: 2024-01-15 10:30:00 UTC
+        base_time = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+
+        # Every hour at minute 0
+        next_run = calculate_next_run("0 * * * *", base_time=base_time)
+
+        # Expected: 2024-01-15 11:00:00 UTC
+        expected = datetime(2024, 1, 15, 11, 0, 0, tzinfo=timezone.utc)
+        assert next_run == int(expected.timestamp())
+
+    def test_calculate_next_run_daily(self):
+        """Test next run calculation for daily schedule."""
+        from agno.scheduler.cron import calculate_next_run
+
+        # Base time: 2024-01-15 10:30:00 UTC
+        base_time = datetime(2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+
+        # Every day at 3 AM
+        next_run = calculate_next_run("0 3 * * *", base_time=base_time)
+
+        # Expected: 2024-01-16 03:00:00 UTC (next day since 3 AM already passed)
+        expected = datetime(2024, 1, 16, 3, 0, 0, tzinfo=timezone.utc)
+        assert next_run == int(expected.timestamp())
+
+    def test_calculate_next_run_invalid_expression(self):
+        """Test that invalid expressions raise ValueError."""
+        from agno.scheduler.cron import calculate_next_run
+
+        with pytest.raises(ValueError, match="Invalid cron expression"):
+            calculate_next_run("invalid")
+
+    def test_calculate_next_run_returns_epoch_seconds(self):
+        """Test that next run is returned as integer epoch seconds."""
+        from agno.scheduler.cron import calculate_next_run
+
+        next_run = calculate_next_run("* * * * *")
+
+        assert isinstance(next_run, int)
+        assert next_run > 0
+
+
+class TestGetCronDescription:
+    """Tests for get_cron_description function."""
+
+    def test_common_patterns(self):
+        """Test descriptions for common cron patterns."""
+        from agno.scheduler.cron import get_cron_description
+
+        assert get_cron_description("* * * * *") == "Every minute"
+        assert get_cron_description("0 * * * *") == "Every hour"
+        assert get_cron_description("0 0 * * *") == "Every day at midnight"
+        assert get_cron_description("0 0 * * 0") == "Every Sunday at midnight"
+        assert get_cron_description("0 0 1 * *") == "First day of every month at midnight"
+
+    def test_custom_time(self):
+        """Test description for custom time patterns."""
+        from agno.scheduler.cron import get_cron_description
+
+        desc = get_cron_description("0 3 * * *")
+        assert "3:00" in desc
+
+    def test_invalid_format_returns_original(self):
+        """Test that invalid format returns original expression."""
+        from agno.scheduler.cron import get_cron_description
+
+        # Too few parts
+        assert get_cron_description("* * *") == "* * *"
+        # Too many parts
+        assert get_cron_description("* * * * * *") == "* * * * * *"

--- a/libs/agno/tests/unit/scheduler/test_executor.py
+++ b/libs/agno/tests/unit/scheduler/test_executor.py
@@ -1,0 +1,188 @@
+"""Unit tests for ScheduleExecutor."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestScheduleExecutorInit:
+    """Tests for ScheduleExecutor initialization."""
+
+    def test_init_with_sync_db(self):
+        """Test executor initialization with sync database."""
+        from agno.scheduler.executor import ScheduleExecutor
+
+        mock_db = MagicMock()
+        # Ensure it doesn't have async methods
+        del mock_db.acreate_schedule_run
+
+        executor = ScheduleExecutor(
+            db=mock_db,
+            base_url="http://localhost:7777",
+            token="test-token",
+        )
+
+        assert executor.db == mock_db
+        assert executor.base_url == "http://localhost:7777"
+        assert executor.token == "test-token"
+        assert executor._is_async_db is False
+
+    def test_init_with_async_db(self):
+        """Test executor initialization with async database."""
+        from agno.scheduler.executor import ScheduleExecutor
+
+        mock_db = MagicMock()
+        mock_db.acreate_schedule_run = AsyncMock()
+
+        executor = ScheduleExecutor(
+            db=mock_db,
+            base_url="http://localhost:7777",
+            token="test-token",
+        )
+
+        assert executor._is_async_db is True
+
+    def test_init_strips_trailing_slash_from_base_url(self):
+        """Test that trailing slash is stripped from base_url."""
+        from agno.scheduler.executor import ScheduleExecutor
+
+        mock_db = MagicMock()
+        del mock_db.acreate_schedule_run
+
+        executor = ScheduleExecutor(
+            db=mock_db,
+            base_url="http://localhost:7777/",
+            token="test-token",
+        )
+
+        assert executor.base_url == "http://localhost:7777"
+
+
+class TestScheduleExecutorAsyncMethods:
+    """Tests for executor async method dispatching."""
+
+    @pytest.mark.asyncio
+    async def test_create_schedule_run_sync_db(self):
+        """Test _create_schedule_run with sync database."""
+        from agno.db.schemas.scheduler import ScheduleRun
+        from agno.scheduler.executor import ScheduleExecutor
+
+        mock_db = MagicMock()
+        del mock_db.acreate_schedule_run
+        mock_db.create_schedule_run.return_value = ScheduleRun(id="run-1", schedule_id="schedule-1")
+
+        executor = ScheduleExecutor(mock_db, "http://localhost", "token")
+
+        run = ScheduleRun(id="run-1", schedule_id="schedule-1")
+        result = await executor._create_schedule_run(run)
+
+        mock_db.create_schedule_run.assert_called_once_with(run)
+        assert result.id == "run-1"
+
+    @pytest.mark.asyncio
+    async def test_create_schedule_run_async_db(self):
+        """Test _create_schedule_run with async database."""
+        from agno.db.schemas.scheduler import ScheduleRun
+        from agno.scheduler.executor import ScheduleExecutor
+
+        mock_db = MagicMock()
+        mock_db.acreate_schedule_run = AsyncMock(return_value=ScheduleRun(id="run-1", schedule_id="schedule-1"))
+
+        executor = ScheduleExecutor(mock_db, "http://localhost", "token")
+
+        run = ScheduleRun(id="run-1", schedule_id="schedule-1")
+        result = await executor._create_schedule_run(run)
+
+        mock_db.acreate_schedule_run.assert_called_once_with(run)
+        assert result.id == "run-1"
+
+    @pytest.mark.asyncio
+    async def test_update_schedule_run_sync_db(self):
+        """Test _update_schedule_run with sync database."""
+        from agno.db.schemas.scheduler import ScheduleRun
+        from agno.scheduler.executor import ScheduleExecutor
+
+        mock_db = MagicMock()
+        del mock_db.aupdate_schedule_run
+        mock_db.update_schedule_run.return_value = ScheduleRun(id="run-1", schedule_id="schedule-1", status="success")
+
+        executor = ScheduleExecutor(mock_db, "http://localhost", "token")
+
+        run = ScheduleRun(id="run-1", schedule_id="schedule-1")
+        await executor._update_schedule_run(run)
+
+        mock_db.update_schedule_run.assert_called_once_with(run)
+
+    @pytest.mark.asyncio
+    async def test_update_schedule_run_async_db(self):
+        """Test _update_schedule_run with async database."""
+        from agno.db.schemas.scheduler import ScheduleRun
+        from agno.scheduler.executor import ScheduleExecutor
+
+        mock_db = MagicMock()
+        mock_db.aupdate_schedule_run = AsyncMock(
+            return_value=ScheduleRun(id="run-1", schedule_id="schedule-1", status="success")
+        )
+
+        executor = ScheduleExecutor(mock_db, "http://localhost", "token")
+
+        run = ScheduleRun(id="run-1", schedule_id="schedule-1")
+        await executor._update_schedule_run(run)
+
+        mock_db.aupdate_schedule_run.assert_called_once_with(run)
+
+    @pytest.mark.asyncio
+    async def test_release_schedule_sync_db(self):
+        """Test _release_schedule with sync database."""
+        from agno.scheduler.executor import ScheduleExecutor
+
+        mock_db = MagicMock()
+        del mock_db.arelease_schedule
+
+        executor = ScheduleExecutor(mock_db, "http://localhost", "token")
+
+        await executor._release_schedule("schedule-1", 1704067200)
+
+        mock_db.release_schedule.assert_called_once_with("schedule-1", 1704067200)
+
+    @pytest.mark.asyncio
+    async def test_release_schedule_async_db(self):
+        """Test _release_schedule with async database."""
+        from agno.scheduler.executor import ScheduleExecutor
+
+        mock_db = MagicMock()
+        mock_db.arelease_schedule = AsyncMock()
+
+        executor = ScheduleExecutor(mock_db, "http://localhost", "token")
+
+        await executor._release_schedule("schedule-1", 1704067200)
+
+        mock_db.arelease_schedule.assert_called_once_with("schedule-1", 1704067200)
+
+
+class TestScheduleExecutorExecute:
+    """Tests for executor execute method."""
+
+    @pytest.mark.asyncio
+    async def test_execute_raises_without_httpx(self):
+        """Test that execute raises ImportError without httpx."""
+        from agno.db.schemas.scheduler import Schedule
+        from agno.scheduler.executor import ScheduleExecutor
+
+        mock_db = MagicMock()
+        del mock_db.acreate_schedule_run
+
+        executor = ScheduleExecutor(mock_db, "http://localhost", "token")
+
+        schedule = Schedule(
+            id="schedule-1",
+            name="test",
+            cron_expr="* * * * *",
+            endpoint="/v1/test",
+        )
+
+        # Patch httpx to None
+        with patch.object(executor, "_create_schedule_run", new_callable=AsyncMock):
+            with patch("agno.scheduler.executor.httpx", None):
+                with pytest.raises(ImportError, match="httpx is required"):
+                    await executor.execute(schedule)

--- a/libs/agno/tests/unit/scheduler/test_models.py
+++ b/libs/agno/tests/unit/scheduler/test_models.py
@@ -1,0 +1,299 @@
+"""Unit tests for scheduler domain models."""
+
+
+
+
+class TestSchedule:
+    """Tests for Schedule dataclass."""
+
+    def test_create_schedule_minimal(self):
+        """Test creating a schedule with minimal required fields."""
+        from agno.db.schemas.scheduler import Schedule
+
+        schedule = Schedule(
+            id="test-id",
+            name="test-schedule",
+            cron_expr="0 3 * * *",
+            endpoint="/v1/agents/my-agent/runs",
+        )
+
+        assert schedule.id == "test-id"
+        assert schedule.name == "test-schedule"
+        assert schedule.cron_expr == "0 3 * * *"
+        assert schedule.endpoint == "/v1/agents/my-agent/runs"
+        assert schedule.method == "POST"  # Default
+        assert schedule.timezone == "UTC"  # Default
+        assert schedule.enabled is True  # Default
+        assert schedule.created_at is not None  # Auto-set
+
+    def test_create_schedule_full(self):
+        """Test creating a schedule with all fields."""
+        from agno.db.schemas.scheduler import Schedule
+
+        schedule = Schedule(
+            id="test-id",
+            name="test-schedule",
+            description="A test schedule",
+            method="POST",
+            endpoint="/v1/agents/my-agent/runs",
+            payload={"message": "Hello"},
+            cron_expr="0 3 * * *",
+            timezone="America/New_York",
+            timeout_seconds=1800,
+            max_retries=3,
+            retry_delay_seconds=120,
+            enabled=False,
+            next_run_at=1704067200,
+            locked_by="container-1",
+            locked_at=1704063600,
+        )
+
+        assert schedule.description == "A test schedule"
+        assert schedule.payload == {"message": "Hello"}
+        assert schedule.timezone == "America/New_York"
+        assert schedule.timeout_seconds == 1800
+        assert schedule.max_retries == 3
+        assert schedule.retry_delay_seconds == 120
+        assert schedule.enabled is False
+        assert schedule.next_run_at == 1704067200
+        assert schedule.locked_by == "container-1"
+        assert schedule.locked_at == 1704063600
+
+    def test_schedule_to_dict(self):
+        """Test Schedule.to_dict() method."""
+        from agno.db.schemas.scheduler import Schedule
+
+        schedule = Schedule(
+            id="test-id",
+            name="test-schedule",
+            cron_expr="0 3 * * *",
+            endpoint="/v1/agents/my-agent/runs",
+        )
+
+        data = schedule.to_dict()
+
+        assert data["id"] == "test-id"
+        assert data["name"] == "test-schedule"
+        assert data["cron_expr"] == "0 3 * * *"
+        assert data["endpoint"] == "/v1/agents/my-agent/runs"
+        assert "created_at" in data
+        # None values should be excluded
+        assert "description" not in data or data.get("description") is None
+
+    def test_schedule_from_dict(self):
+        """Test Schedule.from_dict() method."""
+        from agno.db.schemas.scheduler import Schedule
+
+        data = {
+            "id": "test-id",
+            "name": "test-schedule",
+            "cron_expr": "0 3 * * *",
+            "endpoint": "/v1/agents/my-agent/runs",
+            "method": "POST",
+            "timezone": "UTC",
+            "timeout_seconds": 3600,
+            "max_retries": 0,
+            "retry_delay_seconds": 60,
+            "enabled": True,
+            "created_at": 1704067200,
+        }
+
+        schedule = Schedule.from_dict(data)
+
+        assert schedule.id == "test-id"
+        assert schedule.name == "test-schedule"
+        assert schedule.cron_expr == "0 3 * * *"
+        assert schedule.created_at == 1704067200
+
+    def test_schedule_from_dict_ignores_unknown_keys(self):
+        """Test that from_dict ignores unknown keys."""
+        from agno.db.schemas.scheduler import Schedule
+
+        data = {
+            "id": "test-id",
+            "name": "test-schedule",
+            "cron_expr": "0 3 * * *",
+            "endpoint": "/v1/test",
+            "unknown_field": "should be ignored",
+            "another_unknown": 123,
+        }
+
+        schedule = Schedule.from_dict(data)
+        assert schedule.id == "test-id"
+        # Should not raise an error
+
+    def test_schedule_round_trip(self):
+        """Test that to_dict/from_dict round trip preserves data."""
+        from agno.db.schemas.scheduler import Schedule
+
+        original = Schedule(
+            id="test-id",
+            name="test-schedule",
+            description="Test description",
+            method="POST",
+            endpoint="/v1/agents/my-agent/runs",
+            payload={"key": "value"},
+            cron_expr="0 3 * * *",
+            timezone="America/New_York",
+            timeout_seconds=1800,
+            max_retries=2,
+            retry_delay_seconds=120,
+            enabled=True,
+            next_run_at=1704067200,
+        )
+
+        data = original.to_dict()
+        restored = Schedule.from_dict(data)
+
+        assert restored.id == original.id
+        assert restored.name == original.name
+        assert restored.description == original.description
+        assert restored.method == original.method
+        assert restored.endpoint == original.endpoint
+        assert restored.payload == original.payload
+        assert restored.cron_expr == original.cron_expr
+        assert restored.timezone == original.timezone
+        assert restored.timeout_seconds == original.timeout_seconds
+        assert restored.max_retries == original.max_retries
+        assert restored.retry_delay_seconds == original.retry_delay_seconds
+        assert restored.enabled == original.enabled
+        assert restored.next_run_at == original.next_run_at
+
+
+class TestScheduleRun:
+    """Tests for ScheduleRun dataclass."""
+
+    def test_create_schedule_run_minimal(self):
+        """Test creating a schedule run with minimal fields."""
+        from agno.db.schemas.scheduler import ScheduleRun
+
+        run = ScheduleRun(
+            id="run-1",
+            schedule_id="schedule-1",
+        )
+
+        assert run.id == "run-1"
+        assert run.schedule_id == "schedule-1"
+        assert run.attempt == 1  # Default
+        assert run.status == "running"  # Default
+        assert run.created_at is not None  # Auto-set
+        assert run.triggered_at is not None  # Auto-set to created_at
+
+    def test_create_schedule_run_full(self):
+        """Test creating a schedule run with all fields."""
+        from agno.db.schemas.scheduler import ScheduleRun
+
+        run = ScheduleRun(
+            id="run-1",
+            schedule_id="schedule-1",
+            attempt=2,
+            triggered_at=1704063600,
+            completed_at=1704067200,
+            status="success",
+            status_code=200,
+            run_id="agent-run-123",
+            session_id="session-456",
+            error=None,
+        )
+
+        assert run.attempt == 2
+        assert run.triggered_at == 1704063600
+        assert run.completed_at == 1704067200
+        assert run.status == "success"
+        assert run.status_code == 200
+        assert run.run_id == "agent-run-123"
+        assert run.session_id == "session-456"
+
+    def test_schedule_run_failed_with_error(self):
+        """Test creating a failed schedule run with error."""
+        from agno.db.schemas.scheduler import ScheduleRun
+
+        run = ScheduleRun(
+            id="run-1",
+            schedule_id="schedule-1",
+            status="failed",
+            status_code=500,
+            error="Connection timeout",
+        )
+
+        assert run.status == "failed"
+        assert run.status_code == 500
+        assert run.error == "Connection timeout"
+
+    def test_schedule_run_to_dict(self):
+        """Test ScheduleRun.to_dict() method."""
+        from agno.db.schemas.scheduler import ScheduleRun
+
+        run = ScheduleRun(
+            id="run-1",
+            schedule_id="schedule-1",
+            status="success",
+        )
+
+        data = run.to_dict()
+
+        assert data["id"] == "run-1"
+        assert data["schedule_id"] == "schedule-1"
+        assert data["status"] == "success"
+        assert "created_at" in data
+
+    def test_schedule_run_from_dict(self):
+        """Test ScheduleRun.from_dict() method."""
+        from agno.db.schemas.scheduler import ScheduleRun
+
+        data = {
+            "id": "run-1",
+            "schedule_id": "schedule-1",
+            "attempt": 1,
+            "triggered_at": 1704063600,
+            "completed_at": 1704067200,
+            "status": "success",
+            "status_code": 200,
+            "run_id": "agent-run-123",
+            "session_id": "session-456",
+            "created_at": 1704063600,
+        }
+
+        run = ScheduleRun.from_dict(data)
+
+        assert run.id == "run-1"
+        assert run.schedule_id == "schedule-1"
+        assert run.status == "success"
+        assert run.run_id == "agent-run-123"
+
+    def test_schedule_run_from_dict_ignores_unknown_keys(self):
+        """Test that from_dict ignores unknown keys."""
+        from agno.db.schemas.scheduler import ScheduleRun
+
+        data = {
+            "id": "run-1",
+            "schedule_id": "schedule-1",
+            "unknown_field": "should be ignored",
+        }
+
+        run = ScheduleRun.from_dict(data)
+        assert run.id == "run-1"
+        # Should not raise an error
+
+    def test_schedule_run_round_trip(self):
+        """Test that to_dict/from_dict round trip preserves data."""
+        from agno.db.schemas.scheduler import ScheduleRun
+
+        original = ScheduleRun(
+            id="run-1",
+            schedule_id="schedule-1",
+            attempt=3,
+            status="failed",
+            status_code=503,
+            error="Service unavailable",
+        )
+
+        data = original.to_dict()
+        restored = ScheduleRun.from_dict(data)
+
+        assert restored.id == original.id
+        assert restored.schedule_id == original.schedule_id
+        assert restored.attempt == original.attempt
+        assert restored.status == original.status
+        assert restored.status_code == original.status_code
+        assert restored.error == original.error

--- a/libs/agno/tests/unit/scheduler/test_poller.py
+++ b/libs/agno/tests/unit/scheduler/test_poller.py
@@ -1,0 +1,312 @@
+"""Unit tests for SchedulePoller."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+class TestSchedulePollerInit:
+    """Tests for SchedulePoller initialization."""
+
+    def test_init_with_sync_db(self):
+        """Test poller initialization with sync database."""
+        from agno.scheduler.poller import SchedulePoller
+
+        mock_db = MagicMock()
+        del mock_db.aclaim_due_schedule
+
+        poller = SchedulePoller(
+            db=mock_db,
+            base_url="http://localhost:7777",
+            token="test-token",
+            poll_interval=30,
+            lock_grace_seconds=60,
+            container_id="container-1",
+        )
+
+        assert poller.db == mock_db
+        assert poller.poll_interval == 30
+        assert poller.lock_grace_seconds == 60
+        assert poller.container_id == "container-1"
+        assert poller._is_async_db is False
+        assert poller._running is False
+
+    def test_init_with_async_db(self):
+        """Test poller initialization with async database."""
+        from agno.scheduler.poller import SchedulePoller
+
+        mock_db = MagicMock()
+        mock_db.aclaim_due_schedule = AsyncMock()
+
+        poller = SchedulePoller(
+            db=mock_db,
+            base_url="http://localhost:7777",
+            token="test-token",
+        )
+
+        assert poller._is_async_db is True
+
+    def test_init_generates_container_id_if_not_provided(self):
+        """Test that container_id is generated if not provided."""
+        from agno.scheduler.poller import SchedulePoller
+
+        mock_db = MagicMock()
+        del mock_db.aclaim_due_schedule
+
+        poller = SchedulePoller(
+            db=mock_db,
+            base_url="http://localhost:7777",
+            token="test-token",
+        )
+
+        assert poller.container_id is not None
+        assert len(poller.container_id) > 0
+
+    def test_default_poll_interval(self):
+        """Test default poll interval value."""
+        from agno.scheduler.poller import SchedulePoller
+
+        mock_db = MagicMock()
+        del mock_db.aclaim_due_schedule
+
+        poller = SchedulePoller(
+            db=mock_db,
+            base_url="http://localhost:7777",
+            token="test-token",
+        )
+
+        assert poller.poll_interval == 30
+
+    def test_default_lock_grace_seconds(self):
+        """Test default lock grace seconds value."""
+        from agno.scheduler.poller import SchedulePoller
+
+        mock_db = MagicMock()
+        del mock_db.aclaim_due_schedule
+
+        poller = SchedulePoller(
+            db=mock_db,
+            base_url="http://localhost:7777",
+            token="test-token",
+        )
+
+        assert poller.lock_grace_seconds == 60
+
+
+class TestSchedulePollerProperties:
+    """Tests for poller property methods."""
+
+    def test_is_running_property(self):
+        """Test is_running property."""
+        from agno.scheduler.poller import SchedulePoller
+
+        mock_db = MagicMock()
+        del mock_db.aclaim_due_schedule
+
+        poller = SchedulePoller(mock_db, "http://localhost", "token")
+
+        assert poller.is_running is False
+
+        poller._running = True
+        assert poller.is_running is True
+
+    def test_active_task_count_property(self):
+        """Test active_task_count property."""
+        from agno.scheduler.poller import SchedulePoller
+
+        mock_db = MagicMock()
+        del mock_db.aclaim_due_schedule
+
+        poller = SchedulePoller(mock_db, "http://localhost", "token")
+
+        assert poller.active_task_count == 0
+
+        # Add mock tasks
+        mock_task = MagicMock()
+        poller._active_tasks.add(mock_task)
+        assert poller.active_task_count == 1
+
+
+class TestSchedulePollerAsyncMethods:
+    """Tests for poller async method dispatching."""
+
+    @pytest.mark.asyncio
+    async def test_claim_due_schedule_sync_db(self):
+        """Test _claim_due_schedule with sync database."""
+        from agno.db.schemas.scheduler import Schedule
+        from agno.scheduler.poller import SchedulePoller
+
+        mock_db = MagicMock()
+        del mock_db.aclaim_due_schedule
+        mock_db.claim_due_schedule.return_value = Schedule(
+            id="schedule-1",
+            name="test",
+            cron_expr="* * * * *",
+            endpoint="/v1/test",
+        )
+
+        poller = SchedulePoller(mock_db, "http://localhost", "token")
+        result = await poller._claim_due_schedule()
+
+        mock_db.claim_due_schedule.assert_called_once_with(
+            poller.container_id,
+            lock_grace_seconds=60,
+        )
+        assert result.id == "schedule-1"
+
+    @pytest.mark.asyncio
+    async def test_claim_due_schedule_async_db(self):
+        """Test _claim_due_schedule with async database."""
+        from agno.db.schemas.scheduler import Schedule
+        from agno.scheduler.poller import SchedulePoller
+
+        mock_db = MagicMock()
+        mock_db.aclaim_due_schedule = AsyncMock(
+            return_value=Schedule(
+                id="schedule-1",
+                name="test",
+                cron_expr="* * * * *",
+                endpoint="/v1/test",
+            )
+        )
+
+        poller = SchedulePoller(mock_db, "http://localhost", "token")
+        result = await poller._claim_due_schedule()
+
+        mock_db.aclaim_due_schedule.assert_called_once_with(
+            poller.container_id,
+            lock_grace_seconds=60,
+        )
+        assert result.id == "schedule-1"
+
+    @pytest.mark.asyncio
+    async def test_claim_due_schedule_returns_none(self):
+        """Test _claim_due_schedule when no schedules are due."""
+        from agno.scheduler.poller import SchedulePoller
+
+        mock_db = MagicMock()
+        del mock_db.aclaim_due_schedule
+        mock_db.claim_due_schedule.return_value = None
+
+        poller = SchedulePoller(mock_db, "http://localhost", "token")
+        result = await poller._claim_due_schedule()
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_schedule_sync_db(self):
+        """Test _get_schedule with sync database."""
+        from agno.db.schemas.scheduler import Schedule
+        from agno.scheduler.poller import SchedulePoller
+
+        mock_db = MagicMock()
+        del mock_db.aget_schedule
+        mock_db.get_schedule.return_value = Schedule(
+            id="schedule-1",
+            name="test",
+            cron_expr="* * * * *",
+            endpoint="/v1/test",
+        )
+
+        poller = SchedulePoller(mock_db, "http://localhost", "token")
+        result = await poller._get_schedule("schedule-1")
+
+        mock_db.get_schedule.assert_called_once_with("schedule-1")
+        assert result.id == "schedule-1"
+
+    @pytest.mark.asyncio
+    async def test_get_schedule_async_db(self):
+        """Test _get_schedule with async database."""
+        from agno.db.schemas.scheduler import Schedule
+        from agno.scheduler.poller import SchedulePoller
+
+        mock_db = MagicMock()
+        mock_db.aget_schedule = AsyncMock(
+            return_value=Schedule(
+                id="schedule-1",
+                name="test",
+                cron_expr="* * * * *",
+                endpoint="/v1/test",
+            )
+        )
+
+        poller = SchedulePoller(mock_db, "http://localhost", "token")
+        result = await poller._get_schedule("schedule-1")
+
+        mock_db.aget_schedule.assert_called_once_with("schedule-1")
+        assert result.id == "schedule-1"
+
+
+class TestSchedulePollerTrigger:
+    """Tests for poller trigger_schedule method."""
+
+    @pytest.mark.asyncio
+    async def test_trigger_schedule_not_found(self):
+        """Test trigger_schedule when schedule is not found."""
+        from agno.scheduler.poller import SchedulePoller
+
+        mock_db = MagicMock()
+        del mock_db.aget_schedule
+        mock_db.get_schedule.return_value = None
+
+        poller = SchedulePoller(mock_db, "http://localhost", "token")
+        result = await poller.trigger_schedule("nonexistent")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_trigger_schedule_creates_task(self):
+        """Test trigger_schedule creates an asyncio task."""
+        from agno.db.schemas.scheduler import Schedule
+        from agno.scheduler.poller import SchedulePoller
+
+        mock_db = MagicMock()
+        del mock_db.aget_schedule
+        mock_db.get_schedule.return_value = Schedule(
+            id="schedule-1",
+            name="test",
+            cron_expr="* * * * *",
+            endpoint="/v1/test",
+        )
+
+        poller = SchedulePoller(mock_db, "http://localhost", "token")
+
+        # Mock the executor
+        with patch.object(poller.executor, "execute", new_callable=AsyncMock):
+            result = await poller.trigger_schedule("schedule-1")
+
+            assert result is True
+            assert poller.active_task_count == 1
+
+
+class TestSchedulePollerStop:
+    """Tests for poller stop method."""
+
+    @pytest.mark.asyncio
+    async def test_stop_when_not_running(self):
+        """Test stop when poller is not running."""
+        from agno.scheduler.poller import SchedulePoller
+
+        mock_db = MagicMock()
+        del mock_db.aclaim_due_schedule
+
+        poller = SchedulePoller(mock_db, "http://localhost", "token")
+        poller._running = False
+
+        # Should not raise
+        await poller.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_sets_running_false(self):
+        """Test that stop sets _running to False."""
+        from agno.scheduler.poller import SchedulePoller
+
+        mock_db = MagicMock()
+        del mock_db.aclaim_due_schedule
+
+        poller = SchedulePoller(mock_db, "http://localhost", "token")
+        poller._running = True
+
+        await poller.stop()
+
+        assert poller._running is False


### PR DESCRIPTION
## Summary

Add a built-in scheduler that enables scheduling agent runs, workflow executions, and other endpoint calls on a recurring basis using cron expressions.

This is particularly useful for:
- Running periodic agent tasks (daily reports, hourly checks)
- Scheduling workflow executions (data processing pipelines)
- Automating any AgentOS endpoint call

### Key Features

- **Cron expression support** via `croniter` (optional dependency: `pip install agno[scheduler]`)
- **Distributed locking** using `SELECT FOR UPDATE SKIP LOCKED` for PostgreSQL multi-container deployments
- **Both sync and async** database support (PostgresDb, AsyncPostgresDb, SqliteDb, AsyncSqliteDb)
- **SSE stream consumption** for non-blocking execution tracking
- **REST API** for schedule CRUD and manual triggering
- **Configurable** poll interval and lock grace period

### Architecture

```
┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
│   SchedulePoller │────▶│ ScheduleExecutor│────▶│   AgentOS API   │
└─────────────────┘     └─────────────────┘     └─────────────────┘
         │                       │
         ▼                       ▼
┌─────────────────────────────────────────────────────────────────┐
│                          Database                                │
│   (agno_schedules + agno_schedule_runs tables)                  │
└─────────────────────────────────────────────────────────────────┘
```

### Usage Example

```python
from agno.agent import Agent
from agno.db.sqlite import SqliteDb
from agno.os import AgentOS

agent = Agent(id="my-agent", ...)
db = SqliteDb(db_file="app.db")

agent_os = AgentOS(
    agents=[agent],
    db=db,
    enable_scheduler=True,
    scheduler_poll_interval=30,
)

agent_os.run(port=7777)
```

Then create schedules via the API:

```bash
curl -X POST http://localhost:7777/v1/schedules \
  -H "Content-Type: application/json" \
  -d '{
    "name": "daily-task",
    "endpoint": "/v1/agents/my-agent/runs",
    "cron_expr": "0 3 * * *"
  }'
```

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated
- [x] Tests added/updated

---

## Files Changed

### Core Implementation
- `libs/agno/agno/scheduler/` - Scheduler module (cron.py, executor.py, poller.py)
- `libs/agno/agno/db/schemas/scheduler.py` - Schedule and ScheduleRun dataclasses
- `libs/agno/agno/os/routers/schedules/` - REST API router and schemas
- `libs/agno/agno/os/app.py` - AgentOS integration

### Database Implementations
- `libs/agno/agno/db/base.py` - BaseDb/AsyncBaseDb abstract methods
- `libs/agno/agno/db/postgres/postgres.py` - PostgresDb implementation
- `libs/agno/agno/db/postgres/async_postgres.py` - AsyncPostgresDb implementation
- `libs/agno/agno/db/sqlite/sqlite.py` - SqliteDb implementation
- `libs/agno/agno/db/sqlite/async_sqlite.py` - AsyncSqliteDb implementation
- `libs/agno/agno/db/*/schemas.py` - Table schemas

### Tests
- `libs/agno/tests/unit/scheduler/` - Unit tests
- `libs/agno/tests/integration/scheduler/` - Integration tests

### Cookbooks
- `cookbook/05_agent_os/scheduler/01_basic_scheduler.py`
- `cookbook/05_agent_os/scheduler/02_schedule_agent_runs.py`
- `cookbook/05_agent_os/scheduler/03_schedule_workflow.py`
- `cookbook/05_agent_os/scheduler/04_async_scheduler.py`
- `cookbook/05_agent_os/scheduler/05_manual_trigger.py`

---

## Additional Notes

### Design Decisions

1. **External schedulers recommended**: For production deployments, we recommend using K8s CronJobs, AWS EventBridge, or similar external schedulers that call AgentOS endpoints. The built-in scheduler is a convenience for simpler deployments.

2. **No additional containers**: The scheduler runs within the AgentOS process, avoiding the need for Celery, Redis, or separate scheduler services.

3. **Backwards compatible**: All changes are additive. The scheduler is disabled by default (`enable_scheduler=False`). Tables are created on first use.

4. **JWT incompatibility**: The scheduler uses an internal service token that is not validated by JWT middleware. If using JWT authorization, schedule execution may fail.

### Multi-container Deployments

For PostgreSQL deployments with multiple AgentOS containers:
- Uses `SELECT FOR UPDATE SKIP LOCKED` to ensure jobs execute exactly once
- Lock grace period (configurable) handles crashed containers
- Each container has a unique ID for lock ownership

For SQLite:
- Race conditions possible in multi-process deployments
- Recommended for development/single-process only