### PR TITLE
fix: prevent TypeError when MCP tool parameters collide with framework-injected names

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -851,14 +851,28 @@ class FunctionCall(BaseModel):
         sig = signature(self.function.entrypoint)  # type: ignore
         entrypoint_args = {}
 
+        # User-provided tool arguments — framework args that collide with these
+        # must NOT be injected, to prevent TypeError on duplicate keyword arguments.
+        # This can happen when MCP tools have parameters named 'agent', 'team', etc.
+        # Note: None values are treated as "not provided" — the framework should
+        # still inject its objects when the LLM passes null/None.
+        # See: https://github.com/agno-agi/agno/issues/6760
+        user_args = self.arguments or {}
+
         # Check if the entrypoint has an agent argument (by name)
-        if "agent" in sig.parameters:
+        if "agent" in sig.parameters and not (
+            "agent" in user_args and user_args["agent"] is not None
+        ):
             entrypoint_args["agent"] = self.function._agent
         # Check if the entrypoint has a team argument (by name)
-        if "team" in sig.parameters:
+        if "team" in sig.parameters and not (
+            "team" in user_args and user_args["team"] is not None
+        ):
             entrypoint_args["team"] = self.function._team
         # Check if the entrypoint has a run_context argument
-        if "run_context" in sig.parameters:
+        if "run_context" in sig.parameters and not (
+            "run_context" in user_args and user_args["run_context"] is not None
+        ):
             entrypoint_args["run_context"] = self.function._run_context
         # Check if the entrypoint has an fc argument
         if "fc" in sig.parameters:
@@ -885,6 +899,8 @@ class FunctionCall(BaseModel):
             for param_name, hint in hints.items():
                 if param_name in entrypoint_args:
                     continue  # Already handled by name-based injection
+                if param_name in user_args and user_args[param_name] is not None:
+                    continue  # Collision with user-provided tool argument
                 if isinstance(hint, type):
                     if issubclass(hint, Agent) and self.function._agent is not None:
                         entrypoint_args[param_name] = self.function._agent

--- a/libs/agno/agno/utils/mcp.py
+++ b/libs/agno/agno/utils/mcp.py
@@ -50,6 +50,23 @@ def get_entrypoint_for_tool(
         team: Optional["Team"] = None,
         **kwargs,
     ) -> ToolResult:
+        # Handle name collisions between framework-injected parameters and
+        # MCP tool parameters with the same names (e.g. Linear MCP's 'team').
+        # When _build_entrypoint_args detects a collision it skips injection,
+        # so the LLM-provided value (a JSON primitive) lands on the named
+        # parameter instead of in **kwargs.  Redirect it back to kwargs
+        # where MCP tool arguments belong and reset the framework param.
+        _json_primitives = (str, int, float, bool, list, dict)
+        if team is not None and isinstance(team, _json_primitives):
+            kwargs["team"] = team
+            team = None
+        if agent is not None and isinstance(agent, _json_primitives):
+            kwargs["agent"] = agent
+            agent = None
+        if run_context is not None and isinstance(run_context, _json_primitives):
+            kwargs["run_context"] = run_context
+            run_context = None
+
         # Execute the MCP tool call
         try:
             # Get the appropriate session for this run

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -811,3 +811,48 @@ def test_function_cache_pydantic_model_nested(tmp_path):
 
     retrieved_result = func._get_cached_result(cache_file)
     assert retrieved_result == {"name": "John", "address": {"street": "123 Main St", "city": "Springfield"}}
+
+
+def test_build_entrypoint_args_skips_colliding_framework_params():
+    """Regression test for https://github.com/agno-agi/agno/issues/6760.
+
+    When an MCP tool has a parameter named 'team' or 'agent', the framework
+    must NOT inject its own Agent/Team objects under the same key — otherwise
+    Python raises TypeError('got multiple values for keyword argument').
+    """
+    from functools import partial
+
+    async def call_tool(
+        tool_name: str,
+        run_context=None,
+        agent=None,
+        team=None,
+        **kwargs,
+    ):
+        return {"agent": agent, "team": team, "kwargs": kwargs}
+
+    entrypoint = partial(call_tool, tool_name="save_issue")
+
+    func = Function(name="save_issue", entrypoint=entrypoint)
+    func._agent = object()  # Simulate framework-injected Agent
+    func._team = object()  # Simulate framework-injected Team
+
+    # LLM provides 'team' as a tool argument — collision with framework param
+    fc = FunctionCall(function=func, arguments={"title": "Bug", "team": "Engineering"})
+    args = fc._build_entrypoint_args()
+
+    # 'team' must NOT be in entrypoint_args because it collides with user arg
+    assert "team" not in args, "Framework 'team' should be skipped when user provides 'team'"
+    # 'agent' should still be injected (no collision)
+    assert "agent" in args, "Framework 'agent' should be injected when no collision"
+
+    # Without collision, both should be injected
+    fc_no_collision = FunctionCall(function=func, arguments={"title": "Bug"})
+    args_no_collision = fc_no_collision._build_entrypoint_args()
+    assert "team" in args_no_collision
+    assert "agent" in args_no_collision
+
+    # None values should NOT be treated as collisions — framework should still inject
+    fc_none_value = FunctionCall(function=func, arguments={"title": "Bug", "agent": None})
+    args_none = fc_none_value._build_entrypoint_args()
+    assert "agent" in args_none, "Framework 'agent' should be injected when user provides agent=None"

