### PR TITLE
refactor: convert get_learning_machine() to learning_machine property

### DIFF
--- a/cookbook/08_learning/00_quickstart/01_always_learn.py
+++ b/cookbook/08_learning/00_quickstart/01_always_learn.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         session_id="session_1",
         stream=True,
     )
-    lm = agent.get_learning_machine()
+    lm = agent.learning_machine
     lm.user_profile_store.print(user_id=user_id)
     lm.user_memory_store.print(user_id=user_id)
 

--- a/cookbook/08_learning/00_quickstart/02_agentic_learn.py
+++ b/cookbook/08_learning/00_quickstart/02_agentic_learn.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
         session_id="session_1",
         stream=True,
     )
-    lm = agent.get_learning_machine()
+    lm = agent.learning_machine
     lm.user_profile_store.print(user_id=user_id)
     lm.user_memory_store.print(user_id=user_id)
 

--- a/cookbook/08_learning/00_quickstart/03_learned_knowledge.py
+++ b/cookbook/08_learning/00_quickstart/03_learned_knowledge.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
         session_id="session_1",
         stream=True,
     )
-    lm = agent.get_learning_machine()
+    lm = agent.learning_machine
     lm.learned_knowledge_store.print(query="cloud")
 
     # Session 2: User 2 benefits from the learning

--- a/cookbook/08_learning/01_basics/1a_user_profile_always.py
+++ b/cookbook/08_learning/01_basics/1a_user_profile_always.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
         session_id="session_1",
         stream=True,
     )
-    agent.get_learning_machine().user_profile_store.print(user_id=user_id)
+    agent.learning_machine.user_profile_store.print(user_id=user_id)
 
     # Session 2: New session - profile is recalled automatically
     print("\n" + "=" * 60)
@@ -68,4 +68,4 @@ if __name__ == "__main__":
         session_id="session_2",
         stream=True,
     )
-    agent.get_learning_machine().user_profile_store.print(user_id=user_id)
+    agent.learning_machine.user_profile_store.print(user_id=user_id)

--- a/cookbook/08_learning/01_basics/1b_user_profile_agentic.py
+++ b/cookbook/08_learning/01_basics/1b_user_profile_agentic.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
         session_id="session_1",
         stream=True,
     )
-    agent.get_learning_machine().user_profile_store.print(user_id=user_id)
+    agent.learning_machine.user_profile_store.print(user_id=user_id)
 
     # Session 2: Agent uses stored profile
     print("\n" + "=" * 60)
@@ -67,4 +67,4 @@ if __name__ == "__main__":
         session_id="session_2",
         stream=True,
     )
-    agent.get_learning_machine().user_profile_store.print(user_id=user_id)
+    agent.learning_machine.user_profile_store.print(user_id=user_id)

--- a/cookbook/08_learning/01_basics/2a_user_memory_always.py
+++ b/cookbook/08_learning/01_basics/2a_user_memory_always.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
         session_id="session_1",
         stream=True,
     )
-    agent.get_learning_machine().user_memory_store.print(user_id=user_id)
+    agent.learning_machine.user_memory_store.print(user_id=user_id)
 
     # Session 2: New session - memories are recalled automatically
     print("\n" + "=" * 60)
@@ -72,4 +72,4 @@ if __name__ == "__main__":
         session_id="session_2",
         stream=True,
     )
-    agent.get_learning_machine().user_memory_store.print(user_id=user_id)
+    agent.learning_machine.user_memory_store.print(user_id=user_id)

--- a/cookbook/08_learning/01_basics/2b_user_memory_agentic.py
+++ b/cookbook/08_learning/01_basics/2b_user_memory_agentic.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
         session_id="session_1",
         stream=True,
     )
-    agent.get_learning_machine().user_memory_store.print(user_id=user_id)
+    agent.learning_machine.user_memory_store.print(user_id=user_id)
 
     # Session 2: Agent uses stored memories
     print("\n" + "=" * 60)
@@ -70,4 +70,4 @@ if __name__ == "__main__":
         session_id="session_2",
         stream=True,
     )
-    agent.get_learning_machine().user_memory_store.print(user_id=user_id)
+    agent.learning_machine.user_memory_store.print(user_id=user_id)

--- a/cookbook/08_learning/01_basics/3a_session_context_summary.py
+++ b/cookbook/08_learning/01_basics/3a_session_context_summary.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
         session_id=session_id,
         stream=True,
     )
