### PR TITLE
[feat] make aprint_response return RunOutput

### DIFF
--- a/libs/agno/agno/agent/_cli.py
+++ b/libs/agno/agno/agent/_cli.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
 from agno.filters import FilterExpr
 from agno.media import Audio, File, Image, Video
 from agno.models.message import Message
+from agno.run.agent import RunOutput
 from agno.utils.print_response.agent import (
     aprint_response,
     aprint_response_stream,
@@ -56,7 +57,7 @@ def agent_print_response(
     console: Optional[Any] = None,
     tags_to_include_in_markdown: Optional[Set[str]] = None,
     **kwargs: Any,
-) -> None:
+) -> Optional[RunOutput]:
     from agno.agent import _init
 
     if _init.has_async_db(agent):
@@ -106,9 +107,10 @@ def agent_print_response(
             metadata=metadata,
             **kwargs,
         )
+        return None
 
     else:
-        print_response(
+        return print_response(
             agent=agent,
             input=input,
             session_id=session_id,
@@ -163,7 +165,7 @@ async def agent_aprint_response(
     console: Optional[Any] = None,
     tags_to_include_in_markdown: Optional[Set[str]] = None,
     **kwargs: Any,
-) -> None:
+) -> Optional[RunOutput]:
     if not tags_to_include_in_markdown:
         tags_to_include_in_markdown = {"think", "thinking"}
 
@@ -207,8 +209,9 @@ async def agent_aprint_response(
             metadata=metadata,
             **kwargs,
         )
+        return None
     else:
-        await aprint_response(
+        return await aprint_response(
             agent=agent,
             input=input,
             session_id=session_id,

--- a/libs/agno/agno/agent/_default_tools.py
+++ b/libs/agno/agno/agent/_default_tools.py
@@ -282,7 +282,6 @@ def create_knowledge_search_tool(
         return Function.from_callable(search_knowledge_base, name="search_knowledge_base")
 
 
-
 def get_chat_history_function(agent: Agent, session: AgentSession) -> Callable:
     def get_chat_history(num_chats: Optional[int] = None) -> str:
         """Use this function to get the chat history between the user and agent.

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -1077,7 +1077,7 @@ class Agent:
         console: Optional[Any] = None,
         tags_to_include_in_markdown: Optional[Set[str]] = None,
         **kwargs: Any,
-    ) -> None:
+    ) -> Optional[RunOutput]:
         return _cli.agent_print_response(
             self,
             input=input,
@@ -1133,7 +1133,7 @@ class Agent:
         console: Optional[Any] = None,
         tags_to_include_in_markdown: Optional[Set[str]] = None,
         **kwargs: Any,
-    ) -> None:
+    ) -> Optional[RunOutput]:
         return await _cli.agent_aprint_response(
             self,
             input=input,

--- a/libs/agno/agno/team/_default_tools.py
+++ b/libs/agno/agno/team/_default_tools.py
@@ -1311,7 +1311,6 @@ def create_knowledge_search_tool(
         return Function.from_callable(search_knowledge_base, name="search_knowledge_base")
 
 
-
 def get_relevant_docs_from_knowledge(
     team: "Team",
     query: str,

--- a/libs/agno/agno/utils/print_response/agent.py
+++ b/libs/agno/agno/utils/print_response/agent.py
@@ -663,6 +663,8 @@ def print_response(
         panels = [p for p in panels if not isinstance(p, Status)]
         live_log.update(Group(*panels))
 
+    return run_response
+
 
 async def aprint_response(
     agent: "Agent",
@@ -782,6 +784,8 @@ async def aprint_response(
         # Final update to remove the "Working..." status
         panels = [p for p in panels if not isinstance(p, Status)]
         live_log.update(Group(*panels))
+
+    return run_response
 
 
 def build_panels(

--- a/libs/agno/tests/integration/workflows/test_parallel_steps.py
+++ b/libs/agno/tests/integration/workflows/test_parallel_steps.py
@@ -675,12 +675,13 @@ def test_parallel_name_first_streaming():
 
 
 # ==================================
-# OUTPUT SCHEMA ISOLATION TESTS 
+# OUTPUT SCHEMA ISOLATION TESTS
 
 # When parallel steps contain agents with different output_schema types, each
 # step must receive its own run_context copy so that apply_to_context() writes
 # do not clobber a sibling step's schema.
 # ==================================
+
 
 class ImageClassification(BaseModel):
     """Output schema for image classifier agents."""

--- a/libs/agno/tests/unit/agent/test_knowledge_retriever_tool_priority.py
+++ b/libs/agno/tests/unit/agent/test_knowledge_retriever_tool_priority.py
@@ -6,8 +6,9 @@ get_relevant_docs_from_knowledge(), which checks knowledge_retriever
 first and falls back to knowledge.search().
 """
 
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 
 from agno.agent import Agent
 from agno.agent._tools import aget_tools, get_tools

--- a/libs/agno/tests/unit/agent/test_print_response.py
+++ b/libs/agno/tests/unit/agent/test_print_response.py
@@ -1,0 +1,86 @@
+"""Tests for print_response and aprint_response returning RunOutput."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agno.agent.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.run.agent import RunOutput
+
+
+@pytest.fixture
+def mock_run_output():
+    """Create a mock RunOutput for testing."""
+    return RunOutput(
+        run_id="test-run-id",
+        agent_id="test-agent-id",
+        agent_name="TestAgent",
+        session_id="test-session-id",
+        content="Hello, this is a test response.",
+    )
+
+
+@pytest.fixture
+def agent():
+    """Create a minimal agent with a mock model."""
+    mock_model = MagicMock(spec=OpenAIChat)
+    return Agent(name="TestAgent", model=mock_model, markdown=False)
+
+
+class TestPrintResponseReturnsRunOutput:
+    def test_print_response_returns_run_output(self, agent, mock_run_output, monkeypatch):
+        """Test that print_response returns RunOutput when stream=False."""
+        from agno.agent import _init
+
+        monkeypatch.setattr(_init, "has_async_db", lambda a: False)
+
+        with patch.object(agent, "run", return_value=mock_run_output):
+            result = agent.print_response("Hello", stream=False)
+
+        assert isinstance(result, RunOutput)
+        assert result.run_id == "test-run-id"
+        assert result.content == "Hello, this is a test response."
+
+    def test_print_response_returns_none_when_streaming(self, agent, monkeypatch):
+        """Test that print_response returns None when stream=True."""
+        from agno.agent import _init
+
+        monkeypatch.setattr(_init, "has_async_db", lambda a: False)
+
+        # For streaming, the function iterates over events, so we mock run to return an iterable
+        with patch.object(agent, "run", return_value=iter([])):
+            result = agent.print_response("Hello", stream=True)
+
+        assert result is None
+
+
+class TestAPrintResponseReturnsRunOutput:
+    def test_aprint_response_returns_run_output(self, agent, mock_run_output):
+        """Test that aprint_response returns RunOutput when stream=False."""
+
+        async def _test():
+            with patch.object(agent, "arun", new_callable=AsyncMock, return_value=mock_run_output):
+                result = await agent.aprint_response("Hello", stream=False)
+            return result
+
+        result = asyncio.get_event_loop().run_until_complete(_test())
+        assert isinstance(result, RunOutput)
+        assert result.run_id == "test-run-id"
+        assert result.content == "Hello, this is a test response."
+
+    def test_aprint_response_returns_none_when_streaming(self, agent):
+        """Test that aprint_response returns None when stream=True."""
+
+        async def _empty_async_gen():
+            return
+            yield  # noqa: unreachable - makes this an async generator
+
+        async def _test():
+            with patch.object(agent, "arun", return_value=_empty_async_gen()):
+                result = await agent.aprint_response("Hello", stream=True)
+            return result
+
+        result = asyncio.get_event_loop().run_until_complete(_test())
+        assert result is None

--- a/libs/agno/tests/unit/db/test_datetime_serialization.py
+++ b/libs/agno/tests/unit/db/test_datetime_serialization.py
@@ -173,7 +173,16 @@ class TestSerializeSessionJsonFields:
         result = serialize_session_json_fields(session)
 
         # All fields should be JSON strings now
-        for field in ["session_data", "agent_data", "team_data", "workflow_data", "metadata", "chat_history", "summary", "runs"]:
+        for field in [
+            "session_data",
+            "agent_data",
+            "team_data",
+            "workflow_data",
+            "metadata",
+            "chat_history",
+            "summary",
+            "runs",
+        ]:
             assert isinstance(result[field], str), f"{field} should be a string"
 
     def test_serialize_none_fields(self):


### PR DESCRIPTION
## Summary

Makes `aprint_response` (and `print_response`) return the `RunOutput` object instead of `None`. This allows users to access the response data after printing, enabling patterns like:

```python
result = await agent.aprint_response("What is 2+2?")
print(result.content)  # Access the response content
```

Fixes #6601

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `./scripts/format.sh` and `./scripts/validate.sh`