### PR TITLE
fix: use correct marketplace for code-review plugin

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,5 +32,6 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_CI_API_KEY }}
-          plugins: 'code-review@claude-code-plugins'
+          plugin_marketplaces: 'anthropics/claude-code'
+          plugins: 'code-review@anthropics-claude-code'
           show_full_output: true  # TEMP: remove after validation


### PR DESCRIPTION
## Summary

Fixes the Claude Code workflow to use the correct plugin marketplace. The previous PR (#6560) used `claude-code-plugins` as the marketplace name, but the `code-review` plugin is in `anthropics/claude-code` (the demo marketplace). This adds `plugin_marketplaces` to register the marketplace and uses `code-review@anthropics-claude-code` as the correct plugin identifier.

Also adds review intent detection to CLAUDE.md so natural language like `@claude review this PR` auto-invokes the `/code-review` plugin.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Tested in clean environment

---

## Additional Notes

- `show_full_output: true` is temporarily enabled for validation
- After merge, test by commenting `@claude review this PR` on any open PR