### PR TITLE
ci: switch to Opus /review-pr + pr-review-toolkit for deep PR reviews

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,8 +13,12 @@ on:
     types: [submitted]
 
 jobs:
-  # Automated code review on all PRs
-  code-review:
+  # Automated deep code review on all non-draft PRs
+  # Uses Opus /review-pr (inline comments + summary) stacked with
+  # pr-review-toolkit (6 specialized agents: comment-analyzer,
+  # test-analyzer, silent-failure-hunter, type-design-analyzer,
+  # code-reviewer, code-simplifier)
+  review:
     if: |
       github.event_name == 'pull_request' &&
       !github.event.pull_request.draft
@@ -28,7 +32,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review
@@ -36,12 +40,12 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_CI_API_KEY }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
+          plugins: 'pr-review-toolkit@claude-code-plugins'
           use_sticky_comment: true
-          show_full_output: true
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-        env:
-          FORCE_AUTOUPDATE_PLUGINS: 'true'
+          show_full_output: true  # TEMP: remove after validation
+          prompt: '/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}'
+          claude_args: |
+            --model "claude-opus-4-6"
 
   # Interactive assistant when @claude is mentioned
   assistant:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,19 +242,10 @@ gh api repos/agno-agi/agno/pulls/<PR_NUMBER> -X PATCH -f body="$(cat /path/to/bo
 
 ---
 
-## CI: Review Intent Detection
+## CI: Automated Code Review
 
-When running in GitHub Actions (CI) and a user mentions `@claude` with review intent, automatically invoke the `/code-review` plugin command before responding.
+Every non-draft PR automatically receives a deep review from Opus using `/review-pr` stacked with the `pr-review-toolkit` plugin (6 specialized agents). No manual trigger needed.
 
-**Trigger phrases** (case-insensitive, partial matches count):
-- "review this PR", "review the changes", "review this"
-- "code review", "do a review", "run a review"
-- "check this PR", "check the code", "look at this PR"
-- "what do you think of this PR", "any issues with this PR"
+When running in GitHub Actions (CI) and a user mentions `@claude` asking for a review, use `/review-pr` to run a fresh review pass.
 
-**Do NOT auto-invoke** `/code-review` when the request is clearly about something else:
-- "review my question", "review this error message"
-- Specific file/line questions ("what does line 42 do?")
-- Bug reports, feature requests, or general questions
-
-When in doubt, invoke `/code-review` — it's better to review and answer than to skip the review.
+**CI output rule:** When running as a CI reviewer, always end your response with a plain-text summary of findings. Never let the final action be a tool call — the GitHub Action uses the text output to post the sticky PR comment. If there are no issues, say so explicitly.


### PR DESCRIPTION
## Summary

Replace the `code-review` plugin with Anthropic's own `/review-pr` skill running on Opus, stacked with the `pr-review-toolkit` plugin for maximum review thoroughness.

**Changes:**
- Review job now uses `/review-pr` (Anthropic's built-in skill) with `--model claude-opus-4-6`
- Added `pr-review-toolkit` plugin (6 specialized agents: comment-analyzer, test-analyzer, silent-failure-hunter, type-design-analyzer, code-reviewer, code-simplifier)
- `fetch-depth: 0` for full git history (enables blame analysis)
- CLAUDE.md: replaced verbose "Review Intent Detection" with concise "Automated Code Review" section
- CLAUDE.md: added CI output rule to prevent empty sticky comments (fixes the intermittent 0-comment bug)

## Type of change
- [x] Infrastructure/CI change

## Checklist
- [x] Workflow triggers unchanged (opened, synchronize, ready_for_review, reopened)
- [x] Assistant job unchanged
- [x] Sticky comment enabled
- [x] show_full_output: true for debugging (temporary)