### PR TITLE
fix: resolve scheduler property setter conflict in AgentOS

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -281,7 +281,7 @@ class AgentOS:
         self.run_hooks_in_background = run_hooks_in_background
 
         # Scheduler configuration
-        self.scheduler = scheduler
+        self._scheduler_enabled = scheduler
         self._scheduler_poll_interval = scheduler_poll_interval
         self._scheduler_base_url = scheduler_base_url
         if scheduler and not internal_service_token:
@@ -650,7 +650,7 @@ class AgentOS:
             lifespans.append(partial(db_lifespan, agent_os=self))
 
             # The scheduler lifespan (after db so tables exist)
-            if self.scheduler and self.db is not None:
+            if self._scheduler_enabled and self.db is not None:
                 lifespans.append(partial(scheduler_lifespan, agent_os=self))
 
             # The httpx client cleanup lifespan (should be last to close after other lifespans)
@@ -682,7 +682,7 @@ class AgentOS:
             lifespans.append(partial(db_lifespan, agent_os=self))  # type: ignore
 
             # The scheduler lifespan (after db so tables exist)
-            if self.scheduler and self.db is not None:
+            if self._scheduler_enabled and self.db is not None:
                 lifespans.append(partial(scheduler_lifespan, agent_os=self))
 
             # The httpx client cleanup lifespan (should be last to close after other lifespans)


### PR DESCRIPTION
## Summary

Fixed `AttributeError` in AgentOS where the `__init__` method tried to assign a boolean to `self.scheduler`, conflicting with the read-only `@property scheduler` decorator. Split the boolean enable flag into `_scheduler_enabled` and keep `@property scheduler` for lazy ScheduleManager access.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Tests verified (cookbook example runs without error)