### PR TITLE
ci: smart @claude handler with review/assistant mode routing

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,20 +11,6 @@ on:
     types: [opened, assigned]
   pull_request_review:
     types: [submitted]
-  # Manual trigger for testing on non-default branches (remove after validation)
-  workflow_dispatch:
-    inputs:
-      mode:
-        description: 'Test mode to simulate'
-        required: true
-        type: choice
-        options:
-          - review
-          - assistant
-      test_prompt:
-        description: 'Simulated @claude message'
-        required: false
-        default: '@claude review this PR'
 
 jobs:
   # Auto-review on every non-draft PR open/update
@@ -74,7 +60,6 @@ jobs:
   # "@claude how do hooks work" → general assistant
   claude:
     if: |
-      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body || '', '@claude')) ||
@@ -98,17 +83,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           PR_URL: ${{ github.event.issue.pull_request.url || '' }}
           COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body || '' }}
-          DISPATCH_MODE: ${{ github.event.inputs.mode || '' }}
         run: |
-          # Manual dispatch: whitelist and use the selected mode directly
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            case "$DISPATCH_MODE" in
-              review|assistant) echo "mode=$DISPATCH_MODE" >> "$GITHUB_OUTPUT" ;;
-              *) echo "mode=assistant" >> "$GITHUB_OUTPUT" ;;
-            esac
-            exit 0
-          fi
-
           # Determine if we're in a PR context (not a plain issue)
           IS_PR="false"
           case "$EVENT_NAME" in
@@ -154,4 +129,3 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_CI_API_KEY }}
-          prompt: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.test_prompt || '' }}


### PR DESCRIPTION
## Summary

Combines the separate `review` and `assistant` jobs into a unified smart `@claude` handler that routes based on comment content:

- `@claude review this` on a PR → full review with `code-review` + `pr-review-toolkit` plugins (10 agents)
- `@claude how do hooks work` → general assistant mode
- Auto-review on PR open/update remains unchanged

## How it works

1. **Mode detection step** parses the comment body:
   - Checks if we're in a PR context (not a plain issue)
   - Checks for "review" keyword with word boundary matching
   - Routes to review step (with plugins) or assistant step (bare)

2. **PR context awareness** — `@claude review this` on a regular issue won't trigger review mode (there's no code to review)

3. **Null-coalesced event fields** — `|| ''` on potentially-null fields in job conditions for robustness

## Testing

- [ ] Auto-review triggers on this PR (validates `pull_request` event path)
- [ ] After merge: `@claude review this` on a PR triggers review mode
- [ ] After merge: `@claude how do X work` on a PR triggers assistant mode
- [ ] After merge: `@claude review this` on an issue triggers assistant mode (no PR context)

## Type of change

- [x] Enhancement to CI/CD

## Checklist

- [x] Workflow YAML syntax validated (Ruby YAML parser)
- [x] Codex review completed — addressed all findings
- [x] Mode detection tested: `\breview\b` matches "review", "please review this" but NOT "preview"