### PR TITLE
fix: add stub classes for JWT imports when PyJWT is not installed

### DIFF
--- a/cookbook/04_workflows/_06_advanced_concepts/_04_shared_session_state/condition_with_session_state_in_evaluator_function.py
+++ b/cookbook/04_workflows/_06_advanced_concepts/_04_shared_session_state/condition_with_session_state_in_evaluator_function.py
@@ -70,8 +70,8 @@ workflow = Workflow(
             name="Check If New User",
             description="Check if this is a new user who needs greeting",
             # Condition returns True if user has context, so we negate it
-            evaluator=lambda step_input, session_state: not check_user_has_context(
-                step_input, session_state
+            evaluator=lambda step_input, session_state: (
+                not check_user_has_context(step_input, session_state)
             ),
             steps=[
                 # Only execute these steps for new users

--- a/libs/agno/agno/db/dynamo/dynamo.py
+++ b/libs/agno/agno/db/dynamo/dynamo.py
@@ -948,7 +948,7 @@ class DynamoDb(BaseDb):
             # Convert to list and apply sorting
             stats_list = list(user_stats.values())
             stats_list.sort(
-                key=lambda x: (x["last_memory_updated_at"] if x["last_memory_updated_at"] is not None else 0),
+                key=lambda x: x["last_memory_updated_at"] if x["last_memory_updated_at"] is not None else 0,
                 reverse=True,
             )
 

--- a/libs/agno/agno/os/middleware/__init__.py
+++ b/libs/agno/agno/os/middleware/__init__.py
@@ -1,7 +1,23 @@
-from agno.os.middleware.jwt import (
-    JWTMiddleware,
-    TokenSource,
-)
+try:
+    from agno.os.middleware.jwt import (
+        JWTMiddleware,
+        TokenSource,
+    )
+except ImportError:
+
+    class JWTMiddleware:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "PyJWT is not installed. Please install using `pip install 'agno[os]'` or `pip install PyJWT`"
+            )
+
+    class TokenSource:  # type: ignore
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "PyJWT is not installed. Please install using `pip install 'agno[os]'` or `pip install PyJWT`"
+            )
+
+
 from agno.os.middleware.trailing_slash import TrailingSlashMiddleware
 
 __all__ = [


### PR DESCRIPTION
## Summary

When `PyJWT` is not installed, importing from `agno.os.middleware` would silently swallow the `ImportError`, causing a confusing `NameError` later when users try to use `JWTMiddleware` or `TokenSource`.

This follows the existing pattern from `libs/agno/agno/models/litellm/__init__.py` by creating stub classes that raise a clear, actionable `ImportError` with installation instructions when instantiated.

Related: #6467

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

The same pattern is used in `libs/agno/agno/models/litellm/__init__.py` for optional `openai` dependency handling. This PR also includes minor auto-formatting fixes from `ruff` in two other files.