### PR TITLE
[fix] preserve run_context precedence in dispatch paths

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -930,12 +930,23 @@ def run_dispatch(
             metadata=opts.metadata,
             output_schema=opts.output_schema,
         )
-        # Apply resolved options to run_context (covers both new and caller-provided contexts)
+        # Apply options with precedence: explicit args > existing run_context > resolved defaults.
         if dependencies is not None:
             run_context.dependencies = opts.dependencies
-        run_context.knowledge_filters = opts.knowledge_filters
-        run_context.metadata = opts.metadata
-        run_context.output_schema = opts.output_schema
+        elif run_context.dependencies is None:
+            run_context.dependencies = opts.dependencies
+        if knowledge_filters is not None:
+            run_context.knowledge_filters = opts.knowledge_filters
+        elif run_context.knowledge_filters is None:
+            run_context.knowledge_filters = opts.knowledge_filters
+        if metadata is not None:
+            run_context.metadata = opts.metadata
+        elif run_context.metadata is None:
+            run_context.metadata = opts.metadata
+        if output_schema is not None:
+            run_context.output_schema = opts.output_schema
+        elif run_context.output_schema is None:
+            run_context.output_schema = opts.output_schema
 
         # Resolve dependencies
         if run_context.dependencies is not None:
@@ -1943,12 +1954,23 @@ def arun_dispatch(  # type: ignore
         metadata=opts.metadata,
         output_schema=opts.output_schema,
     )
-    # Apply resolved options to run_context (covers both new and caller-provided contexts)
+    # Apply options with precedence: explicit args > existing run_context > resolved defaults.
     if dependencies is not None:
         run_context.dependencies = opts.dependencies
-    run_context.knowledge_filters = opts.knowledge_filters
-    run_context.metadata = opts.metadata
-    run_context.output_schema = opts.output_schema
+    elif run_context.dependencies is None:
+        run_context.dependencies = opts.dependencies
+    if knowledge_filters is not None:
+        run_context.knowledge_filters = opts.knowledge_filters
+    elif run_context.knowledge_filters is None:
+        run_context.knowledge_filters = opts.knowledge_filters
+    if metadata is not None:
+        run_context.metadata = opts.metadata
+    elif run_context.metadata is None:
+        run_context.metadata = opts.metadata
+    if output_schema is not None:
+        run_context.output_schema = opts.output_schema
+    elif run_context.output_schema is None:
+        run_context.output_schema = opts.output_schema
 
     # Prepare arguments for the model (must be after run_context is fully initialized)
     response_format = agent._get_response_format(run_context=run_context) if agent.parser_model is None else None
@@ -2096,11 +2118,19 @@ def continue_run_dispatch(
         knowledge_filters=opts.knowledge_filters,
         metadata=opts.metadata,
     )
-    # Apply resolved options to run_context (covers both new and caller-provided contexts)
+    # Apply options with precedence: explicit args > existing run_context > resolved defaults.
     if dependencies is not None:
         run_context.dependencies = opts.dependencies
-    run_context.knowledge_filters = opts.knowledge_filters
-    run_context.metadata = opts.metadata
+    elif run_context.dependencies is None:
+        run_context.dependencies = opts.dependencies
+    if knowledge_filters is not None:
+        run_context.knowledge_filters = opts.knowledge_filters
+    elif run_context.knowledge_filters is None:
+        run_context.knowledge_filters = opts.knowledge_filters
+    if metadata is not None:
+        run_context.metadata = opts.metadata
+    elif run_context.metadata is None:
+        run_context.metadata = opts.metadata
 
     # Resolve dependencies
     if run_context.dependencies is not None:
@@ -2744,11 +2774,19 @@ def acontinue_run_dispatch(  # type: ignore
         knowledge_filters=opts.knowledge_filters,
         metadata=opts.metadata,
     )
-    # Apply resolved options to run_context (covers both new and caller-provided contexts)
+    # Apply options with precedence: explicit args > existing run_context > resolved defaults.
     if dependencies is not None:
         run_context.dependencies = opts.dependencies
