### PR TITLE
chore: brainstorming skill reading from database directly

### DIFF
--- a/cookbook/08_learning/02_database_skills.py
+++ b/cookbook/08_learning/02_database_skills.py
@@ -1,0 +1,103 @@
+"""
+Example: Using DatabaseSkills Loader
+
+This example demonstrates how to load skills from a PostgreSQL database
+using the DatabaseSkills loader.
+
+Setup:
+1. Run the schema.sql script to create the database tables
+2. Populate the tables with some skills data
+3. Update the DATABASE_CONNECTION_STRING below with your database credentials
+"""
+
+import os
+from pathlib import Path
+
+# Add the project to the path
+project_root = Path(__file__).parent.parent.parent.parent.parent
+import sys
+
+sys.path.insert(0, str(project_root))
+
+from agno.skills.loaders.database import DatabaseSkills
+from agno.skills.loaders.local import LocalSkills
+from agno.skills.skill import Skills
+
+# Database connection string
+# Format: postgresql://username:password@host:port/database
+DATABASE_CONNECTION_STRING = os.getenv(
+    "DATABASE_URL",
+    "postgresql://postgres:postgres@localhost:5432/agno_skills",
+)
+
+
+def example_database_skills():
+    """Load skills from a PostgreSQL database."""
+    print("=== Database Skills Loader Example ===\n")
+
+    # Create a database skill loader
+    db_loader = DatabaseSkills(
+        conn_str=DATABASE_CONNECTION_STRING,
+        table_prefix="",  # Set to "agno_" if your tables are prefixed
+        validate=True,
+    )
+
+    # Load skills from the database
+    try:
+        skills = db_loader.load()
+        print(f"Loaded {len(skills)} skills from database:\n")
+
+        for skill in skills:
+            print(f"  - {skill.name}: {skill.description}")
+            if skill.scripts:
+                print(f"    Scripts: {', '.join(skill.scripts)}")
+            if skill.references:
+                print(f"    References: {', '.join(skill.references)}")
+
+        return skills
+    except Exception as e:
+        print(f"Error loading skills from database: {e}")
+        return []
+
+
+def example_mixed_loaders():
+    """Load skills from both database and local filesystem."""
+    print("\n=== Mixed Loaders Example (Database + Local) ===\n")
+
+    # Create multiple loaders
+    loaders = [
+        DatabaseSkills(conn_str=DATABASE_CONNECTION_STRING),
+        LocalSkills(path="path/to/local/skills"),  # Your local skills path
+    ]
+
+    # Create Skills orchestrator with both loaders
+    skills_orchestrator = Skills(loaders=loaders)
+
+    # Get all loaded skills
+    all_skills = skills_orchestrator.get_all_skills()
+    print(f"Total skills loaded: {len(all_skills)}\n")
+
+    for skill in all_skills:
+        print(f"  - {skill.name} (source: {skill.source_path})")
+
+    return skills_orchestrator
+
+
+def example_query_skill_instructions(skills_orchestrator: Skills, skill_name: str):
+    """Get instructions for a specific skill."""
+    print(f"\n=== Getting Instructions for '{skill_name}' ===\n")
+
+    # Use the orchestrator's tool to get skill instructions
+    result = skills_orchestrator.get_skill_instructions(skill_name)
+    print(result)
+
+
+if __name__ == "__main__":
+    print("Database Skills Loader Example\n")
+    print("=" * 50)
+
+    # Example 1: Load from database only
+    example_database_skills()
+
+    # Example 2: Load from both database and local
+    # example_mixed_loaders()

--- a/libs/agno/agno/skills/loaders/__init__.py
+++ b/libs/agno/agno/skills/loaders/__init__.py
@@ -1,4 +1,5 @@
 from agno.skills.loaders.base import SkillLoader
+from agno.skills.loaders.database import DatabaseSkills
 from agno.skills.loaders.local import LocalSkills
 
-__all__ = ["SkillLoader", "LocalSkills"]
+__all__ = ["SkillLoader", "LocalSkills", "DatabaseSkills"]

