### PR TITLE
feat: add raw content storage and content refresh

### DIFF
--- a/libs/agno/agno/knowledge/loaders/base.py
+++ b/libs/agno/agno/knowledge/loaders/base.py
@@ -156,16 +156,24 @@ class BaseLoader:
     ) -> Dict[str, Any]:
         """Merge provider metadata with user-provided metadata.
 
-        User metadata takes precedence over provider metadata.
+        Provider metadata (source_type, bucket info, etc.) is stored under the
+        reserved ``_agno`` key so that user PATCH updates cannot overwrite it.
+        User metadata is stored at the top level.
 
         Args:
             provider_metadata: Metadata from the provider (e.g., GitHub, Azure)
             user_metadata: User-provided metadata
 
         Returns:
-            Merged metadata dictionary
+            Merged metadata dictionary with provider fields under ``_agno``
         """
-        return {**provider_metadata, **(user_metadata or {})}
+        merged: Dict[str, Any] = dict(user_metadata or {})
+        # Store provider metadata under reserved _agno key
+        existing_agno = merged.get("_agno", {})
+        if not isinstance(existing_agno, dict):
+            existing_agno = {}
+        merged["_agno"] = {**existing_agno, **provider_metadata}
+        return merged
 
     def _files_to_dict_list(self, files: List[FileToProcess]) -> List[Dict[str, Any]]:
         """Convert FileToProcess objects to dict list for compatibility.

--- a/libs/agno/agno/knowledge/raw_storage.py
+++ b/libs/agno/agno/knowledge/raw_storage.py
@@ -1,0 +1,406 @@
+"""Raw content storage for Knowledge.
+
+Provides storage and retrieval of raw file contents in S3 or local filesystem.
+This enables features like content refresh (re-embedding from original files)
+and raw file access by agents.
+"""
+
+import os
+from typing import Any, Dict, List, Optional
+
+from agno.knowledge.remote_content.config import (
+    LocalStorageConfig,
+    RemoteContentConfig,
+    S3Config,
+)
+from agno.utils.log import log_error, log_info
+
+
+class RawStorage:
+    """Handles storage and retrieval of raw content files.
+
+    Supports two backends:
+    - S3: For production use (via S3Config)
+    - Local filesystem: For development/testing (via LocalStorageConfig)
+    """
+
+    def __init__(
+        self,
+        storage_config: RemoteContentConfig,
+        content_sources: Optional[List[RemoteContentConfig]] = None,
+    ):
+        self.storage_config = storage_config
+        self.content_sources = content_sources or []
+
+    # ==========================================
+    # STORE - Save raw content
+    # ==========================================
+
+    def store(self, content_id: str, filename: str, file_data: bytes) -> Dict[str, Any]:
+        """Store raw content and return storage metadata.
+
+        Args:
+            content_id: The content ID (used as folder prefix)
+            filename: Original filename
+            file_data: Raw file bytes
+
+        Returns:
+            Dict with storage metadata to merge into _agno
+        """
+        if isinstance(self.storage_config, S3Config):
+            return self._store_to_s3(content_id, filename, file_data)
+        elif isinstance(self.storage_config, LocalStorageConfig):
+            return self._store_to_local(content_id, filename, file_data)
+        else:
+            raise ValueError(f"Unsupported raw storage config type: {type(self.storage_config).__name__}")
+
+    async def astore(self, content_id: str, filename: str, file_data: bytes) -> Dict[str, Any]:
+        """Async version of store. Uses sync calls since boto3 is sync-only."""
+        return self.store(content_id, filename, file_data)
+
+    # ==========================================
+    # FETCH - Retrieve raw content
+    # ==========================================
+
+    def fetch(self, agno_metadata: Dict[str, Any]) -> bytes:
+        """Fetch raw content from storage.
+
+        Args:
+            agno_metadata: The _agno metadata dict containing storage info
+
+        Returns:
+            Raw file bytes
+        """
+        raw_storage_type = agno_metadata.get("raw_storage_type")
+        if raw_storage_type == "s3":
+            return self._fetch_from_s3(agno_metadata)
+        elif raw_storage_type == "local":
+            return self._fetch_from_local(agno_metadata)
+        else:
+            raise ValueError(f"Unknown raw storage type: {raw_storage_type}")
+
+    async def afetch(self, agno_metadata: Dict[str, Any]) -> bytes:
+        """Async version of fetch."""
+        return self.fetch(agno_metadata)
+
+    # ==========================================
+    # FETCH FROM ORIGINAL SOURCE
+    # ==========================================
+
+    def fetch_from_source(self, agno_metadata: Dict[str, Any]) -> bytes:
+        """Fetch content from the original cloud source based on _agno metadata.
+
+        Dispatches to the appropriate cloud SDK based on source_type.
+        """
+        source_type = agno_metadata.get("source_type")
+        if not source_type:
+            raise ValueError("No source_type in metadata, cannot fetch from original source")
+
+        if source_type == "s3":
+            return self._fetch_original_s3(agno_metadata)
+        elif source_type == "gcs":
+            return self._fetch_original_gcs(agno_metadata)
+        elif source_type == "sharepoint":
+            return self._fetch_original_sharepoint(agno_metadata)
+        elif source_type == "github":
+            return self._fetch_original_github(agno_metadata)
+        elif source_type == "azure_blob":
+            return self._fetch_original_azure_blob(agno_metadata)
+        else:
+            raise ValueError(f"Unsupported source type for refresh: {source_type}")
+
+    async def afetch_from_source(self, agno_metadata: Dict[str, Any]) -> bytes:
+        """Async version of fetch_from_source."""
+        return self.fetch_from_source(agno_metadata)
+
+    # ==========================================
+    # S3 RAW STORAGE
+    # ==========================================
+
+    def _store_to_s3(self, content_id: str, filename: str, file_data: bytes) -> Dict[str, Any]:
+        """Store raw content to S3."""
+        try:
+            import boto3
+        except ImportError:
+            raise ImportError("The `boto3` package is not installed. Please install it via `pip install boto3`.")
+
+        config = self.storage_config
+        if not isinstance(config, S3Config):
+            raise ValueError("Storage config is not S3Config")
+
+        # Build S3 key
+        prefix = config.prefix.rstrip("/") if config.prefix else "raw"
+        s3_key = f"{prefix}/{content_id}/{filename}"
+
+        # Build session/client
+        session_kwargs: Dict[str, Any] = {}
+        if config.region:
+            session_kwargs["region_name"] = config.region
+
+        client_kwargs: Dict[str, Any] = {}
+        if config.aws_access_key_id and config.aws_secret_access_key:
+            client_kwargs["aws_access_key_id"] = config.aws_access_key_id
+            client_kwargs["aws_secret_access_key"] = config.aws_secret_access_key
+
+        session = boto3.Session(**session_kwargs)
+        s3_client = session.client("s3", **client_kwargs)
+
+        s3_client.put_object(
+            Bucket=config.bucket_name,
+            Key=s3_key,
+            Body=file_data,
+        )
+
+        log_info(f"Stored raw content to s3://{config.bucket_name}/{s3_key}")
+
+        return {
+            "raw_storage_type": "s3",
+            "raw_storage_key": s3_key,
+            "raw_storage_bucket": config.bucket_name,
+            "raw_storage_config_id": config.id,
+        }
+
+    def _fetch_from_s3(self, agno_metadata: Dict[str, Any]) -> bytes:
+        """Fetch raw content from S3."""
+        try:
+            import boto3
+        except ImportError:
+            raise ImportError("The `boto3` package is not installed. Please install it via `pip install boto3`.")
+
+        bucket = agno_metadata.get("raw_storage_bucket")
+        key = agno_metadata.get("raw_storage_key")
+        config_id = agno_metadata.get("raw_storage_config_id")
+
+        if not bucket or not key:
+            raise ValueError("Missing raw_storage_bucket or raw_storage_key in metadata")
+
+        # Try to use the config for credentials
+        config = self._resolve_config(config_id)
+
+        session_kwargs: Dict[str, Any] = {}
+        client_kwargs: Dict[str, Any] = {}
+        if isinstance(config, S3Config):
+            if config.region:
+                session_kwargs["region_name"] = config.region
+            if config.aws_access_key_id and config.aws_secret_access_key:
+                client_kwargs["aws_access_key_id"] = config.aws_access_key_id
+                client_kwargs["aws_secret_access_key"] = config.aws_secret_access_key
+
+        session = boto3.Session(**session_kwargs)
+        s3_client = session.client("s3", **client_kwargs)
+
+        response = s3_client.get_object(Bucket=bucket, Key=key)
+        return response["Body"].read()
+
+    # ==========================================
+    # LOCAL RAW STORAGE
+    # ==========================================
+
+    def _store_to_local(self, content_id: str, filename: str, file_data: bytes) -> Dict[str, Any]:
+        """Store raw content to local filesystem."""
+        config = self.storage_config
+        if not isinstance(config, LocalStorageConfig):
+            raise ValueError("Storage config is not LocalStorageConfig")
+
+        # Build local path
+        dir_path = os.path.join(config.base_path, content_id)
+        os.makedirs(dir_path, exist_ok=True)
+        file_path = os.path.join(dir_path, filename)
+
+        with open(file_path, "wb") as f:
+            f.write(file_data)
+
+        log_info(f"Stored raw content to {file_path}")
+
+        return {
+            "raw_storage_type": "local",
+            "raw_storage_path": file_path,
+            "raw_storage_config_id": config.id,
+        }
+
+    def _fetch_from_local(self, agno_metadata: Dict[str, Any]) -> bytes:
+        """Fetch raw content from local filesystem."""
+        file_path = agno_metadata.get("raw_storage_path")
+        if not file_path:
+            raise ValueError("Missing raw_storage_path in metadata")
+
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"Raw content file not found: {file_path}")
+
+        with open(file_path, "rb") as f:
+            return f.read()
+
+    # ==========================================
+    # ORIGINAL SOURCE FETCHERS
+    # ==========================================
+
+    def _fetch_original_s3(self, agno_metadata: Dict[str, Any]) -> bytes:
+        """Fetch content from original S3 source."""
+        try:
+            import boto3
+        except ImportError:
+            raise ImportError("The `boto3` package is not installed. Please install it via `pip install boto3`.")
+
+        bucket = agno_metadata.get("s3_bucket")
+        key = agno_metadata.get("s3_object_name")
+        config_id = agno_metadata.get("source_config_id")
+
+        if not bucket or not key:
+            raise ValueError("Missing s3_bucket or s3_object_name in metadata")
+
+        config = self._resolve_config(config_id)
+
+        session_kwargs: Dict[str, Any] = {}
+        client_kwargs: Dict[str, Any] = {}
+        if isinstance(config, S3Config):
+            if config.region:
+                session_kwargs["region_name"] = config.region
+            if config.aws_access_key_id and config.aws_secret_access_key:
+                client_kwargs["aws_access_key_id"] = config.aws_access_key_id
+                client_kwargs["aws_secret_access_key"] = config.aws_secret_access_key
+
+        session = boto3.Session(**session_kwargs)
+        s3_client = session.client("s3", **client_kwargs)
+
+        response = s3_client.get_object(Bucket=bucket, Key=key)
+        return response["Body"].read()
+
+    def _fetch_original_gcs(self, agno_metadata: Dict[str, Any]) -> bytes:
+        """Fetch content from original GCS source."""
+        try:
+            from google.cloud import storage as gcs_storage  # type: ignore
+        except ImportError:
+            raise ImportError(
+                "The `google-cloud-storage` package is not installed. "
+                "Please install it via `pip install google-cloud-storage`."
+            )
+
+        bucket_name = agno_metadata.get("gcs_bucket")
+        blob_name = agno_metadata.get("gcs_blob_name")
+
+        if not bucket_name or not blob_name:
+            raise ValueError("Missing gcs_bucket or gcs_blob_name in metadata")
+
+        config_id = agno_metadata.get("source_config_id")
+        config = self._resolve_config(config_id)
+
+        # Build client kwargs
+        client_kwargs: Dict[str, Any] = {}
+        if config and hasattr(config, "project") and config.project:
+            client_kwargs["project"] = config.project
+
+        client = gcs_storage.Client(**client_kwargs)
+        bucket = client.bucket(bucket_name)
+        blob = bucket.blob(blob_name)
+        return blob.download_as_bytes()
+
+    def _fetch_original_sharepoint(self, agno_metadata: Dict[str, Any]) -> bytes:
+        """Fetch content from original SharePoint source."""
+        import httpx
+
+        config_id = agno_metadata.get("source_config_id")
+        config = self._resolve_config(config_id)
+
+        if not config or not hasattr(config, "_get_access_token"):
+            raise ValueError(f"SharePoint config {config_id} not found or invalid")
+
+        access_token = config._get_access_token()
+        if not access_token:
+            raise ValueError("Failed to acquire SharePoint access token")
+
+        site_id = config._get_site_id(access_token)
+        if not site_id:
+            raise ValueError("Failed to get SharePoint site ID")
+
+        file_path = agno_metadata.get("sharepoint_file_path")
+        if not file_path:
+            raise ValueError("Missing sharepoint_file_path in metadata")
+
+        headers = {"Authorization": f"Bearer {access_token}"}
+        encoded_path = file_path.strip("/")
+        url = f"https://graph.microsoft.com/v1.0/sites/{site_id}/drive/root:/{encoded_path}:/content"
+
+        response = httpx.get(url, headers=headers, follow_redirects=True)
+        if response.status_code != 200:
+            raise ValueError(f"SharePoint download failed: {response.status_code} - {response.text}")
+        return response.content
+
+    def _fetch_original_github(self, agno_metadata: Dict[str, Any]) -> bytes:
+        """Fetch content from original GitHub source."""
+        import httpx
+
+        config_id = agno_metadata.get("source_config_id")
+        config = self._resolve_config(config_id)
+
+        repo = agno_metadata.get("github_repo")
+        file_path = agno_metadata.get("github_file_path")
+        branch = agno_metadata.get("github_branch", "main")
+
+        if not repo or not file_path:
+            raise ValueError("Missing github_repo or github_file_path in metadata")
+
+        headers = {"Accept": "application/vnd.github.v3.raw"}
+        if config and hasattr(config, "token") and config.token:
+            headers["Authorization"] = f"token {config.token}"
+
+        url = f"https://api.github.com/repos/{repo}/contents/{file_path}?ref={branch}"
+        response = httpx.get(url, headers=headers)
+        if response.status_code != 200:
+            raise ValueError(f"GitHub download failed: {response.status_code} - {response.text}")
+        return response.content
+
+    def _fetch_original_azure_blob(self, agno_metadata: Dict[str, Any]) -> bytes:
+        """Fetch content from original Azure Blob source."""
+        try:
+            from azure.identity import ClientSecretCredential  # type: ignore
+            from azure.storage.blob import BlobServiceClient  # type: ignore
+        except ImportError:
+            raise ImportError(
+                "The `azure-identity` and `azure-storage-blob` packages are not installed. "
+                "Please install them via `pip install azure-identity azure-storage-blob`."
+            )
+
+        config_id = agno_metadata.get("source_config_id")
+        config = self._resolve_config(config_id)
+
+        storage_account = agno_metadata.get("azure_storage_account")
+        container = agno_metadata.get("azure_container")
+        blob_name = agno_metadata.get("azure_blob_name")
+
+        if not storage_account or not container or not blob_name:
+            raise ValueError("Missing azure_storage_account, azure_container, or azure_blob_name in metadata")
+
+        if not config or not hasattr(config, "tenant_id"):
+            raise ValueError(f"Azure Blob config {config_id} not found or invalid")
+
+        credential = ClientSecretCredential(
+            tenant_id=config.tenant_id,
+            client_id=config.client_id,
+            client_secret=config.client_secret,
+        )
+
+        blob_service = BlobServiceClient(
+            account_url=f"https://{storage_account}.blob.core.windows.net",
+            credential=credential,
+        )
+
+        blob_client = blob_service.get_blob_client(container=container, blob=blob_name)
+        return blob_client.download_blob().readall()
+
+    # ==========================================
+    # HELPERS
+    # ==========================================
+
+    def _resolve_config(self, config_id: Optional[str]) -> Optional[RemoteContentConfig]:
+        """Resolve a config by ID from content_sources or fall back to storage_config."""
+        if not config_id:
+            return self.storage_config
+        # Check content_sources first
+        for source in self.content_sources:
+            if source.id == config_id:
+                return source
+        # Fall back to storage_config if its ID matches
+        if self.storage_config.id == config_id:
+            return self.storage_config
+        log_error(f"Config {config_id} not found in content_sources")
+        return None

--- a/libs/agno/agno/knowledge/remote_content/config.py
+++ b/libs/agno/agno/knowledge/remote_content/config.py
@@ -631,6 +631,25 @@ class GitHubConfig(RemoteContentConfig):
         )
 
 
+class LocalStorageConfig(RemoteContentConfig):
+    """Configuration for local filesystem storage.
+
+    Stores raw content files to a local directory. Useful for development
+    and testing without needing cloud credentials.
+
+    Example:
+        ```python
+        config = LocalStorageConfig(
+            id="local-raw",
+            name="Local Raw Storage",
+            base_path="/tmp/knowledge-raw-storage",
+        )
+        ```
+    """
+
+    base_path: str
+
+
 class AzureBlobConfig(RemoteContentConfig):
     """Configuration for Azure Blob Storage content source.
 