-    agent.get_learning_machine().session_context_store.print(session_id=session_id)
+    agent.learning_machine.session_context_store.print(session_id=session_id)
 
     # Turn 2: Follow-up
     print("\n" + "=" * 60)
@@ -64,7 +64,7 @@ if __name__ == "__main__":
         session_id=session_id,
         stream=True,
     )
-    agent.get_learning_machine().session_context_store.print(session_id=session_id)
+    agent.learning_machine.session_context_store.print(session_id=session_id)
 
     # Turn 3: Test recall
     print("\n" + "=" * 60)
@@ -77,4 +77,4 @@ if __name__ == "__main__":
         session_id=session_id,
         stream=True,
     )
-    agent.get_learning_machine().session_context_store.print(session_id=session_id)
+    agent.learning_machine.session_context_store.print(session_id=session_id)

--- a/cookbook/08_learning/01_basics/3b_session_context_planning.py
+++ b/cookbook/08_learning/01_basics/3b_session_context_planning.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
         session_id=session_id,
         stream=True,
     )
-    agent.get_learning_machine().session_context_store.print(session_id=session_id)
+    agent.learning_machine.session_context_store.print(session_id=session_id)
 
     # Turn 2: Complete first step
     print("\n" + "=" * 60)
@@ -69,7 +69,7 @@ if __name__ == "__main__":
         session_id=session_id,
         stream=True,
     )
-    agent.get_learning_machine().session_context_store.print(session_id=session_id)
+    agent.learning_machine.session_context_store.print(session_id=session_id)
 
     # Turn 3: Complete second step
     print("\n" + "=" * 60)
@@ -82,4 +82,4 @@ if __name__ == "__main__":
         session_id=session_id,
         stream=True,
     )
-    agent.get_learning_machine().session_context_store.print(session_id=session_id)
+    agent.learning_machine.session_context_store.print(session_id=session_id)

--- a/cookbook/08_learning/01_basics/4_learned_knowledge.py
+++ b/cookbook/08_learning/01_basics/4_learned_knowledge.py
@@ -70,7 +70,7 @@ if __name__ == "__main__":
         session_id="session_1",
         stream=True,
     )
-    agent.get_learning_machine().learned_knowledge_store.print(query="cloud")
+    agent.learning_machine.learned_knowledge_store.print(query="cloud")
 
     # Session 2: Apply the learning (new user, new session)
     print("\n" + "=" * 60)

--- a/cookbook/08_learning/01_basics/5a_entity_memory_always.py
+++ b/cookbook/08_learning/01_basics/5a_entity_memory_always.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     )
 
     print("\n--- Extracted Entities ---")
-    entities = agent.get_learning_machine().entity_memory_store.search(
+    entities = agent.learning_machine.entity_memory_store.search(
         query="acme", limit=10
     )
     pprint(entities)
@@ -79,7 +79,7 @@ if __name__ == "__main__":
     )
 
     print("\n--- Updated Entities ---")
-    entities = agent.get_learning_machine().entity_memory_store.search(
+    entities = agent.learning_machine.entity_memory_store.search(
         query="acme", limit=10
     )
     pprint(entities)

--- a/cookbook/08_learning/01_basics/5b_entity_memory_agentic.py
+++ b/cookbook/08_learning/01_basics/5b_entity_memory_agentic.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
     )
 
     print("\n--- Created Entities ---")
-    entities = agent.get_learning_machine().entity_memory_store.search(
+    entities = agent.learning_machine.entity_memory_store.search(
         query="acme", limit=10
     )
     pprint(entities)
@@ -84,7 +84,7 @@ if __name__ == "__main__":
     )
 
     print("\n--- Updated Entities ---")
-    entities = agent.get_learning_machine().entity_memory_store.search(
+    entities = agent.learning_machine.entity_memory_store.search(
         query="acme", limit=10
     )
     pprint(entities)

--- a/cookbook/08_learning/02_user_profile/01_always_extraction.py
+++ b/cookbook/08_learning/02_user_profile/01_always_extraction.py
@@ -52,7 +52,7 @@ if __name__ == "__main__":
         session_id="conv_1",
         stream=True,
     )
