### PR TITLE
fix: resolve ruff lint errors

### DIFF
--- a/cookbook/01_demo/agents/dash/__init__.py
+++ b/cookbook/01_demo/agents/dash/__init__.py
@@ -1,3 +1,6 @@
 """Dash - A self-learning data agent with 6 layers of context."""
 
-from .agent import dash, dash_knowledge, dash_learnings, reasoning_dash
+from .agent import dash as dash
+from .agent import dash_knowledge as dash_knowledge
+from .agent import dash_learnings as dash_learnings
+from .agent import reasoning_dash as reasoning_dash

--- a/cookbook/91_tools/other/human_in_the_loop.py
+++ b/cookbook/91_tools/other/human_in_the_loop.py
@@ -24,7 +24,6 @@ from agno.exceptions import StopAgentRun
 from agno.models.openai import OpenAIChat
 from agno.tools import FunctionCall, tool
 from rich.console import Console
-from rich.prompt import Prompt
 
 # ---------------------------------------------------------------------------
 # Create Agent

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -23,13 +23,6 @@ from uuid import uuid4
 
 from pydantic import BaseModel
 
-if TYPE_CHECKING:
-    from agno.agent.agent import Agent
-
-# Strong references to background tasks so they aren't garbage-collected mid-execution.
-# See: https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
-_background_tasks: set[asyncio.Task[None]] = set()
-
 from agno.agent._init import _initialize_session_state
 from agno.agent._run_options import resolve_run_options
 from agno.agent._session import initialize_session, update_session_metrics
@@ -108,6 +101,13 @@ from agno.utils.log import (
     log_warning,
 )
 from agno.utils.response import get_paused_content
+
+if TYPE_CHECKING:
+    from agno.agent.agent import Agent
+
+# Strong references to background tasks so they aren't garbage-collected mid-execution.
+# See: https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
+_background_tasks: set[asyncio.Task[None]] = set()
 
 # ---------------------------------------------------------------------------
 # Run dependency resolution

--- a/libs/agno/agno/db/migrations/manager.py
+++ b/libs/agno/agno/db/migrations/manager.py
@@ -93,7 +93,6 @@ class MigrationManager:
                     migration_executed = await self._up_migration(version, table_type, table_name)
                     latest_version = normalised_version.public
                     if migration_executed:
-                        any_migration_executed = True
                         latest_version = normalised_version.public
                         log_info(f"Successfully applied migration {normalised_version} on table {table_name}")
                     else:

--- a/libs/agno/agno/os/routers/schedules/router.py
+++ b/libs/agno/agno/os/routers/schedules/router.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import time
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, Literal, Optional
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -22,10 +22,6 @@ from uuid import uuid4
 
 from pydantic import BaseModel
 
-# Strong references to background tasks so they aren't garbage-collected mid-execution.
-# See: https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
-_background_tasks: set[asyncio.Task[None]] = set()
-
 from agno.exceptions import (
     InputCheckError,
     OutputCheckError,
@@ -91,6 +87,10 @@ from agno.utils.log import (
     log_info,
     log_warning,
 )
+
+# Strong references to background tasks so they aren't garbage-collected mid-execution.
+# See: https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
+_background_tasks: set[asyncio.Task[None]] = set()
 
 if TYPE_CHECKING:
     from agno.team.team import Team

--- a/libs/agno/tests/integration/teams/human_in_the_loop/test_team_tool_hitl.py
+++ b/libs/agno/tests/integration/teams/human_in_the_loop/test_team_tool_hitl.py
@@ -10,7 +10,6 @@ import pytest
 from agno.agent import Agent
 from agno.models.openai import OpenAIChat
 from agno.run.team import RunPausedEvent as TeamRunPausedEvent
-from agno.run.team import TeamRunOutput
 from agno.team.team import Team
 from agno.tools.decorator import tool
 

--- a/libs/agno/tests/integration/teams/human_in_the_loop/test_team_user_input_flows.py
+++ b/libs/agno/tests/integration/teams/human_in_the_loop/test_team_user_input_flows.py
@@ -10,7 +10,6 @@ import pytest
 from agno.agent import Agent
 from agno.models.openai import OpenAIChat
 from agno.run.team import RunPausedEvent as TeamRunPausedEvent
-from agno.run.team import TeamRunOutput
 from agno.team.team import Team
 from agno.tools.decorator import tool
 

--- a/libs/agno/tests/unit/knowledge/test_knowledge_isolation.py
+++ b/libs/agno/tests/unit/knowledge/test_knowledge_isolation.py
@@ -209,7 +209,7 @@ class TestLinkedToMetadata:
 
         assert "linked_to" not in result[0].meta_data
 
-    def test_prepare_documents_adds_empty_linked_to_without_name(self):
+    def test_prepare_documents_adds_empty_linked_to_without_name_isolation_enabled(self):
         """Test that linked_to is set to empty string when knowledge has no name but isolation enabled."""
         mock_db = MockVectorDb()
         knowledge = Knowledge(


### PR DESCRIPTION
## Summary

Fix 55 ruff lint errors across the codebase (50 in libs + 5 in cookbooks).

**Fixes applied:**
- **F401 (unused imports):** Use explicit re-exports in `cookbook/01_demo/agents/dash/__init__.py`, remove unused `Prompt` import in cookbook HITL example, remove unused `List` from schedules router, remove unused `TeamRunOutput` from two team HITL test files
- **E402 (import order):** Move `_background_tasks` module-level assignment after all imports in `agno/agent/_run.py` and `agno/team/_run.py`
- **F841 (unused variable):** Remove unused `any_migration_executed` assignment in migration manager
- **F811 (redefinition):** Rename duplicate test method `test_prepare_documents_adds_empty_linked_to_without_name` in knowledge isolation tests

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

All 9 changed files pass `ruff check` with zero errors after the fix.