### PR TITLE
fix: correct priority of requires_user_input in RunRequirement

### DIFF
--- a/libs/agno/agno/run/requirement.py
+++ b/libs/agno/agno/run/requirement.py
@@ -65,12 +65,12 @@ class RunRequirement:
             return False
         if self.tool_execution.answered is True:
             return False
-        if self.user_input_schema:
-            if not all(field.value is not None for field in self.user_input_schema):
-                return True
-            return False
+        if self.tool_execution.requires_user_input:
+            return True
+        if self.user_input_schema and not all(field.value is not None for field in self.user_input_schema):
+            return True
 
-        return self.tool_execution.requires_user_input or False
+        return False
 
     @property
     def needs_external_execution(self) -> bool:


### PR DESCRIPTION
## Summary

Fixes the priority ordering in `RunRequirement.needs_user_input` property. The old logic checked `user_input_schema` first and short-circuited, meaning `requires_user_input` was never evaluated when a schema was present. This reorders the checks so `requires_user_input` is evaluated first (after the existing `answered` guard), then falls back to checking unfilled schema fields.

Also flattens nested conditionals for clarity.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

The `provide_user_input()` method already sets `tool_execution.answered = True` when all schema fields are filled, so the early-exit guard (`answered is True → False`) prevents `requires_user_input` from incorrectly returning `True` after input has been provided.