--- a/libs/agno/agno/os/routers/knowledge/knowledge.py
+++ b/libs/agno/agno/os/routers/knowledge/knowledge.py
@@ -111,6 +111,9 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
         chunker: Optional[str] = Form(None, description="Chunking strategy to apply during processing"),
         chunk_size: Optional[int] = Form(None, description="Chunk size to use for processing"),
         chunk_overlap: Optional[int] = Form(None, description="Chunk overlap to use for processing"),
+        store_raw: Optional[bool] = Form(
+            None, description="Store raw content copy. None=auto (store if configured), True=force, False=skip"
+        ),
         db_id: Optional[str] = Query(default=None, description="Database ID to use for content storage"),
         knowledge_id: Optional[str] = Query(default=None, description="Knowledge base ID (name) to upload to"),
     ):
@@ -200,7 +203,9 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
         content.content_hash = content_hash
         content.id = generate_id(content_hash)
 
-        background_tasks.add_task(process_content, knowledge, content, reader_id, chunker, chunk_size, chunk_overlap)
+        background_tasks.add_task(
+            process_content, knowledge, content, reader_id, chunker, chunk_size, chunk_overlap, store_raw
+        )
 
         response = ContentResponseSchema(
             id=content.id,
@@ -255,6 +260,9 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
         chunker: Optional[str] = Form(None, description="Chunking strategy to apply"),
         chunk_size: Optional[int] = Form(None, description="Chunk size for processing"),
         chunk_overlap: Optional[int] = Form(None, description="Chunk overlap for processing"),
+        store_raw: Optional[bool] = Form(
+            None, description="Store raw content copy. None=auto (store if configured), True=force, False=skip"
+        ),
         db_id: Optional[str] = Query(default=None, description="Database ID to use for content storage"),
         knowledge_id: Optional[str] = Query(default=None, description="Knowledge base ID (name) to upload to"),
     ):