-    agent.get_learning_machine().user_profile_store.print(user_id=user_id)
+    agent.learning_machine.user_profile_store.print(user_id=user_id)
 
     # Conversation 2: Share work context
     print("\n" + "=" * 60)
@@ -65,7 +65,7 @@ if __name__ == "__main__":
         session_id="conv_2",
         stream=True,
     )
-    agent.get_learning_machine().user_profile_store.print(user_id=user_id)
+    agent.learning_machine.user_profile_store.print(user_id=user_id)
 
     # Conversation 3: Preferences
     print("\n" + "=" * 60)
@@ -79,7 +79,7 @@ if __name__ == "__main__":
         session_id="conv_3",
         stream=True,
     )
-    agent.get_learning_machine().user_profile_store.print(user_id=user_id)
+    agent.learning_machine.user_profile_store.print(user_id=user_id)
 
     # Conversation 4: Nickname
     print("\n" + "=" * 60)
@@ -92,4 +92,4 @@ if __name__ == "__main__":
         session_id="conv_4",
         stream=True,
     )
-    agent.get_learning_machine().user_profile_store.print(user_id=user_id)
+    agent.learning_machine.user_profile_store.print(user_id=user_id)

--- a/cookbook/08_learning/02_user_profile/02_agentic_mode.py
+++ b/cookbook/08_learning/02_user_profile/02_agentic_mode.py
@@ -54,7 +54,7 @@ if __name__ == "__main__":
         session_id="session_1",
         stream=True,
     )
-    agent.get_learning_machine().user_profile_store.print(user_id=user_id)
+    agent.learning_machine.user_profile_store.print(user_id=user_id)
 
     # Session 2: Recall in new session
     print("\n" + "=" * 60)
@@ -67,7 +67,7 @@ if __name__ == "__main__":
         session_id="session_2",
         stream=True,
     )
-    agent.get_learning_machine().user_profile_store.print(user_id=user_id)
+    agent.learning_machine.user_profile_store.print(user_id=user_id)
 
     # Session 3: Update preferred name
     print("\n" + "=" * 60)
@@ -80,4 +80,4 @@ if __name__ == "__main__":
         session_id="session_3",
         stream=True,
     )
-    agent.get_learning_machine().user_profile_store.print(user_id=user_id)
+    agent.learning_machine.user_profile_store.print(user_id=user_id)

--- a/cookbook/08_learning/02_user_profile/03_custom_schema.py
+++ b/cookbook/08_learning/02_user_profile/03_custom_schema.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
         session_id="conv_1",
         stream=True,
     )
-    agent.get_learning_machine().user_profile_store.print(user_id=user_id)
+    agent.learning_machine.user_profile_store.print(user_id=user_id)
 
     # Add tech stack details
     print("\n" + "=" * 60)
@@ -99,7 +99,7 @@ if __name__ == "__main__":
         session_id="conv_2",
         stream=True,
     )
-    agent.get_learning_machine().user_profile_store.print(user_id=user_id)
+    agent.learning_machine.user_profile_store.print(user_id=user_id)
 
     # Test personalization
     print("\n" + "=" * 60)

--- a/cookbook/08_learning/03_session_context/01_summary_mode.py
+++ b/cookbook/08_learning/03_session_context/01_summary_mode.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
         session_id=session_id,
         stream=True,
     )
-    agent.get_learning_machine().session_context_store.print(session_id=session_id)
+    agent.learning_machine.session_context_store.print(session_id=session_id)
 
     # Turn 2: More context
     print("\n" + "=" * 60)
@@ -67,7 +67,7 @@ if __name__ == "__main__":
         session_id=session_id,
         stream=True,
     )
-    agent.get_learning_machine().session_context_store.print(session_id=session_id)
+    agent.learning_machine.session_context_store.print(session_id=session_id)
 
     # Turn 3: Follow-up
     print("\n" + "=" * 60)
@@ -80,7 +80,7 @@ if __name__ == "__main__":
         session_id=session_id,
         stream=True,
     )
-    agent.get_learning_machine().session_context_store.print(session_id=session_id)
+    agent.learning_machine.session_context_store.print(session_id=session_id)
 
     # Simulate reconnection
     print("\n" + "=" * 60)

--- a/cookbook/08_learning/03_session_context/02_planning_mode.py
+++ b/cookbook/08_learning/03_session_context/02_planning_mode.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
         session_id=session_id,
         stream=True,
     )
