### PR TITLE
[fix] prevent empty string from overwriting tool name in streaming chunks

### DIFF
--- a/libs/agno/agno/models/litellm/chat.py
+++ b/libs/agno/agno/models/litellm/chat.py
@@ -438,9 +438,10 @@ class LiteLLM(Model):
             if not isinstance(function_data, dict):
                 function_data = {}
 
-            # Update function name if provided
-            if function_data.get("name") is not None:
-                name = function_data.get("name", "")
+            # Update function name if provided (skip empty strings to avoid
+            # overwriting a valid name from a previous chunk)
+            if function_data.get("name"):
+                name = function_data["name"]
                 if isinstance(tool_calls_by_index[index]["function"], dict):
                     # type: ignore
                     tool_calls_by_index[index]["function"]["name"] = name

--- a/libs/agno/tests/unit/models/litellm/test_parse_tool_calls.py
+++ b/libs/agno/tests/unit/models/litellm/test_parse_tool_calls.py
@@ -1,0 +1,87 @@
+"""
+Tests for LiteLLM.parse_tool_calls streaming chunk handling.
+
+Regression test for https://github.com/phidatahq/phidata/issues/6757:
+In streaming mode, tool function names from earlier chunks were overwritten
+by empty strings in subsequent chunks, causing API validation errors.
+"""
+
+from agno.models.litellm import LiteLLM
+
+
+class TestParseToolCallsStreamingName:
+    """Verify that empty-string names in later chunks do not overwrite valid names."""
+
+    def test_empty_name_does_not_overwrite_valid_name(self):
+        """Chunks 2+ carry name="" which must not replace the real name from chunk 1."""
+        chunks = [
+            {"index": 0, "id": "tooluse_abc", "type": "function", "function": {"name": "add", "arguments": ""}},
+            {"index": 0, "id": None, "type": "function", "function": {"name": "", "arguments": '{"a": 5'}},
+            {"index": 0, "id": None, "type": "function", "function": {"name": "", "arguments": ', "b": 3}'}},
+        ]
+
+        result = LiteLLM.parse_tool_calls(chunks)
+
+        assert len(result) == 1
+        assert result[0]["function"]["name"] == "add"
+        assert result[0]["id"] == "tooluse_abc"
+
+    def test_arguments_concatenated_across_chunks(self):
+        """Arguments from multiple chunks must be joined into valid JSON."""
+        chunks = [
+            {"index": 0, "id": "id_1", "type": "function", "function": {"name": "get_weather", "arguments": ""}},
+            {"index": 0, "function": {"name": "", "arguments": '{"city"'}},
+            {"index": 0, "function": {"name": "", "arguments": ': "Tokyo"}'}},
+        ]
+
+        result = LiteLLM.parse_tool_calls(chunks)
+
+        assert result[0]["function"]["name"] == "get_weather"
+        assert result[0]["function"]["arguments"] == '{"city": "Tokyo"}'
+
+    def test_multiple_tool_calls_with_different_indices(self):
+        """Each tool call index preserves its own name independently."""
+        chunks = [
+            {"index": 0, "id": "id_a", "type": "function", "function": {"name": "add", "arguments": ""}},
+            {"index": 1, "id": "id_b", "type": "function", "function": {"name": "multiply", "arguments": ""}},
+            {"index": 0, "function": {"name": "", "arguments": '{"a": 1, "b": 2}'}},
+            {"index": 1, "function": {"name": "", "arguments": '{"x": 3, "y": 4}'}},
+        ]
+
+        result = LiteLLM.parse_tool_calls(chunks)
+
+        assert len(result) == 2
+        names = {r["function"]["name"] for r in result}
+        assert names == {"add", "multiply"}
+
+    def test_name_absent_from_function_data(self):
+        """When name key is entirely absent (not just empty), no overwrite happens."""
+        chunks = [
+            {"index": 0, "id": "id_1", "type": "function", "function": {"name": "search", "arguments": ""}},
+            {"index": 0, "function": {"arguments": '{"q": "test"}'}},
+        ]
+
+        result = LiteLLM.parse_tool_calls(chunks)
+
+        assert result[0]["function"]["name"] == "search"
+
+    def test_empty_tool_calls_returns_empty_list(self):
+        """Empty input returns empty list."""
+        assert LiteLLM.parse_tool_calls([]) == []
+
+    def test_single_chunk_with_complete_data(self):
+        """A single chunk with all data should work without issues."""
+        chunks = [
+            {
+                "index": 0,
+                "id": "id_1",
+                "type": "function",
+                "function": {"name": "greet", "arguments": '{"name": "Alice"}'},
+            },
+        ]
+
+        result = LiteLLM.parse_tool_calls(chunks)
+
+        assert len(result) == 1
+        assert result[0]["function"]["name"] == "greet"
+        assert result[0]["function"]["arguments"] == '{"name": "Alice"}'


### PR DESCRIPTION
## Summary

Fixes #6757

In streaming mode with Claude models via LiteLLM, tool function names are overwritten by empty strings from subsequent stream chunks, causing API validation errors (`Value failed to satisfy constraint: Member must have length greater than or equal to 1`).

## Root Cause

`LiteLLM.parse_tool_calls` checks `function_data.get("name") is not None` before updating the tool name. When LiteLLM splits a Claude tool-call response into multiple chunks, only chunk 1 carries the real name — later chunks send `name: ""`. Because `"" is not None` is `True`, the valid name gets overwritten with an empty string.

## Fix

Changed the condition from `is not None` to a truthiness check so empty strings are skipped:

```python
# Before (bug)
if function_data.get("name") is not None:
    name = function_data.get("name", "")

# After (fix)
if function_data.get("name"):
    name = function_data["name"]
```

## Test Plan

- [x] Added 6 unit tests covering streaming tool call parsing:
  - Empty-string name does not overwrite valid name
  - Arguments concatenated across chunks
  - Multiple tool calls with different indices
  - Name key absent from function data
  - Empty input returns empty list
  - Single chunk with complete data
- [x] All 10 existing + new litellm unit tests pass

> AI-assisted testing, AI-assisted review