### PR TITLE
fix: use full git URL for code-review plugin marketplace

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,6 +32,6 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_CI_API_KEY }}
-          plugin_marketplaces: 'anthropics/claude-code'
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@anthropics-claude-code'
           show_full_output: true  # TEMP: remove after validation


### PR DESCRIPTION
## Summary

Fixes plugin marketplace URL format. The `plugin_marketplaces` parameter requires full Git URLs, not `owner/repo` shorthand.

**Change:** `anthropics/claude-code` -> `https://github.com/anthropics/claude-code.git`

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Self-review completed