### PR TITLE
[fix] Use ensure_ascii=False in debug log to display non-ASCII characters

### DIFF
--- a/libs/agno/agno/models/message.py
+++ b/libs/agno/agno/models/message.py
@@ -375,10 +375,16 @@ class Message(BaseModel):
             if use_compressed_content and self.compressed_content:
                 _logger("Compressed content:\n" + self.compressed_content)
             else:
-                if isinstance(self.content, str) or isinstance(self.content, list):
-                    _logger(self.content)
+                if isinstance(self.content, str):
+                    try:
+                        parsed = json.loads(self.content)
+                        _logger(json.dumps(parsed, indent=2, ensure_ascii=False))
+                    except (json.JSONDecodeError, TypeError):
+                        _logger(self.content)
+                elif isinstance(self.content, list):
+                    _logger(json.dumps(self.content, indent=2, ensure_ascii=False))
                 elif isinstance(self.content, dict):
-                    _logger(json.dumps(self.content, indent=2))
+                    _logger(json.dumps(self.content, indent=2, ensure_ascii=False))
         if self.tool_calls:
             tool_calls_list = ["Tool Calls:"]
             for tool_call in self.tool_calls:


### PR DESCRIPTION
## Summary

Debug mode prints unicode escape sequences (e.g. `\u753b\u5bb6`) instead of actual characters when tool call results contain non-ASCII text like Chinese.

Added `ensure_ascii=False` to `json.dumps` calls in `Message.log_message()`. For string content that contains JSON, re-parse and re-dump with proper unicode output.

Fixes #6758

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Only affects debug logging output no change to message content sent to models or stored in memory.