### PR TITLE
fix(embedder): wrap AzureOpenAIEmbedder input in list for non-default models

### DIFF
--- a/libs/agno/agno/knowledge/embedder/azure_openai.py
+++ b/libs/agno/agno/knowledge/embedder/azure_openai.py
@@ -93,7 +93,7 @@ class AzureOpenAIEmbedder(Embedder):
 
     def _response(self, text: str) -> CreateEmbeddingResponse:
         _request_params: Dict[str, Any] = {
-            "input": text,
+            "input": [text],
             "model": self.id,
             "encoding_format": self.encoding_format,
         }
@@ -124,7 +124,7 @@ class AzureOpenAIEmbedder(Embedder):
     async def _aresponse(self, text: str) -> CreateEmbeddingResponse:
         """Async version of _response method."""
         _request_params: Dict[str, Any] = {
-            "input": text,
+            "input": [text],
             "model": self.id,
             "encoding_format": self.encoding_format,
         }


### PR DESCRIPTION
## Summary

Fixes #6759

Azure-deployed non-OpenAI models (e.g., `Cohere-embed-v3-multilingual`) require the `input` parameter to be a **list of strings**. The `_response()` and `_aresponse()` methods were passing a raw string, causing a 422 error:

```
Input should be a valid list
```

## Root Cause

In `AzureOpenAIEmbedder._response()` and `_aresponse()`, the request was built with:

```python
"input": text,  # raw string
```

While OpenAI's native models accept both string and list formats, Azure-deployed third-party models enforce stricter validation and require list format.

## Fix

Changed `"input": text` to `"input": [text]` in both `_response()` and `_aresponse()`.

This is **backward-compatible** because:
- The OpenAI embeddings API accepts both string and list-of-strings for `input`
- The batch methods (`get_embeddings_batch_and_usage`, `async_get_embeddings_batch_and_usage`) already use list format
- Standard OpenAI models (`text-embedding-3-small/large`, `text-embedding-ada-002`) work correctly with list input

## Testing

- Verified with mocked Azure client that input is correctly sent as `['hello world']` instead of `'hello world'`
- All 100 existing unit tests pass
- No regressions in MCP tools or agent tests