### PR TITLE
ci: fix review — add prompt, remove invalid inputs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -38,11 +38,12 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_CI_API_KEY }}
           plugins: 'code-review,pr-review-toolkit'
           use_sticky_comment: true
-          max_turns: 30
           show_full_output: true  # TEMP: remove after validation
           claude_args: |
             --model "claude-opus-4-6"
-          append_prompt: |
+          prompt: |
+            Review this PR: ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+
             After completing the review, you MUST end with a plain-text markdown summary of findings.
             Never let the final action be a tool call.
             If there are no issues, explicitly say "No high-confidence findings."


### PR DESCRIPTION
## Summary

Fix the review job that was skipping with "No trigger found":
- `append_prompt` and `max_turns` are not valid `claude-code-action` inputs (silently ignored)
- Without `prompt`, the action had no trigger and skipped
- Moved review instructions into the `prompt` field
- Both plugins still enabled: `code-review` + `pr-review-toolkit`

## Type of change
- [x] Bug fix (CI)