### PR TITLE
test: trigger CI review workflow validation

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           use_sticky_comment: true
           track_progress: true
-          show_full_output: true  # TEMP: remove after validation
+          show_full_output: true  # TEMP: remove after validation (test trigger)
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Trivial change to trigger the `review` job in the rewritten `claude.yml` workflow. This PR targets `ci/claude-review` (not `main`) to validate the auto-review pipeline before merging to main.

**Expected:** The `pull_request: opened` event fires the `review` job, Claude posts a sticky review comment.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [x] Other: CI validation test

---

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

This is a throw-away test PR. Will be closed after confirming the workflow runs successfully.