### PR TITLE
fix: correct SiliconFlow base_url from .com to .cn

### DIFF
--- a/libs/agno/agno/models/siliconflow/siliconflow.py
+++ b/libs/agno/agno/models/siliconflow/siliconflow.py
@@ -23,7 +23,7 @@ class Siliconflow(OpenAILike):
     name: str = "Siliconflow"
     provider: str = "Siliconflow"
     api_key: Optional[str] = None
-    base_url: str = "https://api.siliconflow.com/v1"
+    base_url: str = "https://api.siliconflow.cn/v1"
 
     def _get_client_params(self) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## Summary

Fixes #6768

The `base_url` default in the `Siliconflow` model class was set to `https://api.siliconflow.com/v1` but the correct domain is `https://api.siliconflow.cn/v1`.

The docstring already documented the correct URL; only the default value was wrong.

## Changes

- `libs/agno/agno/models/siliconflow/siliconflow.py`: Change `base_url` default from `.com` to `.cn`