### PR TITLE
[feat] batch embedding requests in add_contents()

### DIFF
--- a/libs/agno/agno/knowledge/embedder/base.py
+++ b/libs/agno/agno/knowledge/embedder/base.py
@@ -16,6 +16,27 @@ class Embedder:
     def get_embedding_and_usage(self, text: str) -> Tuple[List[float], Optional[Dict]]:
         raise NotImplementedError
 
+    def get_embeddings_batch_and_usage(self, texts: List[str]) -> Tuple[List[List[float]], List[Optional[Dict]]]:
+        """
+        Get embeddings and usage for multiple texts in batches (sync version).
+
+        Default implementation falls back to individual calls.
+        Subclasses should override for native batch support.
+
+        Args:
+            texts: List of text strings to embed
+
+        Returns:
+            Tuple of (List of embedding vectors, List of usage dictionaries)
+        """
+        all_embeddings: List[List[float]] = []
+        all_usage: List[Optional[Dict]] = []
+        for text in texts:
+            embedding, usage = self.get_embedding_and_usage(text)
+            all_embeddings.append(embedding)
+            all_usage.append(usage)
+        return all_embeddings, all_usage
+
     async def async_get_embedding(self, text: str) -> List[float]:
         raise NotImplementedError
 

--- a/libs/agno/agno/knowledge/embedder/openai.py
+++ b/libs/agno/agno/knowledge/embedder/openai.py
@@ -99,6 +99,59 @@ class OpenAIEmbedder(Embedder):
             log_warning(e)
             return [], None
 
+    def get_embeddings_batch_and_usage(self, texts: List[str]) -> Tuple[List[List[float]], List[Optional[Dict]]]:
+        """
+        Get embeddings and usage for multiple texts in batches (sync version).
+
+        Args:
+            texts: List of text strings to embed
+
+        Returns:
+            Tuple of (List of embedding vectors, List of usage dictionaries)
+        """
+        all_embeddings: List[List[float]] = []
+        all_usage: List[Optional[Dict]] = []
+        log_info(f"Getting embeddings and usage for {len(texts)} texts in batches of {self.batch_size} (sync)")
+
+        for i in range(0, len(texts), self.batch_size):
+            batch_texts = texts[i : i + self.batch_size]
+
+            _request_params: Dict[str, Any] = {
+                "input": batch_texts,
+                "model": self.id,
+                "encoding_format": self.encoding_format,
+            }
+            if self.user is not None:
+                _request_params["user"] = self.user
+            # Pass dimensions for text-embedding-3 models or when using custom base_url (third-party APIs)
+            if self.id.startswith("text-embedding-3") or self.base_url is not None:
+                _request_params["dimensions"] = self.dimensions
+            if self.request_params:
+                _request_params.update(self.request_params)
+
+            try:
+                response: CreateEmbeddingResponse = self.client.embeddings.create(**_request_params)
+                batch_embeddings = [data.embedding for data in response.data]
+                all_embeddings.extend(batch_embeddings)
+
+                # For each embedding in the batch, add the same usage information
+                usage_dict = response.usage.model_dump() if response.usage else None
+                all_usage.extend([usage_dict] * len(batch_embeddings))
+            except Exception as e:
+                log_warning(f"Error in sync batch embedding: {e}")
+                # Fallback to individual calls for this batch
+                for text in batch_texts:
+                    try:
+                        embedding, usage = self.get_embedding_and_usage(text)
+                        all_embeddings.append(embedding)
+                        all_usage.append(usage)
+                    except Exception as e2:
+                        log_warning(f"Error in individual sync embedding fallback: {e2}")
+                        all_embeddings.append([])
+                        all_usage.append(None)
+
+        return all_embeddings, all_usage
+
     async def async_get_embedding(self, text: str) -> List[float]:
         req: Dict[str, Any] = {
             "input": text,

--- a/libs/agno/agno/vectordb/pgvector/pgvector.py
+++ b/libs/agno/agno/vectordb/pgvector/pgvector.py
@@ -327,6 +327,9 @@ class PgVector(VectorDb):
                     batch_docs = documents[i : i + batch_size]
                     log_debug(f"Processing batch starting at index {i}, size: {len(batch_docs)}")
                     try:
+                        # Batch embed all documents in this batch before building records
+                        self._embed_documents(batch_docs)
+
                         # Prepare documents for insertion
                         batch_records = []
                         for doc in batch_docs:
@@ -458,6 +461,9 @@ class PgVector(VectorDb):
                     batch_docs = documents[i : i + batch_size]
                     log_info(f"Processing batch starting at index {i}, size: {len(batch_docs)}")
                     try:
+                        # Batch embed all documents in this batch before building records
+                        self._embed_documents(batch_docs)
+
                         # Prepare documents for upserting
                         batch_records_dict: Dict[str, Dict[str, Any]] = {}  # Use dict to deduplicate by ID
                         for doc in batch_docs:
@@ -503,7 +509,8 @@ class PgVector(VectorDb):
     def _get_document_record(
         self, doc: Document, filters: Optional[Dict[str, Any]] = None, content_hash: str = ""
     ) -> Dict[str, Any]:
-        doc.embed(embedder=self.embedder)
+        if doc.embedding is None:
+            doc.embed(embedder=self.embedder)
         cleaned_content = self._clean_content(doc.content)
         # Include content_hash in ID to ensure uniqueness across different content hashes
         # This allows the same URL/content to be inserted with different descriptions
@@ -525,6 +532,58 @@ class PgVector(VectorDb):
             "content_hash": content_hash,
             "content_id": doc.content_id,
         }
