### PR TITLE
feat: add KnowledgeCatalog and BackupStore for agent document access

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -33,6 +33,9 @@ class Knowledge:
     readers: Optional[Dict[str, Reader]] = None
     content_sources: Optional[List[BaseStorageConfig]] = None
     isolate_vector_search: bool = False
+    enable_catalog: bool = False
+    enable_backup_tools: bool = False
+    backup_dir: Optional[str] = None
 
     def __post_init__(self):
         from agno.vectordb import VectorDb
@@ -68,6 +71,25 @@ class Knowledge:
             pipeline=self._pipeline,
             content_sources=self.content_sources,
         )
+
+        # Initialize catalog (document-level index for system prompt)
+        self._catalog = None
+        if self.enable_catalog and self.contents_db is not None:
+            from agno.knowledge.store.catalog import KnowledgeCatalog
+
+            self._catalog = KnowledgeCatalog(
+                content_store=self._content_store,
+                knowledge_name=self.name,
+            )
+
+        # Initialize backup store (local filesystem for direct document access)
+        self._backup_store = None
+        if self.backup_dir is not None or self.enable_backup_tools:
+            from agno.knowledge.store.backup_store import BackupStore
+
+            backup_path = self.backup_dir or f"tmp/knowledge_backup/{self.name or 'default'}"
+            self._backup_store = BackupStore(base_dir=backup_path)
+            self._pipeline.backup_store = self._backup_store
 
     def _detect_managed_backend(self):
         """Check if vector_db satisfies the ManagedKnowledgeBackend protocol."""
@@ -919,6 +941,10 @@ Make sure to pass the filters as [Dict[str: Any]] to the tool. FOLLOW THIS STRUC
             valid_filters = self.get_valid_filters()
             if valid_filters:
                 context_parts.append(self._get_agentic_filter_instructions(valid_filters))
+        if self._catalog is not None:
+            catalog_context = self._catalog.build_catalog_context()
+            if catalog_context:
+                context_parts.append(catalog_context)
         return "<knowledge_base>\n" + "\n".join(context_parts) + "\n</knowledge_base>"
 
     async def abuild_context(self, enable_agentic_filters: bool = False, **kwargs) -> str:
@@ -927,6 +953,10 @@ Make sure to pass the filters as [Dict[str: Any]] to the tool. FOLLOW THIS STRUC
             valid_filters = await self.aget_valid_filters()
             if valid_filters:
                 context_parts.append(self._get_agentic_filter_instructions(valid_filters))
+        if self._catalog is not None:
+            catalog_context = await self._catalog.abuild_catalog_context()
+            if catalog_context:
+                context_parts.append(catalog_context)
         return "<knowledge_base>\n" + "\n".join(context_parts) + "\n</knowledge_base>"
 
     def get_tools(
@@ -955,7 +985,12 @@ Make sure to pass the filters as [Dict[str: Any]] to the tool. FOLLOW THIS STRUC
                 async_mode=async_mode,
                 agent=agent,
             )
