### PR TITLE
[feat] Add multi-block system message caching for Claude

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -526,7 +526,7 @@ class Claude(Model):
 
     def _prepare_request_kwargs(
         self,
-        system_message: str,
+        system_message: Union[str, List[Dict[str, Any]]],
         tools: Optional[List[Dict[str, Any]]] = None,
         response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
     ) -> Dict[str, Any]:
@@ -534,7 +534,8 @@ class Claude(Model):
         Prepare the request keyword arguments for the API call.
 
         Args:
-            system_message (str): The concatenated system messages.
+            system_message: The system messages, either as a concatenated string
+                or a list of structured blocks with optional cache_control.
             tools: Optional list of tools
             response_format: Optional response format (Pydantic model or dict)
 
@@ -547,7 +548,10 @@ class Claude(Model):
         # Pass response_format and tools to get_request_params for beta header handling
         request_kwargs = self.get_request_params(response_format=response_format, tools=tools).copy()
         if system_message:
-            if self.cache_system_prompt:
+            if isinstance(system_message, list):
+                # Multi-block format with per-message cache_control from format_messages()
+                request_kwargs["system"] = system_message
+            elif self.cache_system_prompt:
                 cache_control = (
                     {"type": "ephemeral", "ttl": "1h"}
                     if self.extended_cache_time is not None and self.extended_cache_time is True

--- a/libs/agno/agno/models/vertexai/claude.py
+++ b/libs/agno/agno/models/vertexai/claude.py
@@ -153,7 +153,7 @@ class Claude(AnthropicClaude):
 
     def _prepare_request_kwargs(
         self,
-        system_message: str,
+        system_message: Union[str, List[Dict[str, Any]]],
         tools: Optional[List[Dict[str, Any]]] = None,
         response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
     ) -> Dict[str, Any]:
@@ -161,7 +161,8 @@ class Claude(AnthropicClaude):
         Prepare the request keyword arguments for the API call.
 
         Args:
-            system_message (str): The concatenated system messages.
+            system_message: The system messages, either as a concatenated string
+                or a list of structured blocks with optional cache_control.
             tools: Optional list of tools
             response_format: Optional response format (Pydantic model or dict)
 
@@ -171,7 +172,10 @@ class Claude(AnthropicClaude):
         # Pass response_format and tools to get_request_params for beta header handling
         request_kwargs = self.get_request_params(response_format=response_format, tools=tools).copy()
         if system_message:
-            if self.cache_system_prompt:
+            if isinstance(system_message, list):
+                # Multi-block format with per-message cache_control from format_messages()
+                request_kwargs["system"] = system_message
+            elif self.cache_system_prompt:
                 cache_control = (
                     {"type": "ephemeral", "ttl": "1h"}
                     if self.extended_cache_time is not None and self.extended_cache_time is True

--- a/libs/agno/tests/unit/utils/test_claude.py
+++ b/libs/agno/tests/unit/utils/test_claude.py
@@ -3,7 +3,8 @@ import base64
 import pytest
 
 from agno.media import File
-from agno.utils.models.claude import _format_file_for_message
+from agno.models.message import Message
+from agno.utils.models.claude import _format_file_for_message, format_messages
 
 
 class TestFormatFileForMessage:
@@ -86,3 +87,154 @@ class TestFormatFileForMessage:
 
         assert result["source"]["data"] == csv_content
         assert result["source"]["data"] != base64.standard_b64encode(csv_content.encode()).decode()
+
+
+class TestFormatMessagesMultiBlockCache:
+    """Tests for multi-block system message caching in format_messages()."""
+
+    def test_no_cache_control_returns_string(self):
+        """Without cache_control, returns concatenated string (backwards compatible)."""
+        messages = [
+            Message(role="system", content="You are helpful."),
+            Message(role="system", content="Be concise."),
+            Message(role="user", content="Hello"),
+        ]
+        chat_messages, system_message = format_messages(messages)
+
+        assert isinstance(system_message, str)
+        assert system_message == "You are helpful. Be concise."
+        assert len(chat_messages) == 1
+        assert chat_messages[0]["role"] == "user"
+
+    def test_with_cache_control_returns_list(self):
+        """With cache_control on any message, returns list of structured blocks."""
+        messages = [
+            Message(
+                role="system",
+                content="Static instructions",
+                provider_data={"cache_control": {"type": "ephemeral"}},
+            ),
+            Message(role="system", content="Dynamic context"),
+            Message(role="user", content="Hello"),
+        ]
+        chat_messages, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert len(system_message) == 2
+        assert system_message[0]["type"] == "text"
+        assert system_message[0]["text"] == "Static instructions"
+        assert system_message[0]["cache_control"] == {"type": "ephemeral"}
+        assert system_message[1]["type"] == "text"
+        assert system_message[1]["text"] == "Dynamic context"
+        assert "cache_control" not in system_message[1]
+
+    def test_cache_control_with_extended_ttl(self):
+        """Cache control with extended TTL is preserved."""
+        messages = [
+            Message(
+                role="system",
+                content="Instructions",
+                provider_data={"cache_control": {"type": "ephemeral", "ttl": "1h"}},
+            ),
+        ]
+        _, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert system_message[0]["cache_control"]["ttl"] == "1h"
+
+    def test_developer_role_treated_as_system(self):
+        """Developer role messages are treated as system messages."""
+        messages = [
+            Message(
+                role="developer",
+                content="Developer instructions",
+                provider_data={"cache_control": {"type": "ephemeral"}},
+            ),
+            Message(role="user", content="Hello"),
+        ]
+        _, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert len(system_message) == 1
+        assert system_message[0]["text"] == "Developer instructions"
+
+    def test_empty_system_messages_returns_empty_string(self):
+        """No system messages returns empty string."""
+        messages = [Message(role="user", content="Hello")]
+        _, system_message = format_messages(messages)
+
+        assert system_message == ""
+
+    def test_provider_data_without_cache_control_returns_string(self):
+        """provider_data without cache_control key returns string format."""
+        messages = [
+            Message(
+                role="system",
+                content="Instructions",
+                provider_data={"other_key": "value"},
+            ),
+        ]
+        _, system_message = format_messages(messages)
+
+        assert isinstance(system_message, str)
+        assert system_message == "Instructions"
+
+    def test_multiple_cache_control_blocks(self):
+        """Multiple blocks can have cache_control."""
+        messages = [
+            Message(
+                role="system",
+                content="Static A",
+                provider_data={"cache_control": {"type": "ephemeral"}},
+            ),
+            Message(role="system", content="Dynamic"),
+            Message(
+                role="system",
+                content="Static B",
+                provider_data={"cache_control": {"type": "ephemeral", "ttl": "1h"}},
+            ),
+            Message(role="user", content="Hello"),
+        ]
+        _, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert len(system_message) == 3
+        assert system_message[0]["cache_control"] == {"type": "ephemeral"}
+        assert "cache_control" not in system_message[1]
+        assert system_message[2]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+    def test_system_messages_order_preserved(self):
+        """System messages maintain their order in list format."""
+        messages = [
+            Message(
+                role="system",
+                content="First",
+                provider_data={"cache_control": {"type": "ephemeral"}},
+            ),
+            Message(role="system", content="Second"),
+            Message(role="system", content="Third"),
+            Message(role="user", content="Hello"),
+        ]
+        _, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert [b["text"] for b in system_message] == ["First", "Second", "Third"]
+
+    def test_chat_messages_unaffected_by_cache_control(self):
+        """User and assistant messages are unaffected by system cache_control."""
+        messages = [
+            Message(
+                role="system",
+                content="System",
+                provider_data={"cache_control": {"type": "ephemeral"}},
+            ),
+            Message(role="user", content="User question"),
+            Message(role="assistant", content="Assistant response"),
+            Message(role="user", content="Follow up"),
+        ]
+        chat_messages, _ = format_messages(messages)
+
+        assert len(chat_messages) == 3
+        assert chat_messages[0]["role"] == "user"
+        assert chat_messages[1]["role"] == "assistant"
+        assert chat_messages[2]["role"] == "user"


### PR DESCRIPTION
## Summary

Adds support for multi-block system message caching for Claude models. This allows users to cache static parts of their system prompt (like base instructions) while keeping dynamic parts (like tenant context) uncached, enabling effective prompt caching in multi-tenant applications.

Fixes #6280

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

### How it works

The existing `Message.provider_data` field carries cache control hints:

```python
Message(
    role="system",
    content="Static instructions...",
    provider_data={"cache_control": {"type": "ephemeral"}}
)
```

When `format_messages()` detects any system message with `provider_data.cache_control`, it returns a list of structured blocks instead of a concatenated string. Each block preserves its individual cache_control setting.

### Backwards Compatibility

- If no messages have `provider_data.cache_control`, behavior is unchanged (concatenated string)
- Existing `cache_system_prompt=True` on the model still works for single-block caching
- Works for Anthropic API, AWS Bedrock, and Vertex AI

### Use Case

Multi-tenant SaaS applications where base instructions (10k+ tokens) are identical across all tenants, but tenant-specific context varies per request. With this change, static instructions can be cached and reused across all tenants.