@@ -307,7 +315,9 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
         content.content_hash = content_hash
         content.id = generate_id(content_hash)
 
-        background_tasks.add_task(process_content, knowledge, content, reader_id, chunker, chunk_size, chunk_overlap)
+        background_tasks.add_task(
+            process_content, knowledge, content, reader_id, chunker, chunk_size, chunk_overlap, store_raw
+        )
 
         response = ContentResponseSchema(
             id=content.id,
@@ -1356,7 +1366,101 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
             ),
         )
 
+    @router.post(
+        "/knowledge/content/{content_id}/refresh",
+        response_model=ContentResponseSchema,
+        status_code=202,
+        operation_id="refresh_content",
+        summary="Refresh Content",
+        description=(
+            "Refresh content by re-fetching from its original source and re-embedding. "
+            "Sources are resolved in priority order: raw storage S3/local, then original cloud source. "
+            "Use cases: embeddings lost, switching embedding model, or source content updated."
+        ),
+        responses={
+            202: {
+                "description": "Content refresh accepted for processing",
+            },
+            400: {
+                "description": "Cannot refresh - no source available",
+                "model": BadRequestResponse,
+            },
+            404: {"description": "Content not found", "model": NotFoundResponse},
+        },
+    )
+    async def refresh_content(
+        request: Request,
+        background_tasks: BackgroundTasks,
+        content_id: str = Path(..., description="Content ID to refresh"),
+        db_id: Optional[str] = Query(default=None, description="Database ID"),
+        knowledge_id: Optional[str] = Query(default=None, description="Knowledge base ID (name)"),
+    ) -> ContentResponseSchema:
+        knowledge = get_knowledge_instance(knowledge_instances, db_id, knowledge_id)
+
+        if isinstance(knowledge, RemoteKnowledge):
+            raise HTTPException(status_code=501, detail="Content refresh not yet supported for RemoteKnowledge")
+
+        # Verify content exists
+        content = await knowledge.aget_content_by_id(content_id=content_id)
+        if not content:
+            raise HTTPException(status_code=404, detail=f"Content not found: {content_id}")
+
+        # Verify there is a source to refresh from
+        agno_meta = (content.metadata or {}).get(Knowledge.RESERVED_METADATA_KEY, {})
+        if not isinstance(agno_meta, dict):
+            agno_meta = {}
+
+        has_raw = bool(agno_meta.get("raw_storage_type"))
+        has_source = bool(agno_meta.get("source_type"))
+        # Also check top-level metadata for backward compatibility
+        has_legacy_source = bool(content.metadata and content.metadata.get("source_type"))
+
+        if not has_raw and not has_source and not has_legacy_source:
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot refresh: no raw storage or original source available",
+            )
+
+        # Mark as processing
+        from agno.knowledge.content import ContentStatus as KnowledgeContentStatus
+
+        content.status = KnowledgeContentStatus.PROCESSING
+        content.status_message = "Refreshing content"
+        await knowledge.apatch_content(content)
+
+        background_tasks.add_task(process_refresh, knowledge, content_id)
+
+        return ContentResponseSchema(
+            id=content_id,
+            name=content.name,
+            description=content.description,
+            metadata=content.metadata,
+            status=ContentStatus.PROCESSING,
+        )
+
     return router