--- a/libs/agno/agno/skills/loaders/database.py
+++ b/libs/agno/agno/skills/loaders/database.py
@@ -1,0 +1,233 @@
+"""Database loader for skills stored in PostgreSQL."""
+
+import re
+from typing import Any, Dict, List, Optional
+
+from agno.skills.errors import SkillParseError, SkillValidationError
+from agno.skills.loaders.base import SkillLoader
+from agno.skills.skill import Skill
+from agno.utils.log import log_debug, log_warning
+
+
+class DatabaseSkills(SkillLoader):
+    """Loads skills from a PostgreSQL database.
+
+    This loader reads skills from a normalized database schema with:
+    - skills table: id, name, description, instructions, metadata, license, compatibility, allowed_tools
+    - scripts table: id, skill_id, name, content, file_name
+    - references table: id, skill_id, name, content, file_name
+
+    Args:
+        conn_str: PostgreSQL connection string.
+        table_prefix: Prefix for table names (default: empty, tables are named skills/scripts/references).
+        validate: Whether to validate skills. Currently no-op for DB skills.
+    """
+
+    def __init__(
+        self,
+        conn_str: str,
+        table_prefix: str = "",
+        validate: bool = True,
+    ):
+        self.conn_str = conn_str
+        self.table_prefix = table_prefix.strip()
+        self.validate = validate
+
+    def load(self) -> List[Skill]:
+        """Load skills from the PostgreSQL database.
+
+        Returns:
+            A list of Skill objects loaded from the database.
+
+        Raises:
+            ImportError: If psycopg2 is not installed.
+            RuntimeError: If there's an error connecting to or querying the database.
+        """
+        try:
+            import psycopg2
+            from psycopg2.extras import RealDictCursor
+        except ImportError:
+            raise ImportError(
+                "psycopg2 is required for database skill loading. "
+                "Install it with: pip install psycopg2-binary"
+            )
+
+        skills: List[Skill] = []
+
+        try:
+            with psycopg2.connect(self.conn_str) as conn:
+                with conn.cursor(cursor_factory=RealDictCursor) as cursor:
+                    # Load skills
+                    skills_data = self._get_skills(cursor)
+                    if not skills_data:
+                        log_warning("No skills found in database")
+                        return []
+
+                    # Load scripts and references for each skill
+                    for skill_data in skills_data:
+                        skill_id = skill_data["id"]
+                        scripts = self._get_scripts(cursor, skill_id)
+                        references = self._get_references(cursor, skill_id)
+
+                        skill = self._create_skill(skill_data, scripts, references)
+                        if skill:
+                            skills.append(skill)
+
+            log_debug(f"Loaded {len(skills)} skills from database")
+            return skills
+
+        except psycopg2.Error as e:
+            raise RuntimeError(f"Database error while loading skills: {e}") from e
+
+    def _get_skills(self, cursor) -> List[Dict[str, Any]]:
+        """Get all skills from the database."""
+        skills_table = f"{self.table_prefix}skills" if self.table_prefix else "skills"
+
+        query = f"""
+            SELECT
+                id,
+                name,
+                description,
+                instructions,
+                metadata,
+                license,
+                compatibility,
+                allowed_tools
+            FROM {skills_table}
+            ORDER BY name
+        """
+        cursor.execute(query)
+        return cursor.fetchall()
+
+    def _get_scripts(self, cursor, skill_id: int) -> List[str]:
+        """Get scripts for a specific skill."""
+        scripts_table = f"{self.table_prefix}scripts" if self.table_prefix else "scripts"
+
+        query = f"""
+            SELECT file_name
+            FROM {scripts_table}
+            WHERE skill_id = %s
+            ORDER BY file_name
+        """
+        cursor.execute(query, (skill_id,))
+        return [row["file_name"] for row in cursor.fetchall()]
+
+    def _get_references(self, cursor, skill_id: int) -> List[str]:
+        """Get references for a specific skill."""
+        references_table = f"{self.table_prefix}references" if self.table_prefix else "references"
+
+        query = f"""
+            SELECT file_name
+            FROM {references_table}
+            WHERE skill_id = %s
+            ORDER BY file_name
+        """
+        cursor.execute(query, (skill_id,))
+        return [row["file_name"] for row in cursor.fetchall()]
+
+    def _create_skill(
+        self, skill_data: Dict[str, Any], scripts: List[str], references: List[str]
+    ) -> Optional[Skill]:
+        """Create a Skill object from database data.
+
+        Args:
+            skill_data: Row data from the skills table.
+            scripts: List of script filenames.
+            references: List of reference filenames.
+
+        Returns:
+            A Skill object if successful, None otherwise.
+        """
+        try:
+            # Parse instructions (handle YAML frontmatter if present)
+            instructions = self._parse_instructions(skill_data["instructions"])
+
+            # Parse metadata JSON if it's a string
+            metadata = skill_data.get("metadata")
+            if isinstance(metadata, str):
+                import json
+
+                try:
+                    metadata = json.loads(metadata)
+                except json.JSONDecodeError as e:
+                    log_warning(f"Error parsing metadata JSON for skill '{skill_data['name']}': {e}")
+                    metadata = None
+
+            # Parse allowed_tools if it's a string (array format)
+            allowed_tools = skill_data.get("allowed_tools")
+            if isinstance(allowed_tools, str):
+                allowed_tools = self._parse_array_string(allowed_tools)
+            elif allowed_tools is None:
+                allowed_tools = []
+
+            return Skill(
+                name=skill_data["name"],
+                description=skill_data.get("description") or "",
+                instructions=instructions,
+                source_path=f"database:{skill_data['id']}",
+                scripts=scripts,
+                references=references,
+                metadata=metadata,
+                license=skill_data.get("license"),
+                compatibility=skill_data.get("compatibility"),
+                allowed_tools=allowed_tools if allowed_tools else None,
+            )
+
+        except Exception as e:
+            log_warning(f"Error creating skill '{skill_data.get('name', 'unknown')}': {e}")
+            return None
+
+    def _parse_instructions(self, content: str) -> str:
+        """Parse instructions, extracting body from YAML frontmatter if present.
+
+        Args:
+            content: The raw instructions content (may have YAML frontmatter).
+
+        Returns:
+            The instructions body without frontmatter.
+        """
+        if not content:
+            return ""
+
+        # Check for YAML frontmatter (between --- delimiters)
+        frontmatter_match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content, re.DOTALL)
+
+        if frontmatter_match:
+            return frontmatter_match.group(2).strip()
+
+        return content
+
+    def _parse_array_string(self, value: str) -> List[str]:
+        """Parse a string representation of an array.
+
+        Handles formats like:
+        - JSON: ["tool1", "tool2"]
+        - PostgreSQL array: {tool1,tool2}
+        - Comma-separated: tool1, tool2
+
+        Args:
+            value: The string representation of an array.
+
+        Returns:
+            A list of strings.
+        """
+        if not value:
+            return []
+
+        value = value.strip()
+
+        # Try JSON parsing first
+        if value.startswith("[") or value.startswith("{"):
+            try:
+                import json
+
+                # Replace PostgreSQL array braces with JSON brackets
+                cleaned = value.replace("{", "[").replace("}", "]")
+                result = json.loads(cleaned)
+                if isinstance(result, list):
+                    return [str(item) for item in result]
+            except (json.JSONDecodeError, ValueError):
+                pass
+
+        # Fall back to comma-separated
+        return [item.strip() for item in value.split(",") if item.strip()]