-    agent.get_learning_machine().session_context_store.print(session_id=session_id)
+    agent.learning_machine.session_context_store.print(session_id=session_id)
 
     # Step 2: Complete first task
     print("\n" + "=" * 60)
@@ -68,7 +68,7 @@ if __name__ == "__main__":
         session_id=session_id,
         stream=True,
     )
-    agent.get_learning_machine().session_context_store.print(session_id=session_id)
+    agent.learning_machine.session_context_store.print(session_id=session_id)
 
     # Step 3: More progress
     print("\n" + "=" * 60)
@@ -81,7 +81,7 @@ if __name__ == "__main__":
         session_id=session_id,
         stream=True,
     )
-    agent.get_learning_machine().session_context_store.print(session_id=session_id)
+    agent.learning_machine.session_context_store.print(session_id=session_id)
 
     # Step 4: What's next?
     print("\n" + "=" * 60)
@@ -94,4 +94,4 @@ if __name__ == "__main__":
         session_id=session_id,
         stream=True,
     )
-    agent.get_learning_machine().session_context_store.print(session_id=session_id)
+    agent.learning_machine.session_context_store.print(session_id=session_id)

--- a/cookbook/08_learning/04_entity_memory/01_facts_and_events.py
+++ b/cookbook/08_learning/04_entity_memory/01_facts_and_events.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     )
     print("\n--- Entities ---")
     pprint(
-        agent.get_learning_machine().entity_memory_store.search(
+        agent.learning_machine.entity_memory_store.search(
             query="datapipe", limit=10
         )
     )
@@ -99,7 +99,7 @@ if __name__ == "__main__":
     )
     print("\n--- Updated Entities ---")
     pprint(
-        agent.get_learning_machine().entity_memory_store.search(
+        agent.learning_machine.entity_memory_store.search(
             query="datapipe", limit=10
         )
     )

--- a/cookbook/08_learning/04_entity_memory/02_entity_relationships.py
+++ b/cookbook/08_learning/04_entity_memory/02_entity_relationships.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
     )
     print("\n--- Entities ---")
     pprint(
-        agent.get_learning_machine().entity_memory_store.search(
+        agent.learning_machine.entity_memory_store.search(
             query="techcorp", limit=10
         )
     )
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     )
     print("\n--- Updated Entities ---")
     pprint(
-        agent.get_learning_machine().entity_memory_store.search(
+        agent.learning_machine.entity_memory_store.search(
             query="techcorp", limit=10
         )
     )

--- a/cookbook/08_learning/05_learned_knowledge/01_agentic_mode.py
+++ b/cookbook/08_learning/05_learned_knowledge/01_agentic_mode.py
@@ -73,7 +73,7 @@ if __name__ == "__main__":
         session_id="session_1",
         stream=True,
     )
-    agent.get_learning_machine().learned_knowledge_store.print(query="cloud egress")
+    agent.learning_machine.learned_knowledge_store.print(query="cloud egress")
 
     # Save another learning
     print("\n" + "=" * 60)
@@ -87,7 +87,7 @@ if __name__ == "__main__":
         session_id="session_2",
         stream=True,
     )
-    agent.get_learning_machine().learned_knowledge_store.print(
+    agent.learning_machine.learned_knowledge_store.print(
         query="database migration"
     )
 

--- a/cookbook/08_learning/05_learned_knowledge/02_propose_mode.py
+++ b/cookbook/08_learning/05_learned_knowledge/02_propose_mode.py
@@ -88,7 +88,7 @@ if __name__ == "__main__":
         session_id=session_id,
         stream=True,
     )
-    agent.get_learning_machine().learned_knowledge_store.print(query="docker localhost")
+    agent.learning_machine.learned_knowledge_store.print(query="docker localhost")
 
     # Rejection example
     print("\n" + "=" * 60)
@@ -108,4 +108,4 @@ if __name__ == "__main__":
         session_id="session_2",
         stream=True,
     )
-    agent.get_learning_machine().learned_knowledge_store.print(query="restart")
+    agent.learning_machine.learned_knowledge_store.print(query="restart")

--- a/cookbook/08_learning/06_quick_tests/01_async_user_profile.py
+++ b/cookbook/08_learning/06_quick_tests/01_async_user_profile.py
@@ -55,7 +55,7 @@ async def main():
         session_id="async_session_1",
         stream=True,
     )
