### PR TITLE
fix(openai): change OpenAILike.api_key default from 'not-provided' to None

### DIFF
--- a/libs/agno/agno/models/openai/like.py
+++ b/libs/agno/agno/models/openai/like.py
@@ -12,12 +12,12 @@ class OpenAILike(OpenAIChat):
     Args:
         id (str): The id of the OpenAI model to use. Defaults to "not-provided".
         name (str): The name of the OpenAI model to use. Defaults to "OpenAILike".
-        api_key (Optional[str]): The API key to use. Defaults to "not-provided".
+        api_key (Optional[str]): The API key to use. If not provided, reads from OPENAI_API_KEY env var.
     """
 
     id: str = "not-provided"
     name: str = "OpenAILike"
-    api_key: Optional[str] = "not-provided"
+    api_key: Optional[str] = None
 
     default_role_map = {
         "system": "system",


### PR DESCRIPTION
## Summary

Fixes #5397

`OpenAILike.api_key` defaulted to the string `"not-provided"`, which is truthy. The parent class `OpenAIChat.__post_init__()` checks `if not self.api_key:` to decide whether to read the `OPENAI_API_KEY` environment variable. Because `"not-provided"` is truthy, the env var was never read when subclassing `OpenAILike` without explicitly passing `api_key`.

### Change

- `api_key: Optional[str] = "not-provided"` → `api_key: Optional[str] = None`
- Updated docstring to reflect env var fallback behavior

This ensures that when `api_key` is not explicitly provided, the parent class correctly falls back to reading `OPENAI_API_KEY` from the environment.

## Test plan

- [ ] Create an `OpenAILike` subclass without passing `api_key`, set `OPENAI_API_KEY` env var, verify the key is read
- [ ] Create an `OpenAILike` subclass with explicit `api_key`, verify the provided key is used
- [ ] Verify no regression for direct `OpenAILike` usage with explicit parameters
