### PR TITLE
fix(tools): strip internal fields from tool schema sent to LLM APIs

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -144,9 +144,16 @@ class Function(BaseModel):
     _files: Optional[Sequence[File]] = None
 
     def to_dict(self) -> Dict[str, Any]:
+        """Serialize the function definition for LLM API calls.
+
+        Only includes fields that are part of the standard function calling
+        schema.  Internal execution flags (requires_confirmation,
+        external_execution, etc.) are intentionally excluded because strict
+        providers like Mistral reject unknown fields with 400 Bad Request.
+        """
         return self.model_dump(
             exclude_none=True,
-            include={"name", "description", "parameters", "strict", "requires_confirmation", "external_execution"},
+            include={"name", "description", "parameters", "strict"},
         )
 
     @classmethod


### PR DESCRIPTION
## Summary

Fixes #5521

`Function.to_dict()` included `requires_confirmation` and `external_execution` in the serialized output sent to LLM APIs. While OpenAI's API silently ignores unknown fields, strict providers like **Mistral** reject them with `400 Bad Request` (`extra_forbidden`).

These are internal execution flags used by agno's HITL and external execution flows — they are **not** part of the OpenAI function calling schema and should never be sent to any LLM provider.

### Root cause

```python
# Before
def to_dict(self) -> Dict[str, Any]:
    return self.model_dump(
        exclude_none=True,
        include={"name", "description", "parameters", "strict", "requires_confirmation", "external_execution"},
    )
```

### Fix

Remove `requires_confirmation` and `external_execution` from the `include` set so that only standard schema fields (`name`, `description`, `parameters`, `strict`) are serialized for API calls.

Note: `from_dict()` still accepts these fields (with defaults) for internal deserialization, so no round-trip functionality is lost.

## Test plan

- [ ] Verify that tool calls work with Mistral models (via LiteLLM proxy or direct)
- [ ] Verify that OpenAI tool calls continue to work
- [ ] Verify that HITL flow (`requires_confirmation=True`) still works (the flag is still on the `Function` object, just not serialized to the API)
- [ ] Verify that external execution flow still works
