### PR TITLE
fix: install test dependencies in dev_setup.sh

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -31,9 +31,8 @@ print_heading "Installing agno"
 print_info "VIRTUAL_ENV=${VENV_DIR} uv pip install -r ${AGNO_DIR}/requirements.txt"
 VIRTUAL_ENV=${VENV_DIR} uv pip install -r ${AGNO_DIR}/requirements.txt
 
-print_heading "Installing agno in editable mode with dev dependencies"
-VIRTUAL_ENV=${VENV_DIR} uv pip install -U -e ${AGNO_DIR}[dev]
-#TODO: Improve the dev setup to handle conflicts which results in missing dependencies
+print_heading "Installing agno in editable mode with test dependencies"
+VIRTUAL_ENV=${VENV_DIR} uv pip install -U -e ${AGNO_DIR}[tests]
 
 print_heading "Installing agno-infra"
 print_info "VIRTUAL_ENV=${VENV_DIR} uv pip install -r ${AGNO_INFRA_DIR}/requirements.txt"


### PR DESCRIPTION
The dev_setup.sh script was installing agno with `[dev]` extras, which only includes dev tooling. Tests that depend on model providers, tools, storage backends, or other extras fail with import errors because those packages are never installed.

This changes `[dev]` to `[tests]`, which transitively includes `[dev]` along with all other extras needed to run the full test suite.

Fixes #6317