--- a/libs/agno/tests/unit/tools/test_mcp.py
+++ b/libs/agno/tests/unit/tools/test_mcp.py
@@ -460,3 +460,46 @@ async def test_hitl_params_with_tool_name_prefix():
     assert "myprefix_SearchTool" in tools.functions
     # HITL setting should still be applied (matched by original name)
     assert tools.functions["myprefix_SearchTool"].requires_confirmation is True
+
+
+@pytest.mark.asyncio
+async def test_call_tool_redirects_colliding_params_to_kwargs():
+    """Regression test for https://github.com/agno-agi/agno/issues/6760.
+
+    When an MCP tool has parameters named 'team' or 'agent' (e.g. Linear MCP),
+    the LLM-provided values must end up in **kwargs (passed to the MCP server),
+    not be consumed by the framework's named parameters.
+    """
+    from unittest.mock import AsyncMock
+
+    from mcp.types import CallToolResult, TextContent
+
+    from agno.utils.mcp import get_entrypoint_for_tool
+
+    mock_tool = MagicMock()
+    mock_tool.name = "save_issue"
+    mock_session = AsyncMock()
+    mock_session.call_tool = AsyncMock(
+        return_value=CallToolResult(
+            content=[TextContent(type="text", text="created")],
+            isError=False,
+        )
+    )
+    mock_session.send_ping = AsyncMock()
+
+    entrypoint = get_entrypoint_for_tool(mock_tool, mock_session)
+
+    # Simulate: LLM calls save_issue(title="Bug", team="Engineering")
+    # Framework does NOT inject team (collision detected by _build_entrypoint_args),
+    # so team="Engineering" lands on the named parameter.
+    result = await entrypoint(
+        tool_name="save_issue",
+        team="Engineering",  # LLM-provided string, not a Team object
+        title="Bug",
+    )
+
+    # The MCP tool should receive both title AND team in kwargs
+    mock_session.call_tool.assert_called_once_with(
+        "save_issue",
+        {"title": "Bug", "team": "Engineering"},
+    )


### PR DESCRIPTION
## Summary

Fixes #6760

When MCP tools have parameters named `team`, `agent`, or `run_context` (e.g. Linear MCP's `save_issue`), the framework injects its own objects under the same keyword argument names, causing:

```
TypeError: functools.partial(<function get_entrypoint_for_tool.<locals>.call_tool>,
  tool_name='save_issue') got multiple values for keyword argument 'team'
```

## Root Cause

1. `_build_entrypoint_args()` inspects `call_tool`'s signature, finds `team` → injects `team=<Team object>`
2. `aexecute()` spreads both `**entrypoint_args` and `**self.arguments` (which contains `team="Engineering"` from the LLM)
3. Python raises `TypeError` because `team` appears twice

## Fix

**Two-part fix** — prevents the collision and ensures correct argument routing:

### 1. `_build_entrypoint_args()` (`function.py`)
Skip framework injection for `agent`/`team`/`run_context` when the same key exists in `self.arguments` (LLM-provided tool args). `None` values are **not** treated as collisions.

### 2. `call_tool()` (`utils/mcp.py`)
When `_build_entrypoint_args` skips injection, the LLM's value (a JSON primitive like `"Engineering"`) lands on the named parameter. The function now detects this via `isinstance` check against JSON primitive types and redirects the value to `**kwargs` (where MCP tool arguments belong), resetting the framework param to `None`.

## Impact

- **Linear MCP**: `save_issue`, `list_projects`, `list_issue_statuses` — all tools with `team` parameter now work
- **Any MCP server** with parameters named `team`, `agent`, or `run_context`
- **No breaking changes** for non-MCP tools or MCP tools without colliding parameter names

## Tests

- Added `test_build_entrypoint_args_skips_colliding_framework_params` — verifies collision detection and None handling
- Added `test_call_tool_redirects_colliding_params_to_kwargs` — verifies LLM values route to MCP server correctly
- All 102 existing unit tests pass