### PR TITLE
ci: use both official review plugins with Opus

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,18 +13,15 @@ on:
     types: [submitted]
 
 jobs:
-  # Automated deep code review on all non-draft PRs
-  # Uses Opus /review-pr (inline comments + summary) stacked with
-  # pr-review-toolkit (6 specialized agents: comment-analyzer,
-  # test-analyzer, silent-failure-hunter, type-design-analyzer,
-  # code-reviewer, code-simplifier)
+  # Automated code review on all non-draft PRs
+  # Uses both official plugins: code-review (4 agents) + pr-review-toolkit (6 agents)
   review:
     if: |
       github.event_name == 'pull_request' &&
       !github.event.pull_request.draft
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
       id-token: write
@@ -39,13 +36,22 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_CI_API_KEY }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'pr-review-toolkit@claude-code-plugins'
+          plugins: 'code-review,pr-review-toolkit'
           use_sticky_comment: true
+          max_turns: 30
           show_full_output: true  # TEMP: remove after validation
-          prompt: '/review-pr REPO: ${{ github.repository }} PR_NUMBER: ${{ github.event.pull_request.number }}'
           claude_args: |
             --model "claude-opus-4-6"
+          append_prompt: |
+            After completing the review, you MUST end with a plain-text markdown summary of findings.
+            Never let the final action be a tool call.
+            If there are no issues, explicitly say "No high-confidence findings."
+
+            Agno-specific checks (always verify):
+            - Both sync and async variants exist for all new public methods
+            - No agent creation inside loops (agents should be reused)
+            - CLAUDE.md coding patterns are followed
+            - No f-strings for print lines where there are no variables
 
   # Interactive assistant when @claude is mentioned
   assistant:


### PR DESCRIPTION
## Summary

Use both official Claude Code plugins for automated PR review with Opus for maximum thoroughness.

**Plugins:**
- `code-review` — 4 parallel agents for broad sweep
- `pr-review-toolkit` — 6 specialized agents (comment-analyzer, test-analyzer, silent-failure-hunter, type-design-analyzer, code-reviewer, code-simplifier)

**Key settings:**
- `append_prompt` forces final text output (fixes intermittent empty sticky comment bug) and adds Agno-specific review rules (sync/async parity, no agents in loops, CLAUDE.md compliance)
- `max_turns: 30` prevents early termination on tool turns
- `--model claude-opus-4-6` for thorough reviews
- `use_sticky_comment: true` edits one comment in place
- `contents: read` — review is read-only
- `fetch-depth: 0` — full git history for blame analysis

## Type of change
- [x] Infrastructure/CI change

## Checklist
- [x] Both official plugins, no custom files
- [x] Empty result bug addressed via append_prompt
- [x] show_full_output: true for debugging (temporary)
- [x] Assistant job unchanged