### PR TITLE
fix: prevent empty string from overwriting tool name in streaming parse_tool_calls

### DIFF
--- a/libs/agno/agno/models/litellm/chat.py
+++ b/libs/agno/agno/models/litellm/chat.py
@@ -438,9 +438,9 @@ class LiteLLM(Model):
             if not isinstance(function_data, dict):
                 function_data = {}
 
-            # Update function name if provided
-            if function_data.get("name") is not None:
-                name = function_data.get("name", "")
+            # Update function name if provided and non-empty
+            if function_data.get("name"):
+                name = function_data["name"]
                 if isinstance(tool_calls_by_index[index]["function"], dict):
                     # type: ignore
                     tool_calls_by_index[index]["function"]["name"] = name


### PR DESCRIPTION
## Problem

When streaming tool call responses via LiteLLM (especially with Claude models), the function name is split across chunks:

```
Chunk 1: {index: 1, function: {name: "add", arguments: ""}}
Chunk 2: {index: 1, function: {name: "", arguments: "{\"a\": 5"}}
Chunk 3: {index: 1, function: {name: "", arguments: ", \"b\": 3}"}}
```

The `parse_tool_calls` method in `litellm/chat.py` checks `function_data.get("name") is not None` before updating the name. Empty string `""` passes this check (it's not `None`), overwriting the valid `"add"` from chunk 1 with `""` from chunks 2/3.

This causes API validation errors like:
```
Value at 'messages.2.member.content.1.member.toolUse.name' failed to satisfy constraint:
Member must have length greater than or equal to 1
```

## Fix

Change the check from `is not None` to truthiness (`if function_data.get("name")`) so empty strings are skipped.

## Test

4 litellm unit tests pass, 2 consecutive clean runs.

Fixes #6757