-    agent.get_learning_machine().user_profile_store.print(user_id=user_id)
+    agent.learning_machine.user_profile_store.print(user_id=user_id)
 
     # Session 2: New session - verify profile persisted (async)
     print("\n" + "=" * 60)
@@ -68,7 +68,7 @@ async def main():
         session_id="async_session_2",
         stream=True,
     )
-    agent.get_learning_machine().user_profile_store.print(user_id=user_id)
+    agent.learning_machine.user_profile_store.print(user_id=user_id)
 
     print("\n" + "=" * 60)
     print("ASYNC TEST COMPLETE")

--- a/cookbook/08_learning/06_quick_tests/02_learning_true_shorthand.py
+++ b/cookbook/08_learning/06_quick_tests/02_learning_true_shorthand.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     print("VERIFICATION: LearningMachine created from learning=True")
     print("=" * 60 + "\n")
 
-    lm = agent.get_learning_machine()
+    lm = agent.learning_machine
     print(f"LearningMachine exists: {lm is not None}")
     print(
         f"UserProfileStore exists: {lm.user_profile_store is not None if lm else False}"

--- a/cookbook/08_learning/06_quick_tests/03_no_db_graceful.py
+++ b/cookbook/08_learning/06_quick_tests/03_no_db_graceful.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
     print("=" * 60 + "\n")
 
     # Check that LearningMachine exists but has no DB
-    lm = agent.get_learning_machine()
+    lm = agent.learning_machine
     print(f"LearningMachine exists: {lm is not None}")
     if lm:
         print(f"DB is None: {lm.db is None}")

--- a/cookbook/08_learning/06_quick_tests/04_claude_model.py
+++ b/cookbook/08_learning/06_quick_tests/04_claude_model.py
@@ -61,7 +61,7 @@ if __name__ == "__main__":
     )
 
     # Check if LearningMachine was initialized
-    lm = agent.get_learning_machine()
+    lm = agent.learning_machine
     print(f"\nLearningMachine exists: {lm is not None}")
 
     if lm and lm.user_profile_store:

--- a/cookbook/08_learning/07_patterns/personal_assistant.py
+++ b/cookbook/08_learning/07_patterns/personal_assistant.py
@@ -79,10 +79,10 @@ if __name__ == "__main__":
         "I prefer concise responses. My sister Sarah is visiting next month.",
         stream=True,
     )
-    agent.get_learning_machine().user_profile_store.print(user_id=user_id)
+    agent.learning_machine.user_profile_store.print(user_id=user_id)
     print("\n--- Entities ---")
     pprint(
-        agent.get_learning_machine().entity_memory_store.search(query="sarah", limit=10)
+        agent.learning_machine.entity_memory_store.search(query="sarah", limit=10)
     )
 
     # Conversation 2: New session (demonstrates memory)
@@ -106,4 +106,4 @@ if __name__ == "__main__":
         "Help me plan activities for Sarah's visit. She likes hiking.",
         stream=True,
     )
-    agent.get_learning_machine().session_context_store.print(session_id="conv_3")
+    agent.learning_machine.session_context_store.print(session_id="conv_3")

--- a/cookbook/08_learning/07_patterns/support_agent.py
+++ b/cookbook/08_learning/07_patterns/support_agent.py
@@ -107,7 +107,7 @@ if __name__ == "__main__":
         "Clearing the cache worked! Thanks so much!",
         stream=True,
     )
