### PR TITLE
feat: add GitHub App auth and file text extraction for models

### DIFF
--- a/cookbook/02_agents/12_multimodal/file_text_extraction.py
+++ b/cookbook/02_agents/12_multimodal/file_text_extraction.py
@@ -1,0 +1,65 @@
+"""
+File Text Extraction for Models
+================================
+
+Some models and providers reject the ``{"type": "file"}`` content format used
+by OpenAI-compatible APIs.  The ``extract_file_text`` flag on ``OpenAIChat``,
+``DeepSeek``, and ``LiteLLM`` model classes extracts text from uploaded files
+and sends them as ``{"type": "text"}`` content blocks instead.
+
+Supported formats:
+- Text files (txt, csv, json, html, css, py, js, md, xml, etc.)
+- PDF files (requires ``pypdf``)
+- DOCX files (requires ``python-docx``)
+
+If extraction fails for a given file, the original ``{"type": "file"}``
+format is used as a fallback.
+
+Usage:
+    Set ``extract_file_text=True`` on the model to enable text extraction.
+
+Run this cookbook:
+    .venvs/demo/bin/python cookbook/02_agents/12_multimodal/file_text_extraction.py
+"""
+
+from agno.agent import Agent
+from agno.media import File
+from agno.models.openai import OpenAIChat
+
+# ---------------------------------------------------------------------------
+# Example: Agent with text extraction enabled
+# ---------------------------------------------------------------------------
+# Models like gpt-4.1-mini via Azure OpenAI reject {"type": "file"} content
+# blocks.  Setting extract_file_text=True extracts text from supported
+# document types and sends it as plain text instead.
+agent = Agent(
+    model=OpenAIChat(id="gpt-4o-mini", extract_file_text=True),
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    # Text file
+    print("--- Text file extraction ---")
+    agent.print_response(
+        "Summarize this file",
+        files=[
+            File(
+                content=b"Project Status Report\n\nThe migration is 80% complete.\nRemaining: testing and docs.",
+                filename="status.txt",
+                mime_type="text/plain",
+            )
+        ],
+    )
+
+    # Python source file
+    print("--- Python file extraction ---")
+    agent.print_response(
+        "What does this code do?",
+        files=[
+            File(
+                content=b"def fibonacci(n):\n    a, b = 0, 1\n    for _ in range(n):\n        a, b = b, a + b\n    return a",
+                filename="fib.py",
+                mime_type="text/x-python",
+            )
+        ],
+    )

--- a/cookbook/07_knowledge/cloud/github.py
+++ b/cookbook/07_knowledge/cloud/github.py
@@ -3,7 +3,11 @@ GitHub Content Source for Knowledge
 ====================================
 
 Load files and folders from GitHub repositories into your Knowledge base.
-Supports both public and private repositories using fine-grained personal access tokens.
+Supports both public and private repositories.
+
+Authentication methods:
+- Personal Access Token (PAT): simple, set ``token``
+- GitHub App: enterprise-grade, set ``app_id``, ``installation_id``, ``private_key``
 
 Features:
 - Load single files or entire folders recursively
@@ -12,10 +16,11 @@ Features:
 - Rich metadata stored for each file (repo, branch, path)
 
 Requirements:
-- For private repos: GitHub fine-grained PAT with "Contents: read" permission
+- For private repos with PAT: GitHub fine-grained PAT with "Contents: read" permission
+- For GitHub App auth: ``pip install PyJWT cryptography``
 
 Usage:
-    1. Configure GitHubConfig with repo and optional token
+    1. Configure GitHubConfig with repo and auth credentials
     2. Register the config on Knowledge via content_sources
     3. Use .file() or .folder() to create content references
     4. Insert into knowledge with knowledge.insert()
@@ -30,7 +35,9 @@ from agno.knowledge.knowledge import Knowledge
 from agno.knowledge.remote_content import GitHubConfig
 from agno.vectordb.pgvector import PgVector
 
-# Configure GitHub content source
+# ---------------------------------------------------------------------------
+# Option 1: Personal Access Token authentication
+# ---------------------------------------------------------------------------
 # For private repos, set GITHUB_TOKEN env var to a fine-grained PAT with "Contents: read"
 github_config = GitHubConfig(
     id="my-repo",
@@ -38,6 +45,21 @@ github_config = GitHubConfig(
     repo="private/repo",  # Format: owner/repo
     token=getenv("GITHUB_TOKEN"),  # Optional for public repos
     branch="main",  # Default branch
+)
+
+# ---------------------------------------------------------------------------
+# Option 2: GitHub App authentication
+# ---------------------------------------------------------------------------
+# For organizations using GitHub Apps instead of personal tokens.
+# Requires: pip install PyJWT cryptography
+github_app_config = GitHubConfig(
+    id="org-repo",
+    name="Org Repository",
+    repo="my-org/private-repo",
+    app_id=getenv("GITHUB_APP_ID"),
+    installation_id=getenv("GITHUB_INSTALLATION_ID"),
+    private_key=getenv("GITHUB_APP_PRIVATE_KEY"),
+    branch="main",
 )
 
 # Create Knowledge with GitHub as a content source

--- a/libs/agno/agno/knowledge/loaders/github.py
+++ b/libs/agno/agno/knowledge/loaders/github.py
@@ -24,9 +24,76 @@ from agno.utils.string import generate_id
 class GitHubLoader(BaseLoader):
     """Loader for GitHub content."""
 
+    # Cache for GitHub App installation tokens: {cache_key: (token, expires_at_timestamp)}
+    _github_app_token_cache: Dict[str, tuple] = {}
+
     # ==========================================
     # GITHUB HELPERS (shared between sync/async)
     # ==========================================
+
+    def _get_github_app_token(self, gh_config: GitHubConfig) -> str:
+        """Generate or retrieve a cached installation access token for GitHub App auth.
+
+        Creates a JWT signed with the app's private key, then exchanges it for
+        an installation access token via the GitHub API.  Tokens are cached
+        until 60 seconds before expiry.
+
+        Requires ``PyJWT[crypto]``: ``pip install PyJWT cryptography``
+        """
+        import time
+
+        cache_key = f"{gh_config.app_id}:{gh_config.installation_id}"
+
+        # Return cached token if still valid (with 60s buffer)
+        cached = self._github_app_token_cache.get(cache_key)
+        if cached is not None:
+            token, expires_at = cached
+            if time.time() < expires_at - 60:
+                return token
+
+        try:
+            import jwt
+        except ImportError:
+            raise ImportError(
+                "GitHub App authentication requires PyJWT with cryptography. "
+                "Install via: pip install PyJWT cryptography"
+            )
+
+        now = int(time.time())
+        payload = {
+            "iat": now - 60,
+            "exp": now + 600,
+            "iss": str(gh_config.app_id),
+        }
+        app_jwt = jwt.encode(payload, gh_config.private_key, algorithm="RS256")
+
+        # Exchange JWT for installation access token
+        url = f"https://api.github.com/app/installations/{gh_config.installation_id}/access_tokens"
+        jwt_headers = {
+            "Authorization": f"Bearer {app_jwt}",
+            "Accept": "application/vnd.github.v3+json",
+            "User-Agent": "Agno-Knowledge",
+        }
+        with httpx.Client() as client:
+            response = client.post(url, headers=jwt_headers, timeout=30.0)
+            response.raise_for_status()
+            data = response.json()
+
+        installation_token: str = data["token"]
+        # Parse expiry: GitHub returns ISO 8601 format
+        expires_at_str = data.get("expires_at", "")
+        if expires_at_str:
+            from datetime import datetime  # noqa: F811
+
+            try:
+                expires_at_ts = datetime.fromisoformat(expires_at_str.replace("Z", "+00:00")).timestamp()
+            except (ValueError, AttributeError):
+                expires_at_ts = float(now + 3600)
+        else:
+            expires_at_ts = float(now + 3600)
+
+        self._github_app_token_cache[cache_key] = (installation_token, expires_at_ts)
+        return installation_token
 
     def _validate_github_config(
         self,
@@ -48,12 +115,19 @@ class GitHubLoader(BaseLoader):
         return gh_config
 
     def _build_github_headers(self, gh_config: GitHubConfig) -> Dict[str, str]:
-        """Build headers for GitHub API requests."""
+        """Build headers for GitHub API requests.
+
+        Uses GitHub App authentication when ``app_id`` is configured,
+        otherwise falls back to the personal access token.
+        """
         headers: Dict[str, str] = {
             "Accept": "application/vnd.github.v3+json",
             "User-Agent": "Agno-Knowledge",
         }
-        if gh_config.token:
+        if gh_config.app_id is not None:
+            token = self._get_github_app_token(gh_config)
+            headers["Authorization"] = f"Bearer {token}"
+        elif gh_config.token:
             headers["Authorization"] = f"Bearer {gh_config.token}"
         return headers
 

--- a/libs/agno/agno/knowledge/remote_content/github.py
+++ b/libs/agno/agno/knowledge/remote_content/github.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union
+
+from pydantic import model_validator
 
 from agno.knowledge.remote_content.base import BaseStorageConfig
 
@@ -9,12 +11,44 @@ if TYPE_CHECKING:
 
 
 class GitHubConfig(BaseStorageConfig):
-    """Configuration for GitHub content source."""
+    """Configuration for GitHub content source.
+
+    Supports two authentication methods:
+    - Personal Access Token: set ``token`` to a fine-grained PAT
+    - GitHub App: set ``app_id``, ``installation_id``, and ``private_key``
+
+    For GitHub App auth, the loader generates a JWT and exchanges it for an
+    installation access token automatically.  Requires ``PyJWT[crypto]``.
+    """
 
     repo: str
     token: Optional[str] = None
     branch: Optional[str] = None
     path: Optional[str] = None
+
+    # GitHub App authentication (alternative to token)
+    app_id: Optional[Union[str, int]] = None
+    installation_id: Optional[Union[str, int]] = None
+    private_key: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _validate_app_auth_fields(self) -> "GitHubConfig":
+        """Ensure all three GitHub App fields are set together."""
+        app_fields = [self.app_id, self.installation_id, self.private_key]
+        provided = [f for f in app_fields if f is not None]
+        if 0 < len(provided) < 3:
+            missing = []
+            if self.app_id is None:
+                missing.append("app_id")
+            if self.installation_id is None:
+                missing.append("installation_id")
+            if self.private_key is None:
+                missing.append("private_key")
+            raise ValueError(
+                f"GitHub App authentication requires all three fields: app_id, installation_id, private_key. "
+                f"Missing: {', '.join(missing)}"
+            )
+        return self
 
     def file(self, file_path: str, branch: Optional[str] = None) -> "GitHubContent":
         """Create a content reference for a specific file.

--- a/libs/agno/agno/models/deepseek/deepseek.py
+++ b/libs/agno/agno/models/deepseek/deepseek.py
@@ -32,6 +32,9 @@ class DeepSeek(OpenAILike):
     # Their support for structured outputs is currently broken
     supports_native_structured_outputs: bool = False
 
+    # When True, extract text from files and send as {"type": "text"} instead of {"type": "file"}.
+    extract_file_text: bool = False
+
     def _get_client_params(self) -> Dict[str, Any]:
         # Fetch API key from env if not already set
         if not self.api_key:
@@ -117,7 +120,7 @@ class DeepSeek(OpenAILike):
                 message_dict["content"] = []
             # Insert each file part before text parts
             for file in message.files:
-                file_part = _format_file_for_message(file)
+                file_part = _format_file_for_message(file, extract_text=self.extract_file_text)
                 if file_part:
                     message_dict["content"].insert(0, file_part)
 

--- a/libs/agno/agno/models/litellm/chat.py
+++ b/libs/agno/agno/models/litellm/chat.py
@@ -47,6 +47,9 @@ class LiteLLM(Model):
     extra_body: Optional[Dict[str, Any]] = None
     request_params: Optional[Dict[str, Any]] = None
 
+    # When True, extract text from files and send as {"type": "text"} instead of {"type": "file"}.
+    extract_file_text: bool = False
+
     client: Optional[Any] = None
 
     # Store the original client to preserve it across copies (e.g., for Router instances)
@@ -146,7 +149,7 @@ class LiteLLM(Model):
                 else:
                     content_list = msg["content"] if isinstance(msg["content"], list) else []
                 for file in m.files:
-                    file_part = _format_file_for_message(file)
+                    file_part = _format_file_for_message(file, extract_text=self.extract_file_text)
                     if file_part:
                         content_list.append(file_part)
                 msg["content"] = content_list

--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -75,6 +75,10 @@ class OpenAIChat(Model):
     request_params: Optional[Dict[str, Any]] = None
     role_map: Optional[Dict[str, str]] = None
 
+    # When True, extract text from files and send as {"type": "text"} instead of {"type": "file"}.
+    # Useful for models that reject the file content type (e.g. gpt-4.1-mini via Azure OpenAI).
+    extract_file_text: bool = False
+
     # Client parameters
     api_key: Optional[str] = None
     organization: Optional[str] = None
@@ -370,7 +374,7 @@ class OpenAIChat(Model):
                 message_dict["content"] = []
             # Insert each file part before text parts
             for file in message.files:
-                file_part = _format_file_for_message(file)
+                file_part = _format_file_for_message(file, extract_text=self.extract_file_text)
                 if file_part:
                     message_dict["content"].insert(0, file_part)
 

--- a/libs/agno/agno/utils/openai.py
+++ b/libs/agno/agno/utils/openai.py
@@ -210,13 +210,114 @@ def images_to_message(images: Sequence[Image]) -> List[Dict[str, Any]]:
     return image_messages
 
 
-def _format_file_for_message(file: File) -> Optional[Dict[str, Any]]:
+def _extract_text_from_file(content: bytes, mime_type: Optional[str], filename: Optional[str]) -> Optional[str]:
+    """Extract plain text from file content based on MIME type.
+
+    Returns extracted text, or ``None`` if the format is unsupported or
+    extraction fails.  Libraries for PDF and DOCX are imported lazily so
+    they remain optional dependencies.
+    """
+    if mime_type is None and filename:
+        mime_type = mimetypes.guess_type(filename)[0]
+
+    if mime_type is None:
+        return None
+
+    # Text-based MIME types: decode directly
+    _text_mime_types = {
+        "text/plain",
+        "text/csv",
+        "text/html",
+        "text/css",
+        "text/xml",
+        "text/rtf",
+        "text/md",
+        "text/markdown",
+        "text/javascript",
+        "application/json",
+        "application/x-javascript",
+        "application/x-python",
+        "text/x-python",
+    }
+    if mime_type in _text_mime_types or mime_type.startswith("text/"):
+        try:
+            return content.decode("utf-8", errors="replace")
+        except Exception:
+            return None
+
+    # PDF extraction via pypdf
+    if mime_type == "application/pdf":
+        try:
+            from io import BytesIO
+
+            from pypdf import PdfReader
+
+            reader = PdfReader(BytesIO(content))
+            pages = [page.extract_text() or "" for page in reader.pages]
+            text = "\n".join(pages).strip()
+            return text if text else None
+        except Exception:
+            return None
+
+    # DOCX extraction via python-docx
+    if mime_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+        try:
+            from io import BytesIO
+
+            from docx import Document as DocxDocument  # type: ignore
+
+            doc = DocxDocument(BytesIO(content))
+            text = "\n\n".join(para.text for para in doc.paragraphs).strip()
+            return text if text else None
+        except Exception:
+            return None
+
+    return None
+
+
+def _format_file_for_message(file: File, extract_text: bool = False) -> Optional[Dict[str, Any]]:
     """
     Add a document url, base64 encoded content or OpenAI file to a message.
+
+    When *extract_text* is ``True``, the function attempts to extract plain
+    text from the file and returns a ``{"type": "text", ...}`` content block
+    instead of ``{"type": "file", ...}``.  This is useful for models that do
+    not support the ``file`` content type (e.g. ``gpt-4.1-mini`` via Azure).
+    Falls back to the standard ``file`` format if extraction fails.
     """
     import base64
     import mimetypes
     from pathlib import Path
+
+    # When extract_text is requested, try to extract text first
+    if extract_text:
+        content_bytes: Optional[bytes] = None
+        _filename: Optional[str] = file.filename
+        _mime: Optional[str] = file.mime_type
+
+        if file.url is not None:
+            from urllib.parse import urlparse
+
+            result = file.file_url_content
+            if result:
+                content_bytes, url_mime = result
+                _filename = _filename or Path(urlparse(file.url).path).name or "file"
+                _mime = _mime or url_mime
+        elif file.filepath is not None:
+            path = Path(file.filepath)
+            if path.is_file():
+                content_bytes = path.read_bytes()
+                _filename = _filename or path.name
+                _mime = _mime or mimetypes.guess_type(path.name)[0]
+        elif file.content is not None:
+            content_bytes = file.content if isinstance(file.content, bytes) else file.content.encode("utf-8")
+            _filename = _filename or "file"
+
+        if content_bytes is not None:
+            extracted = _extract_text_from_file(content_bytes, _mime, _filename)
+            if extracted is not None:
+                display_name = _filename or "file"
+                return {"type": "text", "text": f"[File: {display_name}]\n{extracted}"}
 
     # Case 1: Document is a URL
     if file.url is not None:
@@ -226,11 +327,11 @@ def _format_file_for_message(file: File) -> Optional[Dict[str, Any]]:
         if not result:
             log_error(f"Failed to fetch file from URL: {file.url}")
             return None
-        content_bytes, mime_type = result
+        content_bytes_url, mime_type = result
         name = Path(urlparse(file.url).path).name or "file"
-        _mime = mime_type or file.mime_type or mimetypes.guess_type(name)[0] or "application/pdf"
-        _encoded = base64.b64encode(content_bytes).decode("utf-8")
-        _data_url = f"data:{_mime};base64,{_encoded}"
+        _mime_url = mime_type or file.mime_type or mimetypes.guess_type(name)[0] or "application/pdf"
+        _encoded = base64.b64encode(content_bytes_url).decode("utf-8")
+        _data_url = f"data:{_mime_url};base64,{_encoded}"
         return {"type": "file", "file": {"filename": name, "file_data": _data_url}}
 
     # Case 2: Document is a local file path
@@ -241,17 +342,17 @@ def _format_file_for_message(file: File) -> Optional[Dict[str, Any]]:
             return None
         data = path.read_bytes()
 
-        _mime = file.mime_type or mimetypes.guess_type(path.name)[0] or "application/pdf"
+        _mime_path = file.mime_type or mimetypes.guess_type(path.name)[0] or "application/pdf"
         _encoded = base64.b64encode(data).decode("utf-8")
-        _data_url = f"data:{_mime};base64,{_encoded}"
+        _data_url = f"data:{_mime_path};base64,{_encoded}"
         return {"type": "file", "file": {"filename": path.name, "file_data": _data_url}}
 
     # Case 3: Document is bytes content
     if file.content is not None:
         name = file.filename or "file"
-        _mime = file.mime_type or mimetypes.guess_type(name)[0] or "application/pdf"
+        _mime_bytes = file.mime_type or mimetypes.guess_type(name)[0] or "application/pdf"
         _encoded = base64.b64encode(file.content).decode("utf-8")
-        _data_url = f"data:{_mime};base64,{_encoded}"
+        _data_url = f"data:{_mime_bytes};base64,{_encoded}"
         return {"type": "file", "file": {"filename": name, "file_data": _data_url}}
 
     return None

--- a/libs/agno/tests/unit/knowledge/test_github_loader.py
+++ b/libs/agno/tests/unit/knowledge/test_github_loader.py
@@ -1,0 +1,160 @@
+"""Tests for GitHubLoader authentication helpers."""
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agno.knowledge.loaders.github import GitHubLoader
+from agno.knowledge.remote_content.github import GitHubConfig
+
+
+@pytest.fixture
+def loader():
+    loader = GitHubLoader.__new__(GitHubLoader)
+    # Reset the class-level cache before each test
+    GitHubLoader._github_app_token_cache = {}
+    return loader
+
+
+@pytest.fixture
+def token_config():
+    return GitHubConfig(
+        id="test",
+        name="Test",
+        repo="owner/repo",
+        token="ghp_test_token",
+    )
+
+
+@pytest.fixture
+def app_config():
+    return GitHubConfig(
+        id="test-app",
+        name="Test App",
+        repo="org/repo",
+        app_id=12345,
+        installation_id=67890,
+        private_key="-----BEGIN RSA PRIVATE KEY-----\nfake_key\n-----END RSA PRIVATE KEY-----",
+    )
+
+
+class TestBuildGitHubHeaders:
+    def test_with_token(self, loader, token_config):
+        """Test that _build_github_headers uses the token."""
+        headers = loader._build_github_headers(token_config)
+        assert headers["Authorization"] == "Bearer ghp_test_token"
+        assert headers["Accept"] == "application/vnd.github.v3+json"
+
+    def test_without_auth(self, loader):
+        """Test headers for public repos (no auth)."""
+        config = GitHubConfig(id="pub", name="Pub", repo="owner/public-repo")
+        headers = loader._build_github_headers(config)
+        assert "Authorization" not in headers
+        assert headers["Accept"] == "application/vnd.github.v3+json"
+
+    def test_with_app_auth(self, loader, app_config):
+        """Test that _build_github_headers uses app auth when app_id is set."""
+        with patch.object(loader, "_get_github_app_token", return_value="ghs_installation_token") as mock_get:
+            headers = loader._build_github_headers(app_config)
+            assert headers["Authorization"] == "Bearer ghs_installation_token"
+            mock_get.assert_called_once_with(app_config)
+
+    def test_app_auth_takes_precedence_over_token(self, loader):
+        """Test that app auth is used when both token and app fields are set."""
+        config = GitHubConfig(
+            id="both",
+            name="Both",
+            repo="owner/repo",
+            token="ghp_pat_token",
+            app_id=111,
+            installation_id=222,
+            private_key="-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+        )
+        with patch.object(loader, "_get_github_app_token", return_value="ghs_app_token"):
+            headers = loader._build_github_headers(config)
+            assert headers["Authorization"] == "Bearer ghs_app_token"
+
+
+class TestGetGitHubAppToken:
+    @patch("agno.knowledge.loaders.github.httpx.Client")
+    @patch("jwt.encode", return_value="fake_jwt_token")
+    def test_generates_token(self, mock_jwt_encode, mock_client_cls, loader, app_config):
+        """Test JWT generation and token exchange."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "token": "ghs_installation_abc",
+            "expires_at": "2099-01-01T00:00:00Z",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        token = loader._get_github_app_token(app_config)
+
+        assert token == "ghs_installation_abc"
+        mock_jwt_encode.assert_called_once()
+        call_args = mock_jwt_encode.call_args
+        assert call_args[0][0]["iss"] == "12345"
+        assert call_args[1]["algorithm"] == "RS256"
+
+    @patch("agno.knowledge.loaders.github.httpx.Client")
+    @patch("jwt.encode", return_value="fake_jwt")
+    def test_caches_token(self, mock_jwt_encode, mock_client_cls, loader, app_config):
+        """Test that the token is cached and reused."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "token": "ghs_cached",
+            "expires_at": "2099-01-01T00:00:00Z",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        # First call generates token
+        token1 = loader._get_github_app_token(app_config)
+        # Second call should use cache
+        token2 = loader._get_github_app_token(app_config)
+
+        assert token1 == token2 == "ghs_cached"
+        # JWT should only be generated once
+        assert mock_jwt_encode.call_count == 1
+
+    @patch("agno.knowledge.loaders.github.httpx.Client")
+    @patch("jwt.encode", return_value="fake_jwt")
+    def test_refreshes_expired_token(self, mock_jwt_encode, mock_client_cls, loader, app_config):
+        """Test that an expired cached token is refreshed."""
+        # Pre-populate cache with expired token
+        cache_key = f"{app_config.app_id}:{app_config.installation_id}"
+        GitHubLoader._github_app_token_cache[cache_key] = ("old_token", time.time() - 100)
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "token": "ghs_refreshed",
+            "expires_at": "2099-01-01T00:00:00Z",
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.post.return_value = mock_response
+        mock_client_cls.return_value = mock_client
+
+        token = loader._get_github_app_token(app_config)
+        assert token == "ghs_refreshed"
+        mock_jwt_encode.assert_called_once()
+
+    def test_missing_pyjwt_raises(self, loader, app_config):
+        """Test that missing PyJWT raises ImportError with install instructions."""
+        with patch.dict("sys.modules", {"jwt": None}):
+            with pytest.raises(ImportError, match="PyJWT"):
+                loader._get_github_app_token(app_config)

--- a/libs/agno/tests/unit/knowledge/test_remote_content_config.py
+++ b/libs/agno/tests/unit/knowledge/test_remote_content_config.py
@@ -367,6 +367,59 @@ def test_github_config_with_metadata():
     assert config.metadata == metadata
 
 
+def test_github_config_with_app_auth():
+    """Test creating a GitHub config with GitHub App authentication."""
+    config = GitHubConfig(
+        id="gh-app",
+        name="App Repo",
+        repo="org/repo",
+        app_id=12345,
+        installation_id=67890,
+        private_key="-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+    )
+    assert config.app_id == 12345
+    assert config.installation_id == 67890
+    assert config.private_key is not None
+
+
+def test_github_config_partial_app_auth_raises():
+    """Test that providing only some GitHub App fields raises ValueError."""
+    with pytest.raises(ValidationError, match="Missing"):
+        GitHubConfig(id="gh", name="GH", repo="owner/repo", app_id=123)
+
+    with pytest.raises(ValidationError, match="Missing"):
+        GitHubConfig(id="gh", name="GH", repo="owner/repo", app_id=123, installation_id=456)
+
+
+def test_github_config_app_auth_with_token():
+    """Test that both token and app auth fields can coexist."""
+    config = GitHubConfig(
+        id="gh",
+        name="GH",
+        repo="owner/repo",
+        token="ghp_xxx",
+        app_id=123,
+        installation_id=456,
+        private_key="-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+    )
+    assert config.token == "ghp_xxx"
+    assert config.app_id == 123
+
+
+def test_github_config_app_auth_string_ids():
+    """Test GitHub App auth with string-typed IDs."""
+    config = GitHubConfig(
+        id="gh",
+        name="GH",
+        repo="owner/repo",
+        app_id="12345",
+        installation_id="67890",
+        private_key="-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----",
+    )
+    assert config.app_id == "12345"
+    assert config.installation_id == "67890"
+
+
 # =============================================================================
 # AzureBlobConfig Tests
 # =============================================================================

--- a/libs/agno/tests/unit/utils/test_openai.py
+++ b/libs/agno/tests/unit/utils/test_openai.py
@@ -3,12 +3,12 @@
 import base64
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from agno.media import Audio, File, Image
-from agno.utils.openai import _format_file_for_message, audio_to_message, images_to_message
+from agno.utils.openai import _extract_text_from_file, _format_file_for_message, audio_to_message, images_to_message
 
 
 # Helper function to create dummy file
@@ -405,3 +405,145 @@ def test_format_file_raw_bytes_no_filename():
     data_url = msg["file"]["file_data"]
     assert data_url.startswith("data:application/pdf;base64,")
     assert base64.b64decode(data_url.split(",", 1)[1]) == content
+
+
+# --- Tests for _extract_text_from_file --- #
+
+
+def test_extract_text_plain_text():
+    """Test text extraction from plain text content."""
+    content = b"Hello, world!\nLine two."
+    result = _extract_text_from_file(content, "text/plain", "test.txt")
+    assert result == "Hello, world!\nLine two."
+
+
+def test_extract_text_json():
+    """Test text extraction from JSON content."""
+    content = b'{"key": "value"}'
+    result = _extract_text_from_file(content, "application/json", "data.json")
+    assert result == '{"key": "value"}'
+
+
+def test_extract_text_csv():
+    """Test text extraction from CSV content."""
+    content = b"name,age\nAlice,30"
+    result = _extract_text_from_file(content, "text/csv", "data.csv")
+    assert result == "name,age\nAlice,30"
+
+
+def test_extract_text_python():
+    """Test text extraction from Python source code."""
+    content = b'def hello():\n    print("hi")'
+    result = _extract_text_from_file(content, "text/x-python", "script.py")
+    assert "def hello" in result
+
+
+def test_extract_text_unsupported_mime():
+    """Test that unsupported MIME types return None."""
+    content = b"\x00\x01\x02binary"
+    result = _extract_text_from_file(content, "application/octet-stream", "data.bin")
+    assert result is None
+
+
+def test_extract_text_none_mime_with_txt_filename():
+    """Test MIME type guessing from filename when mime_type is None."""
+    content = b"some text"
+    result = _extract_text_from_file(content, None, "readme.txt")
+    assert result == "some text"
+
+
+def test_extract_text_none_mime_none_filename():
+    """Test that None mime and None filename returns None."""
+    content = b"something"
+    result = _extract_text_from_file(content, None, None)
+    assert result is None
+
+
+def test_extract_text_decode_with_replacement():
+    """Test that invalid UTF-8 still produces output with replacement characters."""
+    content = b"valid \xff\xfe invalid"
+    result = _extract_text_from_file(content, "text/plain", "test.txt")
+    assert result is not None
+    assert "\ufffd" in result  # Replacement character
+
+
+def test_extract_text_pdf():
+    """Test text extraction from PDF content."""
+    mock_page1 = MagicMock()
+    mock_page1.extract_text.return_value = "Page one text"
+    mock_page2 = MagicMock()
+    mock_page2.extract_text.return_value = "Page two text"
+
+    mock_reader = MagicMock()
+    mock_reader.pages = [mock_page1, mock_page2]
+
+    mock_pypdf = MagicMock()
+    mock_pypdf.PdfReader.return_value = mock_reader
+
+    with patch.dict("sys.modules", {"pypdf": mock_pypdf}):
+        result = _extract_text_from_file(b"%PDF-fake", "application/pdf", "doc.pdf")
+    assert result == "Page one text\nPage two text"
+
+
+def test_extract_text_docx():
+    """Test text extraction from DOCX content."""
+    mock_para1 = MagicMock()
+    mock_para1.text = "Paragraph one"
+    mock_para2 = MagicMock()
+    mock_para2.text = "Paragraph two"
+
+    mock_doc = MagicMock()
+    mock_doc.paragraphs = [mock_para1, mock_para2]
+
+    mock_docx = MagicMock()
+    mock_docx.Document.return_value = mock_doc
+
+    with patch.dict("sys.modules", {"docx": mock_docx}):
+        result = _extract_text_from_file(
+            b"PK\x03\x04fake",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "doc.docx",
+        )
+    assert result == "Paragraph one\n\nParagraph two"
+
+
+# --- Tests for _format_file_for_message with extract_text --- #
+
+
+def test_format_file_extract_text_true():
+    """Test that extract_text=True returns a text content block."""
+    content = b"Hello from file"
+    f = File(content=content, filename="notes.txt", mime_type="text/plain")
+    msg = _format_file_for_message(f, extract_text=True)
+    assert msg["type"] == "text"
+    assert "[File: notes.txt]" in msg["text"]
+    assert "Hello from file" in msg["text"]
+
+
+def test_format_file_extract_text_fallback():
+    """Test that extract_text=True falls back to file format when extraction fails."""
+    # Use a PDF MIME type but with invalid content that will fail extraction
+    content = b"\x00\x01\x02not-a-real-pdf"
+    f = File(content=content, filename="broken.pdf", mime_type="application/pdf")
+    msg = _format_file_for_message(f, extract_text=True)
+    # Should fall back to file format since PDF extraction fails on invalid content
+    assert msg["type"] == "file"
+
+
+def test_format_file_extract_text_false_default():
+    """Test that extract_text defaults to False and preserves original behavior."""
+    content = b"text content"
+    f = File(content=content, filename="test.txt", mime_type="text/plain")
+    msg = _format_file_for_message(f)  # No extract_text param
+    assert msg["type"] == "file"  # Default behavior
+
+
+def test_format_file_extract_text_filepath(tmp_path):
+    """Test extract_text=True with a file path."""
+    p = tmp_path / "readme.md"
+    p.write_text("# Heading\nSome content")
+    f = File(filepath=str(p), mime_type="text/md")
+    msg = _format_file_for_message(f, extract_text=True)
+    assert msg["type"] == "text"
+    assert "# Heading" in msg["text"]
+    assert "Some content" in msg["text"]


### PR DESCRIPTION
## Summary

Adds two features addressing customer-reported limitations:

1. **GitHub App Authentication for GitHubConfig** — Extends `GitHubConfig` with `app_id`, `installation_id`, and `private_key` fields as an alternative to personal access tokens. The `GitHubLoader` handles JWT generation (RS256) and installation token exchange automatically, with in-memory token caching. Requires `PyJWT[crypto]` (lazy-imported, not a hard dependency).

2. **Document Text Extraction for Models** — Adds `extract_file_text` flag to `OpenAIChat`, `DeepSeek`, and `LiteLLM` model classes. When enabled, uploaded files (PDF, DOCX, text formats) are sent as `{"type": "text"}` content blocks instead of `{"type": "file"}`, supporting models that reject the file content type (e.g. `gpt-4.1-mini` via Azure OpenAI). Falls back to file format if extraction fails.

Both changes are backward-compatible and opt-in.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

### Files changed

**Feature 1 — GitHub App Auth:**
- `libs/agno/agno/knowledge/remote_content/github.py` — Added `app_id`, `installation_id`, `private_key` fields with validation
- `libs/agno/agno/knowledge/loaders/github.py` — Added `_get_github_app_token()` JWT exchange and updated `_build_github_headers()`
- `cookbook/07_knowledge/cloud/github.py` — Added GitHub App auth example

**Feature 2 — File Text Extraction:**
- `libs/agno/agno/utils/openai.py` — Added `_extract_text_from_file()` and `extract_text` param on `_format_file_for_message()`
- `libs/agno/agno/models/openai/chat.py` — Added `extract_file_text` flag
- `libs/agno/agno/models/deepseek/deepseek.py` — Added `extract_file_text` flag
- `libs/agno/agno/models/litellm/chat.py` — Added `extract_file_text` flag
- `cookbook/02_agents/12_multimodal/file_text_extraction.py` — New cookbook example

**Tests:**
- `libs/agno/tests/unit/knowledge/test_remote_content_config.py` — 4 new tests for app auth config
- `libs/agno/tests/unit/knowledge/test_github_loader.py` — New test file (8 tests for loader auth)
- `libs/agno/tests/unit/utils/test_openai.py` — 14 new tests for text extraction