### PR TITLE
ci: remove github_token to fix sticky comment identity

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_CI_API_KEY }}
-          github_token: ${{ github.token }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: |
             code-review@claude-code-plugins
@@ -84,4 +83,3 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_CI_API_KEY }}
-          github_token: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Removes `github_token: ${{ github.token }}` from both review and assistant jobs
- This was incorrectly added thinking OIDC lacked permissions — the real fix was `track_progress: true`
- With `github_token`, comments post as `github-actions[bot]` which breaks the sticky comment search (it looks for `claude[bot]`)
- Without it, the action uses OIDC → comments post as `claude[bot]` → sticky update works

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the coding style of this project
- [x] I have performed a self-review of my own code