### PR TITLE
fix: skip `init=False` fields in `Workflow.deep_copy()` to prevent TypeError

### DIFF
--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -4854,6 +4854,10 @@ class Workflow:
             # Skip private fields (not part of __init__ signature)
             if f.name.startswith("_"):
                 continue
+            # Skip fields not part of __init__ (init=False runtime-set fields
+            # like team_id, parent_team_id, workflow_id, version)
+            if not f.init:
+                continue
 
             field_value = getattr(self, f.name)
             if field_value is not None:


### PR DESCRIPTION
## Summary

Fixes #6296

When using nested teams, `Workflow.deep_copy()` fails with:
```
TypeError: __init__() got an unexpected keyword argument 'workflow_id'
```

## Root Cause

`deep_copy()` iterates over all `dataclasses.fields(self)` and collects their values to pass to `__init__()`. However, some fields like `team_id`, `parent_team_id`, `workflow_id`, and `version` are defined with `init=False` (they're set at runtime, not via the constructor). These get collected and passed to `__init__()`, which doesn't accept them.

## Fix

Added a check for `f.init` in the field iteration loop. Fields with `init=False` are now skipped, matching the existing skip for private fields (`_`-prefixed).

## Notes

- This is the idiomatic way to handle `init=False` dataclass fields
- The skipped fields get re-initialized during the new instance's `__init__` automatically