### PR TITLE
fix: thread-safe executor init + async telemetry uses create_task

### DIFF
--- a/libs/agno/agno/agent/_telemetry.py
+++ b/libs/agno/agno/agent/_telemetry.py
@@ -66,8 +66,8 @@ async def alog_agent_telemetry(agent: Agent, session_id: str, run_id: Optional[s
     if not agent.telemetry:
         return
 
-    from agno.api._executor import get_telemetry_executor
-    from agno.api.agent import AgentRunCreate, create_agent_run
+    from agno.api._executor import fire_and_forget_async
+    from agno.api.agent import AgentRunCreate, acreate_agent_run
 
     try:
         run = AgentRunCreate(
@@ -75,6 +75,6 @@ async def alog_agent_telemetry(agent: Agent, session_id: str, run_id: Optional[s
             run_id=run_id,
             data=get_telemetry_data(agent),
         )
-        get_telemetry_executor().submit(create_agent_run, run)
+        fire_and_forget_async(acreate_agent_run(run))
     except Exception as e:
         log_debug(f"Could not submit Agent run telemetry event: {e}")

--- a/libs/agno/agno/api/_executor.py
+++ b/libs/agno/agno/api/_executor.py
@@ -2,26 +2,60 @@
 
 from __future__ import annotations
 
+import asyncio
 import atexit
+import threading
 from concurrent.futures import ThreadPoolExecutor
-from typing import Optional
+from typing import Any, Coroutine, Optional
+
+from agno.utils.log import log_debug
 
 _telemetry_executor: Optional[ThreadPoolExecutor] = None
+_executor_lock = threading.Lock()
 
 
 def get_telemetry_executor() -> ThreadPoolExecutor:
     """Lazy-initialize a module-level daemon thread pool for telemetry.
 
     Uses max_workers=2 since telemetry is low-volume (one event per run).
+    Thread-safe via double-checked locking.
     """
     global _telemetry_executor
     if _telemetry_executor is None:
-        _telemetry_executor = ThreadPoolExecutor(
-            max_workers=2,
-            thread_name_prefix="agno-telemetry",
-        )
-        atexit.register(_shutdown_telemetry_executor)
+        with _executor_lock:
+            if _telemetry_executor is None:
+                _telemetry_executor = ThreadPoolExecutor(
+                    max_workers=2,
+                    thread_name_prefix="agno-telemetry",
+                )
+                atexit.register(_shutdown_telemetry_executor)
     return _telemetry_executor
+
+
+def fire_and_forget_async(coro: Coroutine[Any, Any, Any]) -> None:
+    """Schedule a coroutine as a fire-and-forget task on the running event loop.
+
+    Falls back to the thread pool executor if no event loop is running.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+        task = loop.create_task(coro)
+        task.add_done_callback(_log_task_exception)
+    except RuntimeError:
+        # No running event loop — fall back to thread pool.
+        # This shouldn't happen in normal async flows but guards against edge cases.
+        get_telemetry_executor().submit(_run_coro_sync, coro)
+
+
+def _log_task_exception(task: asyncio.Task[Any]) -> None:
+    """Log exceptions from fire-and-forget tasks instead of silently dropping them."""
+    if not task.cancelled() and task.exception() is not None:
+        log_debug(f"Telemetry task failed: {task.exception()}")
+
+
+def _run_coro_sync(coro: Coroutine[Any, Any, Any]) -> None:
+    """Run a coroutine synchronously — used as fallback when no event loop is available."""
+    asyncio.run(coro)
 
 
 def _shutdown_telemetry_executor() -> None:

--- a/libs/agno/agno/team/_telemetry.py
+++ b/libs/agno/agno/team/_telemetry.py
@@ -66,11 +66,11 @@ async def alog_team_telemetry(team: "Team", session_id: str, run_id: Optional[st
     if not team.telemetry:
         return
 
-    from agno.api._executor import get_telemetry_executor
-    from agno.api.team import TeamRunCreate, create_team_run
+    from agno.api._executor import fire_and_forget_async
+    from agno.api.team import TeamRunCreate, acreate_team_run
 
     try:
         run = TeamRunCreate(session_id=session_id, run_id=run_id, data=get_telemetry_data(team))
-        get_telemetry_executor().submit(create_team_run, run)
+        fire_and_forget_async(acreate_team_run(run))
     except Exception as e:
         log_debug(f"Could not submit Team run telemetry event: {e}")

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -4684,12 +4684,12 @@ class Workflow:
         if not self.telemetry:
             return
 
-        from agno.api._executor import get_telemetry_executor
-        from agno.api.workflow import WorkflowRunCreate, create_workflow_run
+        from agno.api._executor import fire_and_forget_async
+        from agno.api.workflow import WorkflowRunCreate, acreate_workflow_run
 
         try:
             workflow = WorkflowRunCreate(session_id=session_id, run_id=run_id, data=self._get_telemetry_data())
-            get_telemetry_executor().submit(create_workflow_run, workflow)
+            fire_and_forget_async(acreate_workflow_run(workflow))
         except Exception as e:
             log_debug(f"Could not submit Workflow run telemetry event: {e}")
 


### PR DESCRIPTION
## Summary

Improvements on top of #6458 to fix a threading bug and eliminate unnecessary thread overhead in async paths.

- **Thread-safe executor init**: Added `threading.Lock` with double-checked locking to `get_telemetry_executor()`. Without this, concurrent callers could race past the `is None` check and create duplicate `ThreadPoolExecutor` instances, leaking threads and registering dangling `atexit` handlers.
- **Async telemetry uses `asyncio.create_task`**: Async telemetry functions (`alog_agent_telemetry`, `alog_team_telemetry`, `_alog_workflow_telemetry`) now schedule the async HTTP coroutine directly on the running event loop instead of submitting sync HTTP to the thread pool. This is zero-overhead — no thread creation or scheduling — and is the natural pattern for fire-and-forget work in async contexts.
- **Graceful fallback**: `fire_and_forget_async()` falls back to the thread pool if somehow called without a running event loop, and logs exceptions via a done-callback instead of silently dropping them.

## Type of change

- [x] Bug fix (thread-safety race condition)
- [x] Improvement (async path optimization)

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)

---

## Additional Notes

Stacks on top of #6458. Only 4 files changed, 49 insertions, 15 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)