### PR TITLE
fix: prevent race condition in MCPTools session creation with header_provider

### DIFF
--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import time
 import weakref
@@ -183,6 +184,7 @@ class MCPTools(Toolkit):
         self._run_sessions: dict[str, Tuple[ClientSession, float]] = {}
         self._run_session_contexts: dict[str, Any] = {}  # Maps run_id to session context managers
         self._session_ttl_seconds: float = 300.0  # 5 minutes TTL for MCP sessions
+        self._run_session_lock = asyncio.Lock()  # Prevents race conditions in parallel tool calls
 
         def cleanup():
             """Cancel active connections"""
@@ -284,6 +286,9 @@ class MCPTools(Toolkit):
         If header_provider is set and run_context is provided, creates a new session
         with dynamic headers merged into the connection config.
 
+        Uses an asyncio.Lock to prevent race conditions when parallel tool calls
+        try to create sessions for the same run_id simultaneously.
+
         Args:
             run_context: The RunContext for the current agent run
             agent: The Agent instance (if running within an agent)
@@ -298,70 +303,78 @@ class MCPTools(Toolkit):
                 raise ValueError("Session is not initialized")
             return self.session
 
-        # Lazy cleanup of stale sessions
-        await self._cleanup_stale_sessions()
-
-        # Check if we already have a session for this run
         run_id = run_context.run_id
+
+        # Fast path: session already exists (no lock needed for read)
         if run_id in self._run_sessions:
             session, _ = self._run_sessions[run_id]
             return session
 
-        # Create a new session with dynamic headers for this run
-        log_debug(f"Creating new session for run_id={run_id} with dynamic headers")
+        # Slow path: acquire lock to create session (prevents duplicate creation)
+        async with self._run_session_lock:
+            # Double-check after acquiring lock (another coroutine may have created it)
+            if run_id in self._run_sessions:
+                session, _ = self._run_sessions[run_id]
+                return session
 
-        # Generate dynamic headers from the provider
-        dynamic_headers = self._call_header_provider(run_context=run_context, agent=agent, team=team)
+            # Lazy cleanup of stale sessions
+            await self._cleanup_stale_sessions()
 
-        # Create new session with merged headers based on transport type
-        if self.transport == "sse":
-            sse_params = asdict(self.server_params) if self.server_params is not None else {}  # type: ignore
-            if "url" not in sse_params:
-                sse_params["url"] = self.url
+            # Create a new session with dynamic headers for this run
+            log_debug(f"Creating new session for run_id={run_id} with dynamic headers")
 
-            # Merge dynamic headers into existing headers
-            existing_headers = sse_params.get("headers", {})
-            sse_params["headers"] = {**existing_headers, **dynamic_headers}
+            # Generate dynamic headers from the provider
+            dynamic_headers = self._call_header_provider(run_context=run_context, agent=agent, team=team)
 
-            context = sse_client(**sse_params)  # type: ignore
-            client_timeout = min(self.timeout_seconds, sse_params.get("timeout", self.timeout_seconds))
+            # Create new session with merged headers based on transport type
+            if self.transport == "sse":
+                sse_params = asdict(self.server_params) if self.server_params is not None else {}  # type: ignore
+                if "url" not in sse_params:
+                    sse_params["url"] = self.url
 
-        elif self.transport == "streamable-http":
-            streamable_http_params = asdict(self.server_params) if self.server_params is not None else {}  # type: ignore
-            if "url" not in streamable_http_params:
-                streamable_http_params["url"] = self.url
+                # Merge dynamic headers into existing headers
+                existing_headers = sse_params.get("headers", {})
+                sse_params["headers"] = {**existing_headers, **dynamic_headers}
 
-            # Merge dynamic headers into existing headers
-            existing_headers = streamable_http_params.get("headers", {})
-            streamable_http_params["headers"] = {**existing_headers, **dynamic_headers}
+                context = sse_client(**sse_params)  # type: ignore
+                client_timeout = min(self.timeout_seconds, sse_params.get("timeout", self.timeout_seconds))
 