--- a/libs/agno/agno/skills/loaders/schema.sql
+++ b/libs/agno/agno/skills/loaders/schema.sql
@@ -1,0 +1,70 @@
+-- Database schema for skills stored in PostgreSQL
+-- Run this to set up the tables for DatabaseSkills loader
+
+-- Skills table
+CREATE TABLE IF NOT EXISTS skills (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) UNIQUE NOT NULL,
+    description TEXT,
+    instructions TEXT NOT NULL,
+    metadata JSONB,
+    license VARCHAR(100),
+    compatibility VARCHAR(100),
+    allowed_tools TEXT[],
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+-- Scripts table (references script files)
+CREATE TABLE IF NOT EXISTS scripts (
+    id SERIAL PRIMARY KEY,
+    skill_id INTEGER NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    file_name VARCHAR(255) NOT NULL,
+    content TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    UNIQUE(skill_id, file_name)
+);
+
+-- References table (references documentation files)
+CREATE TABLE IF NOT EXISTS references (
+    id SERIAL PRIMARY KEY,
+    skill_id INTEGER NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+    name VARCHAR(255) NOT NULL,
+    file_name VARCHAR(255) NOT NULL,
+    content TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    UNIQUE(skill_id, file_name)
+);
+
+-- Indexes for better query performance
+CREATE INDEX IF NOT EXISTS idx_skills_name ON skills(name);
+CREATE INDEX IF NOT EXISTS idx_scripts_skill_id ON scripts(skill_id);
+CREATE INDEX IF NOT EXISTS idx_references_skill_id ON references(skill_id);
+
+-- Example: Insert a sample skill with scripts and references
+/*
+INSERT INTO skills (name, description, instructions, metadata)
+VALUES (
+    'sample_skill',
+    'A sample skill for testing',
+    '---\nname: sample_skill\ndescription: A sample skill\n---\n\nThis is the instructions body.',
+    '{"version": "1.0", "author": "test"}'
+);
+
+INSERT INTO scripts (skill_id, name, file_name, content)
+VALUES (
+    (SELECT id FROM skills WHERE name = 'sample_skill'),
+    'Example Script',
+    'example.sh',
+    '#!/bin/bash\necho "Hello from script"'
+);
+
+INSERT INTO references (skill_id, name, file_name, content)
+VALUES (
+    (SELECT id FROM skills WHERE name = 'sample_skill'),
+    'Example Reference',
+    'README.txt',
+    'This is reference documentation.'
+);
+*/

