### PR TITLE
fix: move concurrency to job level to prevent self-cancellation

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,12 +10,11 @@ on:
   pull_request_review:
     types: [submitted]
 
-concurrency:
-  group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   claude:
+    concurrency:
+      group: claude-${{ github.event.issue.number || github.event.pull_request.number || github.run_id }}
+      cancel-in-progress: true
     timeout-minutes: 15
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||


### PR DESCRIPTION
## Summary

- Moves `concurrency:` from workflow level to job level in the Claude Code workflow
- The action's tracking comment ("Claude Code is working...") triggers a new `issue_comment.created` event, which enters the workflow-level concurrency group and cancels the in-progress review
- At job level, the `if:` condition is evaluated first — non-`@claude` comments skip the job and never enter the concurrency group

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code