### PR TITLE
refactor: consolidate async session setup in Team run lifecycle

### DIFF
--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -86,6 +86,46 @@ if TYPE_CHECKING:
     from agno.team.team import Team
 
 
+async def _asetup_session(
+    team: "Team",
+    run_context: RunContext,
+    session_id: str,
+    user_id: Optional[str],
+    run_id: Optional[str],
+) -> TeamSession:
+    """Read/create session, load state from DB, and resolve callable dependencies.
+
+    Shared setup for _arun() and _arun_stream(). Mirrors what the sync run()
+    does inline before calling _run()/_run_stream().
+    """
+    # Read or create session
+    if team._has_async_db():
+        team_session = await team._aread_or_create_session(session_id=session_id, user_id=user_id)
+    else:
+        team_session = team._read_or_create_session(session_id=session_id, user_id=user_id)
+
+    # Update metadata
+    team._update_metadata(session=team_session)
+
+    # Initialize and load session state from DB
+    run_context.session_state = team._initialize_session_state(
+        session_state=run_context.session_state if run_context.session_state is not None else {},
+        user_id=user_id,
+        session_id=session_id,
+        run_id=run_id,
+    )
+    if run_context.session_state is not None:
+        run_context.session_state = team._load_session_state(
+            session=team_session, session_state=run_context.session_state
+        )
+
+    # Resolve callable dependencies AFTER state is loaded
+    if run_context.dependencies is not None:
+        await team._aresolve_run_dependencies(run_context=run_context)
+
+    return team_session
+
+
 def _run(
     team: "Team",
     run_response: TeamRunOutput,
@@ -926,50 +966,34 @@ async def _arun(
     """Run the Team and return the response.
 
     Steps:
-    1. Read or create session
-    2. Update metadata and session state
-    3. Resolve callable dependencies
-    4. Execute pre-hooks
-    5. Determine tools for model
-    6. Prepare run messages
-    7. Start memory creation in background task
-    8. Reason about the task if reasoning is enabled
-    9. Get a response from the Model
-    10. Update TeamRunOutput with the model response
-    11. Store media if enabled
-    12. Convert response to structured format
-    13. Execute post-hooks
-    14. Wait for background memory creation
-    15. Create session summary
-    16. Cleanup and store (scrub, add to session, calculate metrics, save session)
+    1. Setup session via _asetup_session (read/create, load state, resolve dependencies)
+    2. Execute pre-hooks
+    3. Determine tools for model
+    4. Prepare run messages
+    5. Start memory creation in background task
+    6. Reason about the task if reasoning is enabled
+    7. Get a response from the Model
+    8. Update TeamRunOutput with the model response
+    9. Store media if enabled
+    10. Convert response to structured format
+    11. Execute post-hooks
+    12. Wait for background memory creation
+    13. Create session summary
+    14. Cleanup and store (scrub, add to session, calculate metrics, save session)
     """
     await aregister_run(run_context.run_id)
     log_debug(f"Team Run Start: {run_response.run_id}", center=True)
     memory_task = None
 
     try:
-        # Read or create session once before retry loop
-        if team._has_async_db():
-            team_session = await team._aread_or_create_session(session_id=session_id, user_id=user_id)
-        else:
-            team_session = team._read_or_create_session(session_id=session_id, user_id=user_id)
-
-        # Update metadata and session state
-        team._update_metadata(session=team_session)
-        run_context.session_state = team._initialize_session_state(
-            session_state=run_context.session_state if run_context.session_state is not None else {},
-            user_id=user_id,
+        # Setup session: read/create, load state, resolve dependencies
+        team_session = await _asetup_session(
+            team=team,
+            run_context=run_context,
             session_id=session_id,
+            user_id=user_id,
             run_id=run_response.run_id,
         )
-        if run_context.session_state is not None:
-            run_context.session_state = team._load_session_state(
-                session=team_session, session_state=run_context.session_state
-            )
-
-        # Resolve callable dependencies after session state is loaded (matches sync run() order)
-        if run_context.dependencies is not None:
-            await team._aresolve_run_dependencies(run_context=run_context)
 
         # Set up retry logic
         num_attempts = team.retries + 1
@@ -1231,22 +1255,20 @@ async def _arun_stream(
     background_tasks: Optional[Any] = None,
     **kwargs: Any,
 ) -> AsyncIterator[Union[TeamRunOutputEvent, RunOutputEvent, TeamRunOutput]]:
-    """Run the Team and return the response.
+    """Run the Team and return the response as a stream.
 
     Steps:
-    1. Read or create session
-    2. Update metadata and session state
-    3. Resolve callable dependencies
-    4. Execute pre-hooks
-    5. Determine tools for model
-    6. Prepare run messages
-    7. Start memory creation in background task
-    8. Reason about the task if reasoning is enabled
-    9. Get a response from the model
-    10. Parse response with parser model if provided
-    11. Wait for background memory creation
-    12. Create session summary
-    13. Cleanup and store (scrub, add to session, calculate metrics, save session)
+    1. Setup session via _asetup_session (read/create, load state, resolve dependencies)
+    2. Execute pre-hooks
+    3. Determine tools for model
+    4. Prepare run messages
+    5. Start memory creation in background task
+    6. Reason about the task if reasoning is enabled
+    7. Get a response from the model
+    8. Parse response with parser model if provided
+    9. Wait for background memory creation
+    10. Create session summary
+    11. Cleanup and store (scrub, add to session, calculate metrics, save session)
     """
     log_debug(f"Team Run Start: {run_response.run_id}", center=True)
 
@@ -1255,28 +1277,14 @@ async def _arun_stream(
     memory_task = None
 
     try:
-        # Read or create session once before retry loop
-        if team._has_async_db():
-            team_session = await team._aread_or_create_session(session_id=session_id, user_id=user_id)
-        else:
-            team_session = team._read_or_create_session(session_id=session_id, user_id=user_id)
-
-        # Update metadata and session state
-        team._update_metadata(session=team_session)
-        run_context.session_state = team._initialize_session_state(
-            session_state=run_context.session_state if run_context.session_state is not None else {},
-            user_id=user_id,
+        # Setup session: read/create, load state, resolve dependencies
+        team_session = await _asetup_session(
+            team=team,
+            run_context=run_context,
             session_id=session_id,
+            user_id=user_id,
             run_id=run_response.run_id,
         )
-        if run_context.session_state is not None:
-            run_context.session_state = team._load_session_state(
-                session=team_session, session_state=run_context.session_state
-            )
-
-        # Resolve callable dependencies after session state is loaded (matches sync run() order)
-        if run_context.dependencies is not None:
-            await team._aresolve_run_dependencies(run_context=run_context)
 
         # Set up retry logic
         num_attempts = team.retries + 1

--- a/libs/agno/tests/unit/team/test_basic.py
+++ b/libs/agno/tests/unit/team/test_basic.py
@@ -1,3 +1,5 @@
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from agno.agent import Agent
@@ -7,6 +9,7 @@ from agno.models.openai import OpenAIChat
 from agno.run import RunContext
 from agno.run.team import TeamRunOutput
 from agno.session.team import TeamSession
+from agno.team._run import _asetup_session
 from agno.team.team import Team
 from agno.tools.websearch import WebSearchTools
 from agno.tools.yfinance import YFinanceTools
@@ -153,3 +156,55 @@ def test_team_update_session_metrics_accumulates(team):
 
     assert metrics2.duration == 5.0  # 2.0 + 3.0
     assert metrics2.input_tokens == 150  # 100 + 50
+
+
+@pytest.mark.asyncio
+async def test_asetup_session_resolves_deps_after_state_loaded():
+    """Verify callable dependencies are resolved AFTER session state is loaded from DB.
+
+    This is a regression test: if dependency resolution runs before state loading,
+    the callable won't see DB-stored session state values.
+    """
+    # Create a session with DB-stored state
+    db_session = TeamSession(session_id="test-session")
+    db_session.session_data = {"session_state": {"from_db": "loaded"}}
+
+    # Track the session_state snapshot at the time _aresolve_run_dependencies is called
+    captured_state = {}
+
+    async def capture_state_on_resolve(run_context):
+        """Capture session_state at dep resolution time, then do actual resolution."""
+        captured_state.update(run_context.session_state or {})
+
+    # Create a minimal Team mock
+    team = MagicMock()
+    team._has_async_db.return_value = False
+    team._read_or_create_session.return_value = db_session
+    team._update_metadata.return_value = None
+    team._initialize_session_state.side_effect = lambda session_state, **kw: session_state
+    team._load_session_state.side_effect = lambda session, session_state: {
+        **session_state,
+        **session.session_data.get("session_state", {}),
+    }
+    team._aresolve_run_dependencies = AsyncMock(side_effect=capture_state_on_resolve)
+
+    run_context = RunContext(
+        run_id="test-run",
+        session_id="test-session",
+        session_state={},
+        dependencies={"some_dep": lambda: "value"},
+    )
+
+    result_session = await _asetup_session(
+        team=team,
+        run_context=run_context,
+        session_id="test-session",
+        user_id=None,
+        run_id="test-run",
+    )
+
+    assert result_session == db_session
+    # At the time deps were resolved, session_state should already contain DB values
+    assert captured_state.get("from_db") == "loaded"
+    # And run_context.session_state should have the loaded value
+    assert run_context.session_state["from_db"] == "loaded"


### PR DESCRIPTION
## Summary

The async Team run paths (`_arun()` and `_arun_stream()`) had identical ~20-line session setup blocks that were copy-pasted between the two methods. This PR extracts that duplicated logic into a shared `_asetup_session()` async helper, ensuring:

- **Single source of truth** for the session setup sequence (read/create session, load state from DB, resolve callable dependencies)
- **Correct ordering is enforced once** — dependencies are always resolved *after* session state is loaded from the database, preventing callables from seeing stale/empty state
- **Future changes** to the setup sequence only need to be made in one place

### Background

During analysis, we discovered that:
1. The async dependency ordering bug (deps resolved before state loaded) had already been silently fixed during the decomposition commit (`ad2c91f90`)
2. Full sync/async structural alignment (moving all setup into `arun()`) is not feasible because `arun()` must remain `def` (not `async def`) to support the streaming API pattern (`async for event in team.arun(..., stream=True)`)
3. The pragmatic solution is to consolidate the duplicated async setup into a shared helper

### Changes

- **`_asetup_session()` helper** added to `libs/agno/agno/team/_run.py` — handles session read/create, metadata update, state initialization, state loading from DB, and dependency resolution
- **`_arun()` and `_arun_stream()`** now call the shared helper instead of duplicating the setup block
- **Regression test** added to verify that callable dependencies see DB-loaded session state at resolution time

## Type of change

- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tests added/updated (if applicable)

---

## Additional Notes

- The sync path (`run()` → `_run()`/`_run_stream()`) was not changed — it already has the correct architecture with all setup in the public `run()` method
- 76 unit tests pass across the team test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)