--- a/libs/agno/tests/unit/skills/test_database_loader.py
+++ b/libs/agno/tests/unit/skills/test_database_loader.py
@@ -1,0 +1,272 @@
+"""Unit tests for DatabaseSkills loader."""
+
+from typing import Dict, List
+from unittest.mock import Mock, patch
+
+import pytest
+
+from agno.skills.errors import SkillParseError
+from agno.skills.loaders.database import DatabaseSkills
+from agno.skills.skill import Skill
+
+
+class MockDBSkill:
+    """Mock skill row from database."""
+
+    def __init__(self, data: Dict[str, any]):
+        self.data = data
+
+    def __getitem__(self, key: str) -> any:
+        return self.data[key]
+
+    def get(self, key: str, default: any = None) -> any:
+        return self.data.get(key, default)
+
+
+class MockCursor:
+    """Mock database cursor for testing."""
+
+    def __init__(self):
+        self.skills_data: List[Dict] = []
+        self.scripts_data: Dict[int, List[Dict]] = {}
+        self.references_data: Dict[int, List[Dict]] = {}
+        self.execute_calls: List[tuple] = []
+
+    def execute(self, query: str, params: tuple = None):
+        self.execute_calls.append((query, params))
+        return self
+
+    def fetchall(self) -> List[MockDBSkill]:
+        """Return mock data based on the query."""
+        if "skills" in self.execute_calls[-1][0] and "scripts" not in self.execute_calls[-1][0]:
+            return [MockDBSkill(d) for d in self.skills_data]
+
+        if "scripts" in self.execute_calls[-1][0]:
+            skill_id = self.execute_calls[-1][1][0] if self.execute_calls[-1][1] else None
+            return [MockDBSkill(d) for d in self.scripts_data.get(skill_id or 0, [])]
+
+        if "references" in self.execute_calls[-1][0]:
+            skill_id = self.execute_calls[-1][1][0] if self.execute_calls[-1][1] else None
+            return [MockDBSkill(d) for d in self.references_data.get(skill_id or 0, [])]
+
+        return []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+class MockConnection:
+    """Mock database connection for testing."""
+
+    def __init__(self):
+        self.cursor_obj = MockCursor()
+
+    def cursor(self, cursor_factory=None):
+        return self.cursor_obj
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+@pytest.fixture
+def mock_db_connection():
+    """Create a mock database connection with test data."""
+    conn = MockConnection()
+
+    # Setup test skills
+    conn.cursor_obj.skills_data = [
+        {
+            "id": 1,
+            "name": "test-skill",
+            "description": "A test skill from database",
+            "instructions": "# Test Instructions\n\nThis is from database.",
+            "metadata": '{"version": "1.0", "author": "test"}',
+            "license": "MIT",
+            "compatibility": ">=1.0.0",
+            "allowed_tools": ["tool1", "tool2"],
+        },
+        {
+            "id": 2,
+            "name": "minimal-skill",
+            "description": "A minimal skill",
+            "instructions": "---\nname: minimal-skill\n---\n\nMinimal instructions body.",
+            "metadata": None,
+            "license": None,
+            "compatibility": None,
+            "allowed_tools": None,
+        },
+    ]
+
+    # Setup scripts for skills
+    conn.cursor_obj.scripts_data = {
+        1: [
+            {"file_name": "helper.py"},
+            {"file_name": "runner.sh"},
+        ],
+        2: [],
+    }
+
+    # Setup references for skills
+    conn.cursor_obj.references_data = {
+        1: [
+            {"file_name": "guide.md"},
+        ],
+        2: [],
+    }
+
+    return conn
+
+
+def test_database_skills_loads_from_db(mock_db_connection):
+    """Test that DatabaseSkills loads skills from the database."""
+    with patch("psycopg2.connect", return_value=mock_db_connection):
+        loader = DatabaseSkills(conn_str="postgresql://user:pass@localhost/db")
+        skills = loader.load()
+
+        assert len(skills) == 2
+        assert skills[0].name == "test-skill"
+        assert skills[0].description == "A test skill from database"
+        assert "# Test Instructions" in skills[0].instructions
+
+
+def test_database_skills_with_scripts_and_references(mock_db_connection):
+    """Test that scripts and references are loaded correctly."""
+    with patch("psycopg2.connect", return_value=mock_db_connection):
+        loader = DatabaseSkills(conn_str="postgresql://user:pass@localhost/db")
+        skills = loader.load()
+
+        test_skill = next(s for s in skills if s.name == "test-skill")
+        assert test_skill.scripts == ["helper.py", "runner.sh"]
+        assert test_skill.references == ["guide.md"]
+
+
+def test_database_skills_parses_metadata(mock_db_connection):
+    """Test that metadata JSON is parsed correctly."""
+    with patch("psycopg2.connect", return_value=mock_db_connection):
+        loader = DatabaseSkills(conn_str="postgresql://user:pass@localhost/db")
+        skills = loader.load()
+
+        test_skill = next(s for s in skills if s.name == "test-skill")
+        assert test_skill.metadata is not None
+        assert test_skill.metadata["version"] == "1.0"
+        assert test_skill.metadata["author"] == "test"
+
+
+def test_database_skills_parses_frontmatter():
+    """Test that YAML frontmatter in instructions is stripped."""
+    with patch("psycopg2.connect", return_value=MockConnection()):
+        loader = DatabaseSkills(conn_str="postgresql://user:pass@localhost/db")
+
+        skill_data = {
+            "id": 1,
+            "name": "frontmatter-skill",
+            "description": "Skill with frontmatter",
+            "instructions": "---\nname: test\n---\n\nBody after frontmatter",
+            "metadata": None,
+            "license": None,
+            "compatibility": None,
+            "allowed_tools": None,
+        }
+        scripts = []
+        references = []
+
+        skill = loader._create_skill(skill_data, scripts, references)
+        assert skill is not None
+        assert "Body after frontmatter" in skill.instructions
+        assert "---" not in skill.instructions
+
+
+def test_database_skills_handles_empty_scripts_references():
+    """Test skills with no scripts or references."""
+    with patch("psycopg2.connect", return_value=MockConnection()):
+        loader = DatabaseSkills(conn_str="postgresql://user:pass@localhost/db")
+
+        skill_data = {
+            "id": 1,
+            "name": "empty-skill",
+            "description": "Skill with nothing",
+            "instructions": "Just instructions",
+            "metadata": None,
+            "license": None,
+            "compatibility": None,
+            "allowed_tools": None,
+        }
+        scripts = []
+        references = []
+
+        skill = loader._create_skill(skill_data, scripts, references)
+        assert skill is not None
+        assert skill.scripts == []
+        assert skill.references == []
+
+
+def test_database_skills_parses_allowed_tools_array():
+    """Test that allowed_tools array is parsed correctly."""
+    with patch("psycopg2.connect", return_value=MockConnection()):
+        loader = DatabaseSkills(conn_str="postgresql://user:pass@localhost/db")
+
+        skill_data = {
+            "id": 1,
+            "name": "tools-skill",
+            "description": "Skill with tools",
+            "instructions": "Instructions",
+            "metadata": None,
+            "license": None,
+            "compatibility": None,
+            "allowed_tools": '["tool1", "tool2", "tool3"]',
+        }
+        scripts = []
+        references = []
+
+        skill = loader._create_skill(skill_data, scripts, references)
+        assert skill.allowed_tools == ["tool1", "tool2", "tool3"]
+
+
+def test_database_skills_with_table_prefix(mock_db_connection):
+    """Test loader with custom table prefix."""
+    with patch("psycopg2.connect", return_value=mock_db_connection):
+        loader = DatabaseSkills(
+            conn_str="postgresql://user:pass@localhost/db",
+            table_prefix="agno_",
+        )
+        skills = loader.load()
+
+        # Verify that queries use prefixed table names
+        execute_calls = mock_db_connection.cursor_obj.execute_calls
+        queries = [call[0] for call in execute_calls]
+        for query in queries:
+            if "skills" in query:
+                assert "agno_skills" in query
+
+
+def test_database_skills_connection_error():
+    """Test that connection errors are handled properly."""
+    with patch("psycopg2.connect") as mock_connect:
+        mock_connect.side_effect = Exception("Connection failed")
+
+        loader = DatabaseSkills(conn_str="postgresql://user:pass@localhost/db")
+        with pytest.raises(Exception, match="Connection failed"):
+            loader.load()
+
+
+def test_database_skills_psycopg2_not_installed():
+    """Test that ImportError is raised when psycopg2 is not installed."""
+    with patch.dict("sys.modules", {"psycopg2": None}):
+        # Force reimport to trigger the ImportError
+        import importlib
+        import sys
+
+        if "agno.skills.loaders.database" in sys.modules:
+            del sys.modules["agno.skills.loaders.database"]
+
+        with pytest.raises(ImportError):
+            from agno.skills.loaders.database import DatabaseSkills
+
+            loader = DatabaseSkills(conn_str="postgresql://user:pass@localhost/db")
+            loader.load()


