### PR TITLE
fix: remove prompt input from claude review to enable tag mode

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -66,18 +66,6 @@ jobs:
           use_sticky_comment: true
           claude_args: |
             --model "claude-opus-4-6"
-          prompt: |
-            The user requested a code review via @claude mention.
-
-            After completing the review, you MUST end with a plain-text markdown summary of findings.
-            Never let the final action be a tool call.
-            If there are no issues, explicitly say "No high-confidence findings."
-
-            Agno-specific checks (always verify):
-            - Both sync and async variants exist for all new public methods
-            - No agent creation inside loops (agents should be reused)
-            - CLAUDE.md coding patterns are followed
-            - No f-strings for print lines where there are no variables
 
       - name: Claude Assistant
         if: steps.detect.outputs.mode == 'assistant'


### PR DESCRIPTION
## Summary

- Removes the `prompt:` input from the Claude Review step in the CI workflow
- The `prompt:` input was forcing `claude-code-action` into **agent mode**, which skips tracking comments and PR result posting
- Without `prompt:`, the action correctly detects **tag mode** for `@claude` mentions and handles PR context, tracking comments, and result posting automatically
- Agno-specific review instructions are already in `CLAUDE.md` (CI section), so they're picked up automatically

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code