### PR TITLE
docs: add form parameter descriptions to AgentOS API endpoints

### DIFF
--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -216,13 +216,19 @@ def get_agent_router(
         agent_id: str,
         request: Request,
         background_tasks: BackgroundTasks,
-        message: str = Form(...),
-        stream: bool = Form(True),
-        session_id: Optional[str] = Form(None),
-        user_id: Optional[str] = Form(None),
-        files: Optional[List[UploadFile]] = File(None),
-        version: Optional[str] = Form(None),
-        background: bool = Form(False),
+        message: str = Form(..., description="The input message or prompt to send to the agent"),
+        stream: bool = Form(True, description="Enable streaming responses via Server-Sent Events (SSE)"),
+        session_id: Optional[str] = Form(
+            None, description="Session ID for conversation continuity. If not provided, a new session is created"
+        ),
+        user_id: Optional[str] = Form(None, description="User identifier for tracking and personalization"),
+        files: Optional[List[UploadFile]] = File(
+            None, description="Files to upload (images, audio, video, or documents)"
+        ),
+        version: Optional[str] = Form(None, description="Agent version to use for this run"),
+        background: bool = Form(
+            False, description="Run in background and return immediately with run metadata (requires database)"
+        ),
     ):
         kwargs = await get_request_kwargs(request, create_agent_run)
 
@@ -492,10 +498,10 @@ def get_agent_router(
         run_id: str,
         request: Request,
         background_tasks: BackgroundTasks,
-        tools: str = Form(...),  # JSON string of tools
-        session_id: Optional[str] = Form(None),
-        user_id: Optional[str] = Form(None),
-        stream: bool = Form(True),
+        tools: str = Form(..., description="JSON string of tool call results to continue the paused run"),
+        session_id: Optional[str] = Form(None, description="Session ID for the paused run"),
+        user_id: Optional[str] = Form(None, description="User identifier for tracking and personalization"),
+        stream: bool = Form(True, description="Enable streaming responses via Server-Sent Events (SSE)"),
     ):
         if hasattr(request.state, "user_id") and request.state.user_id is not None:
             user_id = request.state.user_id

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -163,14 +163,20 @@ def get_team_router(
         team_id: str,
         request: Request,
         background_tasks: BackgroundTasks,
-        message: str = Form(...),
-        stream: bool = Form(True),
-        monitor: bool = Form(True),
-        session_id: Optional[str] = Form(None),
-        user_id: Optional[str] = Form(None),
-        files: Optional[List[UploadFile]] = File(None),
-        version: Optional[int] = Form(None),
-        background: bool = Form(False),
+        message: str = Form(..., description="The input message or prompt to send to the team"),
+        stream: bool = Form(True, description="Enable streaming responses via Server-Sent Events (SSE)"),
+        monitor: bool = Form(True, description="Enable monitoring and logging for this run"),
+        session_id: Optional[str] = Form(
+            None, description="Session ID for conversation continuity. If not provided, a new session is created"
+        ),
+        user_id: Optional[str] = Form(None, description="User identifier for tracking and personalization"),
+        files: Optional[List[UploadFile]] = File(
+            None, description="Files to upload (images, audio, video, or documents)"
+        ),
+        version: Optional[int] = Form(None, description="Team version to use for this run"),
+        background: bool = Form(
+            False, description="Run in background and return immediately with run metadata (requires database)"
+        ),
     ):
         kwargs = await get_request_kwargs(request, create_team_run)
 

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -639,11 +639,13 @@ def get_workflow_router(
         workflow_id: str,
         request: Request,
         background_tasks: BackgroundTasks,
-        message: str = Form(...),
-        stream: bool = Form(True),
-        session_id: Optional[str] = Form(None),
-        user_id: Optional[str] = Form(None),
-        version: Optional[int] = Form(None),
+        message: str = Form(..., description="The input message or prompt to send to the workflow"),
+        stream: bool = Form(True, description="Enable streaming responses via Server-Sent Events (SSE)"),
+        session_id: Optional[str] = Form(
+            None, description="Session ID for conversation continuity. If not provided, a new session is created"
+        ),
+        user_id: Optional[str] = Form(None, description="User identifier for tracking and personalization"),
+        version: Optional[int] = Form(None, description="Workflow version to use for this run"),
     ):
         kwargs = await get_request_kwargs(request, create_workflow_run)
 


### PR DESCRIPTION
## Summary

Fixes #6150

The AgentOS API endpoints for agents, teams, and workflows accept several form parameters (`message`, `stream`, `session_id`, `user_id`, `files`, `version`, `background`, `monitor`) that were not showing descriptions in the OpenAPI/Swagger documentation. This made it harder for integrators to discover and understand the API without reading source code.

Added `description=` to all `Form()` and `File()` parameters across:
- `routers/agents/router.py` — `create_agent_run` (7 params) and `continue_agent_run` (4 params)
- `routers/teams/router.py` — `create_team_run` (8 params)
- `routers/workflows/router.py` — `create_workflow_run` (5 params)

No logic changes, purely additive documentation.

---

## Type of change

- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

N/A