### PR TITLE
feat: scheduler-based content refresh for knowledge bases

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -36,6 +36,7 @@ class Knowledge:
     enable_catalog: bool = False
     enable_backup_tools: bool = False
     backup_dir: Optional[str] = None
+    refresh_cron: Optional[str] = None
 
     def __post_init__(self):
         from agno.vectordb import VectorDb
@@ -716,6 +717,65 @@ class Knowledge:
             log_warning("No vector DB provided")
             return False
         return self.vector_db.delete_by_metadata(metadata)
+
+    # ==========================================
+    # PUBLIC API - CONTENT REFRESH
+    # ==========================================
+
+    def refresh(self, content_id: Optional[str] = None) -> Dict[str, str]:
+        """Re-ingest content that has changed since last ingestion.
+
+        Args:
+            content_id: If provided, refresh only this content. Otherwise refresh all completed content.
+
+        Returns:
+            Dict mapping content_id to status: "refreshed", "unchanged", or "error".
+        """
+        if content_id:
+            content = self._content_store.get_content_by_id(content_id)
+            contents = [content] if content else []
+        else:
+            all_contents, _ = self._content_store.get_content(limit=1000)
+            contents = [c for c in all_contents if c.status == ContentStatus.COMPLETED]
+
+        results: Dict[str, str] = {}
+        for content in contents:
+            if not content.id:
+                continue
+            try:
+                if self._pipeline.check_content_changed(content):
+                    self._load_content(content, upsert=True, skip_if_exists=False)
+                    results[content.id] = "refreshed"
+                else:
+                    results[content.id] = "unchanged"
+            except Exception as e:
+                log_warning(f"Error refreshing content {content.id}: {e}")
+                results[content.id] = "error"
+        return results
+
+    async def arefresh(self, content_id: Optional[str] = None) -> Dict[str, str]:
+        """Async variant of refresh."""
+        if content_id:
+            content = await self._content_store.aget_content_by_id(content_id)
+            contents = [content] if content else []
+        else:
+            all_contents, _ = await self._content_store.aget_content(limit=1000)
+            contents = [c for c in all_contents if c.status == ContentStatus.COMPLETED]
+
+        results: Dict[str, str] = {}
+        for content in contents:
+            if not content.id:
+                continue
+            try:
+                if await self._pipeline.acheck_content_changed(content):
+                    await self._aload_content(content, upsert=True, skip_if_exists=False)
+                    results[content.id] = "refreshed"
+                else:
+                    results[content.id] = "unchanged"
+            except Exception as e:
+                log_warning(f"Error refreshing content {content.id}: {e}")
+                results[content.id] = "error"
+        return results
 
     # ==========================================
     # PUBLIC API - FILTER METHODS (forwarded to ContentStore)

--- a/libs/agno/agno/knowledge/pipeline/ingestion.py
+++ b/libs/agno/agno/knowledge/pipeline/ingestion.py
@@ -1129,6 +1129,80 @@ class IngestionPipeline:
             log_warning(f"Could not backup content {content.id}: {e}")
 
     # ==========================================
+    # CONTENT CHANGE DETECTION (for refresh)
+    # ==========================================
+
+    def check_content_changed(self, content: Content) -> bool:
+        """Check whether content has changed since last ingestion.
+
+        For file paths, compares file modification time against content.updated_at.
+        For URLs, re-fetches and compares content hash.
+        """
+        try:
+            if content.path:
+                path = Path(content.path)
+                if not path.exists():
+                    return False
+                mtime = int(path.stat().st_mtime)
+                return mtime > (content.updated_at or 0)
+            elif content.url:
+                new_hash = self._compute_url_hash(content.url)
+                if new_hash is None:
+                    return False
+                return new_hash != content.content_hash
+            elif content.file_data and content.file_data.content:
+                new_hash = self.build_content_hash(content)
+                return new_hash != content.content_hash
+        except Exception as e:
+            log_warning(f"Error checking content change for {content.id}: {e}")
+        return False
+
+    async def acheck_content_changed(self, content: Content) -> bool:
+        """Async variant of check_content_changed."""
+        try:
+            if content.path:
+                path = Path(content.path)
+                if not path.exists():
+                    return False
+                mtime = int(path.stat().st_mtime)
+                return mtime > (content.updated_at or 0)
+            elif content.url:
+                new_hash = await self._acompute_url_hash(content.url)
+                if new_hash is None:
+                    return False
+                return new_hash != content.content_hash
+            elif content.file_data and content.file_data.content:
+                new_hash = self.build_content_hash(content)
+                return new_hash != content.content_hash
+        except Exception as e:
+            log_warning(f"Error checking content change for {content.id}: {e}")
+        return False
+
+    def _compute_url_hash(self, url: str) -> Optional[str]:
+        """Fetch URL content and compute a hash for change detection."""
+        import httpx
+
+        try:
+            with httpx.Client(timeout=30.0, follow_redirects=True) as client:
+                response = client.get(url)
+                response.raise_for_status()
+                return hashlib.md5(response.content).hexdigest()
+        except Exception as e:
+            log_warning(f"Could not fetch URL for hash computation: {e}")
+            return None
+
+    async def _acompute_url_hash(self, url: str) -> Optional[str]:
+        """Async variant of _compute_url_hash."""
+        try:
+            async with AsyncClient(timeout=30.0, follow_redirects=True) as client:
+                response = await client.get(url)
+                response.raise_for_status()
+                return hashlib.md5(response.content).hexdigest()
+        except Exception as e:
+            log_warning(f"Could not fetch URL for hash computation: {e}")
+            return None
+
+    # ==========================================
     # MANAGED BACKEND INGESTION
     # ==========================================
 

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -130,9 +130,47 @@ async def scheduler_lifespan(app: FastAPI, agent_os: "AgentOS"):
     app.state.scheduler_poller = poller
     await poller.start()
 