-    agent.get_learning_machine().learned_knowledge_store.print(
+    agent.learning_machine.learned_knowledge_store.print(
         query="login chrome cache"
     )
 

--- a/cookbook/08_learning/09_decision_logs/1_basic_decision_log.py
+++ b/cookbook/08_learning/09_decision_logs/1_basic_decision_log.py
@@ -55,6 +55,6 @@ agent.print_response(
 
 # View logged decisions
 print("\n=== Decisions Logged ===\n")
-decision_store = agent.get_learning_machine().decision_log_store
+decision_store = agent.learning_machine.decision_log_store
 if decision_store:
     decision_store.print(agent_id="decision-logger", limit=5)

--- a/cookbook/08_learning/09_decision_logs/2_decision_log_always.py
+++ b/cookbook/08_learning/09_decision_logs/2_decision_log_always.py
@@ -51,6 +51,6 @@ agent.print_response(
 
 # View auto-logged decisions
 print("\n=== Auto-Logged Decisions ===\n")
-decision_store = agent.get_learning_machine().decision_log_store
+decision_store = agent.learning_machine.decision_log_store
 if decision_store:
     decision_store.print(agent_id="auto-decision-logger", limit=10)

--- a/cookbook/08_learning/CLAUDE.md
+++ b/cookbook/08_learning/CLAUDE.md
@@ -124,7 +124,7 @@ cookbook/08_learning/
 Access the learning machine from an agent:
 ```python
 # Get the resolved LearningMachine instance
-learning_machine = agent.get_learning_machine()
+learning_machine = agent.learning_machine
 
 # Access individual stores
 learning_machine.user_profile_store.print(user_id=user_id)
@@ -148,7 +148,7 @@ learning_machine.learned_knowledge_store.print(query="...")
 
 5. **Claude model version matters**: Use `claude-sonnet-4-5` or newer. Older model IDs (e.g., `claude-sonnet-4-20250514`) don't support structured outputs and extraction will fail. See `06_quick_tests/04_claude_model.py`.
 
-6. **Lazy initialization**: `LearningMachine` is only initialized when the agent runs, not when constructed. Calling `agent.get_learning_machine()` before the first `print_response()` will return `None`.
+6. **Lazy initialization**: `agent.learning_machine` now lazily initializes, so it works even before the agent runs. There is no need to call `print_response()` first.
 
 7. **upsert_learning doesn't update learning_type**: The `upsert_learning` method in postgres.py (and likely other DB adapters) only updates `content`, `metadata`, and `updated_at` on conflict - it does NOT update `learning_type`. This means if you rename a learning type (e.g., `memories` → `user_memory`), existing rows won't be found. **Future work:** Fix `upsert_learning` to update `learning_type` on conflict.
 

--- a/libs/agno/agno/agent/_managers.py
+++ b/libs/agno/agno/agent/_managers.py
@@ -479,11 +479,3 @@ def start_learning_future(
     return None
 
 
-def get_learning_machine(agent: Agent) -> Optional[LearningMachine]:
-    """Get the resolved LearningMachine instance.
-
-    Returns:
-        The LearningMachine instance if learning is enabled and initialized,
-        None otherwise.
-    """
-    return agent._learning

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -603,7 +603,7 @@ class Agent:
         self.telemetry = telemetry
 
         # Internal use: _learning holds the resolved LearningMachine instance
-        # use get_learning_machine() to access it.
+        # use agent.learning_machine to access it.
         self._learning: Optional[LearningMachine] = None
 
         # If we are caching the agent session
@@ -639,15 +639,18 @@ class Agent:
     def cached_session(self) -> Optional[AgentSession]:
         return self._cached_session
 
+    @property
+    def learning_machine(self) -> Optional[LearningMachine]:
+        if self._learning is None and self.learning is not None and self.learning is not False:
+            _init.set_learning_machine(self)
+        return self._learning
+
     # ---------------------------------------------------------------
     # _init module delegates
     # ---------------------------------------------------------------
 
     def set_id(self) -> None:
         return _init.set_id(self)
-
-    def get_learning_machine(self) -> Optional[LearningMachine]:
-        return _managers.get_learning_machine(self)
 
     def initialize_agent(self, debug_mode: Optional[bool] = None) -> None:
         return _init.initialize_agent(self, debug_mode=debug_mode)


### PR DESCRIPTION
## Summary

Convert `get_learning_machine()` method to a `learning_machine` property with lazy initialization. Previously, calling `get_learning_machine()` before the agent ran would return `None` even when learning was configured — the new property ensures `set_learning_machine()` is called on first access.

**Core changes:**
- `agent.py`: Replace `get_learning_machine()` method with `learning_machine` property (lazy init)
- `_init.py`: Remove the now-unused `get_learning_machine()` function
- 29 cookbook files + `CLAUDE.md`: Update `agent.get_learning_machine()` → `agent.learning_machine`

## Type of change

- [x] Improvement
- [x] Breaking change

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

- Internal code (`_tools.py`, `_messages.py`, `_managers.py`, `_run.py`) accesses `agent._learning` directly, so no changes needed there.
- `set_learning_machine()` is idempotent — safe to call from both `initialize_agent()` and the property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)