### PR TITLE
fix(openai): preserve tool_call_id mapping for mixed external/non-external results

### DIFF
--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -872,7 +872,7 @@ class OpenAIResponses(Model):
         self,
         messages: List[Message],
         function_call_results: List[Message],
-        tool_call_ids: List[str],
+        tool_call_ids: Optional[List[str]] = None,
         compress_tool_results: bool = False,
     ) -> None:
         """
@@ -881,12 +881,20 @@ class OpenAIResponses(Model):
         Args:
             messages (List[Message]): The list of conversation messages.
             function_call_results (List[Message]): The results of the function calls.
-            tool_ids (List[str]): The tool ids.
+            tool_call_ids (Optional[List[str]]): Tool call IDs from provider response.
             compress_tool_results (bool): Whether to compress tool results.
         """
         if len(function_call_results) > 0:
             for _fc_message_index, _fc_message in enumerate(function_call_results):
-                _fc_message.tool_call_id = tool_call_ids[_fc_message_index]
+                # Preserve the tool_call_id produced by function execution whenever available.
+                # This avoids mismatches when only a subset of tool calls are executed (e.g.,
+                # mixed external_execution and non-external_execution tool calls).
+                if (
+                    not _fc_message.tool_call_id
+                    and tool_call_ids is not None
+                    and _fc_message_index < len(tool_call_ids)
+                ):
+                    _fc_message.tool_call_id = tool_call_ids[_fc_message_index]
                 messages.append(_fc_message)
 
     def _parse_provider_response(self, response: Response, **kwargs) -> ModelResponse:

--- a/libs/agno/tests/unit/models/openai/test_openai_responses_id_handling.py
+++ b/libs/agno/tests/unit/models/openai/test_openai_responses_id_handling.py
@@ -188,3 +188,40 @@ def test_reasoning_previous_response_skips_prior_function_call_items(monkeypatch
 
     # Expect no re-sent function_call when previous_response_id is present for reasoning models
     assert all(x.get("type") != "function_call" for x in fm)
+
+
+def test_format_function_call_results_preserves_existing_tool_call_id():
+    model = OpenAIResponses(id="gpt-4.1-mini")
+
+    # Simulate mixed tool calls where only one tool result is available now
+    function_call_results = [
+        Message(role="tool", tool_call_id="call_non_external", content="ok"),
+    ]
+    messages: List[Message] = []
+
+    model.format_function_call_results(
+        messages=messages,
+        function_call_results=function_call_results,
+        tool_call_ids=["call_external", "call_non_external"],
+    )
+
+    assert len(messages) == 1
+    assert messages[0].tool_call_id == "call_non_external"
+
+
+def test_format_function_call_results_backfills_missing_tool_call_id_from_extra():
+    model = OpenAIResponses(id="gpt-4.1-mini")
+
+    function_call_results = [
+        Message(role="tool", content="ok"),
+    ]
+    messages: List[Message] = []
+
+    model.format_function_call_results(
+        messages=messages,
+        function_call_results=function_call_results,
+        tool_call_ids=["call_def456"],
+    )
+
+    assert len(messages) == 1
+    assert messages[0].tool_call_id == "call_def456"


### PR DESCRIPTION
## Summary
Fixes incorrect `tool_call_id` assignment in mixed external/non-external tool-call outputs for OpenAI Responses API handling.

- Preserve each result's existing `tool_call_id` when present.
- Only backfill from `tool_call_ids` for results missing `tool_call_id`.
- Make `tool_call_ids` optional in `format_function_call_results` to support mixed payloads safely.

## Why
When external tool calls are mixed with non-external calls, index-based reassignment can map results to the wrong tool-call IDs. This breaks response-item linkage and can cause downstream tool output mismatches.

## Changes
- `libs/agno/agno/models/openai/responses.py`
  - Updated `format_function_call_results` logic to avoid overwriting valid IDs.
  - Signature now uses `tool_call_ids: Optional[List[str]] = None`.
- `libs/agno/tests/unit/models/openai/test_openai_responses_id_handling.py`
  - Added regression tests covering mixed external/non-external ID handling.

## Validation
- `python -m py_compile libs/agno/agno/models/openai/responses.py`
- `python -m py_compile libs/agno/tests/unit/models/openai/test_openai_responses_id_handling.py`

Closes #6612