### PR TITLE
fix: correct API signatures and references in knowledge cookbooks

### DIFF
--- a/cookbook/07_knowledge/04_advanced/01_custom_retriever.py
+++ b/cookbook/07_knowledge/04_advanced/01_custom_retriever.py
@@ -4,8 +4,8 @@ Custom Retriever: Bypass the Knowledge Class
 Sometimes you need full control over retrieval logic. Instead of using
 the Knowledge class, you can provide a custom retriever function.
 
-The function receives the query and returns a list of Documents.
-This is useful for:
+The function receives (query, num_documents, **kwargs) and returns
+a list of dicts. This is useful for:
 - Non-vector retrieval (SQL queries, API calls, file lookups)
 - Custom ranking logic
 - Combining multiple data sources with custom logic
@@ -13,47 +13,56 @@ This is useful for:
 See also: ../01_getting_started/02_agentic_rag.py for standard Knowledge-based RAG.
 """
 
+from typing import Optional
+
 from agno.agent import Agent
-from agno.knowledge.document import Document
 from agno.models.openai import OpenAIResponses
 
 # ---------------------------------------------------------------------------
 # Custom Retriever
 # ---------------------------------------------------------------------------
 
+# Simulated knowledge base
+_DOCUMENTS = {
+    "engineering": {
+        "name": "Engineering",
+        "content": "The engineering team uses Python and TypeScript. "
+        "They follow trunk-based development with CI/CD.",
+    },
+    "sales": {
+        "name": "Sales",
+        "content": "Q4 revenue was $2.3M, up 40% year-over-year. "
+        "The sales team closed 145 deals in Q4.",
+    },
+    "hr": {
+        "name": "HR Policy",
+        "content": "PTO policy: 25 days per year. Remote work is allowed "
+        "3 days per week. All employees get learning stipends.",
+    },
+}
 
-def company_retriever(query: str) -> list[Document]:
+
+def company_retriever(
+    query: str, num_documents: Optional[int] = None, **kwargs
+) -> list[dict]:
     """Custom retriever that returns relevant documents based on the query.
+
+    The signature must be (query, num_documents=None, **kwargs) and the
+    return type must be list[dict].
 
     In production, this could query a SQL database, call an API, or
     implement any custom retrieval logic.
     """
-    # Simulated knowledge base
-    documents = {
-        "engineering": Document(
-            name="Engineering",
-            content="The engineering team uses Python and TypeScript. "
-            "They follow trunk-based development with CI/CD.",
-        ),
-        "sales": Document(
-            name="Sales",
-            content="Q4 revenue was $2.3M, up 40% year-over-year. "
-            "The sales team closed 145 deals in Q4.",
-        ),
-        "hr": Document(
-            name="HR Policy",
-            content="PTO policy: 25 days per year. Remote work is allowed "
-            "3 days per week. All employees get learning stipends.",
-        ),
-    }
-
     # Simple keyword matching (replace with your logic)
     results = []
-    for _key, doc in documents.items():
-        if any(term in query.lower() for term in doc.name.lower().split()):
+    for doc in _DOCUMENTS.values():
+        if any(term in query.lower() for term in doc["name"].lower().split()):
             results.append(doc)
 
-    return results or list(documents.values())
+    all_results = results or list(_DOCUMENTS.values())
+    if num_documents is not None:
+        all_results = all_results[:num_documents]
+    return all_results
 
 
 # ---------------------------------------------------------------------------

--- a/cookbook/07_knowledge/04_advanced/03_graph_rag.py
+++ b/cookbook/07_knowledge/04_advanced/03_graph_rag.py
@@ -14,9 +14,7 @@ Requirements: pip install lightrag-agno
 """
 
 from agno.agent import Agent
-from agno.knowledge.embedder.openai import OpenAIEmbedder
-from agno.knowledge.knowledge import Knowledge
-from agno.models.openai import OpenAIChat, OpenAIResponses
+from agno.models.openai import OpenAIResponses
 
 # ---------------------------------------------------------------------------
 # Setup
@@ -25,24 +23,19 @@ from agno.models.openai import OpenAIChat, OpenAIResponses
 try:
     from agno.vectordb.lightrag import LightRag
 
-    knowledge = Knowledge(
-        vector_db=LightRag(
-            db_url="postgresql+psycopg://ai:ai@localhost:5532/ai",
-            collection_name="graph_rag_demo",
-            llm_model=OpenAIChat(id="gpt-4o"),
-            embedder=OpenAIEmbedder(id="text-embedding-3-small"),
-        ),
-    )
+    # LightRag connects to a running LightRAG server.
+    # Start one with: lightrag-server --host 0.0.0.0 --port 9621
+    lightrag = LightRag(server_url="http://localhost:9621")
 
     agent = Agent(
         model=OpenAIResponses(id="gpt-5.2"),
-        knowledge=knowledge,
+        knowledge_retriever=lightrag.lightrag_knowledge_retriever,
         search_knowledge=True,
         markdown=True,
     )
 
 except ImportError:
-    knowledge = None
+    lightrag = None
     agent = None
     print("LightRAG not installed. Run: pip install lightrag-agno")
 
@@ -51,10 +44,10 @@ except ImportError:
 # ---------------------------------------------------------------------------
 
 if __name__ == "__main__":
-    if knowledge and agent:
-        knowledge.insert(
-            url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf"
-        )
+    if lightrag and agent:
+        # Note: Documents must be ingested into LightRAG via its own API
+        # (e.g. lightrag.insert_file_bytes or lightrag.insert_text).
+        # The server handles chunking, entity extraction, and graph building.
 
         print("\n" + "=" * 60)
         print("Graph RAG: knowledge graph-based retrieval")

--- a/cookbook/07_knowledge/05_integrations/cloud/03_gcp.py
+++ b/cookbook/07_knowledge/05_integrations/cloud/03_gcp.py
@@ -20,17 +20,17 @@ Environment Variables:
 from os import getenv
 
 from agno.knowledge.knowledge import Knowledge
-from agno.knowledge.remote_content import GCSConfig
+from agno.knowledge.remote_content import GcsConfig
 from agno.vectordb.qdrant import Qdrant
 
 # ---------------------------------------------------------------------------
 # Setup
 # ---------------------------------------------------------------------------
 
-gcs_config = GCSConfig(
+gcs_config = GcsConfig(
     id="my-gcs-bucket",
     name="My GCS Bucket",
-    bucket=getenv("GCS_BUCKET_NAME", "my-bucket"),
+    bucket_name=getenv("GCS_BUCKET_NAME", "my-bucket"),
 )
 
 knowledge = Knowledge(

--- a/cookbook/07_knowledge/README.md
+++ b/cookbook/07_knowledge/README.md
@@ -51,8 +51,7 @@ cookbook/07_knowledge/
 |-- 01_getting_started/        Start here
 |   |-- 01_basic_rag.py            Traditional RAG with context injection
 |   |-- 02_agentic_rag.py          Agent-driven search decisions
-|   |-- 03_loading_content.py      All source types: file, URL, text, topics
-|   +-- 04_choosing_components.md  Decision guide
+|   +-- 03_loading_content.py      All source types: file, URL, text, topics
 |
 |-- 02_building_blocks/        Core components
 |   |-- 01_chunking_strategies.py  Side-by-side comparison
@@ -65,7 +64,7 @@ cookbook/07_knowledge/
 |   |-- 01_multi_source_rag.py     Multiple content types
 |   |-- 02_knowledge_lifecycle.py  Insert, update, remove, track
 |   |-- 03_multi_tenant.py         Per-tenant isolation
-|   +-- 04_error_handling.py       Robust ingestion
+|   +-- 04_agent_os.py             Agent OS integration
 |
 |-- 04_advanced/               Power user patterns
 |   |-- 01_custom_retriever.py     Custom retrieval function


### PR DESCRIPTION
## Summary

Fixes 5 bugs in the knowledge cookbook restructure (PR #6681):

**3 code bugs:**
1. `04_advanced/01_custom_retriever.py` — Wrong signature `(query) -> list[Document]`. Fixed to `(query, num_documents=None, **kwargs) -> list[dict]` to match the `knowledge_retriever` contract.
2. `04_advanced/03_graph_rag.py` — `LightRag(db_url=...)` passes nonexistent params (`db_url`, `collection_name`, `llm_model`, `embedder`), causing `TypeError` on init. Fixed to use `LightRag(server_url=...)` with `knowledge_retriever`.
3. `05_integrations/cloud/03_gcp.py` — `GCSConfig` doesn't exist (it's `GcsConfig`), and `bucket` should be `bucket_name`. Causes `ImportError` at module load.

**2 README errors:**
4. `README.md:55` — References `04_choosing_components.md` which doesn't exist in the PR. Removed.
5. `README.md:68` — References `04_error_handling.py` which doesn't exist. Fixed to `04_agent_os.py`.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

All fixes verified against the actual source code in `libs/agno/agno/`:
- `agent/agent.py:146-148` — `knowledge_retriever` signature
- `vectordb/lightrag/lightrag.py:19-27` — `LightRag.__init__` params
- `knowledge/remote_content/gcs.py:11` — `GcsConfig` class name
- `knowledge/remote_content/__init__.py` — exports `GcsConfig`, not `GCSConfig`