### PR TITLE
ci: smart @claude handler with review plugin routing

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,38 +1,60 @@
 name: Claude Code
 
 on:
-  pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
   issue_comment:
     types: [created]
   pull_request_review_comment:
     types: [created]
   issues:
-    types: [opened, assigned]
+    types: [opened]
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
-  # Automated code review on all non-draft PRs
-  # Uses both official plugins: code-review (4 agents) + pr-review-toolkit (6 agents)
-  review:
+  claude:
+    timeout-minutes: 15
     if: |
-      github.event_name == 'pull_request' &&
-      !github.event.pull_request.draft
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body || '', '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body || '', '@claude') || contains(github.event.issue.title || '', '@claude')))
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
+      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Run Claude Code Review
-        id: claude-review
+      - name: Detect mode
+        id: detect
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_URL: ${{ github.event.issue.pull_request.url || '' }}
+          COMMENT_BODY: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body || '' }}
+        run: |
+          IS_PR="false"
+          case "$EVENT_NAME" in
+            pull_request_review_comment|pull_request_review) IS_PR="true" ;;
+            issue_comment) [ -n "$PR_URL" ] && IS_PR="true" ;;
+          esac
+
+          if [ "$IS_PR" = "true" ] && echo "$COMMENT_BODY" | grep -iqE '\breview\b'; then
+            echo "mode=review" >> "$GITHUB_OUTPUT"
+          else
+            echo "mode=assistant" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Claude Review
+        if: steps.detect.outputs.mode == 'review'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_CI_API_KEY }}
@@ -42,11 +64,10 @@ jobs:
             pr-review-toolkit@claude-code-plugins
           track_progress: true
           use_sticky_comment: true
-          show_full_output: true  # TEMP: remove after validation
           claude_args: |
             --model "claude-opus-4-6"
           prompt: |
-            Review this PR: ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+            The user requested a code review via @claude mention.
 
             After completing the review, you MUST end with a plain-text markdown summary of findings.
             Never let the final action be a tool call.
@@ -58,28 +79,8 @@ jobs:
             - CLAUDE.md coding patterns are followed
             - No f-strings for print lines where there are no variables
 
-  # Interactive assistant when @claude is mentioned
-  assistant:
-    if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-      actions: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Run Claude Code
-        id: claude
+      - name: Claude Assistant
+        if: steps.detect.outputs.mode == 'assistant'
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_CI_API_KEY }}


### PR DESCRIPTION
## Summary

Replaces the current two-job workflow (auto-review + plain assistant) with a single smart `@claude` handler:

- **`@claude review this`** on a PR → full 10-agent review with `code-review` + `pr-review-toolkit` plugins (Opus)
- **`@claude how do hooks work`** → plain assistant mode (no plugins)
- **PR opened/pushed** → nothing (removes auto-review spam)

## Changes

- Remove `pull_request` trigger and `review` job (no more auto-review on every push)
- Merge `review` + `assistant` jobs into single `claude` job with mode detection
- Add `Detect mode` step: checks PR context + "review" keyword → routes to plugins or assistant
- Add `concurrency` control keyed by issue/PR number (prevents duplicate runs)
- Add `timeout-minutes: 15` (prevents runaway jobs)
- Remove `id-token: write` (not needed with API key auth)
- Remove `issues: assigned` trigger (prevents phantom retriggers)
- Add `|| ''` null coalescing for nullable event fields

## How it works

```
@claude review this   →  Detect "review" + PR context  →  10-agent plugin review
@claude fix this bug  →  No "review" keyword            →  Plain assistant
@claude (on issue)    →  Not a PR context               →  Plain assistant
```

## Validation

- Simulated 14 scenarios covering all trigger types, edge cases (null bodies, case sensitivity, non-PR contexts) — all pass
- YAML syntax validated
- Dual-reviewed by Opus + Codex (two independent passes)

## Type of change

- [x] CI/CD change

## Checklist

- [x] Workflow triggers only on `@claude` mentions (no auto-review)
- [x] Review plugins fire only when "review" keyword detected on PR
- [x] Concurrency prevents duplicate runs
- [x] Timeout prevents runaway jobs
- [x] Null-safe event field access