### PR TITLE
[fix] correct Siliconflow default API base URL

### DIFF
--- a/libs/agno/agno/models/siliconflow/siliconflow.py
+++ b/libs/agno/agno/models/siliconflow/siliconflow.py
@@ -23,7 +23,7 @@ class Siliconflow(OpenAILike):
     name: str = "Siliconflow"
     provider: str = "Siliconflow"
     api_key: Optional[str] = None
-    base_url: str = "https://api.siliconflow.com/v1"
+    base_url: str = "https://api.siliconflow.cn/v1"
 
     def _get_client_params(self) -> Dict[str, Any]:
         """


### PR DESCRIPTION
## Summary

Fixes #6768

The `Siliconflow` model class uses `https://api.siliconflow.com/v1` as the default `base_url`, but the correct endpoint is `https://api.siliconflow.cn/v1`. This causes all API requests to fail unless the user manually overrides the URL.

## Fix

Changed `base_url` default from `.com` to `.cn` in `libs/agno/agno/models/siliconflow/siliconflow.py`.

> AI-assisted testing, AI-assisted review