+
+    def _embed_documents(self, batch_docs: List[Document]) -> None:
+        """
+        Embed a batch of documents using either batch embedding or individual embedding (sync version).
+
+        Args:
+            batch_docs: List of documents to embed
+        """
+        if self.embedder.enable_batch and hasattr(self.embedder, "get_embeddings_batch_and_usage"):
+            # Use batch embedding when enabled and supported
+            try:
+                # Extract content from all documents
+                doc_contents = [doc.content for doc in batch_docs]
+
+                # Get batch embeddings and usage
+                embeddings, usages = self.embedder.get_embeddings_batch_and_usage(doc_contents)
+
+                # Process documents with pre-computed embeddings
+                for j, doc in enumerate(batch_docs):
+                    try:
+                        if j < len(embeddings):
+                            doc.embedding = embeddings[j]
+                            doc.usage = usages[j] if j < len(usages) else None
+                    except Exception as e:
+                        log_error(f"Error assigning batch embedding to document '{doc.name}': {e}")
+
+            except Exception as e:
+                # Check if this is a rate limit error - don't fall back as it would make things worse
+                error_str = str(e).lower()
+                is_rate_limit = any(
+                    phrase in error_str
+                    for phrase in ["rate limit", "too many requests", "429", "trial key", "api calls / minute"]
+                )
+
+                if is_rate_limit:
+                    log_error(f"Rate limit detected during batch embedding.  {e}")
+                    raise e
+                else:
+                    log_warning(f"Sync batch embedding failed, falling back to individual embeddings: {e}")
+                    # Fall back to individual embedding
+                    for doc in batch_docs:
+                        try:
+                            doc.embed(embedder=self.embedder)
+                        except Exception as e2:
+                            log_error(f"Error embedding document '{doc.name}': {e2}")
+        else:
+            # Use individual embedding
+            for doc in batch_docs:
+                try:
+                    doc.embed(embedder=self.embedder)
+                except Exception as e:
+                    log_error(f"Error embedding document '{doc.name}': {e}")
 
     async def _async_embed_documents(self, batch_docs: List[Document]) -> None:
         """

--- a/libs/agno/tests/unit/vectordb/test_batch_embedding.py
+++ b/libs/agno/tests/unit/vectordb/test_batch_embedding.py
@@ -1,0 +1,328 @@
+"""Tests for batch embedding support in Embedder base class and PgVector sync insert/upsert."""
+
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agno.knowledge.document import Document
+from agno.knowledge.embedder.base import Embedder
+
+# ========== Embedder base class tests ==========
+
+
+class ConcreteEmbedder(Embedder):
+    """Concrete embedder for testing that tracks calls."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.individual_call_count = 0
+
+    def get_embedding(self, text: str) -> List[float]:
+        self.individual_call_count += 1
+        return [0.1] * (self.dimensions or 1536)
+
+    def get_embedding_and_usage(self, text: str) -> Tuple[List[float], Optional[Dict]]:
+        self.individual_call_count += 1
+        return [0.1] * (self.dimensions or 1536), {"prompt_tokens": len(text), "total_tokens": len(text)}
+
+
+class BatchEmbedder(ConcreteEmbedder):
+    """Embedder with native batch support that tracks batch calls."""
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.batch_call_count = 0
+
+    def get_embeddings_batch_and_usage(self, texts: List[str]) -> Tuple[List[List[float]], List[Optional[Dict]]]:
+        self.batch_call_count += 1
+        dims = self.dimensions or 1536
+        embeddings = [[0.1] * dims for _ in texts]
+        usages: List[Optional[Dict[str, Any]]] = [{"prompt_tokens": len(t), "total_tokens": len(t)} for t in texts]
+        return embeddings, usages
+
+
+def test_base_embedder_has_batch_method():
+    """Embedder base class should have get_embeddings_batch_and_usage method."""
+    embedder = ConcreteEmbedder()
+    assert hasattr(embedder, "get_embeddings_batch_and_usage")
+
+
+def test_base_embedder_batch_fallback_calls_individual():
+    """Default batch implementation should fall back to individual calls."""
+    embedder = ConcreteEmbedder(dimensions=4)
+    texts = ["hello", "world", "test"]
+
+    embeddings, usages = embedder.get_embeddings_batch_and_usage(texts)
+
+    assert len(embeddings) == 3
+    assert len(usages) == 3
+    assert embedder.individual_call_count == 3
+    for emb in embeddings:
+        assert len(emb) == 4
+    for usage in usages:
+        assert usage is not None
+        assert "prompt_tokens" in usage
+
+
+def test_base_embedder_batch_single_text():
+    """Batch method should work with a single text."""
+    embedder = ConcreteEmbedder(dimensions=4)
+
+    embeddings, usages = embedder.get_embeddings_batch_and_usage(["single"])
+
+    assert len(embeddings) == 1
+    assert len(usages) == 1
+    assert embedder.individual_call_count == 1
+
+
+def test_base_embedder_batch_empty_list():
+    """Batch method should handle empty list."""
+    embedder = ConcreteEmbedder(dimensions=4)
+
+    embeddings, usages = embedder.get_embeddings_batch_and_usage([])
+
+    assert len(embeddings) == 0
+    assert len(usages) == 0
+    assert embedder.individual_call_count == 0
+
+
+def test_subclass_batch_method_is_used():
+    """When a subclass provides get_embeddings_batch_and_usage, it should be used."""
+    embedder = BatchEmbedder(dimensions=4, enable_batch=True)
+    texts = ["hello", "world", "test"]
+
+    embeddings, usages = embedder.get_embeddings_batch_and_usage(texts)
+
+    assert len(embeddings) == 3
+    assert len(usages) == 3
+    assert embedder.batch_call_count == 1
+    assert embedder.individual_call_count == 0
+
+
+def test_document_embed_sets_embedding():
+    """Document.embed should set embedding and usage from embedder."""
+    embedder = ConcreteEmbedder(dimensions=4)
+    doc = Document(content="test content", name="test")
+
+    doc.embed(embedder=embedder)
+
+    assert doc.embedding is not None
+    assert len(doc.embedding) == 4
+    assert doc.usage is not None
+    assert embedder.individual_call_count == 1
+
+
+def test_document_already_embedded_skipped_by_check():
+    """Pre-embedded documents should be detected by checking embedding is not None."""
+    doc = Document(
+        content="test",
+        name="test",
+        embedding=[0.5, 0.5, 0.5, 0.5],
+        usage={"prompt_tokens": 1},
+    )
+
+    # Simulate the pattern used in _get_document_record:
+    # if doc.embedding is None: doc.embed(embedder=...)
+    embedder = ConcreteEmbedder(dimensions=4)
+    if doc.embedding is None:
+        doc.embed(embedder=embedder)
+
+    # Should NOT have been called since embedding already exists
+    assert embedder.individual_call_count == 0
+    assert doc.embedding == [0.5, 0.5, 0.5, 0.5]
+
+
+# ========== PgVector batch embedding tests (require sqlalchemy) ==========
+
+try:
+    import sqlalchemy  # noqa: F401
+
+    HAS_SQLALCHEMY = True
+except ImportError:
+    HAS_SQLALCHEMY = False
+
+
+@pytest.fixture
+def mock_pgvector_for_batch():
+    """Create a PgVector instance with mocked dependencies for batch embedding tests."""
+    pytest.importorskip("sqlalchemy", reason="sqlalchemy not installed")
+    from sqlalchemy.engine import URL, Engine
+
+    mock_engine = MagicMock(spec=Engine)
+    url = MagicMock(spec=URL)
+    url.get_backend_name.return_value = "postgresql"
+    mock_engine.url = url
+    mock_engine.inspect = MagicMock(return_value=MagicMock())
+
+    embedder = BatchEmbedder(dimensions=4, enable_batch=True)
+
+    with patch("agno.vectordb.pgvector.pgvector.inspect") as mock_inspect:
+        inspector = MagicMock()
+        inspector.has_table.return_value = False
+        mock_inspect.return_value = inspector
+
+        with patch("agno.vectordb.pgvector.pgvector.scoped_session") as mock_scoped_session:
+            mock_session_factory = MagicMock()
+            mock_scoped_session.return_value = mock_session_factory
+            mock_session_instance = MagicMock()
+            mock_session_factory.return_value.__enter__.return_value = mock_session_instance
+
+            with patch("agno.vectordb.pgvector.pgvector.Vector"):
+                from agno.vectordb.pgvector import PgVector
+
+                db = PgVector(
+                    table_name="test_batch_vectors",
+                    schema="test_schema",
+                    db_engine=mock_engine,
+                    embedder=embedder,
+                )
+                db.table = MagicMock()
+                db.table.fullname = "test_schema.test_batch_vectors"
+                db.Session = mock_session_factory
+
+                yield db, embedder
+
+
+@pytest.mark.skipif(not HAS_SQLALCHEMY, reason="sqlalchemy not installed")
+def test_embed_documents_uses_batch_when_enabled(mock_pgvector_for_batch):
+    """_embed_documents should use batch embedding when embedder has enable_batch=True."""
+    db, embedder = mock_pgvector_for_batch
+    docs = [
+        Document(content="doc 1", name="d1"),
+        Document(content="doc 2", name="d2"),
+        Document(content="doc 3", name="d3"),
+    ]
+
+    db._embed_documents(docs)
+
+    # Batch method should have been called once
+    assert embedder.batch_call_count == 1
+    # Individual calls should not have been made
+    assert embedder.individual_call_count == 0
+    # All documents should now have embeddings
+    for doc in docs:
+        assert doc.embedding is not None
+        assert len(doc.embedding) == 4
+        assert doc.usage is not None
+
+
+@pytest.mark.skipif(not HAS_SQLALCHEMY, reason="sqlalchemy not installed")
+def test_embed_documents_individual_when_batch_disabled(mock_pgvector_for_batch):
+    """_embed_documents should use individual embedding when enable_batch=False."""
+    db, embedder = mock_pgvector_for_batch
+    embedder.enable_batch = False
+
+    docs = [
+        Document(content="doc 1", name="d1"),
+        Document(content="doc 2", name="d2"),
+    ]
+
+    db._embed_documents(docs)
+
+    # Batch method should NOT have been called
+    assert embedder.batch_call_count == 0
+    # Individual calls should have been made (2 docs)
+    assert embedder.individual_call_count == 2
+    # All documents should now have embeddings
+    for doc in docs:
+        assert doc.embedding is not None
+
+
+@pytest.mark.skipif(not HAS_SQLALCHEMY, reason="sqlalchemy not installed")
+def test_get_document_record_skips_embed_when_already_embedded(mock_pgvector_for_batch):
+    """_get_document_record should not re-embed if document already has an embedding."""
+    db, embedder = mock_pgvector_for_batch
+
+    doc = Document(
+        id="test-id",
+        content="already embedded content",
+        name="test_doc",
+        embedding=[0.5] * 4,
+        usage={"prompt_tokens": 5, "total_tokens": 5},
+    )
+
+    record = db._get_document_record(doc, filters=None, content_hash="test_hash")
+
+    # Embedding should remain unchanged
+    assert record["embedding"] == [0.5] * 4
+    # No individual calls should have been made
+    assert embedder.individual_call_count == 0
+    assert embedder.batch_call_count == 0
+
+
+@pytest.mark.skipif(not HAS_SQLALCHEMY, reason="sqlalchemy not installed")
+def test_insert_uses_batch_embedding(mock_pgvector_for_batch):
+    """Insert should batch embed documents before building records."""
+    db, embedder = mock_pgvector_for_batch
+
+    docs = [
+        Document(id="d1", content="content 1", name="doc_1"),
+        Document(id="d2", content="content 2", name="doc_2"),
+        Document(id="d3", content="content 3", name="doc_3"),
+    ]
+
+    sess = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = sess
+    db.Session.return_value = cm
+
+    with patch("agno.vectordb.pgvector.pgvector.postgresql.insert") as mock_insert:
+        insert_stmt_sentinel = object()
+        mock_insert.return_value = insert_stmt_sentinel
+
+        db.insert(content_hash="test_hash", documents=docs)
+
+        # Batch embedding should be called once (all 3 docs in one batch)
+        assert embedder.batch_call_count == 1
+        assert embedder.individual_call_count == 0
+
+        # All records should have been inserted
+        args, kwargs = sess.execute.call_args
+        batch_records = args[1]
+        assert len(batch_records) == 3
+
+        # Each record should have an embedding
+        for record in batch_records:
+            assert record["embedding"] is not None
+            assert len(record["embedding"]) == 4
+
+
+@pytest.mark.skipif(not HAS_SQLALCHEMY, reason="sqlalchemy not installed")
+def test_upsert_uses_batch_embedding(mock_pgvector_for_batch):
+    """Upsert should batch embed documents before building records."""
+    db, embedder = mock_pgvector_for_batch
+
+    docs = [
+        Document(id="d1", content="content 1", name="doc_1"),
+        Document(id="d2", content="content 2", name="doc_2"),
+    ]
+
+    sess = MagicMock()
+    cm = MagicMock()
+    cm.__enter__.return_value = sess
+    db.Session.return_value = cm
+
+    with patch("agno.vectordb.pgvector.pgvector.postgresql.insert") as mock_insert:
+        insert_stmt = MagicMock(name="insert_stmt")
+        after_values = MagicMock(name="after_values")
+        after_values.excluded = MagicMock(name="excluded")
+        upsert_stmt = object()
+
+        mock_insert.return_value = insert_stmt
+        insert_stmt.values.return_value = after_values
+        after_values.on_conflict_do_update.return_value = upsert_stmt
+
+        with patch.object(db, "content_hash_exists", return_value=False):
+            db.upsert(content_hash="test_hash", documents=docs)
+
+        # Batch embedding should be called once
+        assert embedder.batch_call_count == 1
+        assert embedder.individual_call_count == 0
+
+        # Records should have been created
+        assert insert_stmt.values.called
+        (values_arg,), _ = insert_stmt.values.call_args
+        assert len(values_arg) == 2
+        for record in values_arg:
+            assert record["embedding"] is not None


### PR DESCRIPTION
## Summary

Batches embedding requests in `add_contents()` instead of making individual API calls per content item. This significantly reduces the number of API calls and improves performance when adding multiple documents to a knowledge base.

Previously, each content item triggered a separate embedding API call. Now, texts are collected and embedded in batches, then results are mapped back to their respective documents.

Fixes #5896

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `./scripts/format.sh` and `./scripts/validate.sh`