### PR TITLE
fix(litellm): prevent empty strings from overwriting tool metadata in streaming

### DIFF
--- a/libs/agno/agno/models/litellm/chat.py
+++ b/libs/agno/agno/models/litellm/chat.py
@@ -426,11 +426,11 @@ class LiteLLM(Model):
             if index not in tool_calls_by_index:
                 tool_calls_by_index[index] = {"id": None, "type": "function", "function": {"name": "", "arguments": ""}}
 
-            # Update with new information
-            if tc.get("id") is not None:
+            # Update with new information (skip empty strings to avoid overwriting valid data)
+            if tc.get("id"):
                 tool_calls_by_index[index]["id"] = tc["id"]
 
-            if tc.get("type") is not None:
+            if tc.get("type"):
                 tool_calls_by_index[index]["type"] = tc["type"]
 
             # Update function information
@@ -438,9 +438,9 @@ class LiteLLM(Model):
             if not isinstance(function_data, dict):
                 function_data = {}
 
-            # Update function name if provided
-            if function_data.get("name") is not None:
-                name = function_data.get("name", "")
+            # Update function name if provided (skip empty strings to avoid overwriting valid names)
+            if function_data.get("name"):
+                name = function_data["name"]
                 if isinstance(tool_calls_by_index[index]["function"], dict):
                     # type: ignore
                     tool_calls_by_index[index]["function"]["name"] = name


### PR DESCRIPTION
## Summary

Fixes #6757

When using Agno Agent with tools in streaming mode (particularly with Claude models via LiteLLM), tool function names are overwritten with empty strings, causing LLM API validation errors.

## Root Cause

LiteLLM splits tool call data across multiple streaming chunks:

```
Chunk 1: {index: 0, id: "tooluse_...", function: {name: "add", arguments: ""}}
Chunk 2: {index: 0, id: None, function: {name: "", arguments: "{\"a\": 5"}}
Chunk 3: {index: 0, id: None, function: {name: "", arguments: ", \"b\": 3}"}}
```

In `parse_tool_calls()`, the condition `function_data.get("name") is not None` evaluates `True` for empty strings (`"" is not None`), causing the valid tool name `"add"` to be overwritten with `""`.

## Fix

Changed truthiness checks from `is not None` to truthy evaluation for `name`, `id`, and `type` fields:

```python
# Before (buggy): empty string passes the check
if function_data.get("name") is not None:

# After (fixed): empty string is falsy, skipped
if function_data.get("name"):
```

The `arguments` field correctly retains `is not None` since empty argument strings need to be concatenated across chunks.

## Testing

- Verified with simulated streaming chunks: tool name correctly preserved as `"add"` instead of being overwritten to `""`
- All 100 existing unit tests pass
- No regressions