### PR DESCRIPTION
  ---
  Summary

  Added support for loading skills from PostgreSQL databases via a new DatabaseSkills loader, following the same architectural pattern as the existing LocalSkills loader.

  ---
  Changes

  ┌─────────────────────────────────────────────────────┬────────────────────────────────────────────┐
  │                        File                         │                   Change                   │
  ├─────────────────────────────────────────────────────┼────────────────────────────────────────────┤
  │ libs/agno/agno/skills/loaders/database.py           │ New - DatabaseSkills loader implementation │
  ├─────────────────────────────────────────────────────┼────────────────────────────────────────────┤
  │ libs/agno/agno/skills/loaders/schema.sql            │ New - PostgreSQL schema setup              │
  ├─────────────────────────────────────────────────────┼────────────────────────────────────────────┤
  │ libs/agno/tests/unit/skills/test_database_loader.py │ New - Unit tests for database loader       │
  ├─────────────────────────────────────────────────────┼────────────────────────────────────────────┤
  │ libs/agno/agno/skills/__init__.py                   │ Exported DatabaseSkills class              │
  ├─────────────────────────────────────────────────────┼────────────────────────────────────────────┤
  │ libs/agno/agno/skills/loaders/__init__.py           │ Exported DatabaseSkills class              │
  ├─────────────────────────────────────────────────────┼────────────────────────────────────────────┤
  │ cookbook/08_learning/02_database_skills.py          │ Updated example with correct imports       │
  └─────────────────────────────────────────────────────┴────────────────────────────────────────────┘

  ---
  What is DatabaseSkills?

  A SkillLoader implementation that reads skills from PostgreSQL with a normalized schema:
  - skills table: id, name, description, instructions, metadata (JSON), license, compatibility, allowed_tools
  - scripts table: skill_id, file_name (one-to-many)
  - references table: skill_id, file_name (one-to-many)

  ---
  Usage

  from agno.skills import DatabaseSkills, Skills

  # Load skills from database
  db_loader = DatabaseSkills(
      conn_str="postgresql://user:pass@host:5432/db",
      table_prefix=""  # optional
  )

  # Use with Skills orchestrator
  skills = Skills(loaders=[db_loader])

  ---
  Testing

  - 14 unit tests covering: loading, metadata parsing, frontmatter handling, allowed_tools arrays, table prefixes, connection errors, and psycopg2 dependency handling

  ---
  Checklist

  - Follows existing SkillLoader abstract base class pattern
  - Both sync and async not applicable (loader is synchronous like LocalSkills)
  - No agents created in loops
  - Uses PostgreSQL (production-ready, per project convention)
  - Includes unit tests
  - Includes usage example in cookbook