### PR TITLE
fix: resolve hook metadata, guardrail bypass, async redirect, and PII bugs

### DIFF
--- a/libs/agno/agno/guardrails/pii.py
+++ b/libs/agno/agno/guardrails/pii.py
@@ -38,7 +38,7 @@ class PIIDetectionGuardrail(BaseGuardrail):
         if enable_credit_card_check:
             self.pii_patterns["Credit Card"] = re.compile(r"\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b")
         if enable_email_check:
-            self.pii_patterns["Email"] = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b")
+            self.pii_patterns["Email"] = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
         if enable_phone_check:
             self.pii_patterns["Phone"] = re.compile(r"\b\d{3}[\s.-]?\d{3}[\s.-]?\d{4}\b")
 
@@ -53,7 +53,7 @@ class PIIDetectionGuardrail(BaseGuardrail):
             if pattern.search(content):
                 detected_pii.append(pii_type)
         if detected_pii:
-            if self.mask_pii:
+            if self.mask_pii and isinstance(run_input.input_content, str):
                 for pii_type in detected_pii:
 
                     def mask_match(match):
@@ -77,7 +77,7 @@ class PIIDetectionGuardrail(BaseGuardrail):
             if pattern.search(content):
                 detected_pii.append(pii_type)
         if detected_pii:
-            if self.mask_pii:
+            if self.mask_pii and isinstance(run_input.input_content, str):
                 for pii_type in detected_pii:
 
                     def mask_match(match):

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -1540,7 +1540,7 @@ class Knowledge(RemoteKnowledge):
 
         bytes_content = None
         if file_extension:
-            async with AsyncClient() as client:
+            async with AsyncClient(follow_redirects=True) as client:
                 response = await async_fetch_with_retry(content.url, client=client)
             bytes_content = BytesIO(response.content)
 

