### PR TITLE
fix: tool cache for Pydantic model return types (#6676)

### DIFF
--- a/cookbook/scripts/test_pydantic_cache.py
+++ b/cookbook/scripts/test_pydantic_cache.py
@@ -1,0 +1,63 @@
+"""
+Test that tool cache works when a tool returns a Pydantic model (issue #6676).
+Run: .venv/bin/python cookbook/scripts/test_pydantic_cache.py
+"""
+import tempfile
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from agno.tools import tool
+from agno.tools.function import FunctionCall
+
+# Unique cache dir per run so we start with empty cache
+CACHE_DIR = Path(tempfile.mkdtemp(prefix="agno_test_pydantic_cache_"))
+
+
+class OrderResponse(BaseModel):
+    success: bool
+    data: dict | None = None
+
+
+call_count = 0
+
+
+def get_order_impl(order_id: int) -> OrderResponse:
+    """Get order by ID."""
+    global call_count
+    call_count += 1
+    return OrderResponse(success=True, data={"id": order_id, "status": "delivered"})
+
+
+get_order = tool(cache_results=True, cache_ttl=300, cache_dir=str(CACHE_DIR))(get_order_impl)
+
+
+def main():
+    global call_count
+    # get_order is a Function (returned by @tool decorator)
+
+    call1 = FunctionCall(function=get_order, arguments={"order_id": 12345})
+    call_count = 0
+    print("First call (should execute function)...")
+    r1 = call1.execute()
+    first_count = call_count
+    print("  call_count after first run:", first_count, " result:", r1.result)
+
+    call2 = FunctionCall(function=get_order, arguments={"order_id": 12345})
+    print("Second call with same args (should hit cache)...")
+    r2 = call2.execute()
+    second_count = call_count
+    print("  call_count after second run:", second_count, " result:", r2.result)
+
+    if first_count == 1 and second_count == 1:
+        print("PASS: Second call used cache (function ran only once).")
+    else:
+        print("FAIL: Function ran", second_count, "times; expected 1 (cache hit).")
+
+    import shutil
+
+    shutil.rmtree(CACHE_DIR, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, validate_call
 from agno.exceptions import AgentRunException
 from agno.media import Audio, File, Image, Video
 from agno.run import RunContext
+from agno.utils.common import nested_model_dump
 from agno.utils.log import log_debug, log_error, log_exception, log_warning
 
 T = TypeVar("T")
@@ -698,8 +699,9 @@ class Function(BaseModel):
         from time import time
 
         try:
+            serializable_result = nested_model_dump(result)
             with open(cache_file, "w") as f:
-                json.dump({"timestamp": time(), "result": result}, f)
+                json.dump({"timestamp": time(), "result": serializable_result}, f)
         except Exception as e:
             log_error(f"Error writing cache: {e}")
 

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable, Dict
 
 import pytest
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from agno.tools.decorator import tool
 from agno.tools.function import Function, FunctionCall
@@ -318,6 +318,25 @@ def test_function_cache_ttl(tmp_path):
 
     # Verify cache is no longer valid
     assert func._get_cached_result(cache_file) is None
+
+
+def test_function_cache_pydantic_model_result(tmp_path):
+    """Test that cache save/retrieve works when tool returns a Pydantic model."""
+    import os
+
+    class OrderResponse(BaseModel):
+        success: bool
+        data: dict | None = None
+
+    func = Function(name="test_func", cache_results=True, cache_dir=str(tmp_path))
+    result = OrderResponse(success=True, data={"id": 12345, "status": "delivered"})
+    cache_file = os.path.join(str(tmp_path), "pydantic_cache.json")
+
+    func._save_to_cache(cache_file, result)
+
+    assert os.path.exists(cache_file)
+    retrieved = func._get_cached_result(cache_file)
+    assert retrieved == {"success": True, "data": {"id": 12345, "status": "delivered"}}
 
 
 def test_function_call_initialization():


### PR DESCRIPTION
## Summary

Fix tool cache silently failing when a `@tool`-decorated function returns a Pydantic `BaseModel` and has `cache_results=True`. Previously `_save_to_cache` called `json.dump()` on the raw result, which raised for Pydantic models and was caught and only logged, so the cache was never written.

- In `Function._save_to_cache()`, serialize the result with `nested_model_dump()` before `json.dump()` so Pydantic models (and nested structures) are stored as JSON-serializable dicts.
- Add unit test `test_function_cache_pydantic_model_result` and a cookbook script to verify cache hit when a tool returns a Pydantic model.

Fixes #6676

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

Cached results for Pydantic-returning tools are stored and returned as dicts (from `model_dump()`). Downstream only stringifies the result for the LLM, so this is backward compatible.
