### PR TITLE
fix: change store_history_messages default to False

### DIFF
--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -332,8 +332,12 @@ class Agent:
     store_media: bool = True
     # If True, store tool results in run output
     store_tool_messages: bool = True
-    # If True, store history messages in run output
-    store_history_messages: bool = True
+    # If True, store history messages in run output.
+    # When False (default): Each run stores only its own messages. History is reconstructed
+    # on-the-fly by traversing previous runs. This results in linear storage growth.
+    # When True: Each run stores all messages including history from previous runs.
+    # This allows inspecting full context in stored runs but causes quadratic storage growth.
+    store_history_messages: bool = False
 
     # --- System message settings ---
     # Provide the system message as a string or function
@@ -504,7 +508,7 @@ class Agent:
         max_tool_calls_from_history: Optional[int] = None,
         store_media: bool = True,
         store_tool_messages: bool = True,
-        store_history_messages: bool = True,
+        store_history_messages: bool = False,
         knowledge: Optional[KnowledgeProtocol] = None,
         knowledge_filters: Optional[Union[Dict[str, Any], List[FilterExpr]]] = None,
         enable_agentic_knowledge_filters: Optional[bool] = None,
@@ -7819,7 +7823,7 @@ class Agent:
             send_media_to_model=config.get("send_media_to_model", True),
             store_media=config.get("store_media", True),
             store_tool_messages=config.get("store_tool_messages", True),
-            store_history_messages=config.get("store_history_messages", True),
+            store_history_messages=config.get("store_history_messages", False),
             # --- System message settings ---
             system_message=config.get("system_message"),
             system_message_role=config.get("system_message_role", "system"),

--- a/libs/agno/tests/integration/agent/test_disable_storing_tool_and_history_messages.py
+++ b/libs/agno/tests/integration/agent/test_disable_storing_tool_and_history_messages.py
@@ -120,8 +120,8 @@ async def test_store_tool_results_disabled_async(tmp_path):
 
 
 # --- History Message Storage Tests ---
-def test_store_history_messages_enabled_by_default(tmp_path):
-    """Test that history messages are stored by default."""
+def test_store_history_messages_disabled_by_default(tmp_path):
+    """Test that history messages are NOT stored by default (prevents quadratic storage growth)."""
     agent = Agent(
         model=OpenAIChat(id="gpt-4o-mini"),
         db=SqliteDb(db_file=str(tmp_path / "test.db")),
@@ -129,8 +129,8 @@ def test_store_history_messages_enabled_by_default(tmp_path):
         num_history_runs=2,
     )
 
-    # Default should be True
-    assert agent.store_history_messages is True
+    # Default should be False to prevent quadratic storage growth
+    assert agent.store_history_messages is False
 
     # First run to establish history
     agent.run("My name is Alice")
@@ -143,9 +143,9 @@ def test_store_history_messages_enabled_by_default(tmp_path):
     assert stored_run is not None
 
     if stored_run.messages:
-        # Should have history messages
+        # Should NOT have history messages stored (they're reconstructed on-the-fly)
         history_msgs = [m for m in stored_run.messages if m.from_history]
-        assert len(history_msgs) > 0
+        assert len(history_msgs) == 0
 
 
 def test_store_history_messages_disabled(tmp_path):


### PR DESCRIPTION
## Summary

Fixes session storage exponential/quadratic growth when using `add_history_to_context=True` with high `num_history_runs` values.

**Root Cause:** When `store_history_messages=True` (the previous default), each run stored all history messages in addition to its own messages. This caused storage to grow as O(N^2) instead of O(N), with sessions reaching hundreds of MB and failing database upserts.

**The Fix:** Change the default of `store_history_messages` from `True` to `False`. History is still fully functional - it's reconstructed on-the-fly by traversing previous runs via `get_messages()`.

**Breaking Change Mitigation:** Users who need to store full context in each run (for debugging, audit logging, etc.) can explicitly set `store_history_messages=True`.

Fixes #5741

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

### Files Changed
- `libs/agno/agno/agent/agent.py` - Changed default value in 3 locations (class field, `__init__` parameter, `from_config` fallback) and updated docstring
- `libs/agno/tests/integration/agent/test_disable_storing_tool_and_history_messages.py` - Updated test to reflect new default

### Test Results
All 16 tests in `test_disable_storing_tool_and_history_messages.py` pass, including:
- `test_store_history_messages_disabled_by_default` - Validates new default behavior
- `test_history_available_during_execution` - Confirms history still works when not stored

### API Impact
- `GET /sessions/{id}` -> `chat_history`: **No change** (already filtered out history messages)
- `GET /sessions/{id}/runs/{run_id}` -> `messages`: Will show fewer messages (only new messages from that run)

### Migration Path
Users who relied on the old default can restore behavior with:
```python
agent = Agent(
    # ...
    store_history_messages=True,
)
```