### PR TITLE
[fix] scheduler pagination - use page instead of offset

### DIFF
--- a/libs/agno/agno/os/routers/schedules/schema.py
+++ b/libs/agno/agno/os/routers/schedules/schema.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
-_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9 ._-]*$")
 
 
 class ScheduleCreate(BaseModel):
@@ -24,7 +24,7 @@ class ScheduleCreate(BaseModel):
     @classmethod
     def validate_name(cls, v: str) -> str:
         if not _NAME_PATTERN.match(v):
-            raise ValueError("Name must start with alphanumeric and contain only alphanumeric, '.', '_', '-'")
+            raise ValueError("Name must start with alphanumeric and contain only alphanumeric, spaces, '.', '_', '-'")
         return v
 
     @field_validator("method")
@@ -61,7 +61,7 @@ class ScheduleUpdate(BaseModel):
     @classmethod
     def validate_name(cls, v: Optional[str]) -> Optional[str]:
         if v is not None and not _NAME_PATTERN.match(v):
-            raise ValueError("Name must start with alphanumeric and contain only alphanumeric, '.', '_', '-'")
+            raise ValueError("Name must start with alphanumeric and contain only alphanumeric, spaces, '.', '_', '-'")
         return v
 
     @field_validator("method")


### PR DESCRIPTION
## Summary

Updates scheduler pagination to match the standard pattern used in other AgentOS APIs:
- Changed from `offset` to `page` parameter
- Return `PaginatedResponse` with `meta` containing `page`, `limit`, `total_pages`, `total_count`
- Consistent with `/sessions`, `/memories`, `/traces`, and other paginated endpoints

## Changes

### API Changes
- **GET /schedules**: Now returns `{data: [...], meta: {...}}` instead of `[...]`
- **GET /schedules/{schedule_id}/runs**: Now returns `{data: [...], meta: {...}}` instead of `[...]`
- Query parameter changed from `offset` to `page` (1-indexed)

### Database Changes
Updated all database implementations (SQLite sync/async, Postgres sync/async):
- `get_schedules(page=1)`: Returns `(schedules, total_count)` tuple
- `get_schedule_runs(page=1)`: Returns `(runs, total_count)` tuple
- Added COUNT queries to get total counts
- Calculate offset internally as `(page - 1) * limit`

### Files Changed
- `agno/os/routers/schedules/router.py` - Router endpoints
- `agno/db/base.py` - Base interface
- `agno/db/sqlite/sqlite.py` - SQLite sync implementation
- `agno/db/sqlite/async_sqlite.py` - SQLite async implementation
- `agno/db/postgres/postgres.py` - Postgres sync implementation
- `agno/db/postgres/async_postgres.py` - Postgres async implementation
- `cookbook/05_agent_os/scheduler/rest_api_schedules.py` - Updated example

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

This makes scheduler pagination consistent with all other paginated APIs in AgentOS. The change improves the API by:
1. Making page-based pagination more intuitive than offset-based
2. Providing pagination metadata (total_pages, total_count) for building UIs
3. Following established patterns across the codebase

Tested with all 10 scheduler cookbooks - all passing.