### PR TITLE
feat: add split_messages option to WhatsAppTools

### DIFF
--- a/libs/agno/agno/tools/whatsapp.py
+++ b/libs/agno/agno/tools/whatsapp.py
@@ -19,6 +19,8 @@ class WhatsAppTools(Toolkit):
         version: Optional[str] = None,
         recipient_waid: Optional[str] = None,
         async_mode: bool = False,
+        split_messages: bool = False,
+        split_separator: str = "\n\n",
     ):
         """Initialize WhatsApp toolkit.
 
@@ -28,6 +30,8 @@ class WhatsAppTools(Toolkit):
             version: API version to use
             recipient_waid: Default recipient WhatsApp ID (optional)
             async_mode: Whether to use async methods (default: False)
+            split_messages: Whether to split text messages by separator and send as multiple messages (default: False)
+            split_separator: Separator used to split messages when split_messages is True (default: "\\n\\n")
         """
         # Core credentials
         self.access_token = access_token or getenv("WHATSAPP_ACCESS_TOKEN")
@@ -46,6 +50,8 @@ class WhatsAppTools(Toolkit):
         # API version and mode
         self.version = version or getenv("WHATSAPP_VERSION", "v22.0")
         self.async_mode = async_mode
+        self.split_messages = split_messages
+        self.split_separator = split_separator
 
         tools: List[Any] = []
         if self.async_mode:
@@ -129,6 +135,33 @@ class WhatsAppTools(Toolkit):
 
         logger.debug(f"Sending WhatsApp message to {recipient}: {text}")
         logger.debug(f"Current config - Phone Number ID: {self.phone_number_id}, Version: {self.version}")
+
+        if self.split_messages:
+            parts = [part.strip() for part in text.split(self.split_separator) if part.strip()]
+            if len(parts) > 1:
+                message_ids: List[str] = []
+                for part in parts:
+                    data = {
+                        "messaging_product": "whatsapp",
+                        "recipient_type": recipient_type,
+                        "to": recipient,
+                        "type": "text",
+                        "text": {"preview_url": preview_url, "body": part},
+                    }
+                    try:
+                        response = self._send_message_sync(data)
+                        message_id = response.get("messages", [{}])[0].get("id", "unknown")
+                        message_ids.append(message_id)
+                    except httpx.HTTPStatusError as e:
+                        logger.error(f"Failed to send WhatsApp message: {e}")
+                        logger.error(
+                            f"Error response: {e.response.text if hasattr(e, 'response') else 'No response text'}"
+                        )
+                        raise
+                    except Exception as e:
+                        logger.error(f"Unexpected error sending WhatsApp message: {str(e)}")
+                        raise
+                return f"Sent {len(message_ids)} messages. Message IDs: {', '.join(message_ids)}"
 
         data = {
             "messaging_product": "whatsapp",
@@ -220,6 +253,33 @@ class WhatsAppTools(Toolkit):
 
         logger.debug(f"Sending WhatsApp message to {recipient}: {text}")
         logger.debug(f"Current config - Phone Number ID: {self.phone_number_id}, Version: {self.version}")
+
+        if self.split_messages:
+            parts = [part.strip() for part in text.split(self.split_separator) if part.strip()]
+            if len(parts) > 1:
+                message_ids: List[str] = []
+                for part in parts:
+                    data = {
+                        "messaging_product": "whatsapp",
+                        "recipient_type": recipient_type,
+                        "to": recipient,
+                        "type": "text",
+                        "text": {"preview_url": preview_url, "body": part},
+                    }
+                    try:
+                        response = await self._send_message_async(data)
+                        message_id = response.get("messages", [{}])[0].get("id", "unknown")
+                        message_ids.append(message_id)
+                    except httpx.HTTPStatusError as e:
+                        logger.error(f"Failed to send WhatsApp message: {e}")
+                        logger.error(
+                            f"Error response: {e.response.text if hasattr(e, 'response') else 'No response text'}"
+                        )
+                        raise
+                    except Exception as e:
+                        logger.error(f"Unexpected error sending WhatsApp message: {str(e)}")
+                        raise
+                return f"Sent {len(message_ids)} messages. Message IDs: {', '.join(message_ids)}"
 
         data = {
             "messaging_product": "whatsapp",


### PR DESCRIPTION
## Summary

Add a `split_messages` option to `WhatsAppTools` that splits agent responses by a configurable separator (default: `\n\n`) and sends each part as a separate WhatsApp message. This better matches WhatsApp conversation style where replies are typically short, paragraph-separated messages rather than a single large text block.

Closes #4083

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

- New parameters: `split_messages: bool = False` and `split_separator: str = "\n\n"`
- Default behavior unchanged (`split_messages=False`)
- When enabled, empty segments (whitespace-only after split) are skipped
- If text has only one segment after splitting, falls through to normal single-message send
- Implemented for both sync (`send_text_message_sync`) and async (`send_text_message_async`) methods
- Returns summary like `"Sent 3 messages. Message IDs: id1, id2, id3"` when multiple messages sent