### PR TITLE
fix: add foreign key constraint to schedule_runs.schedule_id

### DIFF
--- a/libs/agno/agno/db/postgres/schemas.py
+++ b/libs/agno/agno/db/postgres/schemas.py
@@ -247,7 +247,7 @@ SCHEDULE_TABLE_SCHEMA = {
 
 SCHEDULE_RUNS_TABLE_SCHEMA = {
     "id": {"type": String, "primary_key": True, "nullable": False},
-    "schedule_id": {"type": String, "nullable": False, "index": True},
+    "schedule_id": {"type": String, "nullable": False, "index": True, "foreign_key": "schedules.id"},
     "attempt": {"type": BigInteger, "nullable": False},
     "triggered_at": {"type": BigInteger, "nullable": True},
     "completed_at": {"type": BigInteger, "nullable": True},

--- a/libs/agno/agno/db/sqlite/schemas.py
+++ b/libs/agno/agno/db/sqlite/schemas.py
@@ -238,7 +238,7 @@ SCHEDULE_TABLE_SCHEMA = {
 
 SCHEDULE_RUNS_TABLE_SCHEMA = {
     "id": {"type": String, "primary_key": True, "nullable": False},
-    "schedule_id": {"type": String, "nullable": False, "index": True},
+    "schedule_id": {"type": String, "nullable": False, "index": True, "foreign_key": "schedules.id"},
     "attempt": {"type": BigInteger, "nullable": False},
     "triggered_at": {"type": BigInteger, "nullable": True},
     "completed_at": {"type": BigInteger, "nullable": True},


### PR DESCRIPTION
## Summary

Adds foreign key constraint from `schedule_runs.schedule_id` to `schedules.id` to prevent orphaned schedule run records when schedules are deleted.

## Changes

- Updated `libs/agno/agno/db/postgres/schemas.py`: Added FK constraint to `schedule_id` field
- Updated `libs/agno/agno/db/sqlite/schemas.py`: Added FK constraint to `schedule_id` field

## Why

Currently, if a schedule is deleted, the associated schedule_runs records remain in the database. This FK constraint enforces referential integrity at the database level.

## Related

Addresses blocking issue identified in PR #6431 review.