### PR TITLE
fix: preserve user_id, agent_id, team_id in update_memory

### DIFF
--- a/libs/agno/agno/memory/manager.py
+++ b/libs/agno/agno/memory/manager.py
@@ -1356,9 +1356,11 @@ class MemoryManager:
                 db.upsert_user_memory(
                     UserMemory(
                         memory_id=memory_id,
+                        user_id=user_id,
+                        agent_id=agent_id,
+                        team_id=team_id,
                         memory=memory,
                         topics=topics,
-                        user_id=user_id,
                         input=input_string,
                     )
                 )
@@ -1479,6 +1481,9 @@ class MemoryManager:
                     await db.upsert_user_memory(
                         UserMemory(
                             memory_id=memory_id,
+                            user_id=user_id,
+                            agent_id=agent_id,
+                            team_id=team_id,
                             memory=memory,
                             topics=topics,
                             input=input_string,
@@ -1488,6 +1493,9 @@ class MemoryManager:
                     db.upsert_user_memory(
                         UserMemory(
                             memory_id=memory_id,
+                            user_id=user_id,
+                            agent_id=agent_id,
+                            team_id=team_id,
                             memory=memory,
                             topics=topics,
                             input=input_string,


### PR DESCRIPTION
## Summary

Fixes #5735

The `update_memory` function (both sync and async) creates `UserMemory` objects without `agent_id` and `team_id` (and in the async variant, also missing `user_id`). Since `upsert_user_memory` replaces the entire document, these fields are set to `null` on update, breaking user/agent-level memory management.

## Root Cause

Comparing `add_memory` (correct) with `update_memory` (buggy):

**add_memory** passes all identifiers:
```python
UserMemory(
    memory_id=memory_id,
    user_id=user_id,
    agent_id=agent_id,  # ✅ present
    team_id=team_id,    # ✅ present
    memory=memory,
    topics=topics,
    input=input_string,
)
```

**update_memory (sync)** was missing `agent_id` and `team_id`:
```python
UserMemory(
    memory_id=memory_id,
    memory=memory,
    topics=topics,
    user_id=user_id,
    input=input_string,
    # ❌ agent_id missing
    # ❌ team_id missing
)
```

**update_memory (async)** was missing `user_id`, `agent_id`, AND `team_id`.

## Fix

Add the missing `user_id`, `agent_id`, and `team_id` fields to both sync and async `update_memory` functions, matching the `add_memory` implementation.