### PR TITLE
fix: handle RunOutput objects in format_sse_event for RemoteAgent teams

### DIFF
--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -179,8 +179,11 @@ def format_sse_event(event: Union[RunOutputEvent, TeamRunOutputEvent, WorkflowRu
         ```
     """
     try:
-        # Parse the JSON to extract the event type
-        event_type = event.event or "message"
+        # Parse the JSON to extract the event type.
+        # Some objects (e.g. RunOutput from RemoteAgent in a Team) have
+        # 'events' (plural) instead of 'event', so use getattr with a
+        # fallback to avoid AttributeError.
+        event_type = getattr(event, "event", None) or "message"
 
         # Serialize to valid JSON with double quotes and no newlines
         clean_json = event.to_json(separators=(",", ":"), indent=None)


### PR DESCRIPTION
## Summary

Fixes #6443

When a `RemoteAgent` is used as a Team member and responses are streamed, the `agent_response_streamer` iterates over chunks that may be `RunOutput` objects instead of `RunOutputEvent` objects. `RunOutput` has an `events` attribute (plural), not `event` (singular).

## Root Cause

`format_sse_event` (utils.py:183) directly accesses `event.event`:

```python
event_type = event.event or "message"  # AttributeError for RunOutput
```

This raises `AttributeError: 'RunOutput' object has no attribute 'event'. Did you mean: 'events'?`

## Fix

Replace direct attribute access with `getattr` and a fallback:

```python
event_type = getattr(event, "event", None) or "message"
```

This gracefully handles both `RunOutputEvent` (which has `.event`) and `RunOutput` (which does not).