### PR TITLE
fix: avoid hardcoded PK constraint name in v2.5.0 migration

### DIFF
--- a/libs/agno/agno/db/migrations/versions/v2_5_0.py
+++ b/libs/agno/agno/db/migrations/versions/v2_5_0.py
@@ -7,7 +7,7 @@ Changes:
 
 from agno.db.base import AsyncBaseDb, BaseDb
 from agno.db.migrations.utils import quote_db_identifier
-from agno.utils.log import log_error, log_info
+from agno.utils.log import log_error, log_info, log_warning
 
 try:
     from sqlalchemy import text


### PR DESCRIPTION
## Summary

- Update `_has_constraint` helper to check PRIMARY KEY by `constraint_type` instead of assuming the `{table_name}_pkey` naming convention, making PK detection robust regardless of how the constraint was originally created
- Dynamically look up the actual PK constraint name before issuing `DROP CONSTRAINT` in both sync and async revert functions
- Follows up on #6412

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed

## Additional Notes

The async Postgres migration already checked by type only — this brings the sync variant and both revert paths into alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)