### PR TITLE
fix: prioritize UUID id over name in get_member_id

### DIFF
--- a/libs/agno/agno/utils/team.py
+++ b/libs/agno/agno/utils/team.py
@@ -44,12 +44,10 @@ def get_member_id(member: Union[Agent, "Team"]) -> str:
         url_safe_member_id = url_safe_string(member.id)
     elif isinstance(member, Team) and member.id is not None and (not is_valid_uuid(member.id)):
         url_safe_member_id = url_safe_string(member.id)
+    elif isinstance(member, (Agent, Team)) and member.id is not None:
+        url_safe_member_id = member.id
     elif member.name is not None:
         url_safe_member_id = url_safe_string(member.name)
-    elif isinstance(member, Agent) and member.id is not None:
-        url_safe_member_id = member.id
-    elif isinstance(member, Team) and member.id is not None:
-        url_safe_member_id = member.id
     else:
         url_safe_member_id = None
     return url_safe_member_id


### PR DESCRIPTION
## Summary

Fixes phidatahq/phidata#6332

**Root cause:** `get_member_id()` checked for `member.name` before checking for a valid UUID `member.id`. When both were present, the name was returned instead of the UUID, which is counter-intuitive for an identity function.

## Changes

- `libs/agno/agno/utils/team.py`: Reordered the priority chain in `get_member_id()`:
  1. Non-UUID custom string ID (highest priority - user set custom ID)
  2. UUID ID (user explicitly set a UUID)
  3. Name as fallback (converted to URL-safe string)

## Risk Assessment

**Medium** - Changes the return value for members that have both a UUID id and a name. The new behavior (returning UUID) is what users expect from an ID function.