--- a/libs/agno/tests/unit/agent/test_hooks.py
+++ b/libs/agno/tests/unit/agent/test_hooks.py
@@ -1,0 +1,289 @@
+"""Tests for agent hook execution — metadata injection and guardrail background safety."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agno.agent._hooks import _is_guardrail_hook, execute_post_hooks, execute_pre_hooks
+from agno.exceptions import InputCheckError
+from agno.guardrails.pii import PIIDetectionGuardrail
+from agno.run import RunContext
+from agno.run.agent import RunInput, RunOutput
+from agno.session import AgentSession
+
+
+def _make_agent(**overrides):
+    agent = MagicMock()
+    agent.debug_mode = False
+    agent._run_hooks_in_background = False
+    agent.events_to_skip = set()
+    agent.store_events = False
+    for k, v in overrides.items():
+        setattr(agent, k, v)
+    return agent
+
+
+def _make_run_context(metadata=None):
+    ctx = MagicMock(spec=RunContext)
+    ctx.metadata = metadata
+    return ctx
+
+
+def _make_run_input(content="hello"):
+    ri = MagicMock(spec=RunInput)
+    ri.input_content = content
+    ri.input_content_string.return_value = content
+    return ri
+
+
+def _make_run_output():
+    return MagicMock(spec=RunOutput)
+
+
+# --- P-H1: metadata in all_args ---
+
+
+def test_pre_hook_receives_metadata():
+    """Pre-hooks should receive metadata from run_context."""
+    received = {}
+
+    def my_hook(run_input, metadata):
+        received["metadata"] = metadata
+
+    agent = _make_agent()
+    run_input = _make_run_input()
+    run_context = _make_run_context(metadata={"email": "test@example.com"})
+    session = MagicMock(spec=AgentSession)
+    run_response = _make_run_output()
+    run_response.input = run_input
+
+    list(
+        execute_pre_hooks(
+            agent,
+            hooks=[my_hook],
+            run_response=run_response,
+            run_input=run_input,
+            session=session,
+            run_context=run_context,
+        )
+    )
+
+    assert received["metadata"] == {"email": "test@example.com"}
+
+
+def test_post_hook_receives_metadata():
+    """Post-hooks should receive metadata from run_context."""
+    received = {}
+
+    def my_hook(run_output, metadata):
+        received["metadata"] = metadata
+
+    agent = _make_agent()
+    run_context = _make_run_context(metadata={"key": "value"})
+    session = MagicMock(spec=AgentSession)
+    run_output = _make_run_output()
+
+    list(
+        execute_post_hooks(
+            agent,
+            hooks=[my_hook],
+            run_output=run_output,
+            session=session,
+            run_context=run_context,
+        )
+    )
+
+    assert received["metadata"] == {"key": "value"}
+
+
+def test_hook_metadata_none_when_no_run_context():
+    """Metadata should be None when run_context is None."""
+    received = {}
+
+    def my_hook(run_input, metadata):
+        received["metadata"] = metadata
+
+    agent = _make_agent()
+    run_input = _make_run_input()
+    session = MagicMock(spec=AgentSession)
+    run_response = _make_run_output()
+    run_response.input = run_input
+
+    list(
+        execute_pre_hooks(
+            agent,
+            hooks=[my_hook],
+            run_response=run_response,
+            run_input=run_input,
+            session=session,
+            run_context=None,
+        )
+    )
+
+    assert received["metadata"] is None
+
+
+# --- P-H2: guardrail detection ---
+
+
+def test_is_guardrail_hook_detects_bound_method():
+    """_is_guardrail_hook should detect bound methods from BaseGuardrail instances."""
+    guardrail = PIIDetectionGuardrail()
+    assert _is_guardrail_hook(guardrail.check) is True
+    assert _is_guardrail_hook(guardrail.async_check) is True
+
+
+def test_is_guardrail_hook_rejects_plain_functions():
+    """_is_guardrail_hook should return False for plain functions."""
+
+    def plain_hook(run_input):
+        pass
+
+    assert _is_guardrail_hook(plain_hook) is False
+
+
+def test_guardrail_not_backgrounded_when_run_hooks_in_background():
+    """Guardrails should run inline even when _run_hooks_in_background=True."""
+    guardrail = PIIDetectionGuardrail()
+
+    agent = _make_agent(_run_hooks_in_background=True)
+    run_input = _make_run_input("My SSN is 123-45-6789")
+    run_context = _make_run_context()
+    session = MagicMock(spec=AgentSession)
+    run_response = _make_run_output()
+    run_response.input = run_input
+    background_tasks = MagicMock()
+
+    with pytest.raises(InputCheckError):
+        list(
+            execute_pre_hooks(
+                agent,
+                hooks=[guardrail.check],
+                run_response=run_response,
+                run_input=run_input,
+                session=session,
+                run_context=run_context,
+                background_tasks=background_tasks,
+            )
+        )
+
+    # Guardrail should NOT have been added to background tasks
+    background_tasks.add_task.assert_not_called()
+
+
+def test_non_guardrail_hooks_still_backgrounded():
+    """Regular hooks should still be backgrounded when _run_hooks_in_background=True."""
+
+    def my_hook(run_input):
+        pass
+
+    agent = _make_agent(_run_hooks_in_background=True)
+    run_input = _make_run_input()
+    run_context = _make_run_context()
+    session = MagicMock(spec=AgentSession)
+    run_response = _make_run_output()
+    run_response.input = run_input
+    background_tasks = MagicMock()
+
+    list(
+        execute_pre_hooks(
+            agent,
+            hooks=[my_hook],
+            run_response=run_response,
+            run_input=run_input,
+            session=session,
+            run_context=run_context,
+            background_tasks=background_tasks,
+        )
+    )
+
+    background_tasks.add_task.assert_called_once()
+
+
+# --- P-H4: email regex ---
+
+
+def test_pii_email_regex_no_pipe():
+    """Email regex should not match pipe character as valid TLD character."""
+    guardrail = PIIDetectionGuardrail(
+        enable_ssn_check=False,
+        enable_credit_card_check=False,
+        enable_phone_check=False,
+    )
+    pattern = guardrail.pii_patterns["Email"]
+    assert pattern.search("user@example.com") is not None
+    # Pipe should NOT be matched as a valid TLD character
+    assert pattern.search("user@example.c|m") is None
+
+
+# --- P-H3: PII mask type coercion ---
+
+
+def test_pii_mask_preserves_string_type():
+    """Masking should work for string input_content."""
+    guardrail = PIIDetectionGuardrail(
+        mask_pii=True,
+        enable_ssn_check=True,
+        enable_credit_card_check=False,
+        enable_email_check=False,
+        enable_phone_check=False,
+    )
+    run_input = RunInput(input_content="My SSN is 123-45-6789")
+    guardrail.check(run_input)
+    assert isinstance(run_input.input_content, str)
+    assert "123-45-6789" not in run_input.input_content
+
+
+def test_pii_mask_raises_for_non_string_input():
+    """Masking should raise InputCheckError for non-string input to avoid type coercion."""
+    guardrail = PIIDetectionGuardrail(
+        mask_pii=True,
+        enable_ssn_check=True,
+        enable_credit_card_check=False,
+        enable_email_check=False,
+        enable_phone_check=False,
+    )
+    run_input = RunInput(input_content=["My SSN is 123-45-6789"])
+    with pytest.raises(InputCheckError):
+        guardrail.check(run_input)
+
+
+# --- Codex-suggested edge cases ---
+
+
+def test_kwargs_hook_receives_metadata():
+    """Hooks with **kwargs should receive metadata without breaking."""
+    received = {}
+
+    def my_hook(run_input, **kwargs):
+        received.update(kwargs)
+
+    agent = _make_agent()
+    run_input = _make_run_input()
+    run_context = _make_run_context(metadata={"key": "val"})
+    session = MagicMock(spec=AgentSession)
+    run_response = _make_run_output()
+    run_response.input = run_input
+
+    list(
+        execute_pre_hooks(
+            agent,
+            hooks=[my_hook],
+            run_response=run_response,
+            run_input=run_input,
+            session=session,
+            run_context=run_context,
+        )
+    )
+
+    assert "metadata" in received
+    assert received["metadata"] == {"key": "val"}
+
+
+def test_partial_wrapped_guardrail_detected():
+    """Guardrails wrapped in functools.partial should still be detected."""
+    from functools import partial
+
+    guardrail = PIIDetectionGuardrail()
+    wrapped = partial(guardrail.check)
+    assert _is_guardrail_hook(wrapped) is True


### PR DESCRIPTION
## Summary

Fixes 5 pre-existing bugs discovered during the v2.5 code review audit. These bugs exist on `main` today and affect hook metadata delivery, guardrail safety, async knowledge loading, and PII detection.

All fixes were validated with a dual-model review (Opus 4.6 + Codex 5.2/5.3).

---

### Bug 1 — P-H1 (HIGH): Hook metadata not available to hook functions

**Problem:** When a user passes `metadata={"user_id": "..."}` to `agent.run()`, hook functions that declare a `metadata` parameter never receive it. The value is silently dropped.

**Root cause:** `run_dispatch()` stores metadata in `run_context.metadata`, but the hook execution functions (`execute_pre_hooks`, `execute_post_hooks`, and their async variants) never extract it into `all_args`. Since `filter_hook_args` introspects hook parameter names against `all_args` keys, `metadata` is simply absent.

**Fix:** Added `"metadata": run_context.metadata if run_context else None` to `all_args` in all 4 hook execution functions.

**Data flow:**
```
agent.run(metadata={...})
  → run_dispatch() stores in run_context.metadata
    → execute_pre_hooks() builds all_args
      → all_args["metadata"] = run_context.metadata   ← NEW
        → filter_hook_args() matches "metadata" param
          → hook(metadata={...})                       ← now works
```

---

### Bug 2 — P-H2 (HIGH): Background hooks silently bypass guardrails

**Problem:** When `_run_hooks_in_background=True` (set by AgentOS/FastAPI), ALL hooks — including guardrails — are scheduled as fire-and-forget background tasks via `BackgroundTasks.add_task()`. Guardrail exceptions (`InputCheckError`, `OutputCheckError`) are never caught by the request handler, so PII checks and injection guards are silently skipped.

**Root cause:** The background scheduling code treats all hooks uniformly without distinguishing guardrails from regular hooks.

**Fix:** Added `_is_guardrail_hook()` helper that detects bound methods from `BaseGuardrail` instances (with `functools.partial` unwrapping). Guardrails are now always executed inline, even when the background flag is set. Applied to all 8 scheduling paths (4 functions x 2 paths: "all hooks background" + "per-hook decorator").

**Why `__self__` detection works:** `normalize_pre_hooks()` converts `BaseGuardrail` instances to their `.check`/`.async_check` bound methods before they reach the execution functions. Bound methods retain `__self__` pointing to the guardrail instance.

---

### Bug 3 — BUG-01 (HIGH): Async knowledge loading fails on redirects

**Problem:** URL-based async knowledge loading fails silently on any HTTP redirect (301, 302, 307). The sync code path already passes `follow_redirects=True` to `httpx.Client`, but the async path does not.

**Fix:** Added `follow_redirects=True` to `AsyncClient()` constructor at `knowledge.py:1543`.

---

### Bug 4 — P-H4 (LOW): Email regex matches pipe as valid TLD character

**Problem:** The PII email detection regex used `[A-Z|a-z]` for the TLD portion, which includes the literal pipe character `|` as a valid character. This means `user@example.c|m` would incorrectly match as a valid email.

**Fix:** Changed to `[A-Za-z]` (standard character class without pipe).

---

### Bug 5 — P-H3 (MED): PII masking silently coerces non-string input

**Problem:** When `mask_pii=True` and `input_content` is a `list` or `dict`, the guardrail calls `str(input_content)` to detect PII, finds matches, then writes the masked string back to `input_content` — silently converting the original type to a string. Downstream code expecting a list/dict breaks.

**Fix:** Added `isinstance(run_input.input_content, str)` check to both `check()` and `async_check()`. Non-string inputs with PII now raise `InputCheckError` instead of being silently coerced.

---

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

### Test coverage

12 new unit tests in `libs/agno/tests/unit/agent/test_hooks.py`:

| Bug | Tests | What's verified |
|-----|-------|----------------|
| P-H1 | 3 | Pre-hook receives metadata, post-hook receives metadata, `None` when no `run_context` |
| P-H2 | 4 | Guardrail detected via `_is_guardrail_hook`, plain functions rejected, guardrail runs inline with background flag, non-guardrail hooks still backgrounded |
| P-H4 | 1 | Pipe character rejected in email TLD |
| P-H3 | 2 | String input masked correctly, non-string input raises `InputCheckError` |
| Edge cases | 2 | `**kwargs` hooks receive metadata, `functools.partial`-wrapped guardrails detected |

### Dual-model review summary

- **Codex 5.2 (architecture):** Confirmed correctness. Noted that `bg_args` snapshot ordering is acceptable (guardrails use `all_args`, not `bg_args`). Decorator-wrapped guardrail detection edge case is not currently reachable via `normalize_pre_hooks` pipeline.
- **Codex 5.3 (security):** No new attack vectors introduced. `__self__` spoofing requires developer-level access to hook registration. `follow_redirects` SSRF risk is pre-existing from the sync path.

### Files changed

| File | Delta | Changes |
|------|-------|---------|
| `libs/agno/agno/agent/_hooks.py` | +56/-4 | P-H1: metadata in `all_args`; P-H2: `_is_guardrail_hook()` + inline guardrail execution |
| `libs/agno/agno/guardrails/pii.py` | +3/-3 | P-H4: email regex; P-H3: type check before masking |
| `libs/agno/agno/knowledge/knowledge.py` | +1/-1 | BUG-01: `follow_redirects=True` on `AsyncClient` |
| `libs/agno/tests/unit/agent/test_hooks.py` | +289 (new) | 12 unit tests covering all fixes |