-        return [tool]
+        tools: List[Any] = [tool]
+        if self._catalog is not None and self.enable_catalog:
+            tools.extend(self._catalog.get_tools())
+        if self._backup_store is not None and self.enable_backup_tools:
+            tools.extend(self._backup_store.get_tools())
+        return tools
 
     async def aget_tools(
         self,

--- a/libs/agno/agno/knowledge/pipeline/ingestion.py
+++ b/libs/agno/agno/knowledge/pipeline/ingestion.py
@@ -43,6 +43,7 @@ class IngestionPipeline:
     knowledge_name: Optional[str] = None
     isolate_vector_search: bool = False
     managed_backend: Optional[Any] = None
+    backup_store: Optional[Any] = None
 
     # ==========================================
     # MAIN ENTRY POINTS
@@ -902,6 +903,7 @@ class IngestionPipeline:
 
         content.status = ContentStatus.COMPLETED
         self.content_store.update(content, vector_db=self.vector_db)  # type: ignore[union-attr]
+        self._backup_documents(content, read_documents)
 
     async def ahandle_vector_db_insert(self, content: Content, read_documents: List[Document], upsert: bool) -> None:
         from agno.vectordb import VectorDb
@@ -940,6 +942,7 @@ class IngestionPipeline:
 
         content.status = ContentStatus.COMPLETED
         await self.content_store.aupdate(content, vector_db=self.vector_db)  # type: ignore[union-attr]
+        await self._abackup_documents(content, read_documents)
 
     # ==========================================
     # HASHING
@@ -1086,6 +1089,44 @@ class IngestionPipeline:
         for doc in documents:
             chunked_documents.extend(reader.chunk_document(doc))
         return chunked_documents
+
+    # ==========================================
+    # BACKUP STORE
+    # ==========================================
+
+    def _backup_documents(self, content: Content, read_documents: List[Document]) -> None:
+        """Store parsed text to the backup store after successful ingestion."""
+        if self.backup_store is None or not content.id:
+            return
+        try:
+            parsed_text = "\n\n".join(doc.content for doc in read_documents if doc.content)
+            if parsed_text:
+                metadata = {"name": content.name, "path": content.path, "url": content.url}
+                self.backup_store.store(
+                    content_id=content.id,
+                    parsed_text=parsed_text,
+                    file_extension=content.file_type,
+                    metadata={k: v for k, v in metadata.items() if v is not None},
+                )
+        except Exception as e:
+            log_warning(f"Could not backup content {content.id}: {e}")
+
+    async def _abackup_documents(self, content: Content, read_documents: List[Document]) -> None:
+        """Async variant of _backup_documents."""
+        if self.backup_store is None or not content.id:
+            return
+        try:
+            parsed_text = "\n\n".join(doc.content for doc in read_documents if doc.content)
+            if parsed_text:
+                metadata = {"name": content.name, "path": content.path, "url": content.url}
+                await self.backup_store.astore(
+                    content_id=content.id,
+                    parsed_text=parsed_text,
+                    file_extension=content.file_type,
+                    metadata={k: v for k, v in metadata.items() if v is not None},
+                )
+        except Exception as e:
+            log_warning(f"Could not backup content {content.id}: {e}")
 
     # ==========================================
     # MANAGED BACKEND INGESTION

--- a/libs/agno/agno/knowledge/store/__init__.py
+++ b/libs/agno/agno/knowledge/store/__init__.py
@@ -1,3 +1,5 @@
+from agno.knowledge.store.backup_store import BackupStore
+from agno.knowledge.store.catalog import KnowledgeCatalog
 from agno.knowledge.store.content_store import ContentStore
 
-__all__ = ["ContentStore"]
+__all__ = ["BackupStore", "ContentStore", "KnowledgeCatalog"]

--- a/libs/agno/agno/knowledge/store/backup_store.py
+++ b/libs/agno/agno/knowledge/store/backup_store.py
@@ -1,0 +1,340 @@
+"""BackupStore — local filesystem store for original documents.
+
+Stores parsed text alongside optional raw bytes so agents can
+directly read and grep documents without going through vector search.
+Each document gets its own directory under ``base_dir``.
+
+Directory layout::
+
+    base_dir/
+        <content_id>/
+            parsed.txt      # Parsed text content
+            raw.<ext>        # Original file (optional)
+            metadata.json    # Content metadata
+"""
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from agno.utils.log import log_debug, log_error, log_info, log_warning
+
+
+@dataclass
+class GrepResult:
+    """A single match from a grep operation."""
+
+    content_id: str
+    line_number: int
+    line: str
+    context_before: List[str] = field(default_factory=list)
+    context_after: List[str] = field(default_factory=list)
+
+    def to_str(self) -> str:
+        parts = []
+        for ctx in self.context_before:
+            parts.append(f"  {ctx}")
+        parts.append(f"  {self.line_number}: {self.line}")
+        for ctx in self.context_after:
+            parts.append(f"  {ctx}")
+        return "\n".join(parts)
+
+
+@dataclass
+class BackupStore:
+    """Local filesystem store for original document content."""
+
+    base_dir: str = "tmp/knowledge_backup"
+
+    def _content_dir(self, content_id: str) -> Path:
+        return Path(self.base_dir) / content_id
+
+    def store(
+        self,
+        content_id: str,
+        parsed_text: str,
+        raw_bytes: Optional[bytes] = None,
+        file_extension: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Store parsed text and optional raw content for a document."""
+        content_dir = self._content_dir(content_id)
+        content_dir.mkdir(parents=True, exist_ok=True)
+
+        # Write parsed text
+        parsed_path = content_dir / "parsed.txt"
+        parsed_path.write_text(parsed_text, encoding="utf-8")
+        log_info(f"Stored parsed text for {content_id} ({len(parsed_text)} chars)")
+
+        # Write raw bytes if provided
+        if raw_bytes is not None:
+            ext = file_extension or ".bin"
+            if not ext.startswith("."):
+                ext = f".{ext}"
+            raw_path = content_dir / f"raw{ext}"
+            raw_path.write_bytes(raw_bytes)
+            log_debug(f"Stored raw file for {content_id} ({len(raw_bytes)} bytes)")
+
+        # Write metadata
+        if metadata:
+            meta_path = content_dir / "metadata.json"
+            meta_path.write_text(json.dumps(metadata, indent=2, default=str), encoding="utf-8")
+
+    async def astore(
+        self,
+        content_id: str,
+        parsed_text: str,
+        raw_bytes: Optional[bytes] = None,
+        file_extension: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Async variant of store. Uses sync I/O internally (local filesystem)."""
+        self.store(
+            content_id=content_id,
+            parsed_text=parsed_text,
+            raw_bytes=raw_bytes,
+            file_extension=file_extension,
+            metadata=metadata,
+        )
+
+    def read(
+        self,
+        content_id: str,
+        offset: int = 0,
+        limit: int = 200,
+    ) -> Optional[str]:
+        """Read parsed text for a document with line-based pagination.
+
+        Args:
+            content_id: The content ID to read.
+            offset: Line number to start from (0-based).
+            limit: Maximum number of lines to return.
+
+        Returns:
+            The requested lines as a string, or None if not found.
+        """
+        parsed_path = self._content_dir(content_id) / "parsed.txt"
+        if not parsed_path.exists():
+            return None
+
+        lines = parsed_path.read_text(encoding="utf-8").splitlines()
+        total = len(lines)
+        selected = lines[offset : offset + limit]
+
+        header = f"[Lines {offset + 1}-{min(offset + limit, total)} of {total}]"
+        numbered = [f"{offset + i + 1}: {line}" for i, line in enumerate(selected)]
+        return header + "\n" + "\n".join(numbered)
+
+    async def aread(
+        self,
+        content_id: str,
+        offset: int = 0,
+        limit: int = 200,
+    ) -> Optional[str]:
+        """Async variant of read."""
+        return self.read(content_id=content_id, offset=offset, limit=limit)
+
+    def grep(
+        self,
+        content_id: str,
+        pattern: str,
+        context: int = 2,
+        max_matches: int = 20,
+    ) -> List[GrepResult]:
+        """Search within a single document's parsed text.
+
+        Args:
+            content_id: The content ID to search.
+            pattern: Regex pattern to search for.
+            context: Number of context lines before and after each match.
+            max_matches: Maximum number of matches to return.
+
+        Returns:
+            List of GrepResult objects.
+        """
+        parsed_path = self._content_dir(content_id) / "parsed.txt"
+        if not parsed_path.exists():
+            return []
+
+        try:
+            compiled = re.compile(pattern, re.IGNORECASE)
+        except re.error as e:
+            log_warning(f"Invalid regex pattern '{pattern}': {e}")
+            return []
+
+        lines = parsed_path.read_text(encoding="utf-8").splitlines()
+        results: List[GrepResult] = []
+
+        for i, line in enumerate(lines):
+            if compiled.search(line):
+                before = lines[max(0, i - context) : i]
+                after = lines[i + 1 : min(len(lines), i + 1 + context)]
+                results.append(
+                    GrepResult(
+                        content_id=content_id,
+                        line_number=i + 1,
+                        line=line,
+                        context_before=before,
+                        context_after=after,
+                    )
+                )
+                if len(results) >= max_matches:
+                    break
+
+        return results
+
+    async def agrep(
+        self,
+        content_id: str,
+        pattern: str,
+        context: int = 2,
+        max_matches: int = 20,
+    ) -> List[GrepResult]:
+        """Async variant of grep."""
+        return self.grep(content_id=content_id, pattern=pattern, context=context, max_matches=max_matches)
+
+    def grep_all(
+        self,
+        pattern: str,
+        context: int = 2,
+        max_matches: int = 50,
+    ) -> List[GrepResult]:
+        """Search across all stored documents.
+
+        Args:
+            pattern: Regex pattern to search for.
+            context: Number of context lines before and after each match.
+            max_matches: Maximum total matches across all documents.
+
+        Returns:
+            List of GrepResult objects from all documents.
+        """
+        base = Path(self.base_dir)
+        if not base.exists():
+            return []
+
+        results: List[GrepResult] = []
+        for content_dir in sorted(base.iterdir()):
+            if not content_dir.is_dir():
+                continue
+            content_id = content_dir.name
+            remaining = max_matches - len(results)
+            if remaining <= 0:
+                break
+            results.extend(self.grep(content_id, pattern, context=context, max_matches=remaining))
+
+        return results
+
+    async def agrep_all(
+        self,
+        pattern: str,
+        context: int = 2,
+        max_matches: int = 50,
+    ) -> List[GrepResult]:
+        """Async variant of grep_all."""
+        return self.grep_all(pattern=pattern, context=context, max_matches=max_matches)
+
+    def get_tools(self) -> List[Any]:
+        """Return read_backup and grep_backup Function tools for the agent."""
+        from agno.tools.function import Function
+
+        store = self
+
+        def read_backup(content_id: str, offset: int = 0, limit: int = 200) -> str:
+            """Read a document from the backup store with line-based pagination.
+
+            Args:
+                content_id: The ID of the document to read.
+                offset: Line number to start from (0-based). Default: 0
+                limit: Maximum number of lines to return. Default: 200
+
+            Returns:
+                str: The document content with line numbers, or an error message.
+            """
+            result = store.read(content_id=content_id, offset=offset, limit=limit)
+            if result is None:
+                return f"Document '{content_id}' not found in backup store."
+            return result
+
+        async def aread_backup(content_id: str, offset: int = 0, limit: int = 200) -> str:
+            """Read a document from the backup store (async).
+
+            Args:
+                content_id: The ID of the document to read.
+                offset: Line number to start from (0-based). Default: 0
+                limit: Maximum number of lines to return. Default: 200
+
+            Returns:
+                str: The document content with line numbers, or an error message.
+            """
+            result = await store.aread(content_id=content_id, offset=offset, limit=limit)
+            if result is None:
+                return f"Document '{content_id}' not found in backup store."
+            return result
+
+        def grep_backup(pattern: str, content_id: Optional[str] = None) -> str:
+            """Search for a pattern in backup documents using regex.
+
+            Args:
+                pattern: Regex pattern to search for.
+                content_id: If provided, search only this document. Otherwise search all documents.
+
+            Returns:
+                str: Matching lines with context, or a message if no matches found.
+            """
+            if content_id:
+                results = store.grep(content_id=content_id, pattern=pattern)
+            else:
+                results = store.grep_all(pattern=pattern)
+
+            if not results:
+                return f"No matches found for pattern '{pattern}'."
+
+            parts = []
+            for result in results:
+                parts.append(f"[{result.content_id}:{result.line_number}]")
+                parts.append(result.to_str())
+            return "\n".join(parts)
+
+        async def agrep_backup(pattern: str, content_id: Optional[str] = None) -> str:
+            """Search for a pattern in backup documents (async).
+
+            Args:
+                pattern: Regex pattern to search for.
+                content_id: If provided, search only this document. Otherwise search all documents.
+
+            Returns:
+                str: Matching lines with context, or a message if no matches found.
+            """
+            if content_id:
+                results = await store.agrep(content_id=content_id, pattern=pattern)
+            else:
+                results = await store.agrep_all(pattern=pattern)
+
+            if not results:
+                return f"No matches found for pattern '{pattern}'."
+
+            parts = []
+            for result in results:
+                parts.append(f"[{result.content_id}:{result.line_number}]")
+                parts.append(result.to_str())
+            return "\n".join(parts)
+
+        read_tool = Function(
+            name="read_backup",
+            description="Read a document from the knowledge backup store with line-based pagination.",
+            entrypoint=read_backup,
+            async_entrypoint=aread_backup,
+        )
+
+        grep_tool = Function(
+            name="grep_backup",
+            description="Search for a regex pattern in one or all backup documents.",
+            entrypoint=grep_backup,
+            async_entrypoint=agrep_backup,
+        )
+
+        log_debug("Created read_backup and grep_backup tools from BackupStore")
+        return [read_tool, grep_tool]

--- a/libs/agno/agno/knowledge/store/catalog.py
+++ b/libs/agno/agno/knowledge/store/catalog.py
@@ -1,0 +1,143 @@
+"""KnowledgeCatalog — document-level index for agent system prompt injection.
+
+Gives agents awareness of what documents exist in the knowledge base
+without requiring a search query. The catalog is injected into the
+system prompt so the agent knows what content is available.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from agno.knowledge.store.content_store import ContentStore
+from agno.utils.log import log_debug, log_warning
+
+
+@dataclass
+class KnowledgeCatalog:
+    """Builds a document catalog from the ContentStore for system prompt injection."""
+
+    content_store: Optional[ContentStore] = None
+    knowledge_name: Optional[str] = None
+    _cached_summaries: Optional[List[Dict[str, Any]]] = field(default=None, repr=False)
+
+    def get_summaries(self, limit: int = 100) -> List[Dict[str, Any]]:
+        """Get a list of document summaries from the content store."""
+        if self.content_store is None or self.content_store.contents_db is None:
+            return []
+
+        try:
+            contents, _ = self.content_store.get_content(limit=limit)
+        except Exception as e:
+            log_warning(f"Could not fetch content for catalog: {e}")
+            return []
+
+        summaries = []
+        for content in contents:
+            summary: Dict[str, Any] = {}
+            if content.id:
+                summary["id"] = content.id
+            if content.name:
+                summary["name"] = content.name
+            if content.description:
+                summary["description"] = content.description
+            if content.file_type:
+                summary["type"] = content.file_type
+            if content.status:
+                summary["status"] = content.status.value if hasattr(content.status, "value") else str(content.status)
+            if summary:
+                summaries.append(summary)
+        return summaries
+
+    async def aget_summaries(self, limit: int = 100) -> List[Dict[str, Any]]:
+        """Async variant of get_summaries."""
+        if self.content_store is None or self.content_store.contents_db is None:
+            return []
+
+        try:
+            contents, _ = await self.content_store.aget_content(limit=limit)
+        except Exception as e:
+            log_warning(f"Could not fetch content for catalog: {e}")
+            return []
+
+        summaries = []
+        for content in contents:
+            summary: Dict[str, Any] = {}
+            if content.id:
+                summary["id"] = content.id
+            if content.name:
+                summary["name"] = content.name
+            if content.description:
+                summary["description"] = content.description
+            if content.file_type:
+                summary["type"] = content.file_type
+            if content.status:
+                summary["status"] = content.status.value if hasattr(content.status, "value") else str(content.status)
+            if summary:
+                summaries.append(summary)
+        return summaries
+
+    def build_catalog_context(self) -> str:
+        """Build a formatted catalog string for system prompt injection."""
+        summaries = self.get_summaries()
+        return self._format_catalog(summaries)
+
+    async def abuild_catalog_context(self) -> str:
+        """Async variant of build_catalog_context."""
+        summaries = await self.aget_summaries()
+        return self._format_catalog(summaries)
+
+    def _format_catalog(self, summaries: List[Dict[str, Any]]) -> str:
+        """Format document summaries into a readable catalog string."""
+        if not summaries:
+            return ""
+
+        lines = ["The following documents are available in the knowledge base:"]
+        for i, summary in enumerate(summaries, 1):
+            name = summary.get("name", "Unknown")
+            desc = summary.get("description", "")
+            doc_type = summary.get("type", "")
+            parts = [f"{i}. {name}"]
+            if doc_type:
+                parts.append(f"({doc_type})")
+            if desc:
+                parts.append(f"- {desc}")
+            lines.append(" ".join(parts))
+
+        return "\n".join(lines)
+
+    def get_tools(self) -> List[Any]:
+        """Return a list_documents Function tool for the agent."""
+        from agno.tools.function import Function
+
+        catalog = self
+
+        def list_documents() -> str:
+            """List all documents available in the knowledge base.
+
+            Returns:
+                str: A formatted list of documents with their names and descriptions.
+            """
+            summaries = catalog.get_summaries()
+            if not summaries:
+                return "No documents found in the knowledge base."
+            return catalog._format_catalog(summaries)
+
+        async def alist_documents() -> str:
+            """List all documents available in the knowledge base (async).
+
+            Returns:
+                str: A formatted list of documents with their names and descriptions.
+            """
+            summaries = await catalog.aget_summaries()
+            if not summaries:
+                return "No documents found in the knowledge base."
+            return catalog._format_catalog(summaries)
+
+        tool = Function(
+            name="list_documents",
+            description="List all documents available in the knowledge base with their names and descriptions.",
+            entrypoint=list_documents,
+            async_entrypoint=alist_documents,
+        )
+        log_debug("Created list_documents tool from KnowledgeCatalog")
+        return [tool]

--- a/libs/agno/tests/unit/knowledge/test_backup_store.py
+++ b/libs/agno/tests/unit/knowledge/test_backup_store.py
@@ -1,0 +1,223 @@
+"""Tests for BackupStore."""
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from agno.knowledge.store.backup_store import BackupStore, GrepResult
+
+
+@pytest.fixture
+def tmp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield d
+
+
+@pytest.fixture
+def store(tmp_dir):
+    return BackupStore(base_dir=tmp_dir)
+
+
+class TestStore:
+    def test_store_creates_directory_and_files(self, store, tmp_dir):
+        store.store(
+            content_id="doc1",
+            parsed_text="Hello world\nLine 2",
+            metadata={"name": "test.pdf"},
+        )
+
+        content_dir = Path(tmp_dir) / "doc1"
+        assert content_dir.exists()
+        assert (content_dir / "parsed.txt").exists()
+        assert (content_dir / "metadata.json").exists()
+
+        parsed = (content_dir / "parsed.txt").read_text()
+        assert parsed == "Hello world\nLine 2"
+
+        meta = json.loads((content_dir / "metadata.json").read_text())
+        assert meta["name"] == "test.pdf"
+
+    def test_store_with_raw_bytes(self, store, tmp_dir):
+        store.store(
+            content_id="doc2",
+            parsed_text="content",
+            raw_bytes=b"raw pdf data",
+            file_extension=".pdf",
+        )
+
+        raw_path = Path(tmp_dir) / "doc2" / "raw.pdf"
+        assert raw_path.exists()
+        assert raw_path.read_bytes() == b"raw pdf data"
+
+    def test_store_extension_normalization(self, store, tmp_dir):
+        store.store(
+            content_id="doc3",
+            parsed_text="content",
+            raw_bytes=b"data",
+            file_extension="txt",
+        )
+
+        raw_path = Path(tmp_dir) / "doc3" / "raw.txt"
+        assert raw_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_astore(self, store, tmp_dir):
+        await store.astore(
+            content_id="doc4",
+            parsed_text="async content",
+        )
+
+        parsed = (Path(tmp_dir) / "doc4" / "parsed.txt").read_text()
+        assert parsed == "async content"
+
+
+class TestRead:
+    def test_read_full_document(self, store):
+        store.store("doc1", "Line 1\nLine 2\nLine 3\nLine 4\nLine 5")
+
+        result = store.read("doc1")
+        assert result is not None
+        assert "[Lines 1-5 of 5]" in result
+        assert "1: Line 1" in result
+        assert "5: Line 5" in result
+
+    def test_read_with_pagination(self, store):
+        lines = "\n".join(f"Line {i}" for i in range(1, 11))
+        store.store("doc1", lines)
+
+        result = store.read("doc1", offset=3, limit=4)
+        assert result is not None
+        assert "[Lines 4-7 of 10]" in result
+        assert "4: Line 4" in result
+        assert "7: Line 7" in result
+
+    def test_read_nonexistent_returns_none(self, store):
+        assert store.read("nonexistent") is None
+
+    @pytest.mark.asyncio
+    async def test_aread(self, store):
+        store.store("doc1", "content")
+        result = await store.aread("doc1")
+        assert result is not None
+
+
+class TestGrep:
+    def test_grep_finds_pattern(self, store):
+        store.store("doc1", "apple\nbanana\ncherry\ndate\nelderberry")
+
+        results = store.grep("doc1", "cherry")
+        assert len(results) == 1
+        assert results[0].line_number == 3
+        assert results[0].line == "cherry"
+
+    def test_grep_with_context(self, store):
+        store.store("doc1", "line1\nline2\nmatch\nline4\nline5")
+
+        results = store.grep("doc1", "match", context=1)
+        assert len(results) == 1
+        assert results[0].context_before == ["line2"]
+        assert results[0].context_after == ["line4"]
+
+    def test_grep_regex(self, store):
+        store.store("doc1", "foo123\nbar456\nbaz789")
+
+        results = store.grep("doc1", r"\d{3}")
+        assert len(results) == 3
+
+    def test_grep_max_matches(self, store):
+        store.store("doc1", "\n".join(f"match {i}" for i in range(50)))
+
+        results = store.grep("doc1", "match", max_matches=5)
+        assert len(results) == 5
+
+    def test_grep_invalid_regex(self, store):
+        store.store("doc1", "content")
+        results = store.grep("doc1", "[invalid")
+        assert results == []
+
+    def test_grep_nonexistent_document(self, store):
+        results = store.grep("nonexistent", "pattern")
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_agrep(self, store):
+        store.store("doc1", "findme\nignore")
+        results = await store.agrep("doc1", "findme")
+        assert len(results) == 1
+
+
+class TestGrepAll:
+    def test_grep_all_searches_multiple_docs(self, store):
+        store.store("doc1", "apple pie\norange juice")
+        store.store("doc2", "apple sauce\ngrape soda")
+
+        results = store.grep_all("apple")
+        assert len(results) == 2
+        content_ids = [r.content_id for r in results]
+        assert "doc1" in content_ids
+        assert "doc2" in content_ids
+
+    def test_grep_all_max_matches(self, store):
+        store.store("doc1", "match\nmatch\nmatch")
+        store.store("doc2", "match\nmatch")
+
+        results = store.grep_all("match", max_matches=3)
+        assert len(results) == 3
+
+    def test_grep_all_empty_store(self, store):
+        results = store.grep_all("pattern")
+        assert results == []
+
+
+class TestGetTools:
+    def test_get_tools_returns_two_tools(self, store):
+        tools = store.get_tools()
+        assert len(tools) == 2
+        names = {t.name for t in tools}
+        assert "read_backup" in names
+        assert "grep_backup" in names
+
+    def test_read_backup_tool(self, store):
+        store.store("doc1", "hello world")
+        tools = store.get_tools()
+        read_tool = next(t for t in tools if t.name == "read_backup")
+        result = read_tool.entrypoint("doc1")
+        assert "hello world" in result
+
+    def test_read_backup_not_found(self, store):
+        tools = store.get_tools()
+        read_tool = next(t for t in tools if t.name == "read_backup")
+        result = read_tool.entrypoint("missing")
+        assert "not found" in result
+
+    def test_grep_backup_tool(self, store):
+        store.store("doc1", "findme\nignore")
+        tools = store.get_tools()
+        grep_tool = next(t for t in tools if t.name == "grep_backup")
+        result = grep_tool.entrypoint("findme", content_id="doc1")
+        assert "findme" in result
+
+    def test_grep_backup_no_matches(self, store):
+        store.store("doc1", "nothing here")
+        tools = store.get_tools()
+        grep_tool = next(t for t in tools if t.name == "grep_backup")
+        result = grep_tool.entrypoint("xyz")
+        assert "No matches found" in result
+
+
+class TestGrepResultFormat:
+    def test_to_str(self):
+        result = GrepResult(
+            content_id="doc1",
+            line_number=5,
+            line="matched line",
+            context_before=["before1", "before2"],
+            context_after=["after1"],
+        )
+        formatted = result.to_str()
+        assert "before1" in formatted
+        assert "before2" in formatted
+        assert "5: matched line" in formatted
+        assert "after1" in formatted

--- a/libs/agno/tests/unit/knowledge/test_catalog.py
+++ b/libs/agno/tests/unit/knowledge/test_catalog.py
@@ -1,0 +1,123 @@
+"""Tests for KnowledgeCatalog."""
+
+from typing import List, Tuple
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from agno.knowledge.content import Content, ContentStatus
+from agno.knowledge.store.catalog import KnowledgeCatalog
+from agno.knowledge.store.content_store import ContentStore
+
+
+def _make_content(name: str, description: str = "", file_type: str = "", status: str = "completed") -> Content:
+    return Content(
+        id=f"id-{name}",
+        name=name,
+        description=description,
+        file_type=file_type,
+        status=ContentStatus(status) if status else None,
+    )
+
+
+class TestBuildCatalogContext:
+    def test_empty_catalog(self):
+        catalog = KnowledgeCatalog(content_store=None)
+        assert catalog.build_catalog_context() == ""
+
+    def test_catalog_with_documents(self):
+        store = MagicMock(spec=ContentStore)
+        store.contents_db = MagicMock()
+        store.get_content = MagicMock(
+            return_value=(
+                [
+                    _make_content("report.pdf", "Quarterly earnings report", ".pdf"),
+                    _make_content("manual.txt", "Product manual", ".txt"),
+                ],
+                2,
+            )
+        )
+
+        catalog = KnowledgeCatalog(content_store=store)
+        context = catalog.build_catalog_context()
+
+        assert "report.pdf" in context
+        assert "Quarterly earnings report" in context
+        assert "manual.txt" in context
+        assert "Product manual" in context
+        assert "1." in context
+        assert "2." in context
+
+    def test_catalog_with_no_descriptions(self):
+        store = MagicMock(spec=ContentStore)
+        store.contents_db = MagicMock()
+        store.get_content = MagicMock(
+            return_value=(
+                [_make_content("data.csv", file_type=".csv")],
+                1,
+            )
+        )
+
+        catalog = KnowledgeCatalog(content_store=store)
+        context = catalog.build_catalog_context()
+
+        assert "data.csv" in context
+        assert "(.csv)" in context
+
+    @pytest.mark.asyncio
+    async def test_async_catalog(self):
+        store = MagicMock(spec=ContentStore)
+        store.contents_db = MagicMock()
+        store.aget_content = AsyncMock(
+            return_value=(
+                [_make_content("notes.md", "Meeting notes")],
+                1,
+            )
+        )
+
+        catalog = KnowledgeCatalog(content_store=store)
+        context = await catalog.abuild_catalog_context()
+
+        assert "notes.md" in context
+        assert "Meeting notes" in context
+
+
+class TestGetTools:
+    def test_get_tools_returns_list_documents(self):
+        store = MagicMock(spec=ContentStore)
+        store.contents_db = MagicMock()
+        store.get_content = MagicMock(return_value=([], 0))
+
+        catalog = KnowledgeCatalog(content_store=store)
+        tools = catalog.get_tools()
+
+        assert len(tools) == 1
+        assert tools[0].name == "list_documents"
+
+    def test_list_documents_tool_works(self):
+        store = MagicMock(spec=ContentStore)
+        store.contents_db = MagicMock()
+        store.get_content = MagicMock(
+            return_value=(
+                [_make_content("doc1.pdf", "A document")],
+                1,
+            )
+        )
+
+        catalog = KnowledgeCatalog(content_store=store)
+        tools = catalog.get_tools()
+        result = tools[0].entrypoint()
+
+        assert "doc1.pdf" in result
+        assert "A document" in result
+
+    def test_list_documents_empty(self):
+        store = MagicMock(spec=ContentStore)
+        store.contents_db = MagicMock()
+        store.get_content = MagicMock(return_value=([], 0))
+
+        catalog = KnowledgeCatalog(content_store=store)
+        tools = catalog.get_tools()
+        result = tools[0].entrypoint()
+
+        assert "No documents found" in result


### PR DESCRIPTION
## Summary

Phase 4 of the Knowledge refactor. Adds two new components that give agents 3 tiers of knowledge access:

1. **KnowledgeCatalog** — Document-level index injected into the agent's system prompt, so the agent knows what documents exist before searching
2. **BackupStore** — Local filesystem store for parsed text + raw bytes, with `read_backup` and `grep_backup` tools that let agents directly read and search documents

### New files
- `libs/agno/agno/knowledge/store/catalog.py` — `KnowledgeCatalog` with `build_catalog_context()` and `list_documents` tool
- `libs/agno/agno/knowledge/store/backup_store.py` — `BackupStore` with paginated `read()`, regex `grep()`, and `grep_all()` across all documents
- `libs/agno/tests/unit/knowledge/test_catalog.py` — 7 tests
- `libs/agno/tests/unit/knowledge/test_backup_store.py` — 24 tests

### Modified files
- `libs/agno/agno/knowledge/knowledge.py` — Wires catalog/backup into `__post_init__`, `build_context()`, and `get_tools()`
- `libs/agno/agno/knowledge/pipeline/ingestion.py` — Calls `backup_store.store()` after successful ingestion
- `libs/agno/agno/knowledge/store/__init__.py` — Exports new classes

### Usage

```python
knowledge = Knowledge(
    vector_db=qdrant,
    enable_catalog=True,        # Injects document list into system prompt
    enable_backup_tools=True,   # Adds read_backup + grep_backup tools
    backup_dir="/tmp/backups",  # Where parsed text is stored
)
```

Depends on Phase 3 (#6726).

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

All 31 new tests pass. No pre-existing tests broken. This is Phase 4 of the Knowledge refactor plan — targets the Phase 3 branch as its base.