### PR TITLE
fix: avoid keyword argument collision in MCP tool entrypoints

### DIFF
--- a/libs/agno/agno/utils/mcp.py
+++ b/libs/agno/agno/utils/mcp.py
@@ -45,11 +45,13 @@ def get_entrypoint_for_tool(
 
     async def call_tool(
         tool_name: str,
-        run_context: Optional["RunContext"] = None,
-        agent: Optional["Agent"] = None,
-        team: Optional["Team"] = None,
         **kwargs,
     ) -> ToolResult:
+        # Extract framework-injected parameters to avoid collisions
+        # with MCP tool parameters that may share the same names
+        run_context: Optional["RunContext"] = kwargs.pop("run_context", None)
+        agent: Optional["Agent"] = kwargs.pop("agent", None)
+        team: Optional["Team"] = kwargs.pop("team", None)
         # Execute the MCP tool call
         try:
             # Get the appropriate session for this run


### PR DESCRIPTION
## Problem

When using `MCPTools` with MCP servers whose tools have parameters named `team`, `agent`, or `run_context` (e.g., Linear's MCP server), all tool calls fail with:

```
TypeError: functools.partial(...) got multiple values for keyword argument 'team'
```

### Root Cause

`call_tool()` in `agno/utils/mcp.py` declares `team`, `agent`, and `run_context` as explicit keyword parameters:

```python
async def call_tool(
    tool_name: str,
    run_context: Optional["RunContext"] = None,
    agent: Optional["Agent"] = None,
    team: Optional["Team"] = None,
    **kwargs,
) -> ToolResult:
```

When the framework calls the entrypoint at `function.py:1011`:
```python
result = self.function.entrypoint(**entrypoint_args, **self.arguments)
```

`entrypoint_args` contains framework-injected `{agent: ..., team: ..., run_context: ...}` and `self.arguments` contains the MCP tool's parameters — if the MCP tool also has a parameter named `team`, it appears in both dicts, causing the `TypeError`.

## Fix

Replace explicit `team`/`agent`/`run_context` parameters with `**kwargs` and `pop()` the framework-injected ones before passing the remaining args to the MCP server:

```python
async def call_tool(tool_name: str, **kwargs) -> ToolResult:
    run_context = kwargs.pop("run_context", None)
    agent = kwargs.pop("agent", None)
    team = kwargs.pop("team", None)
    # kwargs now contains only the MCP tool's parameters
```

## Test

26 MCP unit tests pass, 2 consecutive clean runs.

Fixes #6760