+
+
+async def process_refresh(knowledge: Knowledge, content_id: str):
+    """Background task to refresh content by re-fetching and re-embedding."""
+    try:
+        await knowledge.arefresh_content(content_id)
+        log_info(f"Content {content_id} refreshed successfully")
+    except Exception as e:
+        log_error(f"Error refreshing content {content_id}: {e}")
+        try:
+            from agno.knowledge.content import ContentStatus as KnowledgeContentStatus
+
+            content = await knowledge.aget_content_by_id(content_id)
+            if content:
+                content.status = KnowledgeContentStatus.FAILED
+                content.status_message = str(e)
+                if knowledge.contents_db is not None and isinstance(knowledge.contents_db, AsyncBaseDb):
+                    await knowledge.apatch_content(content)
+                else:
+                    knowledge.patch_content(content)
+        except Exception:
+            pass
 
 
 async def process_content(
@@ -1366,6 +1470,7 @@ async def process_content(
     chunker: Optional[str] = None,
     chunk_size: Optional[int] = None,
     chunk_overlap: Optional[int] = None,
+    store_raw: Optional[bool] = None,
 ):
     """Background task to process the content"""
 
@@ -1398,7 +1503,7 @@ async def process_content(
             log_debug(f"Set chunking strategy: {chunker}")
 
         log_debug(f"Using reader: {content.reader.__class__.__name__}")
-        await knowledge._aload_content(content, upsert=False, skip_if_exists=True)
+        await knowledge._aload_content(content, upsert=False, skip_if_exists=True, store_raw=store_raw)
         log_info(f"Content {content.id} processed successfully")
     except Exception as e:
         log_info(f"Error processing content: {e}")


### PR DESCRIPTION
## Summary

Add raw content storage and content refresh capabilities to the Knowledge system. This enables:

1. **Raw Content Storage**: During ingestion, raw file bytes can be stored in S3 or local filesystem (controlled by `store_raw` parameter). This allows content to be re-embedded later without needing access to the original source.

2. **Content Refresh**: A new endpoint (`POST /knowledge/content/{content_id}/refresh`) that re-fetches content from raw storage or original cloud sources and re-embeds it with the current chunking/embedding configuration.

3. **Reserved Metadata**: System metadata (source type, bucket info, raw storage location) is now stored under a reserved `_agno` key in content metadata, preventing user PATCH updates from overwriting it.

### Key changes:
- New `RawStorage` class (`raw_storage.py`) with S3 and local filesystem support (sync + async)
- New `LocalStorageConfig` for dev/testing without cloud credentials
- `store_raw` parameter added to `insert()`/`ainsert()` and both upload endpoints
- `refresh_content()`/`arefresh_content()` methods on Knowledge class
- New refresh API endpoint with background task processing
- `BaseLoader._merge_metadata()` updated to store provider metadata under `_agno` key
- `_merge_user_metadata()`, `_set_agno_metadata()`, `_get_agno_metadata()` static helpers

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

- `mypy` was not run because no `.venv` is available in this workspace — only `ruff check` and `ruff format` were verified
- All cloud SDK calls (boto3, etc.) are synchronous — async variants use the same sync calls (per design decision from planning session)
- Backward compatible: refresh endpoint checks both `_agno` sub-dict and top-level metadata for `source_type`
- `RawStorage` uses composition pattern (lazy property on Knowledge) to avoid bloating the main class