### PR TITLE
ci: enable show_full_output for claude review debugging

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -63,6 +63,7 @@ jobs:
             code-review@claude-code-plugins
             pr-review-toolkit@claude-code-plugins
           use_sticky_comment: true
+          show_full_output: true
           claude_args: |
             --model "claude-opus-4-6"
 


### PR DESCRIPTION
## Summary

- Temporarily enables `show_full_output: true` on the Claude Review step
- This will show all Claude messages in the job logs so we can verify the review plugins (code-review, pr-review-toolkit) are actually invoking multi-agent behavior
- **WARNING**: Full output may contain sensitive info in logs — this is temporary for debugging

## Type of change

- [x] Other (CI debugging)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code