-    run_context.knowledge_filters = opts.knowledge_filters
-    run_context.metadata = opts.metadata
+    elif run_context.dependencies is None:
+        run_context.dependencies = opts.dependencies
+    if knowledge_filters is not None:
+        run_context.knowledge_filters = opts.knowledge_filters
+    elif run_context.knowledge_filters is None:
+        run_context.knowledge_filters = opts.knowledge_filters
+    if metadata is not None:
+        run_context.metadata = opts.metadata
+    elif run_context.metadata is None:
+        run_context.metadata = opts.metadata
 
     if opts.stream:
         return acontinue_run_stream_impl(

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -849,6 +849,11 @@ def run(
     # Update session state from DB
     session_state = team._load_session_state(session=team_session, session_state=session_state)
 
+    dependencies_provided = dependencies is not None
+    knowledge_filters_provided = knowledge_filters is not None
+    metadata_provided = metadata is not None
+    output_schema_provided = output_schema is not None
+
     # Determine runtime dependencies
     dependencies = dependencies if dependencies is not None else team.dependencies
 
@@ -900,10 +905,23 @@ def run(
         metadata=metadata,
         output_schema=output_schema,
     )
-    # Apply resolved options to run_context (covers both new and caller-provided contexts)
-    run_context.output_schema = output_schema
-    run_context.metadata = metadata
-    run_context.knowledge_filters = effective_filters
+    # Apply options with precedence: explicit args > existing run_context > resolved defaults.
+    if dependencies_provided:
+        run_context.dependencies = dependencies
+    elif run_context.dependencies is None:
+        run_context.dependencies = dependencies
+    if knowledge_filters_provided:
+        run_context.knowledge_filters = effective_filters
+    elif run_context.knowledge_filters is None:
+        run_context.knowledge_filters = effective_filters
+    if metadata_provided:
+        run_context.metadata = metadata
+    elif run_context.metadata is None:
+        run_context.metadata = metadata
+    if output_schema_provided:
+        run_context.output_schema = output_schema
+    elif run_context.output_schema is None:
+        run_context.output_schema = output_schema
 
     # Resolve callable dependencies once before retry loop
     if run_context.dependencies is not None:
@@ -1715,6 +1733,11 @@ def arun(  # type: ignore
         images=images, videos=videos, audios=audio, files=files
     )
 
+    dependencies_provided = dependencies is not None
+    knowledge_filters_provided = knowledge_filters is not None
+    metadata_provided = metadata is not None
+    output_schema_provided = output_schema is not None
+
     # Resolve variables
     dependencies = dependencies if dependencies is not None else team.dependencies
     add_dependencies = (
@@ -1773,10 +1796,23 @@ def arun(  # type: ignore
         metadata=metadata,
         output_schema=output_schema,
     )
-    # Apply resolved options to run_context (covers both new and caller-provided contexts)
-    run_context.output_schema = output_schema
-    run_context.metadata = metadata
-    run_context.knowledge_filters = effective_filters
+    # Apply options with precedence: explicit args > existing run_context > resolved defaults.
+    if dependencies_provided:
+        run_context.dependencies = dependencies
+    elif run_context.dependencies is None:
+        run_context.dependencies = dependencies
+    if knowledge_filters_provided:
+        run_context.knowledge_filters = effective_filters
+    elif run_context.knowledge_filters is None:
+        run_context.knowledge_filters = effective_filters
+    if metadata_provided:
+        run_context.metadata = metadata
+    elif run_context.metadata is None:
+        run_context.metadata = metadata
+    if output_schema_provided:
+        run_context.output_schema = output_schema
+    elif run_context.output_schema is None:
+        run_context.output_schema = output_schema
 
     # Configure the model for runs
     response_format: Optional[Union[Dict, Type[BaseModel]]] = (

--- a/libs/agno/tests/unit/team/test_run_context_precedence.py
+++ b/libs/agno/tests/unit/team/test_run_context_precedence.py
@@ -1,0 +1,230 @@
+from typing import Any, Optional
+
+import pytest
+
+from agno.run import RunContext
+from agno.run.cancel import cleanup_run
+from agno.run.team import TeamRunOutput
+from agno.session.team import TeamSession
+from agno.team import _run
+from agno.team.team import Team
+
+
+def _make_precedence_test_team() -> Team:
+    return Team(
+        name="precedence-team",
+        members=[],
+        dependencies={"team_dep": "default"},
+        knowledge_filters={"team_filter": "default"},
+        metadata={"team_meta": "default"},
+        output_schema={"type": "object", "properties": {"team": {"type": "string"}}},
+    )
+
+
+def _patch_team_dispatch_dependencies(team: Team, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(team, "_has_async_db", lambda: False)
+    monkeypatch.setattr(team, "initialize_team", lambda debug_mode=None: None)
+    monkeypatch.setattr(team, "_initialize_session", lambda session_id=None, user_id=None: (session_id, user_id))
+    monkeypatch.setattr(
+        team,
+        "_read_or_create_session",
+        lambda session_id, user_id: TeamSession(session_id=session_id, user_id=user_id),
+    )
+    monkeypatch.setattr(team, "_update_metadata", lambda session: None)
+    monkeypatch.setattr(team, "_initialize_session_state", lambda session_state, **kwargs: session_state)
+    monkeypatch.setattr(team, "_load_session_state", lambda session, session_state: session_state)
+    monkeypatch.setattr(team, "_resolve_run_dependencies", lambda run_context: None)
+    monkeypatch.setattr(team, "_get_response_format", lambda run_context=None: None)
+    monkeypatch.setattr(
+        team,
+        "_get_effective_filters",
+        lambda knowledge_filters=None: {"team_filter": "default", **(knowledge_filters or {})},
+    )
+
+
+def test_run_respects_run_context_precedence(monkeypatch: pytest.MonkeyPatch):
+    team = _make_precedence_test_team()
+    _patch_team_dispatch_dependencies(team, monkeypatch)
+
+    def fake_run(
+        run_response: TeamRunOutput,
+        run_context: RunContext,
+        session: TeamSession,
+        user_id: Optional[str] = None,
+        add_history_to_context: Optional[bool] = None,
+        add_dependencies_to_context: Optional[bool] = None,
+        add_session_state_to_context: Optional[bool] = None,
+        response_format: Optional[Any] = None,
+        stream_events: bool = False,
+        debug_mode: Optional[bool] = None,
+        background_tasks: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> TeamRunOutput:
+        cleanup_run(run_response.run_id)  # type: ignore[arg-type]
+        return run_response
+
+    monkeypatch.setattr(team, "_run", fake_run)
+
+    preserved_context = RunContext(
+        run_id="team-preserve",
+        session_id="session-1",
+        session_state={},
+        dependencies={"ctx_dep": "keep"},
+        knowledge_filters={"ctx_filter": "keep"},
+        metadata={"ctx_meta": "keep"},
+        output_schema={"ctx_schema": "keep"},
+    )
+    _run.run(
+        team=team,
+        input="hello",
+        run_id="run-preserve",
+        session_id="session-1",
+        stream=False,
+        run_context=preserved_context,
+    )
+    assert preserved_context.dependencies == {"ctx_dep": "keep"}
+    assert preserved_context.knowledge_filters == {"ctx_filter": "keep"}
+    assert preserved_context.metadata == {"ctx_meta": "keep"}
+    assert preserved_context.output_schema == {"ctx_schema": "keep"}
+
+    override_context = RunContext(
+        run_id="team-override",
+        session_id="session-1",
+        session_state={},
+        dependencies={"ctx_dep": "keep"},
+        knowledge_filters={"ctx_filter": "keep"},
+        metadata={"ctx_meta": "keep"},
+        output_schema={"ctx_schema": "keep"},
+    )
+    _run.run(
+        team=team,
+        input="hello",
+        run_id="run-override",
+        session_id="session-1",
+        stream=False,
+        run_context=override_context,
+        dependencies={"call_dep": "override"},
+        knowledge_filters={"call_filter": "override"},
+        metadata={"call_meta": "override"},
+        output_schema={"call_schema": "override"},
+    )
+    assert override_context.dependencies == {"call_dep": "override"}
+    assert override_context.knowledge_filters == {"team_filter": "default", "call_filter": "override"}
+    assert override_context.metadata == {"call_meta": "override", "team_meta": "default"}
+    assert override_context.output_schema == {"call_schema": "override"}
+
+    empty_context = RunContext(
+        run_id="team-empty",
+        session_id="session-1",
+        session_state={},
+        dependencies=None,
+        knowledge_filters=None,
+        metadata=None,
+        output_schema=None,
+    )
+    _run.run(
+        team=team,
+        input="hello",
+        run_id="run-empty",
+        session_id="session-1",
+        stream=False,
+        run_context=empty_context,
+    )
+    assert empty_context.dependencies == {"team_dep": "default"}
+    assert empty_context.knowledge_filters == {"team_filter": "default"}
+    assert empty_context.metadata == {"team_meta": "default"}
+    assert empty_context.output_schema == {"type": "object", "properties": {"team": {"type": "string"}}}
+
+
+@pytest.mark.asyncio
+async def test_arun_respects_run_context_precedence(monkeypatch: pytest.MonkeyPatch):
+    team = _make_precedence_test_team()
+    _patch_team_dispatch_dependencies(team, monkeypatch)
+
+    async def fake_arun(
+        run_response: TeamRunOutput,
+        run_context: RunContext,
+        session_id: str,
+        user_id: Optional[str] = None,
+        add_history_to_context: Optional[bool] = None,
+        add_dependencies_to_context: Optional[bool] = None,
+        add_session_state_to_context: Optional[bool] = None,
+        response_format: Optional[Any] = None,
+        stream_events: bool = False,
+        debug_mode: Optional[bool] = None,
+        background_tasks: Optional[Any] = None,
+        **kwargs: Any,
+    ) -> TeamRunOutput:
+        return run_response
+
+    monkeypatch.setattr(team, "_arun", fake_arun)
+
+    preserved_context = RunContext(
+        run_id="ateam-preserve",
+        session_id="session-1",
+        session_state={},
+        dependencies={"ctx_dep": "keep"},
+        knowledge_filters={"ctx_filter": "keep"},
+        metadata={"ctx_meta": "keep"},
+        output_schema={"ctx_schema": "keep"},
+    )
+    await _run.arun(
+        team=team,
+        input="hello",
+        run_id="arun-preserve",
+        session_id="session-1",
+        stream=False,
+        run_context=preserved_context,
+    )
+    assert preserved_context.dependencies == {"ctx_dep": "keep"}
+    assert preserved_context.knowledge_filters == {"ctx_filter": "keep"}
+    assert preserved_context.metadata == {"ctx_meta": "keep"}
+    assert preserved_context.output_schema == {"ctx_schema": "keep"}
+
+    override_context = RunContext(
+        run_id="ateam-override",
+        session_id="session-1",
+        session_state={},
+        dependencies={"ctx_dep": "keep"},
+        knowledge_filters={"ctx_filter": "keep"},
+        metadata={"ctx_meta": "keep"},
+        output_schema={"ctx_schema": "keep"},
+    )
+    await _run.arun(
+        team=team,
+        input="hello",
+        run_id="arun-override",
+        session_id="session-1",
+        stream=False,
+        run_context=override_context,
+        dependencies={"call_dep": "override"},
+        knowledge_filters={"call_filter": "override"},
+        metadata={"call_meta": "override"},
+        output_schema={"call_schema": "override"},
+    )
+    assert override_context.dependencies == {"call_dep": "override"}
+    assert override_context.knowledge_filters == {"team_filter": "default", "call_filter": "override"}
+    assert override_context.metadata == {"call_meta": "override", "team_meta": "default"}
+    assert override_context.output_schema == {"call_schema": "override"}
+
+    empty_context = RunContext(
+        run_id="ateam-empty",
+        session_id="session-1",
+        session_state={},
+        dependencies=None,
+        knowledge_filters=None,
+        metadata=None,
+        output_schema=None,
+    )
+    await _run.arun(
+        team=team,
+        input="hello",
+        run_id="arun-empty",
+        session_id="session-1",
+        stream=False,
+        run_context=empty_context,
+    )
+    assert empty_context.dependencies == {"team_dep": "default"}
+    assert empty_context.knowledge_filters == {"team_filter": "default"}
+    assert empty_context.metadata == {"team_meta": "default"}
+    assert empty_context.output_schema == {"type": "object", "properties": {"team": {"type": "string"}}}


### PR DESCRIPTION
## Summary

- Fix RunContext precedence regression introduced by the v2.5 PR #6372 integration.
- Ensure dispatch assignment order is:
  1. explicit per-call kwargs
  2. existing `run_context` values
  3. Agent/Team defaults only when `run_context` field is `None`
- Apply this consistently in Agent dispatch paths (`run`, `arun`, `continue_run`, `acontinue_run`) and Team dispatch paths (`run`, `arun`).
- Add targeted unit tests for Agent and Team sync/async behavior.

(If applicable, issue number: #____)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

Validation run for this patch:
- `.venvs/demo/bin/ruff check libs/agno/agno/agent/_run.py libs/agno/agno/team/_run.py libs/agno/tests/unit/agent/test_run_regressions.py libs/agno/tests/unit/team/test_run_context_precedence.py`
- `.venvs/demo/bin/pytest libs/agno/tests/unit/agent/test_run_regressions.py libs/agno/tests/unit/team/test_run_context_precedence.py`

Context handoff note updated at `.context/run_context_issue_status.md`.