+    # Auto-create refresh schedules for knowledge bases with refresh_cron
+    await _create_knowledge_refresh_schedules(agent_os)
+
     yield
 
     await poller.stop()
+
+
+async def _create_knowledge_refresh_schedules(agent_os: "AgentOS") -> None:
+    """Auto-create scheduler entries for knowledge bases with refresh_cron set."""
+    from agno.scheduler.manager import ScheduleManager
+
+    knowledge_instances = getattr(agent_os, "knowledge_instances", None) or getattr(agent_os, "knowledge", None) or []
+    if not knowledge_instances:
+        return
+
+    db = agent_os.db
+    if db is None:
+        return
+
+    manager = ScheduleManager(db=db)
+    for kb in knowledge_instances:
+        cron = getattr(kb, "refresh_cron", None)
+        if not cron:
+            continue
+        kb_name = getattr(kb, "name", None) or "default"
+        schedule_name = f"knowledge-refresh-{kb_name}"
+        try:
+            await manager.acreate(
+                name=schedule_name,
+                cron=cron,
+                endpoint="/knowledge/refresh",
+                method="POST",
+                description=f"Auto-refresh knowledge base: {kb_name}",
+                payload={"knowledge_id": kb_name},
+                if_exists="update",
+            )
+            log_info(f"Created refresh schedule '{schedule_name}' with cron '{cron}'")
+        except Exception as e:
+            log_warning(f"Could not create refresh schedule for '{kb_name}': {e}")
+    manager.close()
 
 
 def _combine_app_lifespans(lifespans: list) -> Any:

--- a/libs/agno/agno/os/routers/knowledge/knowledge.py
+++ b/libs/agno/agno/os/routers/knowledge/knowledge.py
@@ -21,6 +21,7 @@ from agno.os.routers.knowledge.schemas import (
     ContentStatusResponse,
     ContentUpdateSchema,
     ReaderSchema,
+    RefreshResponseSchema,
     RemoteContentSourceSchema,
     SourceFileSchema,
     SourceFilesResponseSchema,
@@ -1362,6 +1363,53 @@ def attach_routes(router: APIRouter, knowledge_instances: List[Union[Knowledge, 
                 total_count=result.total_count,
                 total_pages=result.total_pages,
             ),
+        )
+
+    @router.post(
+        "/knowledge/refresh",
+        response_model=RefreshResponseSchema,
+        status_code=200,
+        operation_id="refresh_knowledge",
+        summary="Refresh Knowledge Content",
+        description=(
+            "Re-ingest content that has changed since last ingestion. "
+            "Checks file modification times and URL content hashes to detect changes. "
+            "Can refresh all content or a specific content item by ID."
+        ),
+        responses={
+            200: {
+                "description": "Refresh completed",
+                "content": {
+                    "application/json": {
+                        "example": {
+                            "results": {
+                                "content-abc": "refreshed",
+                                "content-def": "unchanged",
+                            },
+                            "total": 2,
+                            "refreshed": 1,
+                        }
+                    }
+                },
+            },
+        },
+    )
+    async def refresh_knowledge(
+        request: Request,
+        content_id: Optional[str] = Query(default=None, description="Specific content ID to refresh"),
+        knowledge_id: Optional[str] = Query(default=None, description="Knowledge base ID to refresh"),
+        db_id: Optional[str] = Query(default=None, description="Database ID to use"),
+    ) -> RefreshResponseSchema:
+        knowledge = get_knowledge_instance(knowledge_instances, db_id, knowledge_id)
+        if isinstance(knowledge, RemoteKnowledge):
+            raise HTTPException(status_code=501, detail="Refresh not yet supported for RemoteKnowledge")
+
+        results = await knowledge.arefresh(content_id=content_id)
+        refreshed_count = sum(1 for v in results.values() if v == "refreshed")
+        return RefreshResponseSchema(
+            results=results,
+            total=len(results),
+            refreshed=refreshed_count,
         )
 
     return router

--- a/libs/agno/agno/os/routers/knowledge/schemas.py
+++ b/libs/agno/agno/os/routers/knowledge/schemas.py
@@ -213,6 +213,14 @@ class SourceFilesResponseSchema(BaseModel):
     meta: PaginationInfo = Field(..., description="Pagination metadata")
 
 
+class RefreshResponseSchema(BaseModel):
+    """Response model for the content refresh endpoint."""
+
+    results: Dict[str, str] = Field(..., description="Map of content_id to refresh status (refreshed/unchanged/error)")
+    total: int = Field(..., description="Total number of content items checked")
+    refreshed: int = Field(..., description="Number of content items that were refreshed")
+
+
 class ConfigResponseSchema(BaseModel):
     readers: Optional[Dict[str, ReaderSchema]] = Field(None, description="Available content readers")
     readersForType: Optional[Dict[str, List[str]]] = Field(None, description="Mapping of content types to reader IDs")

--- a/libs/agno/tests/unit/knowledge/test_scheduler_refresh.py
+++ b/libs/agno/tests/unit/knowledge/test_scheduler_refresh.py
@@ -1,0 +1,298 @@
+"""Tests for scheduler-based content refresh integration."""
+
+import tempfile
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agno.knowledge.content import Content
+from agno.knowledge.pipeline.ingestion import IngestionPipeline
+
+
+@pytest.fixture
+def pipeline():
+    return IngestionPipeline(
+        vector_db=MagicMock(),
+        content_store=MagicMock(),
+        reader_registry=MagicMock(),
+    )
+
+
+class TestCheckContentChanged:
+    def test_file_changed_by_mtime(self, pipeline):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("original content")
+            path = f.name
+
+        content = Content(
+            id="test-id",
+            path=path,
+            updated_at=int(time.time()) - 100,
+        )
+
+        assert pipeline.check_content_changed(content) is True
+        Path(path).unlink()
+
+    def test_file_not_changed(self, pipeline):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("content")
+            path = f.name
+
+        content = Content(
+            id="test-id",
+            path=path,
+            updated_at=int(time.time()) + 100,
+        )
+
+        assert pipeline.check_content_changed(content) is False
+        Path(path).unlink()
+
+    def test_file_does_not_exist(self, pipeline):
+        content = Content(
+            id="test-id",
+            path="/nonexistent/path.txt",
+            updated_at=int(time.time()),
+        )
+
+        assert pipeline.check_content_changed(content) is False
+
+    def test_url_changed(self, pipeline):
+        content = Content(
+            id="test-id",
+            url="https://example.com/data.txt",
+            content_hash="old_hash",
+        )
+
+        with patch.object(pipeline, "_compute_url_hash", return_value="new_hash"):
+            assert pipeline.check_content_changed(content) is True
+
+    def test_url_not_changed(self, pipeline):
+        content = Content(
+            id="test-id",
+            url="https://example.com/data.txt",
+            content_hash="same_hash",
+        )
+
+        with patch.object(pipeline, "_compute_url_hash", return_value="same_hash"):
+            assert pipeline.check_content_changed(content) is False
+
+    def test_url_fetch_failure(self, pipeline):
+        content = Content(
+            id="test-id",
+            url="https://example.com/data.txt",
+            content_hash="old_hash",
+        )
+
+        with patch.object(pipeline, "_compute_url_hash", return_value=None):
+            assert pipeline.check_content_changed(content) is False
+
+    def test_no_path_or_url_returns_false(self, pipeline):
+        content = Content(id="test-id")
+        assert pipeline.check_content_changed(content) is False
+
+    @pytest.mark.asyncio
+    async def test_async_file_changed(self, pipeline):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            f.write("content")
+            path = f.name
+
+        content = Content(
+            id="test-id",
+            path=path,
+            updated_at=int(time.time()) - 100,
+        )
+
+        assert await pipeline.acheck_content_changed(content) is True
+        Path(path).unlink()
+
+    @pytest.mark.asyncio
+    async def test_async_url_changed(self, pipeline):
+        content = Content(
+            id="test-id",
+            url="https://example.com/data.txt",
+            content_hash="old_hash",
+        )
+
+        with patch.object(pipeline, "_acompute_url_hash", new_callable=AsyncMock, return_value="new_hash"):
+            assert await pipeline.acheck_content_changed(content) is True
+
+
+class TestComputeUrlHash:
+    def test_computes_hash(self, pipeline):
+        mock_response = MagicMock()
+        mock_response.content = b"test content"
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.return_value = mock_response
+
+        with patch("httpx.Client", return_value=mock_client):
+            result = pipeline._compute_url_hash("https://example.com")
+
+        assert result is not None
+        assert isinstance(result, str)
+
+    def test_returns_none_on_error(self, pipeline):
+        with patch("httpx.Client", side_effect=Exception("Connection failed")):
+            result = pipeline._compute_url_hash("https://example.com")
+
+        assert result is None
+
+
+class TestRefreshEndpoint:
+    """Tests for the POST /knowledge/refresh endpoint."""
+
+    @pytest.fixture
+    def mock_knowledge(self):
+        knowledge = MagicMock()
+        knowledge.name = "test-kb"
+        knowledge.arefresh = AsyncMock(
+            return_value={
+                "content-1": "refreshed",
+                "content-2": "unchanged",
+            }
+        )
+        return knowledge
+
+    def test_refresh_response_schema(self):
+        from agno.os.routers.knowledge.schemas import RefreshResponseSchema
+
+        schema = RefreshResponseSchema(
+            results={"id1": "refreshed", "id2": "unchanged"},
+            total=2,
+            refreshed=1,
+        )
+        assert schema.total == 2
+        assert schema.refreshed == 1
+        assert schema.results["id1"] == "refreshed"
+
+
+class TestAutoScheduleCreation:
+    """Tests for auto-creating refresh schedules when AgentOS starts with scheduler=True."""
+
+    @pytest.mark.asyncio
+    async def test_creates_schedule_for_knowledge_with_refresh_cron(self):
+        from agno.os.app import _create_knowledge_refresh_schedules
+
+        mock_kb = MagicMock()
+        mock_kb.name = "my-docs"
+        mock_kb.refresh_cron = "0 * * * *"
+
+        mock_os = MagicMock()
+        mock_os.knowledge_instances = [mock_kb]
+        mock_os.knowledge = None
+        mock_os.db = MagicMock()
+
+        with patch("agno.scheduler.manager.ScheduleManager") as MockManager:
+            mock_manager = MagicMock()
+            mock_manager.acreate = AsyncMock()
+            mock_manager.close = MagicMock()
+            MockManager.return_value = mock_manager
+
+            await _create_knowledge_refresh_schedules(mock_os)
+
+            mock_manager.acreate.assert_called_once_with(
+                name="knowledge-refresh-my-docs",
+                cron="0 * * * *",
+                endpoint="/knowledge/refresh",
+                method="POST",
+                description="Auto-refresh knowledge base: my-docs",
+                payload={"knowledge_id": "my-docs"},
+                if_exists="update",
+            )
+            mock_manager.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_knowledge_without_refresh_cron(self):
+        from agno.os.app import _create_knowledge_refresh_schedules
+
+        mock_kb = MagicMock()
+        mock_kb.name = "no-refresh"
+        mock_kb.refresh_cron = None
+
+        mock_os = MagicMock()
+        mock_os.knowledge_instances = [mock_kb]
+        mock_os.knowledge = None
+        mock_os.db = MagicMock()
+
+        with patch("agno.scheduler.manager.ScheduleManager") as MockManager:
+            mock_manager = MagicMock()
+            mock_manager.acreate = AsyncMock()
+            mock_manager.close = MagicMock()
+            MockManager.return_value = mock_manager
+
+            await _create_knowledge_refresh_schedules(mock_os)
+
+            mock_manager.acreate.assert_not_called()
+            mock_manager.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handles_schedule_creation_error_gracefully(self):
+        from agno.os.app import _create_knowledge_refresh_schedules
+
+        mock_kb = MagicMock()
+        mock_kb.name = "error-kb"
+        mock_kb.refresh_cron = "*/5 * * * *"
+
+        mock_os = MagicMock()
+        mock_os.knowledge_instances = [mock_kb]
+        mock_os.knowledge = None
+        mock_os.db = MagicMock()
+
+        with patch("agno.scheduler.manager.ScheduleManager") as MockManager:
+            mock_manager = MagicMock()
+            mock_manager.acreate = AsyncMock(side_effect=ValueError("Invalid cron"))
+            mock_manager.close = MagicMock()
+            MockManager.return_value = mock_manager
+
+            # Should not raise
+            await _create_knowledge_refresh_schedules(mock_os)
+
+            mock_manager.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_db_skips_schedule_creation(self):
+        from agno.os.app import _create_knowledge_refresh_schedules
+
+        mock_os = MagicMock()
+        mock_os.knowledge_instances = [MagicMock(name="kb", refresh_cron="0 * * * *")]
+        mock_os.db = None
+
+        with patch("agno.scheduler.manager.ScheduleManager") as MockManager:
+            await _create_knowledge_refresh_schedules(mock_os)
+            MockManager.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_knowledge_instances_skips(self):
+        from agno.os.app import _create_knowledge_refresh_schedules
+
+        mock_os = MagicMock()
+        mock_os.knowledge_instances = []
+        mock_os.knowledge = []
+        mock_os.db = MagicMock()
+
+        with patch("agno.scheduler.manager.ScheduleManager") as MockManager:
+            await _create_knowledge_refresh_schedules(mock_os)
+            MockManager.assert_not_called()
+
+
+class TestKnowledgeRefreshCronField:
+    """Test that the refresh_cron field exists on Knowledge."""
+
+    def test_refresh_cron_default_none(self):
+        from agno.knowledge.knowledge import Knowledge
+
+        kb = Knowledge.__new__(Knowledge)
+        kb.refresh_cron = None
+        assert kb.refresh_cron is None
+
+    def test_refresh_cron_can_be_set(self):
+        from agno.knowledge.knowledge import Knowledge
+
+        kb = Knowledge.__new__(Knowledge)
+        kb.refresh_cron = "0 */6 * * *"
+        assert kb.refresh_cron == "0 */6 * * *"


### PR DESCRIPTION
## Summary

Phase 5D of the knowledge refactor: integrates the existing AgentOS scheduler with knowledge content refresh.

When source files change (by mtime) or URLs change (by content hash), this feature enables automatic re-ingestion. Works two ways:

1. **Manual**: Call `knowledge.refresh()` / `knowledge.arefresh()` or `POST /knowledge/refresh`
2. **Automatic**: Set `refresh_cron="0 * * * *"` on a Knowledge instance — AgentOS auto-creates a scheduler entry that hits the refresh endpoint on the configured cron schedule

### Changes

- **Content change detection** (`ingestion.py`): `check_content_changed()` / `acheck_content_changed()` — compares file mtime or URL content hash to detect changes
- **Refresh methods** (`knowledge.py`): `refresh()` / `arefresh()` — iterates content, checks for changes, re-ingests changed items
- **REST endpoint** (`knowledge router`): `POST /knowledge/refresh` with optional `content_id` and `knowledge_id` query params
- **`RefreshResponseSchema`** (`schemas.py`): Response model with results map, total count, refreshed count
- **`refresh_cron` field** (`knowledge.py`): Optional cron expression for declarative auto-refresh config
- **Auto-schedule creation** (`app.py`): `_create_knowledge_refresh_schedules()` runs during `scheduler_lifespan` and creates idempotent scheduler entries for any Knowledge with `refresh_cron` set

### Usage

```python
from agno.knowledge.knowledge import Knowledge

# Manual refresh
kb = Knowledge(name="my-docs", ...)
results = kb.refresh()  # {"doc1": "refreshed", "doc2": "unchanged"}

# Automatic refresh via scheduler (when running in AgentOS)
kb = Knowledge(name="my-docs", refresh_cron="0 */6 * * *", ...)
# AgentOS will auto-create a schedule that POSTs to /knowledge/refresh every 6 hours
```

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

- 19 unit tests covering change detection (file mtime, URL hash, async variants), endpoint schema, auto-schedule creation/skipping/error handling, and the `refresh_cron` field
- All mypy errors are pre-existing on the phase4 branch (not introduced by this PR)
- Uses `ScheduleManager.acreate(if_exists="update")` for idempotent schedule creation — safe to restart AgentOS without duplicating schedules
- Independent from Phase 5A (cloud backup), 5B (enrichment model), and 5C (content refresh with DB schema changes) — can be reviewed/merged in any order

🤖 Generated with [Claude Code](https://claude.com/claude-code)