-            context = streamablehttp_client(**streamable_http_params)  # type: ignore
-            params_timeout = streamable_http_params.get("timeout", self.timeout_seconds)
-            if isinstance(params_timeout, timedelta):
-                params_timeout = int(params_timeout.total_seconds())
-            client_timeout = min(self.timeout_seconds, params_timeout)
-        else:
-            # stdio doesn't support headers, fall back to default session
-            log_warning(f"Cannot use dynamic headers with {self.transport} transport, using default session")
-            if self.session is None:
-                raise ValueError("Session is not initialized")
-            return self.session
+            elif self.transport == "streamable-http":
+                streamable_http_params = asdict(self.server_params) if self.server_params is not None else {}  # type: ignore
+                if "url" not in streamable_http_params:
+                    streamable_http_params["url"] = self.url
 
-        # Enter the context and create session
-        session_params = await context.__aenter__()  # type: ignore
-        read, write = session_params[0:2]
+                # Merge dynamic headers into existing headers
+                existing_headers = streamable_http_params.get("headers", {})
+                streamable_http_params["headers"] = {**existing_headers, **dynamic_headers}
 
-        session_context = ClientSession(read, write, read_timeout_seconds=timedelta(seconds=client_timeout))  # type: ignore
-        session = await session_context.__aenter__()  # type: ignore
+                context = streamablehttp_client(**streamable_http_params)  # type: ignore
+                params_timeout = streamable_http_params.get("timeout", self.timeout_seconds)
+                if isinstance(params_timeout, timedelta):
+                    params_timeout = int(params_timeout.total_seconds())
+                client_timeout = min(self.timeout_seconds, params_timeout)
+            else:
+                # stdio doesn't support headers, fall back to default session
+                log_warning(f"Cannot use dynamic headers with {self.transport} transport, using default session")
+                if self.session is None:
+                    raise ValueError("Session is not initialized")
+                return self.session
 
-        # Initialize the session
-        await session.initialize()
+            # Enter the context and create session
+            session_params = await context.__aenter__()  # type: ignore
+            read, write = session_params[0:2]
 
-        # Store the session with timestamp and context for cleanup
-        self._run_sessions[run_id] = (session, time.time())
-        self._run_session_contexts[run_id] = (context, session_context)
+            session_context = ClientSession(read, write, read_timeout_seconds=timedelta(seconds=client_timeout))  # type: ignore
+            session = await session_context.__aenter__()  # type: ignore
 
-        return session
+            # Initialize the session
+            await session.initialize()
+
+            # Store the session with timestamp and context for cleanup
+            self._run_sessions[run_id] = (session, time.time())
+            self._run_session_contexts[run_id] = (context, session_context)
+
+            return session
 
     async def cleanup_run_session(self, run_id: str) -> None:
         """


### PR DESCRIPTION
## Summary

Fixes #6094

When `header_provider` is set on `MCPTools`, parallel tool calls within the same run hang indefinitely because multiple coroutines race to create sessions for the same `run_id`.

## Root Cause

`get_session_for_run()` has a TOCTOU race condition:
1. Coroutine A checks `run_id in self._run_sessions` → `False`
2. Coroutine B checks `run_id in self._run_sessions` → `False` (session not stored yet)
3. Both coroutines create independent sessions for the same `run_id`
4. Coroutine B's session overwrites Coroutine A's in `_run_sessions`
5. Coroutine A's tool call waits on a session that was silently discarded

## Fix

Added `asyncio.Lock` with double-checked locking pattern:

```python
# Fast path: no lock needed for read
if run_id in self._run_sessions:
    return self._run_sessions[run_id]

# Slow path: acquire lock, re-check, create if absent
async with self._run_session_lock:
    if run_id in self._run_sessions:
        return self._run_sessions[run_id]
    # ... create session ...
```

This ensures:
- Only **one** session is created per `run_id`
- All parallel tool calls in the same run **share** the same session
- No contention overhead on the fast path (read-only check)