### PR TITLE
fix: resolve Pydantic v2 field alias warnings in AGUI interface

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/__init__.py
+++ b/libs/agno/agno/os/interfaces/agui/__init__.py
@@ -1,3 +1,16 @@
+import warnings
+
 from agno.os.interfaces.agui.agui import AGUI
+
+# Suppress Pydantic v2 UnsupportedFieldAttributeWarning from ag_ui models.
+# The ag_ui library uses alias_generator=to_camel in ConfigDict, which in some
+# Pydantic v2 versions triggers spurious warnings about field aliases having no
+# effect when models are used in discriminated unions or FastAPI route parameters.
+warnings.filterwarnings(
+    "ignore",
+    message=r".*alias.*",
+    category=UserWarning,
+    module=r"pydantic\._internal\._generate_schema",
+)
 
 __all__ = ["AGUI"]

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, Generic, List, Optional, TypeVar, Union
+from typing import Annotated, Any, Dict, Generic, List, Optional, TypeVar, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -702,7 +702,7 @@ class SchemaMetadata(BaseModel):
     """Metadata for schema registry components."""
 
     class_path: str = Field(..., description="Full module path to the schema class")
-    schema_: Optional[Dict[str, Any]] = Field(None, alias="schema", description="JSON schema definition")
+    schema_: Annotated[Optional[Dict[str, Any]], Field(alias="schema", description="JSON schema definition")] = None
     schema_error: Optional[str] = Field(None, description="Error message if schema generation failed")
 
 


### PR DESCRIPTION
## Summary

Fixes #6126

When using the AGUI interface with FastAPI, Pydantic v2 emits `UnsupportedFieldAttributeWarning` about field aliases having no effect. Two separate causes:

1. The `ag_ui` library uses `alias_generator=to_camel` in `ConfigDict`, which triggers spurious warnings in some Pydantic v2 versions when these models are used in discriminated unions or as FastAPI route parameters. Since these warnings come from a third-party dependency and are harmless, we suppress them with a targeted `warnings.filterwarnings` call.

2. `SchemaMetadata.schema_` in `agno/os/schema.py` used `Field(alias="schema")` directly, which is the non-idiomatic pattern that Pydantic v2 warns about. Switched to the recommended `Annotated` pattern.

---

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

N/A