### PR TITLE
refactor: remove TTFT from ModelMetrics, fix run TTFT overwrite

### DIFF
--- a/libs/agno/agno/metrics.py
+++ b/libs/agno/agno/metrics.py
@@ -64,7 +64,6 @@ class ModelMetrics(BaseMetrics):
 
     id: str = ""
     provider: str = ""
-    time_to_first_token: Optional[float] = None
     provider_metrics: Optional[Dict[str, Any]] = None
 
     def accumulate(self, other: "ModelMetrics") -> None:
@@ -80,12 +79,6 @@ class ModelMetrics(BaseMetrics):
         self.reasoning_tokens += other.reasoning_tokens or 0
         if other.cost is not None:
             self.cost = (self.cost or 0) + other.cost
-        # Keep earliest TTFT
-        if other.time_to_first_token is not None:
-            if self.time_to_first_token is not None:
-                self.time_to_first_token = min(self.time_to_first_token, other.time_to_first_token)
-            else:
-                self.time_to_first_token = other.time_to_first_token
         # Merge provider_metrics
         if other.provider_metrics is not None:
             if self.provider_metrics is None:
@@ -677,7 +670,6 @@ def accumulate_model_metrics(
         cache_read_tokens=cache_read_tokens,
         cache_write_tokens=cache_write_tokens,
         reasoning_tokens=reasoning_tokens,
-        time_to_first_token=usage.time_to_first_token,
         cost=usage.cost,
         provider_metrics=usage.provider_metrics,
     )
@@ -709,13 +701,6 @@ def accumulate_model_metrics(
     # Accumulate cost
     if usage.cost is not None:
         metrics.cost = (metrics.cost or 0) + usage.cost
-
-    # TTFT: only set top-level if model_type is "model" or "reasoning_model"
-    if (
-        model_type == ModelType.MODEL or model_type == ModelType.REASONING_MODEL
-    ) and usage.time_to_first_token is not None:
-        if metrics.time_to_first_token is None or usage.time_to_first_token < metrics.time_to_first_token:
-            metrics.time_to_first_token = usage.time_to_first_token
 
 
 def accumulate_eval_metrics(

--- a/libs/agno/tests/unit/test_model_type.py
+++ b/libs/agno/tests/unit/test_model_type.py
@@ -180,34 +180,12 @@ class TestAccumulateModelMetrics:
         assert details["output_model"][0].id == "gpt-4o-mini"
         assert run_response.metrics.total_tokens == 180
 
-    def test_time_to_first_token_set_for_model_type(self):
-        """TTFT should only be set for MODEL and REASONING_MODEL types."""
+    def test_accumulate_does_not_set_run_ttft(self):
+        """Run TTFT is set by providers via set_time_to_first_token(), not by accumulate_model_metrics."""
         run_response = _make_run_response()
         model = _make_model()
 
         accumulate_model_metrics(_make_model_response(ttft=0.5), model, ModelType.MODEL, run_response)
-        assert run_response.metrics.time_to_first_token == 0.5
-
-    def test_time_to_first_token_set_for_reasoning_model(self):
-        run_response = _make_run_response()
-        model = _make_model()
-
-        accumulate_model_metrics(_make_model_response(ttft=0.3), model, ModelType.REASONING_MODEL, run_response)
-        assert run_response.metrics.time_to_first_token == 0.3
-
-    def test_time_to_first_token_not_set_for_output_model(self):
-        """TTFT should NOT be set for output_model, parser_model, etc."""
-        run_response = _make_run_response()
-        model = _make_model()
-
-        accumulate_model_metrics(_make_model_response(ttft=0.5), model, ModelType.OUTPUT_MODEL, run_response)
-        assert run_response.metrics.time_to_first_token is None
-
-    def test_time_to_first_token_not_set_for_memory_model(self):
-        run_response = _make_run_response()
-        model = _make_model()
-
-        accumulate_model_metrics(_make_model_response(ttft=0.5), model, ModelType.MEMORY_MODEL, run_response)
         assert run_response.metrics.time_to_first_token is None
 
     def test_none_response_usage_is_no_op(self):


### PR DESCRIPTION
## Summary

Fix broken TTFT logic where `accumulate_model_metrics()` was overwriting the run-level TTFT (measured from run timer) with the message-level TTFT (measured from message timer), making them always converge to the same value.

Changes:
- **Remove `time_to_first_token` from `ModelMetrics`** — meaningless as an aggregate ("min TTFT across all calls to a model" isn't actionable)
- **Remove TTFT logic from `accumulate_model_metrics()`** — this was the bug that clobbered run TTFT on every model call
- **Remove TTFT accumulation from `ModelMetrics.accumulate()`** — no longer needed

TTFT now has clear semantics:
- `MessageMetrics.time_to_first_token` = per-API-call latency (message timer)
- `RunMetrics.time_to_first_token` = user-facing latency from run start to first token (run timer), set once by providers, never overwritten

## Type of change

- [x] Bug fix
- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Tests added/updated (if applicable)

---

## Additional Notes

Targets `metrics-update-v2.5` branch. Unit tests updated to verify `accumulate_model_metrics` no longer sets run TTFT. Legacy serialized data with `time_to_first_token` on ModelMetrics is silently dropped by `from_dict()` field filtering.