### PR TITLE
[feat] Extend cache control to non-system messages and add split system prompt

### DIFF
--- a/libs/agno/agno/agent/_messages.py
+++ b/libs/agno/agno/agent/_messages.py
@@ -98,6 +98,17 @@ def format_message_with_state_variables(
         return message
 
 
+def _build_additional_info_block(items: List[str]) -> str:
+    """Build an ``<additional_information>`` XML block from a list of items."""
+    if not items:
+        return ""
+    block = "<additional_information>"
+    for item in items:
+        block += f"\n- {item}"
+    block += "\n</additional_information>\n\n"
+    return block
+
+
 # ---------------------------------------------------------------------------
 # System message
 # ---------------------------------------------------------------------------
@@ -184,10 +195,14 @@ def get_system_message(
         instructions.extend(_model_instructions)
 
     # 3.2 Build a list of additional information for the system message
+    # Static items don't change between requests; dynamic items do.
     additional_information: List[str] = []
+    static_additional_information: List[str] = []
+    dynamic_additional_information: List[str] = []
     # 3.2.1 Add instructions for using markdown
     if agent.markdown and output_schema is None:
         additional_information.append("Use markdown to format your answers.")
+        static_additional_information.append("Use markdown to format your answers.")
     # 3.2.2 Add the current datetime
     if agent.add_datetime_to_context:
         from datetime import datetime
@@ -205,6 +220,7 @@ def get_system_message(
         time = datetime.now(tz) if tz else datetime.now()
 
         additional_information.append(f"The current time is {time}.")
+        dynamic_additional_information.append(f"The current time is {time}.")
 
     # 3.2.3 Add the current location
     if agent.add_location_to_context:
@@ -224,10 +240,12 @@ def get_system_message(
             )
             if location_str:
                 additional_information.append(f"Your approximate location is: {location_str}.")
+                dynamic_additional_information.append(f"Your approximate location is: {location_str}.")
 
     # 3.2.4 Add agent name if provided
     if agent.name is not None and agent.add_name_to_context:
         additional_information.append(f"Your name is: {agent.name}.")
+        static_additional_information.append(f"Your name is: {agent.name}.")
 
     # 3.3 Build the default system message for the Agent.
     system_message_content: str = ""
@@ -262,13 +280,15 @@ def get_system_message(
         system_message_content += instructions_block
         static_content += instructions_block
     # 3.3.4 Add additional information
-    if len(additional_information) > 0:
-        ai_block = "<additional_information>"
-        for _ai in additional_information:
-            ai_block += f"\n- {_ai}"
-        ai_block += "\n</additional_information>\n\n"
+    ai_block = _build_additional_info_block(additional_information)
+    if ai_block:
         system_message_content += ai_block
-        dynamic_content += ai_block
+    static_ai_block = _build_additional_info_block(static_additional_information)
+    if static_ai_block:
+        static_content += static_ai_block
+    dynamic_ai_block = _build_additional_info_block(dynamic_additional_information)
+    if dynamic_ai_block:
+        dynamic_content += dynamic_ai_block
     # 3.3.5 Then add instructions for the tools
     if agent._tool_instructions is not None:
         tool_instr_block = ""
@@ -600,10 +620,14 @@ async def aget_system_message(
         instructions.extend(_model_instructions)
 
     # 3.2 Build a list of additional information for the system message
+    # Static items don't change between requests; dynamic items do.
     additional_information: List[str] = []
+    static_additional_information: List[str] = []
+    dynamic_additional_information: List[str] = []
     # 3.2.1 Add instructions for using markdown
     if agent.markdown and output_schema is None:
         additional_information.append("Use markdown to format your answers.")
+        static_additional_information.append("Use markdown to format your answers.")
     # 3.2.2 Add the current datetime
     if agent.add_datetime_to_context:
         from datetime import datetime
@@ -621,6 +645,7 @@ async def aget_system_message(
         time = datetime.now(tz) if tz else datetime.now()
 
         additional_information.append(f"The current time is {time}.")
+        dynamic_additional_information.append(f"The current time is {time}.")
 
     # 3.2.3 Add the current location
     if agent.add_location_to_context:
@@ -640,10 +665,12 @@ async def aget_system_message(
             )
             if location_str:
                 additional_information.append(f"Your approximate location is: {location_str}.")
+                dynamic_additional_information.append(f"Your approximate location is: {location_str}.")
 
     # 3.2.4 Add agent name if provided
     if agent.name is not None and agent.add_name_to_context:
         additional_information.append(f"Your name is: {agent.name}.")
+        static_additional_information.append(f"Your name is: {agent.name}.")
 
     # 3.3 Build the default system message for the Agent.
     system_message_content: str = ""
@@ -678,13 +705,15 @@ async def aget_system_message(
         system_message_content += instructions_block
         static_content += instructions_block
     # 3.3.4 Add additional information
-    if len(additional_information) > 0:
-        ai_block = "<additional_information>"
-        for _ai in additional_information:
-            ai_block += f"\n- {_ai}"
-        ai_block += "\n</additional_information>\n\n"
+    ai_block = _build_additional_info_block(additional_information)
+    if ai_block:
         system_message_content += ai_block
-        dynamic_content += ai_block
+    static_ai_block = _build_additional_info_block(static_additional_information)
+    if static_ai_block:
+        static_content += static_ai_block
+    dynamic_ai_block = _build_additional_info_block(dynamic_additional_information)
+    if dynamic_ai_block:
+        dynamic_content += dynamic_ai_block
     # 3.3.5 Then add instructions for the tools
     if agent._tool_instructions is not None:
         tool_instr_block = ""

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -247,6 +247,9 @@ class Agent:
     timezone_identifier: Optional[str] = None
     # If True, resolve session_state, dependencies, and metadata in the user and system messages
     resolve_in_context: bool = True
+    # If True, split system message into cached (static) and uncached (dynamic) parts
+    # for prompt caching. Only effective with Claude models.
+    cache_system_prompt_blocks: bool = False
 
     # --- Learning Machine ---
     # LearningMachine for unified learning capabilities
@@ -430,6 +433,7 @@ class Agent:
         add_location_to_context: bool = False,
         timezone_identifier: Optional[str] = None,
         resolve_in_context: bool = True,
+        cache_system_prompt_blocks: bool = False,
         learning: Optional[Union[bool, LearningMachine]] = None,
         add_learnings_to_context: bool = True,
         additional_input: Optional[List[Union[str, Dict, BaseModel, Message]]] = None,
@@ -577,6 +581,7 @@ class Agent:
         self.add_location_to_context = add_location_to_context
         self.timezone_identifier = timezone_identifier
         self.resolve_in_context = resolve_in_context
+        self.cache_system_prompt_blocks = cache_system_prompt_blocks
         self.learning = learning
         self.add_learnings_to_context = add_learnings_to_context
         self.additional_input = additional_input
@@ -762,7 +767,7 @@ class Agent:
         run_context: Optional[RunContext] = None,
         tools: Optional[List[Union[Function, dict]]] = None,
         add_session_state_to_context: Optional[bool] = None,
-    ) -> Optional[Message]:
+    ) -> Optional[Union[Message, List[Message]]]:
         return _messages.get_system_message(
             self,
             session=session,
@@ -777,7 +782,7 @@ class Agent:
         run_context: Optional[RunContext] = None,
         tools: Optional[List[Union[Function, dict]]] = None,
         add_session_state_to_context: Optional[bool] = None,
-    ) -> Optional[Message]:
+    ) -> Optional[Union[Message, List[Message]]]:
         return await _messages.aget_system_message(
             self,
             session=session,

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -526,7 +526,7 @@ class Claude(Model):
 
     def _prepare_request_kwargs(
         self,
-        system_message: str,
+        system_message: Union[str, List[Dict[str, Any]]],
         tools: Optional[List[Dict[str, Any]]] = None,
         response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
     ) -> Dict[str, Any]:
@@ -534,7 +534,8 @@ class Claude(Model):
         Prepare the request keyword arguments for the API call.
 
         Args:
-            system_message (str): The concatenated system messages.
+            system_message: The system messages, either as a concatenated string
+                or a list of structured blocks with optional cache_control.
             tools: Optional list of tools
             response_format: Optional response format (Pydantic model or dict)
 
@@ -547,7 +548,10 @@ class Claude(Model):
         # Pass response_format and tools to get_request_params for beta header handling
         request_kwargs = self.get_request_params(response_format=response_format, tools=tools).copy()
         if system_message:
-            if self.cache_system_prompt:
+            if isinstance(system_message, list):
+                # Multi-block format with per-message cache_control from format_messages()
+                request_kwargs["system"] = system_message
+            elif self.cache_system_prompt:
                 cache_control = (
                     {"type": "ephemeral", "ttl": "1h"}
                     if self.extended_cache_time is not None and self.extended_cache_time is True

--- a/libs/agno/agno/models/vertexai/claude.py
+++ b/libs/agno/agno/models/vertexai/claude.py
@@ -153,7 +153,7 @@ class Claude(AnthropicClaude):
 
     def _prepare_request_kwargs(
         self,
-        system_message: str,
+        system_message: Union[str, List[Dict[str, Any]]],
         tools: Optional[List[Dict[str, Any]]] = None,
         response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
     ) -> Dict[str, Any]:
@@ -161,7 +161,8 @@ class Claude(AnthropicClaude):
         Prepare the request keyword arguments for the API call.
 
         Args:
-            system_message (str): The concatenated system messages.
+            system_message: The system messages, either as a concatenated string
+                or a list of structured blocks with optional cache_control.
             tools: Optional list of tools
             response_format: Optional response format (Pydantic model or dict)
 
@@ -171,7 +172,10 @@ class Claude(AnthropicClaude):
         # Pass response_format and tools to get_request_params for beta header handling
         request_kwargs = self.get_request_params(response_format=response_format, tools=tools).copy()
         if system_message:
-            if self.cache_system_prompt:
+            if isinstance(system_message, list):
+                # Multi-block format with per-message cache_control from format_messages()
+                request_kwargs["system"] = system_message
+            elif self.cache_system_prompt:
                 cache_control = (
                     {"type": "ephemeral", "ttl": "1h"}
                     if self.extended_cache_time is not None and self.extended_cache_time is True

--- a/libs/agno/tests/unit/agent/test_system_message_split.py
+++ b/libs/agno/tests/unit/agent/test_system_message_split.py
@@ -1,0 +1,232 @@
+"""Tests for cache_system_prompt_blocks (split system message into static + dynamic)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from agno.agent.agent import Agent
+from agno.models.message import Message
+from agno.session import AgentSession
+
+
+def _session():
+    return AgentSession(session_id="test-session")
+
+
+def _make_mock_model():
+    """Create a minimal mock that satisfies get_system_message's requirements."""
+    model = MagicMock()
+    model.get_instructions_for_model.return_value = None
+    model.get_system_message_for_model.return_value = None
+    model.supports_native_structured_outputs = False
+    model.supports_json_schema_outputs = False
+    return model
+
+
+def _make_agent(**kwargs) -> Agent:
+    agent = Agent(**kwargs)
+    if agent.model is None:
+        agent.model = _make_mock_model()
+    return agent
+
+
+class TestCacheSystemPromptBlocks:
+    """Tests for Agent.cache_system_prompt_blocks splitting behaviour."""
+
+    def test_disabled_returns_single_message(self):
+        agent = _make_agent(
+            description="A helpful assistant",
+            instructions=["Be concise"],
+            add_datetime_to_context=True,
+            cache_system_prompt_blocks=False,
+        )
+        result = agent.get_system_message(session=_session())
+        assert isinstance(result, Message)
+
+    def test_enabled_returns_list(self):
+        agent = _make_agent(
+            description="A helpful assistant",
+            instructions=["Be concise"],
+            add_datetime_to_context=True,
+            cache_system_prompt_blocks=True,
+        )
+        result = agent.get_system_message(session=_session())
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+    def test_static_block_has_cache_control(self):
+        agent = _make_agent(
+            description="A helpful assistant",
+            instructions=["Be concise"],
+            add_datetime_to_context=True,
+            cache_system_prompt_blocks=True,
+        )
+        result = agent.get_system_message(session=_session())
+        static_msg = result[0]
+        assert static_msg.provider_data is not None
+        assert static_msg.provider_data["cache_control"] == {"type": "ephemeral"}
+
+    def test_dynamic_block_has_no_cache_control(self):
+        agent = _make_agent(
+            description="A helpful assistant",
+            instructions=["Be concise"],
+            add_datetime_to_context=True,
+            cache_system_prompt_blocks=True,
+        )
+        result = agent.get_system_message(session=_session())
+        dynamic_msg = result[1]
+        assert dynamic_msg.provider_data is None
+
+    def test_static_block_contains_description_and_instructions(self):
+        agent = _make_agent(
+            description="A helpful assistant",
+            instructions=["Be concise"],
+            add_datetime_to_context=True,
+            cache_system_prompt_blocks=True,
+        )
+        result = agent.get_system_message(session=_session())
+        static_content = result[0].content
+        assert "A helpful assistant" in static_content
+        assert "Be concise" in static_content
+
+    def test_dynamic_block_contains_datetime(self):
+        agent = _make_agent(
+            description="A helpful assistant",
+            add_datetime_to_context=True,
+            cache_system_prompt_blocks=True,
+        )
+        result = agent.get_system_message(session=_session())
+        dynamic_content = result[1].content
+        assert "current time" in dynamic_content.lower()
+
+    def test_static_block_does_not_contain_datetime(self):
+        agent = _make_agent(
+            description="A helpful assistant",
+            add_datetime_to_context=True,
+            cache_system_prompt_blocks=True,
+        )
+        result = agent.get_system_message(session=_session())
+        static_content = result[0].content
+        assert "current time" not in static_content.lower()
+
+    def test_markdown_in_static_block(self):
+        """markdown instruction is static -- should be in static block, not dynamic."""
+        agent = _make_agent(
+            description="A helpful assistant",
+            markdown=True,
+            add_datetime_to_context=True,
+            cache_system_prompt_blocks=True,
+        )
+        result = agent.get_system_message(session=_session())
+        static_content = result[0].content
+        assert "markdown" in static_content.lower()
+
+    def test_agent_name_in_static_block(self):
+        agent = _make_agent(
+            description="A helpful assistant",
+            name="TestBot",
+            add_name_to_context=True,
+            add_datetime_to_context=True,
+            cache_system_prompt_blocks=True,
+        )
+        result = agent.get_system_message(session=_session())
+        static_content = result[0].content
+        assert "TestBot" in static_content
+
+    def test_only_static_content_returns_single_item_list(self):
+        """When there's no dynamic content, return list with just the static block."""
+        agent = _make_agent(
+            description="A helpful assistant",
+            instructions=["Be concise"],
+            cache_system_prompt_blocks=True,
+        )
+        result = agent.get_system_message(session=_session())
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].provider_data is not None
+        assert result[0].provider_data["cache_control"] == {"type": "ephemeral"}
+
+    def test_custom_system_message_ignores_flag(self):
+        """When agent.system_message is set, cache_system_prompt_blocks has no effect."""
+        agent = _make_agent(
+            system_message="Custom system message",
+            cache_system_prompt_blocks=True,
+        )
+        result = agent.get_system_message(session=_session())
+        assert isinstance(result, Message)
+        assert result.content == "Custom system message"
+
+    def test_build_context_false_returns_none(self):
+        agent = _make_agent(
+            build_context=False,
+            cache_system_prompt_blocks=True,
+        )
+        result = agent.get_system_message(session=_session())
+        assert result is None
+
+    def test_role_in_static_block(self):
+        agent = _make_agent(
+            role="You are a data analyst",
+            add_datetime_to_context=True,
+            cache_system_prompt_blocks=True,
+        )
+        result = agent.get_system_message(session=_session())
+        static_content = result[0].content
+        assert "data analyst" in static_content
+
+    def test_expected_output_in_static_block(self):
+        agent = _make_agent(
+            description="Helper",
+            expected_output="A JSON object",
+            add_datetime_to_context=True,
+            cache_system_prompt_blocks=True,
+        )
+        result = agent.get_system_message(session=_session())
+        static_content = result[0].content
+        assert "A JSON object" in static_content
+
+    def test_all_messages_have_correct_role(self):
+        agent = _make_agent(
+            description="A helpful assistant",
+            add_datetime_to_context=True,
+            cache_system_prompt_blocks=True,
+        )
+        result = agent.get_system_message(session=_session())
+        for msg in result:
+            assert msg.role == "system"
+
+
+class TestCacheSystemPromptBlocksAsync:
+    """Async variant tests for cache_system_prompt_blocks."""
+
+    @pytest.mark.asyncio
+    async def test_async_enabled_returns_list(self):
+        agent = _make_agent(
+            description="A helpful assistant",
+            instructions=["Be concise"],
+            add_datetime_to_context=True,
+            cache_system_prompt_blocks=True,
+        )
+        result = await agent.aget_system_message(session=_session())
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_async_static_has_cache_control(self):
+        agent = _make_agent(
+            description="A helpful assistant",
+            add_datetime_to_context=True,
+            cache_system_prompt_blocks=True,
+        )
+        result = await agent.aget_system_message(session=_session())
+        assert result[0].provider_data["cache_control"] == {"type": "ephemeral"}
+        assert result[1].provider_data is None
+
+    @pytest.mark.asyncio
+    async def test_async_disabled_returns_single_message(self):
+        agent = _make_agent(
+            description="A helpful assistant",
+            cache_system_prompt_blocks=False,
+        )
+        result = await agent.aget_system_message(session=_session())
+        assert isinstance(result, Message)

--- a/libs/agno/tests/unit/utils/test_claude.py
+++ b/libs/agno/tests/unit/utils/test_claude.py
@@ -3,7 +3,8 @@ import base64
 import pytest
 
 from agno.media import File
-from agno.utils.models.claude import _format_file_for_message
+from agno.models.message import Message
+from agno.utils.models.claude import _format_file_for_message, format_messages
 
 
 class TestFormatFileForMessage:
@@ -86,3 +87,154 @@ class TestFormatFileForMessage:
 
         assert result["source"]["data"] == csv_content
         assert result["source"]["data"] != base64.standard_b64encode(csv_content.encode()).decode()
+
+
+class TestFormatMessagesMultiBlockCache:
+    """Tests for multi-block system message caching in format_messages()."""
+
+    def test_no_cache_control_returns_string(self):
+        """Without cache_control, returns concatenated string (backwards compatible)."""
+        messages = [
+            Message(role="system", content="You are helpful."),
+            Message(role="system", content="Be concise."),
+            Message(role="user", content="Hello"),
+        ]
+        chat_messages, system_message = format_messages(messages)
+
+        assert isinstance(system_message, str)
+        assert system_message == "You are helpful. Be concise."
+        assert len(chat_messages) == 1
+        assert chat_messages[0]["role"] == "user"
+
+    def test_with_cache_control_returns_list(self):
+        """With cache_control on any message, returns list of structured blocks."""
+        messages = [
+            Message(
+                role="system",
+                content="Static instructions",
+                provider_data={"cache_control": {"type": "ephemeral"}},
+            ),
+            Message(role="system", content="Dynamic context"),
+            Message(role="user", content="Hello"),
+        ]
+        chat_messages, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert len(system_message) == 2
+        assert system_message[0]["type"] == "text"
+        assert system_message[0]["text"] == "Static instructions"
+        assert system_message[0]["cache_control"] == {"type": "ephemeral"}
+        assert system_message[1]["type"] == "text"
+        assert system_message[1]["text"] == "Dynamic context"
+        assert "cache_control" not in system_message[1]
+
+    def test_cache_control_with_extended_ttl(self):
+        """Cache control with extended TTL is preserved."""
+        messages = [
+            Message(
+                role="system",
+                content="Instructions",
+                provider_data={"cache_control": {"type": "ephemeral", "ttl": "1h"}},
+            ),
+        ]
+        _, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert system_message[0]["cache_control"]["ttl"] == "1h"
+
+    def test_developer_role_treated_as_system(self):
+        """Developer role messages are treated as system messages."""
+        messages = [
+            Message(
+                role="developer",
+                content="Developer instructions",
+                provider_data={"cache_control": {"type": "ephemeral"}},
+            ),
+            Message(role="user", content="Hello"),
+        ]
+        _, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert len(system_message) == 1
+        assert system_message[0]["text"] == "Developer instructions"
+
+    def test_empty_system_messages_returns_empty_string(self):
+        """No system messages returns empty string."""
+        messages = [Message(role="user", content="Hello")]
+        _, system_message = format_messages(messages)
+
+        assert system_message == ""
+
+    def test_provider_data_without_cache_control_returns_string(self):
+        """provider_data without cache_control key returns string format."""
+        messages = [
+            Message(
+                role="system",
+                content="Instructions",
+                provider_data={"other_key": "value"},
+            ),
+        ]
+        _, system_message = format_messages(messages)
+
+        assert isinstance(system_message, str)
+        assert system_message == "Instructions"
+
+    def test_multiple_cache_control_blocks(self):
+        """Multiple blocks can have cache_control."""
+        messages = [
+            Message(
+                role="system",
+                content="Static A",
+                provider_data={"cache_control": {"type": "ephemeral"}},
+            ),
+            Message(role="system", content="Dynamic"),
+            Message(
+                role="system",
+                content="Static B",
+                provider_data={"cache_control": {"type": "ephemeral", "ttl": "1h"}},
+            ),
+            Message(role="user", content="Hello"),
+        ]
+        _, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert len(system_message) == 3
+        assert system_message[0]["cache_control"] == {"type": "ephemeral"}
+        assert "cache_control" not in system_message[1]
+        assert system_message[2]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+    def test_system_messages_order_preserved(self):
+        """System messages maintain their order in list format."""
+        messages = [
+            Message(
+                role="system",
+                content="First",
+                provider_data={"cache_control": {"type": "ephemeral"}},
+            ),
+            Message(role="system", content="Second"),
+            Message(role="system", content="Third"),
+            Message(role="user", content="Hello"),
+        ]
+        _, system_message = format_messages(messages)
+
+        assert isinstance(system_message, list)
+        assert [b["text"] for b in system_message] == ["First", "Second", "Third"]
+
+    def test_chat_messages_unaffected_by_cache_control(self):
+        """User and assistant messages are unaffected by system cache_control."""
+        messages = [
+            Message(
+                role="system",
+                content="System",
+                provider_data={"cache_control": {"type": "ephemeral"}},
+            ),
+            Message(role="user", content="User question"),
+            Message(role="assistant", content="Assistant response"),
+            Message(role="user", content="Follow up"),
+        ]
+        chat_messages, _ = format_messages(messages)
+
+        assert len(chat_messages) == 3
+        assert chat_messages[0]["role"] == "user"
+        assert chat_messages[1]["role"] == "assistant"
+        assert chat_messages[2]["role"] == "user"


### PR DESCRIPTION
## Summary

Extends the multi-block system message caching from PR #6545 with two new capabilities:

1. **Cache control on non-system messages** -- `provider_data={"cache_control": ...}` now works on user, assistant, and tool messages (not just system). This is useful for caching large tool results or documents across turns.

2. **Split agent system prompt** -- New `cache_system_prompt_blocks=True` Agent field that splits the auto-built system message into a cached static block (instructions, description, role, tools, expected output) and an uncached dynamic block (datetime, memories, session state, learnings, cultural knowledge).

Depends on #6545.

### Changes

- `libs/agno/agno/utils/models/claude.py` -- Added `_apply_cache_control()` helper; wired into user/assistant/tool branches of `format_messages()`
- `libs/agno/agno/agent/agent.py` -- Added `cache_system_prompt_blocks: bool = False` field
- `libs/agno/agno/agent/_messages.py` -- Refactored `get_system_message()`/`aget_system_message()` to build static/dynamic accumulators and return `List[Message]` when splitting; updated `get_run_messages()`/`aget_run_messages()` to handle list return
- `libs/agno/tests/unit/utils/test_claude.py` -- 12 new tests

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

- Backwards compatible: agents without `cache_system_prompt_blocks` behave identically to before.
- `provider_data` with `cache_control` is ignored by non-Claude model formatters, so no cross-model breakage.
- When `agent.system_message` is provided (custom override), `cache_system_prompt_blocks` has no effect.