### PR TITLE
feat: add S3 and GCS backends for BackupStore

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -36,6 +36,7 @@ class Knowledge:
     enable_catalog: bool = False
     enable_backup_tools: bool = False
     backup_dir: Optional[str] = None
+    backup_store: Optional[Any] = None
 
     def __post_init__(self):
         from agno.vectordb import VectorDb
@@ -82,9 +83,13 @@ class Knowledge:
                 knowledge_name=self.name,
             )
 
-        # Initialize backup store (local filesystem for direct document access)
+        # Initialize backup store (local filesystem, S3, or GCS for direct document access)
         self._backup_store = None
-        if self.backup_dir is not None or self.enable_backup_tools:
+        if self.backup_store is not None:
+            # User provided a pre-configured store (S3BackupStore, GCSBackupStore, etc.)
+            self._backup_store = self.backup_store
+            self._pipeline.backup_store = self._backup_store
+        elif self.backup_dir is not None or self.enable_backup_tools:
             from agno.knowledge.store.backup_store import BackupStore
 
             backup_path = self.backup_dir or f"tmp/knowledge_backup/{self.name or 'default'}"

--- a/libs/agno/agno/knowledge/store/__init__.py
+++ b/libs/agno/agno/knowledge/store/__init__.py
@@ -1,5 +1,7 @@
 from agno.knowledge.store.backup_store import BackupStore
 from agno.knowledge.store.catalog import KnowledgeCatalog
 from agno.knowledge.store.content_store import ContentStore
+from agno.knowledge.store.gcs_backup_store import GCSBackupStore
+from agno.knowledge.store.s3_backup_store import S3BackupStore
 
-__all__ = ["BackupStore", "ContentStore", "KnowledgeCatalog"]
+__all__ = ["BackupStore", "ContentStore", "GCSBackupStore", "KnowledgeCatalog", "S3BackupStore"]

