### PR TITLE
fix: skip validate_call for functions with Agent/Team type annotations

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -493,11 +493,24 @@ class Function(BaseModel):
         if framework_params & set(sig.parameters.keys()):
             return func
 
+        # Also check for Agent/Team type annotations (not just parameter names)
+        # This handles cases like `my_agent: Agent` where the name differs
+        try:
+            hints = get_type_hints(func)
+            for hint in hints.values():
+                # Get the type name, handling both direct types and string annotations
+                type_name = getattr(hint, "__name__", str(hint))
+                if type_name in ("Agent", "Team"):
+                    return func
+        except Exception:
+            # If we can't resolve type hints (e.g., forward references),
+            # fall through to try validate_call which will log any issues
+            pass
+
         # Wrap the callable with validate_call
-        else:
-            wrapped = validate_call(func, config=dict(arbitrary_types_allowed=True))  # type: ignore
-            wrapped._wrapped_for_validation = True  # Mark as wrapped to avoid infinite recursion
-            return wrapped
+        wrapped = validate_call(func, config=dict(arbitrary_types_allowed=True))  # type: ignore
+        wrapped._wrapped_for_validation = True  # Mark as wrapped to avoid infinite recursion
+        return wrapped
 
     def process_schema_for_strict(self):
         """Process the schema to make it strict mode compliant."""


### PR DESCRIPTION
The `@tool` decorator wraps functions with Pydantic's `validate_call`, which uses `get_type_hints()` to resolve type annotations. When a function has an `Agent` or `Team` type annotation (e.g., `my_agent: Agent`), Pydantic tries to resolve the full class hierarchy including `BaseDb`, which isn't in scope of the decorated function's globals.

Previously, we only skipped validation for parameters named `agent` or `team`, but this missed functions using different parameter names like `my_agent: Agent`.

This fix adds a check for `Agent`/`Team` type annotations in addition to the existing parameter name check:

```python
# Also check for Agent/Team type annotations (not just parameter names)
try:
    hints = get_type_hints(func)
    for hint in hints.values():
        type_name = getattr(hint, "__name__", str(hint))
        if type_name in ("Agent", "Team"):
            return func
except Exception:
    pass
```

The `except Exception` block catches any issues resolving type hints (like forward references) and allows the code to continue to `validate_call`, which will log warnings if needed.

Fixes #6344