### PR TITLE
fix: user input propogation team hitl

### DIFF
--- a/libs/agno/agno/run/requirement.py
+++ b/libs/agno/agno/run/requirement.py
@@ -109,6 +109,11 @@ class RunRequirement:
             for input_field in self.user_input_schema:
                 if input_field.name in values:
                     input_field.value = values[input_field.name]
+            # Also update tool_execution's user_input_schema so handle_user_input_update can copy to tool_args
+            if self.tool_execution and self.tool_execution.user_input_schema:
+                for tool_input_field in self.tool_execution.user_input_schema:
+                    if tool_input_field.name in values:
+                        tool_input_field.value = values[tool_input_field.name]
             # Only mark as answered when all fields have values
             if all(f.value is not None for f in self.user_input_schema) and self.tool_execution:
                 self.tool_execution.answered = True


### PR DESCRIPTION
## Summary

- Fix `provide_user_input` to also update `tool_execution.user_input_schema`  so values are properly copied to `tool_args` when the tool executes: This is needed because `_propagate_member_pause` deepcopies both schemas separately, causing them to diverge.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
