### PR TITLE
fix: make Message.metrics non-Optional to resolve mypy errors

### DIFF
--- a/cookbook/90_models/openai/chat/pdf_input_bytes.py
+++ b/cookbook/90_models/openai/chat/pdf_input_bytes.py
@@ -1,4 +1,3 @@
-
 """
 Openai Pdf Input Bytes
 =========================
@@ -8,8 +7,8 @@ from pathlib import Path
 
 from agno.agent import Agent
 from agno.media import File
-from agno.utils.media import download_file
 from agno.models.openai.chat import OpenAIChat
+from agno.utils.media import download_file
 
 # ---------------------------------------------------------------------------
 # Create Agent

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1401,7 +1401,7 @@ class Model(ABC):
                         _stream_model_response.response_usage = assistant_message.metrics
                         accumulate_model_metrics(_stream_model_response, self, self.model_type, run_response)
 
-                else:   
+                else:
                     # Initialize message metrics and start timer before model call
                     self._ensure_message_metrics_initialized(assistant_message)
                     self._process_model_response(

--- a/libs/agno/agno/models/message.py
+++ b/libs/agno/agno/models/message.py
@@ -109,8 +109,8 @@ class Message(BaseModel):
     add_to_agent_memory: bool = True
     # This flag is enabled when a message is fetched from the agent's memory.
     from_history: bool = False
-    # Metrics for the message. Only set on assistant messages from model responses.
-    metrics: Optional[MessageMetrics] = None
+    # Metrics for the message. Defaults to empty MessageMetrics; populated on assistant messages.
+    metrics: MessageMetrics = Field(default_factory=MessageMetrics)
     # The references added to the message for RAG
     references: Optional[MessageReferences] = None
     # The Unix timestamp the message was created.
@@ -272,11 +272,12 @@ class Message(BaseModel):
                     data["video_output"] = Video(**vid_data)
 
         # Handle metrics deserialization, convert dict to MessageMetrics
-        if "metrics" in data and data["metrics"] is not None:
+        if "metrics" in data:
             if isinstance(data["metrics"], dict):
                 data["metrics"] = MessageMetrics.from_dict(data["metrics"])
             elif not isinstance(data["metrics"], MessageMetrics):
-                data["metrics"] = None
+                # Remove invalid/None values so Pydantic default factory creates empty MessageMetrics
+                data.pop("metrics")
 
         return cls(**data)
 


### PR DESCRIPTION
## Summary

`Message.metrics` was typed as `Optional[MessageMetrics] = None`, but all 15 model providers access `.start_timer()`, `.stop_timer()`, `.set_time_to_first_token()` etc. without null checks — causing 126 mypy errors (`Item "None" of "MessageMetrics | None" has no attribute ...`).

This changes the field to `MessageMetrics = Field(default_factory=MessageMetrics)` so it's always initialized. Updates `from_dict()` to pop invalid/None metrics values instead of setting `None`, so Pydantic's default factory creates an empty `MessageMetrics` for legacy serialized data.

## Type of change

- [x] Bug fix
- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Tested in clean environment

---

## Additional Notes

- `./scripts/validate.sh` now passes with **0 mypy errors** (was 126)
- No behavioral change — providers never checked for None before, and the default `MessageMetrics()` has all fields at 0/None just like the old None case