--- a/libs/agno/agno/knowledge/store/gcs_backup_store.py
+++ b/libs/agno/agno/knowledge/store/gcs_backup_store.py
@@ -1,0 +1,368 @@
+"""GCSBackupStore — Google Cloud Storage store for original documents.
+
+Same interface as ``BackupStore`` but stores files in GCS instead of
+the local filesystem. Parsed text, raw bytes, and metadata are stored
+as blobs under ``{prefix}/{content_id}/``.
+
+Blob layout::
+
+    gs://{bucket_name}/{prefix}/
+        <content_id>/
+            parsed.txt      # Parsed text content
+            raw.<ext>        # Original file (optional)
+            metadata.json    # Content metadata
+"""
+
+import asyncio
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from agno.knowledge.store.backup_store import GrepResult
+from agno.utils.log import log_debug, log_info, log_warning
+
+
+@dataclass
+class GCSBackupStore:
+    """Google Cloud Storage store for original document content."""
+
+    bucket_name: str
+    prefix: str = "knowledge_backup"
+    project: Optional[str] = None
+    credentials_path: Optional[str] = None
+
+    def _blob_name(self, content_id: str, filename: str) -> str:
+        return f"{self.prefix.rstrip('/')}/{content_id}/{filename}"
+
+    def _get_bucket(self):
+        try:
+            from google.cloud import storage
+        except ImportError:
+            raise ImportError(
+                "google-cloud-storage is required for GCSBackupStore. Install it with: pip install google-cloud-storage"
+            )
+
+        kwargs: Dict[str, Any] = {}
+        if self.project:
+            kwargs["project"] = self.project
+        if self.credentials_path:
+            from google.oauth2 import service_account
+
+            credentials = service_account.Credentials.from_service_account_file(self.credentials_path)
+            kwargs["credentials"] = credentials
+
+        client = storage.Client(**kwargs)
+        return client.bucket(self.bucket_name)
+
+    def store(
+        self,
+        content_id: str,
+        parsed_text: str,
+        raw_bytes: Optional[bytes] = None,
+        file_extension: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Store parsed text and optional raw content in GCS."""
+        bucket = self._get_bucket()
+
+        blob = bucket.blob(self._blob_name(content_id, "parsed.txt"))
+        blob.upload_from_string(parsed_text, content_type="text/plain")
+        log_info(f"Stored parsed text for {content_id} in GCS ({len(parsed_text)} chars)")
+
+        if raw_bytes is not None:
+            ext = file_extension or ".bin"
+            if not ext.startswith("."):
+                ext = f".{ext}"
+            raw_blob = bucket.blob(self._blob_name(content_id, f"raw{ext}"))
+            raw_blob.upload_from_string(raw_bytes)
+            log_debug(f"Stored raw file for {content_id} in GCS ({len(raw_bytes)} bytes)")
+
+        if metadata:
+            meta_blob = bucket.blob(self._blob_name(content_id, "metadata.json"))
+            meta_blob.upload_from_string(
+                json.dumps(metadata, indent=2, default=str),
+                content_type="application/json",
+            )
+
+    async def astore(
+        self,
+        content_id: str,
+        parsed_text: str,
+        raw_bytes: Optional[bytes] = None,
+        file_extension: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Async variant of store. Uses asyncio.to_thread for GCS (no native async)."""
+        await asyncio.to_thread(
+            self.store,
+            content_id=content_id,
+            parsed_text=parsed_text,
+            raw_bytes=raw_bytes,
+            file_extension=file_extension,
+            metadata=metadata,
+        )
+
+    def _get_text(self, blob_name: str) -> Optional[str]:
+        """Get text content from GCS, returns None if not found."""
+        bucket = self._get_bucket()
+        blob = bucket.blob(blob_name)
+        if not blob.exists():
+            return None
+        return blob.download_as_text(encoding="utf-8")
+
+    async def _aget_text(self, blob_name: str) -> Optional[str]:
+        """Async variant of _get_text."""
+        return await asyncio.to_thread(self._get_text, blob_name)
+
+    def read(
+        self,
+        content_id: str,
+        offset: int = 0,
+        limit: int = 200,
+    ) -> Optional[str]:
+        """Read parsed text for a document with line-based pagination."""
+        text = self._get_text(self._blob_name(content_id, "parsed.txt"))
+        if text is None:
+            return None
+
+        lines = text.splitlines()
+        total = len(lines)
+        selected = lines[offset : offset + limit]
+
+        header = f"[Lines {offset + 1}-{min(offset + limit, total)} of {total}]"
+        numbered = [f"{offset + i + 1}: {line}" for i, line in enumerate(selected)]
+        return header + "\n" + "\n".join(numbered)
+
+    async def aread(
+        self,
+        content_id: str,
+        offset: int = 0,
+        limit: int = 200,
+    ) -> Optional[str]:
+        """Async variant of read."""
+        text = await self._aget_text(self._blob_name(content_id, "parsed.txt"))
+        if text is None:
+            return None
+
+        lines = text.splitlines()
+        total = len(lines)
+        selected = lines[offset : offset + limit]
+
+        header = f"[Lines {offset + 1}-{min(offset + limit, total)} of {total}]"
+        numbered = [f"{offset + i + 1}: {line}" for i, line in enumerate(selected)]
+        return header + "\n" + "\n".join(numbered)
+
+    def _grep_text(
+        self, content_id: str, text: str, pattern: re.Pattern, context: int, max_matches: int
+    ) -> List[GrepResult]:
+        """Grep through text content, returning matches with context."""
+        lines = text.splitlines()
+        results: List[GrepResult] = []
+
+        for i, line in enumerate(lines):
+            if pattern.search(line):
+                before = lines[max(0, i - context) : i]
+                after = lines[i + 1 : min(len(lines), i + 1 + context)]
+                results.append(
+                    GrepResult(
+                        content_id=content_id,
+                        line_number=i + 1,
+                        line=line,
+                        context_before=before,
+                        context_after=after,
+                    )
+                )
+                if len(results) >= max_matches:
+                    break
+
+        return results
+
+    def grep(
+        self,
+        content_id: str,
+        pattern: str,
+        context: int = 2,
+        max_matches: int = 20,
+    ) -> List[GrepResult]:
+        """Search within a single document's parsed text in GCS."""
+        try:
+            compiled = re.compile(pattern, re.IGNORECASE)
+        except re.error as e:
+            log_warning(f"Invalid regex pattern '{pattern}': {e}")
+            return []
+
+        text = self._get_text(self._blob_name(content_id, "parsed.txt"))
+        if text is None:
+            return []
+
+        return self._grep_text(content_id, text, compiled, context, max_matches)
+
+    async def agrep(
+        self,
+        content_id: str,
+        pattern: str,
+        context: int = 2,
+        max_matches: int = 20,
+    ) -> List[GrepResult]:
+        """Async variant of grep."""
+        try:
+            compiled = re.compile(pattern, re.IGNORECASE)
+        except re.error as e:
+            log_warning(f"Invalid regex pattern '{pattern}': {e}")
+            return []
+
+        text = await self._aget_text(self._blob_name(content_id, "parsed.txt"))
+        if text is None:
+            return []
+
+        return self._grep_text(content_id, text, compiled, context, max_matches)
+
+    def _list_content_ids(self) -> List[str]:
+        """List all content IDs stored in GCS under the prefix."""
+        bucket = self._get_bucket()
+        prefix = self.prefix.rstrip("/") + "/"
+        content_ids: set = set()
+
+        for blob in bucket.list_blobs(prefix=prefix):
+            # blob.name looks like "prefix/content_id/parsed.txt"
+            relative = blob.name[len(prefix) :]
+            parts = relative.split("/", 1)
+            if parts[0]:
+                content_ids.add(parts[0])
+
+        return sorted(content_ids)
+
+    async def _alist_content_ids(self) -> List[str]:
+        """Async variant of _list_content_ids."""
+        return await asyncio.to_thread(self._list_content_ids)
+
+    def grep_all(
+        self,
+        pattern: str,
+        context: int = 2,
+        max_matches: int = 50,
+    ) -> List[GrepResult]:
+        """Search across all stored documents in GCS."""
+        try:
+            re.compile(pattern, re.IGNORECASE)
+        except re.error as e:
+            log_warning(f"Invalid regex pattern '{pattern}': {e}")
+            return []
+
+        results: List[GrepResult] = []
+        for content_id in self._list_content_ids():
+            remaining = max_matches - len(results)
+            if remaining <= 0:
+                break
+            results.extend(self.grep(content_id, pattern, context=context, max_matches=remaining))
+
+        return results
+
+    async def agrep_all(
+        self,
+        pattern: str,
+        context: int = 2,
+        max_matches: int = 50,
+    ) -> List[GrepResult]:
+        """Async variant of grep_all."""
+        try:
+            re.compile(pattern, re.IGNORECASE)
+        except re.error as e:
+            log_warning(f"Invalid regex pattern '{pattern}': {e}")
+            return []
+
+        results: List[GrepResult] = []
+        for content_id in await self._alist_content_ids():
+            remaining = max_matches - len(results)
+            if remaining <= 0:
+                break
+            results.extend(await self.agrep(content_id, pattern, context=context, max_matches=remaining))
+
+        return results
+
+    def get_tools(self) -> List[Any]:
+        """Return read_backup and grep_backup Function tools for the agent."""
+        from agno.tools.function import Function
+
+        store = self
+
+        def read_backup(content_id: str, offset: int = 0, limit: int = 200) -> str:
+            """Read a document from the backup store with line-based pagination.
+
+            Args:
+                content_id: The ID of the document to read.
+                offset: Line number to start from (0-based). Default: 0
+                limit: Maximum number of lines to return. Default: 200
+
+            Returns:
+                str: The document content with line numbers, or an error message.
+            """
+            result = store.read(content_id=content_id, offset=offset, limit=limit)
+            if result is None:
+                return f"Document '{content_id}' not found in backup store."
+            return result
+
+        async def aread_backup(content_id: str, offset: int = 0, limit: int = 200) -> str:
+            """Read a document from the backup store (async)."""
+            result = await store.aread(content_id=content_id, offset=offset, limit=limit)
+            if result is None:
+                return f"Document '{content_id}' not found in backup store."
+            return result
+
+        def grep_backup(pattern: str, content_id: Optional[str] = None) -> str:
+            """Search for a pattern in backup documents using regex.
+
+            Args:
+                pattern: Regex pattern to search for.
+                content_id: If provided, search only this document. Otherwise search all documents.
+
+            Returns:
+                str: Matching lines with context, or a message if no matches found.
+            """
+            if content_id:
+                results = store.grep(content_id=content_id, pattern=pattern)
+            else:
+                results = store.grep_all(pattern=pattern)
+
+            if not results:
+                return f"No matches found for pattern '{pattern}'."
+
+            parts = []
+            for result in results:
+                parts.append(f"[{result.content_id}:{result.line_number}]")
+                parts.append(result.to_str())
+            return "\n".join(parts)
+
+        async def agrep_backup(pattern: str, content_id: Optional[str] = None) -> str:
+            """Search for a pattern in backup documents (async)."""
+            if content_id:
+                results = await store.agrep(content_id=content_id, pattern=pattern)
+            else:
+                results = await store.agrep_all(pattern=pattern)
+
+            if not results:
+                return f"No matches found for pattern '{pattern}'."
+
+            parts = []
+            for result in results:
+                parts.append(f"[{result.content_id}:{result.line_number}]")
+                parts.append(result.to_str())
+            return "\n".join(parts)
+
+        read_tool = Function(
+            name="read_backup",
+            description="Read a document from the knowledge backup store with line-based pagination.",
+            entrypoint=read_backup,
+            async_entrypoint=aread_backup,
+        )
+
+        grep_tool = Function(
+            name="grep_backup",
+            description="Search for a regex pattern in one or all backup documents.",
+            entrypoint=grep_backup,
+            async_entrypoint=agrep_backup,
+        )
+
+        log_debug("Created read_backup and grep_backup tools from GCSBackupStore")
+        return [read_tool, grep_tool]

--- a/libs/agno/agno/knowledge/store/s3_backup_store.py
+++ b/libs/agno/agno/knowledge/store/s3_backup_store.py
@@ -1,0 +1,423 @@
+"""S3BackupStore — Amazon S3 store for original documents.
+
+Same interface as ``BackupStore`` but stores files in S3 instead of
+the local filesystem. Parsed text, raw bytes, and metadata are stored
+as objects under ``{prefix}/{content_id}/``.
+
+Object layout::
+
+    s3://{bucket_name}/{prefix}/
+        <content_id>/
+            parsed.txt      # Parsed text content
+            raw.<ext>        # Original file (optional)
+            metadata.json    # Content metadata
+"""
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from agno.knowledge.store.backup_store import GrepResult
+from agno.utils.log import log_debug, log_info, log_warning
+
+
+@dataclass
+class S3BackupStore:
+    """Amazon S3 store for original document content."""
+
+    bucket_name: str
+    prefix: str = "knowledge_backup"
+    region: Optional[str] = None
+    aws_access_key_id: Optional[str] = None
+    aws_secret_access_key: Optional[str] = None
+
+    def _key(self, content_id: str, filename: str) -> str:
+        return f"{self.prefix.rstrip('/')}/{content_id}/{filename}"
+
+    def _get_client(self):
+        try:
+            import boto3
+        except ImportError:
+            raise ImportError("boto3 is required for S3BackupStore. Install it with: pip install boto3")
+
+        kwargs: Dict[str, Any] = {}
+        if self.region:
+            kwargs["region_name"] = self.region
+        if self.aws_access_key_id and self.aws_secret_access_key:
+            kwargs["aws_access_key_id"] = self.aws_access_key_id
+            kwargs["aws_secret_access_key"] = self.aws_secret_access_key
+        return boto3.client("s3", **kwargs)
+
+    async def _get_async_client(self):
+        try:
+            import aioboto3
+        except ImportError:
+            raise ImportError("aioboto3 is required for async S3 operations. Install it with: pip install aioboto3")
+        kwargs: Dict[str, Any] = {}
+        if self.region:
+            kwargs["region_name"] = self.region
+        if self.aws_access_key_id and self.aws_secret_access_key:
+            kwargs["aws_access_key_id"] = self.aws_access_key_id
+            kwargs["aws_secret_access_key"] = self.aws_secret_access_key
+        return aioboto3.Session(**kwargs)
+
+    def store(
+        self,
+        content_id: str,
+        parsed_text: str,
+        raw_bytes: Optional[bytes] = None,
+        file_extension: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Store parsed text and optional raw content in S3."""
+        client = self._get_client()
+
+        client.put_object(
+            Bucket=self.bucket_name,
+            Key=self._key(content_id, "parsed.txt"),
+            Body=parsed_text.encode("utf-8"),
+            ContentType="text/plain",
+        )
+        log_info(f"Stored parsed text for {content_id} in S3 ({len(parsed_text)} chars)")
+
+        if raw_bytes is not None:
+            ext = file_extension or ".bin"
+            if not ext.startswith("."):
+                ext = f".{ext}"
+            client.put_object(
+                Bucket=self.bucket_name,
+                Key=self._key(content_id, f"raw{ext}"),
+                Body=raw_bytes,
+            )
+            log_debug(f"Stored raw file for {content_id} in S3 ({len(raw_bytes)} bytes)")
+
+        if metadata:
+            client.put_object(
+                Bucket=self.bucket_name,
+                Key=self._key(content_id, "metadata.json"),
+                Body=json.dumps(metadata, indent=2, default=str).encode("utf-8"),
+                ContentType="application/json",
+            )
+
+    async def astore(
+        self,
+        content_id: str,
+        parsed_text: str,
+        raw_bytes: Optional[bytes] = None,
+        file_extension: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Async variant of store using aioboto3."""
+        session = await self._get_async_client()
+        async with session.client("s3") as client:
+            await client.put_object(
+                Bucket=self.bucket_name,
+                Key=self._key(content_id, "parsed.txt"),
+                Body=parsed_text.encode("utf-8"),
+                ContentType="text/plain",
+            )
+            log_info(f"Stored parsed text for {content_id} in S3 ({len(parsed_text)} chars)")
+
+            if raw_bytes is not None:
+                ext = file_extension or ".bin"
+                if not ext.startswith("."):
+                    ext = f".{ext}"
+                await client.put_object(
+                    Bucket=self.bucket_name,
+                    Key=self._key(content_id, f"raw{ext}"),
+                    Body=raw_bytes,
+                )
+
+            if metadata:
+                await client.put_object(
+                    Bucket=self.bucket_name,
+                    Key=self._key(content_id, "metadata.json"),
+                    Body=json.dumps(metadata, indent=2, default=str).encode("utf-8"),
+                    ContentType="application/json",
+                )
+
+    def _get_text(self, key: str) -> Optional[str]:
+        """Get text content from S3, returns None if not found."""
+        client = self._get_client()
+        try:
+            response = client.get_object(Bucket=self.bucket_name, Key=key)
+            return response["Body"].read().decode("utf-8")
+        except client.exceptions.NoSuchKey:
+            return None
+
+    async def _aget_text(self, key: str) -> Optional[str]:
+        """Async variant of _get_text."""
+        session = await self._get_async_client()
+        async with session.client("s3") as client:
+            try:
+                response = await client.get_object(Bucket=self.bucket_name, Key=key)
+                body = await response["Body"].read()
+                return body.decode("utf-8")
+            except Exception:
+                return None
+
+    def read(
+        self,
+        content_id: str,
+        offset: int = 0,
+        limit: int = 200,
+    ) -> Optional[str]:
+        """Read parsed text for a document with line-based pagination."""
+        text = self._get_text(self._key(content_id, "parsed.txt"))
+        if text is None:
+            return None
+
+        lines = text.splitlines()
+        total = len(lines)
+        selected = lines[offset : offset + limit]
+
+        header = f"[Lines {offset + 1}-{min(offset + limit, total)} of {total}]"
+        numbered = [f"{offset + i + 1}: {line}" for i, line in enumerate(selected)]
+        return header + "\n" + "\n".join(numbered)
+
+    async def aread(
+        self,
+        content_id: str,
+        offset: int = 0,
+        limit: int = 200,
+    ) -> Optional[str]:
+        """Async variant of read."""
+        text = await self._aget_text(self._key(content_id, "parsed.txt"))
+        if text is None:
+            return None
+
+        lines = text.splitlines()
+        total = len(lines)
+        selected = lines[offset : offset + limit]
+
+        header = f"[Lines {offset + 1}-{min(offset + limit, total)} of {total}]"
+        numbered = [f"{offset + i + 1}: {line}" for i, line in enumerate(selected)]
+        return header + "\n" + "\n".join(numbered)
+
+    def _grep_text(
+        self, content_id: str, text: str, pattern: re.Pattern, context: int, max_matches: int
+    ) -> List[GrepResult]:
+        """Grep through text content, returning matches with context."""
+        lines = text.splitlines()
+        results: List[GrepResult] = []
+
+        for i, line in enumerate(lines):
+            if pattern.search(line):
+                before = lines[max(0, i - context) : i]
+                after = lines[i + 1 : min(len(lines), i + 1 + context)]
+                results.append(
+                    GrepResult(
+                        content_id=content_id,
+                        line_number=i + 1,
+                        line=line,
+                        context_before=before,
+                        context_after=after,
+                    )
+                )
+                if len(results) >= max_matches:
+                    break
+
+        return results
+
+    def grep(
+        self,
+        content_id: str,
+        pattern: str,
+        context: int = 2,
+        max_matches: int = 20,
+    ) -> List[GrepResult]:
+        """Search within a single document's parsed text in S3."""
+        try:
+            compiled = re.compile(pattern, re.IGNORECASE)
+        except re.error as e:
+            log_warning(f"Invalid regex pattern '{pattern}': {e}")
+            return []
+
+        text = self._get_text(self._key(content_id, "parsed.txt"))
+        if text is None:
+            return []
+
+        return self._grep_text(content_id, text, compiled, context, max_matches)
+
+    async def agrep(
+        self,
+        content_id: str,
+        pattern: str,
+        context: int = 2,
+        max_matches: int = 20,
+    ) -> List[GrepResult]:
+        """Async variant of grep."""
+        try:
+            compiled = re.compile(pattern, re.IGNORECASE)
+        except re.error as e:
+            log_warning(f"Invalid regex pattern '{pattern}': {e}")
+            return []
+
+        text = await self._aget_text(self._key(content_id, "parsed.txt"))
+        if text is None:
+            return []
+
+        return self._grep_text(content_id, text, compiled, context, max_matches)
+
+    def _list_content_ids(self) -> List[str]:
+        """List all content IDs stored in S3 under the prefix."""
+        client = self._get_client()
+        prefix = self.prefix.rstrip("/") + "/"
+        content_ids: List[str] = []
+        paginator = client.get_paginator("list_objects_v2")
+
+        for page in paginator.paginate(Bucket=self.bucket_name, Prefix=prefix, Delimiter="/"):
+            for cp in page.get("CommonPrefixes", []):
+                # cp["Prefix"] looks like "prefix/content_id/"
+                content_id = cp["Prefix"][len(prefix) :].rstrip("/")
+                if content_id:
+                    content_ids.append(content_id)
+
+        return sorted(content_ids)
+
+    async def _alist_content_ids(self) -> List[str]:
+        """Async variant of _list_content_ids."""
+        session = await self._get_async_client()
+        prefix = self.prefix.rstrip("/") + "/"
+        content_ids: List[str] = []
+
+        async with session.client("s3") as client:
+            paginator = client.get_paginator("list_objects_v2")
+            async for page in paginator.paginate(Bucket=self.bucket_name, Prefix=prefix, Delimiter="/"):
+                for cp in page.get("CommonPrefixes", []):
+                    content_id = cp["Prefix"][len(prefix) :].rstrip("/")
+                    if content_id:
+                        content_ids.append(content_id)
+
+        return sorted(content_ids)
+
+    def grep_all(
+        self,
+        pattern: str,
+        context: int = 2,
+        max_matches: int = 50,
+    ) -> List[GrepResult]:
+        """Search across all stored documents in S3."""
+        try:
+            re.compile(pattern, re.IGNORECASE)
+        except re.error as e:
+            log_warning(f"Invalid regex pattern '{pattern}': {e}")
+            return []
+
+        results: List[GrepResult] = []
+        for content_id in self._list_content_ids():
+            remaining = max_matches - len(results)
+            if remaining <= 0:
+                break
+            results.extend(self.grep(content_id, pattern, context=context, max_matches=remaining))
+
+        return results
+
+    async def agrep_all(
+        self,
+        pattern: str,
+        context: int = 2,
+        max_matches: int = 50,
+    ) -> List[GrepResult]:
+        """Async variant of grep_all."""
+        try:
+            re.compile(pattern, re.IGNORECASE)
+        except re.error as e:
+            log_warning(f"Invalid regex pattern '{pattern}': {e}")
+            return []
+
+        results: List[GrepResult] = []
+        for content_id in await self._alist_content_ids():
+            remaining = max_matches - len(results)
+            if remaining <= 0:
+                break
+            results.extend(await self.agrep(content_id, pattern, context=context, max_matches=remaining))
+
+        return results
+
+    def get_tools(self) -> List[Any]:
+        """Return read_backup and grep_backup Function tools for the agent."""
+        from agno.tools.function import Function
+
+        store = self
+
+        def read_backup(content_id: str, offset: int = 0, limit: int = 200) -> str:
+            """Read a document from the backup store with line-based pagination.
+
+            Args:
+                content_id: The ID of the document to read.
+                offset: Line number to start from (0-based). Default: 0
+                limit: Maximum number of lines to return. Default: 200
+
+            Returns:
+                str: The document content with line numbers, or an error message.
+            """
+            result = store.read(content_id=content_id, offset=offset, limit=limit)
+            if result is None:
+                return f"Document '{content_id}' not found in backup store."
+            return result
+
+        async def aread_backup(content_id: str, offset: int = 0, limit: int = 200) -> str:
+            """Read a document from the backup store (async)."""
+            result = await store.aread(content_id=content_id, offset=offset, limit=limit)
+            if result is None:
+                return f"Document '{content_id}' not found in backup store."
+            return result
+
+        def grep_backup(pattern: str, content_id: Optional[str] = None) -> str:
+            """Search for a pattern in backup documents using regex.
+
+            Args:
+                pattern: Regex pattern to search for.
+                content_id: If provided, search only this document. Otherwise search all documents.
+
+            Returns:
+                str: Matching lines with context, or a message if no matches found.
+            """
+            if content_id:
+                results = store.grep(content_id=content_id, pattern=pattern)
+            else:
+                results = store.grep_all(pattern=pattern)
+
+            if not results:
+                return f"No matches found for pattern '{pattern}'."
+
+            parts = []
+            for result in results:
+                parts.append(f"[{result.content_id}:{result.line_number}]")
+                parts.append(result.to_str())
+            return "\n".join(parts)
+
+        async def agrep_backup(pattern: str, content_id: Optional[str] = None) -> str:
+            """Search for a pattern in backup documents (async)."""
+            if content_id:
+                results = await store.agrep(content_id=content_id, pattern=pattern)
+            else:
+                results = await store.agrep_all(pattern=pattern)
+
+            if not results:
+                return f"No matches found for pattern '{pattern}'."
+
+            parts = []
+            for result in results:
+                parts.append(f"[{result.content_id}:{result.line_number}]")
+                parts.append(result.to_str())
+            return "\n".join(parts)
+
+        read_tool = Function(
+            name="read_backup",
+            description="Read a document from the knowledge backup store with line-based pagination.",
+            entrypoint=read_backup,
+            async_entrypoint=aread_backup,
+        )
+
+        grep_tool = Function(
+            name="grep_backup",
+            description="Search for a regex pattern in one or all backup documents.",
+            entrypoint=grep_backup,
+            async_entrypoint=agrep_backup,
+        )
+
+        log_debug("Created read_backup and grep_backup tools from S3BackupStore")
+        return [read_tool, grep_tool]

--- a/libs/agno/tests/unit/knowledge/test_gcs_backup_store.py
+++ b/libs/agno/tests/unit/knowledge/test_gcs_backup_store.py
@@ -1,0 +1,167 @@
+"""Tests for GCSBackupStore."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agno.knowledge.store.backup_store import GrepResult
+
+
+class MockBlob:
+    """Mock GCS blob with in-memory storage."""
+
+    def __init__(self, name, storage):
+        self.name = name
+        self._storage = storage
+
+    def upload_from_string(self, data, content_type=None):
+        if isinstance(data, str):
+            self._storage[self.name] = data.encode("utf-8")
+        else:
+            self._storage[self.name] = data
+
+    def exists(self):
+        return self.name in self._storage
+
+    def download_as_text(self, encoding="utf-8"):
+        return self._storage[self.name].decode(encoding)
+
+
+class MockBucket:
+    """Mock GCS bucket with in-memory storage."""
+
+    def __init__(self):
+        self._storage = {}
+
+    def blob(self, name):
+        return MockBlob(name, self._storage)
+
+    def list_blobs(self, prefix=""):
+        blobs = []
+        for key in sorted(self._storage.keys()):
+            if key.startswith(prefix):
+                blob = MagicMock()
+                blob.name = key
+                blobs.append(blob)
+        return blobs
+
+
+@pytest.fixture
+def mock_bucket():
+    return MockBucket()
+
+
+@pytest.fixture
+def store(mock_bucket):
+    """Create a GCSBackupStore with mocked GCS client."""
+    with patch("agno.knowledge.store.gcs_backup_store.GCSBackupStore._get_bucket", return_value=mock_bucket):
+        from agno.knowledge.store.gcs_backup_store import GCSBackupStore
+
+        s = GCSBackupStore(bucket_name="test-bucket", prefix="backups")
+        s._mock_bucket = mock_bucket
+        yield s
+
+
+class TestStore:
+    def test_store_writes_parsed_text(self, store, mock_bucket):
+        with patch.object(store, "_get_bucket", return_value=mock_bucket):
+            store.store(content_id="doc1", parsed_text="Hello world\nLine 2")
+
+        assert b"Hello world\nLine 2" == mock_bucket._storage["backups/doc1/parsed.txt"]
+
+    def test_store_writes_raw_bytes(self, store, mock_bucket):
+        with patch.object(store, "_get_bucket", return_value=mock_bucket):
+            store.store(content_id="doc1", parsed_text="text", raw_bytes=b"raw pdf data", file_extension=".pdf")
+
+        assert b"raw pdf data" == mock_bucket._storage["backups/doc1/raw.pdf"]
+
+    def test_store_writes_metadata(self, store, mock_bucket):
+        with patch.object(store, "_get_bucket", return_value=mock_bucket):
+            store.store(content_id="doc1", parsed_text="text", metadata={"name": "test.pdf"})
+
+        meta = json.loads(mock_bucket._storage["backups/doc1/metadata.json"].decode())
+        assert meta["name"] == "test.pdf"
+
+    def test_store_extension_normalization(self, store, mock_bucket):
+        with patch.object(store, "_get_bucket", return_value=mock_bucket):
+            store.store(content_id="doc1", parsed_text="text", raw_bytes=b"data", file_extension="txt")
+
+        assert "backups/doc1/raw.txt" in mock_bucket._storage
+
+
+class TestRead:
+    def test_read_full_document(self, store, mock_bucket):
+        mock_bucket._storage["backups/doc1/parsed.txt"] = b"Line 1\nLine 2\nLine 3"
+
+        with patch.object(store, "_get_bucket", return_value=mock_bucket):
+            result = store.read("doc1")
+
+        assert result is not None
+        assert "[Lines 1-3 of 3]" in result
+        assert "1: Line 1" in result
+
+    def test_read_with_pagination(self, store, mock_bucket):
+        lines = "\n".join(f"Line {i}" for i in range(1, 11))
+        mock_bucket._storage["backups/doc1/parsed.txt"] = lines.encode()
+
+        with patch.object(store, "_get_bucket", return_value=mock_bucket):
+            result = store.read("doc1", offset=3, limit=4)
+
+        assert result is not None
+        assert "[Lines 4-7 of 10]" in result
+
+    def test_read_nonexistent_returns_none(self, store, mock_bucket):
+        with patch.object(store, "_get_bucket", return_value=mock_bucket):
+            result = store.read("nonexistent")
+
+        assert result is None
+
+
+class TestGrep:
+    def test_grep_finds_pattern(self, store, mock_bucket):
+        mock_bucket._storage["backups/doc1/parsed.txt"] = b"apple\nbanana\ncherry"
+
+        with patch.object(store, "_get_bucket", return_value=mock_bucket):
+            results = store.grep("doc1", "cherry")
+
+        assert len(results) == 1
+        assert results[0].line_number == 3
+        assert results[0].line == "cherry"
+
+    def test_grep_nonexistent_document(self, store, mock_bucket):
+        with patch.object(store, "_get_bucket", return_value=mock_bucket):
+            results = store.grep("nonexistent", "pattern")
+
+        assert results == []
+
+
+class TestGrepAll:
+    def test_grep_all_searches_multiple_docs(self, store, mock_bucket):
+        mock_bucket._storage["backups/doc1/parsed.txt"] = b"apple pie"
+        mock_bucket._storage["backups/doc2/parsed.txt"] = b"apple sauce"
+
+        with patch.object(store, "_get_bucket", return_value=mock_bucket):
+            results = store.grep_all("apple")
+
+        assert len(results) == 2
+
+
+class TestGetTools:
+    def test_get_tools_returns_two_tools(self, store):
+        tools = store.get_tools()
+        assert len(tools) == 2
+        names = {t.name for t in tools}
+        assert "read_backup" in names
+        assert "grep_backup" in names
+
+
+class TestBlobNameGeneration:
+    def test_blob_name_format(self, store):
+        assert store._blob_name("doc1", "parsed.txt") == "backups/doc1/parsed.txt"
+
+    def test_blob_name_strips_trailing_slash(self):
+        from agno.knowledge.store.gcs_backup_store import GCSBackupStore
+
+        s = GCSBackupStore(bucket_name="test", prefix="backups/")
+        assert s._blob_name("doc1", "parsed.txt") == "backups/doc1/parsed.txt"

--- a/libs/agno/tests/unit/knowledge/test_s3_backup_store.py
+++ b/libs/agno/tests/unit/knowledge/test_s3_backup_store.py
@@ -1,0 +1,180 @@
+"""Tests for S3BackupStore."""
+
+import json
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agno.knowledge.store.backup_store import GrepResult
+
+
+@pytest.fixture
+def mock_s3_client():
+    """Create a mock S3 client with in-memory storage."""
+    storage = {}
+
+    client = MagicMock()
+
+    def put_object(Bucket, Key, Body, **kwargs):
+        if isinstance(Body, bytes):
+            storage[Key] = Body
+        elif isinstance(Body, str):
+            storage[Key] = Body.encode("utf-8")
+        else:
+            storage[Key] = Body
+
+    def get_object(Bucket, Key):
+        if Key not in storage:
+            error = type("NoSuchKey", (Exception,), {})
+            raise client.exceptions.NoSuchKey({}, "NoSuchKey")
+        body = MagicMock()
+        body.read.return_value = storage[Key]
+        return {"Body": body}
+
+    # Set up paginator for list operations
+    def get_paginator(operation):
+        paginator = MagicMock()
+
+        def paginate(Bucket, Prefix, Delimiter="/"):
+            # Find all "directories" under the prefix
+            common_prefixes = set()
+            for key in storage:
+                if key.startswith(Prefix):
+                    relative = key[len(Prefix) :]
+                    parts = relative.split("/", 1)
+                    if len(parts) > 1:
+                        common_prefixes.add(Prefix + parts[0] + "/")
+
+            return [{"CommonPrefixes": [{"Prefix": cp} for cp in sorted(common_prefixes)]}]
+
+        paginator.paginate = paginate
+        return paginator
+
+    # Set up exceptions
+    no_such_key = type("NoSuchKey", (Exception,), {})
+    client.exceptions = MagicMock()
+    client.exceptions.NoSuchKey = no_such_key
+
+    client.put_object = put_object
+    client.get_object = get_object
+    client.get_paginator = get_paginator
+    client._storage = storage  # Expose for test assertions
+
+    return client
+
+
+@pytest.fixture
+def store(mock_s3_client):
+    """Create an S3BackupStore with mocked S3 client."""
+    with patch("agno.knowledge.store.s3_backup_store.S3BackupStore._get_client", return_value=mock_s3_client):
+        from agno.knowledge.store.s3_backup_store import S3BackupStore
+
+        s = S3BackupStore(bucket_name="test-bucket", prefix="backups")
+        s._mock_client = mock_s3_client
+        yield s
+
+
+class TestStore:
+    def test_store_writes_parsed_text(self, store, mock_s3_client):
+        with patch.object(store, "_get_client", return_value=mock_s3_client):
+            store.store(content_id="doc1", parsed_text="Hello world\nLine 2")
+
+        assert b"Hello world\nLine 2" == mock_s3_client._storage["backups/doc1/parsed.txt"]
+
+    def test_store_writes_raw_bytes(self, store, mock_s3_client):
+        with patch.object(store, "_get_client", return_value=mock_s3_client):
+            store.store(content_id="doc1", parsed_text="text", raw_bytes=b"raw pdf data", file_extension=".pdf")
+
+        assert b"raw pdf data" == mock_s3_client._storage["backups/doc1/raw.pdf"]
+
+    def test_store_writes_metadata(self, store, mock_s3_client):
+        with patch.object(store, "_get_client", return_value=mock_s3_client):
+            store.store(content_id="doc1", parsed_text="text", metadata={"name": "test.pdf"})
+
+        meta = json.loads(mock_s3_client._storage["backups/doc1/metadata.json"].decode())
+        assert meta["name"] == "test.pdf"
+
+    def test_store_extension_normalization(self, store, mock_s3_client):
+        with patch.object(store, "_get_client", return_value=mock_s3_client):
+            store.store(content_id="doc1", parsed_text="text", raw_bytes=b"data", file_extension="txt")
+
+        assert "backups/doc1/raw.txt" in mock_s3_client._storage
+
+
+class TestRead:
+    def test_read_full_document(self, store, mock_s3_client):
+        mock_s3_client._storage["backups/doc1/parsed.txt"] = b"Line 1\nLine 2\nLine 3"
+
+        with patch.object(store, "_get_client", return_value=mock_s3_client):
+            result = store.read("doc1")
+
+        assert result is not None
+        assert "[Lines 1-3 of 3]" in result
+        assert "1: Line 1" in result
+
+    def test_read_with_pagination(self, store, mock_s3_client):
+        lines = "\n".join(f"Line {i}" for i in range(1, 11))
+        mock_s3_client._storage["backups/doc1/parsed.txt"] = lines.encode()
+
+        with patch.object(store, "_get_client", return_value=mock_s3_client):
+            result = store.read("doc1", offset=3, limit=4)
+
+        assert result is not None
+        assert "[Lines 4-7 of 10]" in result
+
+    def test_read_nonexistent_returns_none(self, store, mock_s3_client):
+        with patch.object(store, "_get_client", return_value=mock_s3_client):
+            result = store.read("nonexistent")
+
+        assert result is None
+
+
+class TestGrep:
+    def test_grep_finds_pattern(self, store, mock_s3_client):
+        mock_s3_client._storage["backups/doc1/parsed.txt"] = b"apple\nbanana\ncherry"
+
+        with patch.object(store, "_get_client", return_value=mock_s3_client):
+            results = store.grep("doc1", "cherry")
+
+        assert len(results) == 1
+        assert results[0].line_number == 3
+        assert results[0].line == "cherry"
+
+    def test_grep_nonexistent_document(self, store, mock_s3_client):
+        with patch.object(store, "_get_client", return_value=mock_s3_client):
+            results = store.grep("nonexistent", "pattern")
+
+        assert results == []
+
+
+class TestGrepAll:
+    def test_grep_all_searches_multiple_docs(self, store, mock_s3_client):
+        mock_s3_client._storage["backups/doc1/parsed.txt"] = b"apple pie"
+        mock_s3_client._storage["backups/doc2/parsed.txt"] = b"apple sauce"
+
+        with patch.object(store, "_get_client", return_value=mock_s3_client):
+            with patch.object(store, "_list_content_ids", return_value=["doc1", "doc2"]):
+                results = store.grep_all("apple")
+
+        assert len(results) == 2
+
+
+class TestGetTools:
+    def test_get_tools_returns_two_tools(self, store):
+        tools = store.get_tools()
+        assert len(tools) == 2
+        names = {t.name for t in tools}
+        assert "read_backup" in names
+        assert "grep_backup" in names
+
+
+class TestKeyGeneration:
+    def test_key_format(self, store):
+        assert store._key("doc1", "parsed.txt") == "backups/doc1/parsed.txt"
+
+    def test_key_strips_trailing_slash(self):
+        from agno.knowledge.store.s3_backup_store import S3BackupStore
+
+        s = S3BackupStore(bucket_name="test", prefix="backups/")
+        assert s._key("doc1", "parsed.txt") == "backups/doc1/parsed.txt"


### PR DESCRIPTION
## Summary

Adds `S3BackupStore` and `GCSBackupStore` as cloud alternatives to the local `BackupStore`. Same interface (store, read, grep, grep_all, get_tools) — users just swap the store class.

### New files
- `libs/agno/agno/knowledge/store/s3_backup_store.py` — S3 backend using boto3/aioboto3
- `libs/agno/agno/knowledge/store/gcs_backup_store.py` — GCS backend using google-cloud-storage
- `libs/agno/tests/unit/knowledge/test_s3_backup_store.py` — 13 tests
- `libs/agno/tests/unit/knowledge/test_gcs_backup_store.py` — 13 tests

### Modified files
- `libs/agno/agno/knowledge/store/__init__.py` — Added exports
- `libs/agno/agno/knowledge/knowledge.py` — Added `backup_store` field for passing pre-configured stores

### Usage

```python
from agno.knowledge.store import S3BackupStore

knowledge = Knowledge(
    vector_db=qdrant,
    backup_store=S3BackupStore(bucket_name="my-bucket", prefix="backups"),
    enable_backup_tools=True,
)
```

```python
from agno.knowledge.store import GCSBackupStore

knowledge = Knowledge(
    vector_db=qdrant,
    backup_store=GCSBackupStore(bucket_name="my-bucket", project="my-project"),
    enable_backup_tools=True,
)
```

Depends on Phase 4 (#6727).

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

All 26 new tests pass with mocked cloud clients. Reuses `GrepResult` from backup_store.py.