### PR TITLE
perf(website-reader): use deque for BFS crawl queue — O(1) popleft

### DIFF
--- a/libs/agno/agno/knowledge/reader/website_reader.py
+++ b/libs/agno/agno/knowledge/reader/website_reader.py
@@ -1,8 +1,9 @@
 import asyncio
 import random
 import time
+from collections import deque
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Deque, Dict, List, Optional, Set, Tuple
 from urllib.parse import urljoin, urlparse
 
 import httpx
@@ -28,7 +29,7 @@ class WebsiteReader(Reader):
     max_links: int = 10
 
     _visited: Set[str] = field(default_factory=set)
-    _urls_to_crawl: List[Tuple[str, int]] = field(default_factory=list)
+    _urls_to_crawl: Deque[Tuple[str, int]] = field(default_factory=deque)
 
     def __init__(
         self,
@@ -46,7 +47,7 @@ class WebsiteReader(Reader):
         self.timeout = timeout
 
         self._visited = set()
-        self._urls_to_crawl = []
+        self._urls_to_crawl: Deque[Tuple[str, int]] = deque()
 
     @classmethod
     def get_supported_chunking_strategies(cls) -> List[ChunkingStrategyType]:
@@ -167,10 +168,10 @@ class WebsiteReader(Reader):
 
         # Clear state so URLs from previous crawls aren't incorrectly skipped (matches async_crawl)
         self._visited = set()
-        self._urls_to_crawl = [(url, starting_depth)]
+        self._urls_to_crawl = deque([(url, starting_depth)])
         while self._urls_to_crawl:
             # Unpack URL and depth from the global list
-            current_url, current_depth = self._urls_to_crawl.pop(0)
+            current_url, current_depth = self._urls_to_crawl.popleft()
 
             # Skip if
             # - URL is already visited
@@ -280,12 +281,11 @@ class WebsiteReader(Reader):
 
         # Clear previously visited URLs and URLs to crawl
         self._visited = set()
-        self._urls_to_crawl = [(url, starting_depth)]
-
+        self._urls_to_crawl = deque([(url, starting_depth)])
         client_args = {"proxy": self.proxy} if self.proxy else {}
         async with httpx.AsyncClient(**client_args) as client:  # type: ignore
             while self._urls_to_crawl and num_links < self.max_links:
-                current_url, current_depth = self._urls_to_crawl.pop(0)
+                current_url, current_depth = self._urls_to_crawl.popleft()
 
                 if (
                     current_url in self._visited


### PR DESCRIPTION
## Problem

`WebsiteReader.crawl()` and `async_crawl()` use `list.pop(0)` to dequeue the next URL during breadth-first crawl.  `list.pop(0)` is **O(n)** because every remaining element must be shifted left, giving overall **O(n²)** cost for a full crawl when `max_links` is large.

## Solution

Replace the internal `_urls_to_crawl` list with a `collections.deque`, which provides **O(1)** `popleft()`.  The `append()` cost remains O(1), and the existing `not in` membership check is unaffected.

### Changes
- Import `deque` from `collections`
- Change type annotation and default factory to `Deque[Tuple[str, int]]` / `deque`
- Replace `.pop(0)` → `.popleft()` in both `crawl()` and `async_crawl()`

## Testing

All 14 unit tests pass (`tests/unit/reader/test_website_reader.py`), including sync and async crawl paths.