### PR TITLE
fix: parse raw JSON before cleaning to preserve fenced code blocks (fixes #5901)

### DIFF
--- a/libs/agno/agno/utils/string.py
+++ b/libs/agno/agno/utils/string.py
@@ -170,25 +170,38 @@ def parse_response_model_str(content: str, output_schema: Type[BaseModel]) -> Op
         if reasoning_content:
             content = output_content
 
-    # Clean content first to simplify all parsing attempts
+    # First, try parsing raw content directly — avoids destroying valid JSON
+    # that contains fenced code blocks inside string values.
+    try:
+        structured_output = output_schema.model_validate_json(content)
+        return structured_output
+    except ValidationError:
+        pass
+
+    try:
+        data = json.loads(content)
+        structured_output = output_schema.model_validate(data)
+        return structured_output
+    except (ValidationError, json.JSONDecodeError):
+        pass
+
+    # Clean content as fallback — this may strip code blocks from values,
+    # but is needed for LLM outputs wrapped in markdown fences.
     cleaned_content = _clean_json_content(content)
 
     try:
-        # First attempt: direct JSON validation on cleaned content
         structured_output = output_schema.model_validate_json(cleaned_content)
-    except (ValidationError, json.JSONDecodeError):
+    except ValidationError:
         try:
-            # Second attempt: Parse as Python dict
             data = json.loads(cleaned_content)
             structured_output = output_schema.model_validate(data)
         except (ValidationError, json.JSONDecodeError) as e:
             logger.warning(f"Failed to parse cleaned JSON: {e}")
 
-            # Third attempt: Extract individual JSON objects
+            # Extract individual JSON objects
             candidate_jsons = _extract_json_objects(cleaned_content)
 
             if len(candidate_jsons) == 1:
-                # Single JSON object - try to parse it directly
                 try:
                     data = json.loads(candidate_jsons[0])
                     structured_output = output_schema.model_validate(data)
@@ -214,27 +227,31 @@ def parse_response_dict_str(content: str) -> Optional[dict]:
         if reasoning_content:
             content = output_content
 
-    # Clean content first to simplify all parsing attempts
+    # First, try parsing raw content directly — avoids destroying valid JSON
+    # that contains fenced code blocks inside string values.
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError:
+        pass
+
+    # Clean content as fallback
     cleaned_content = _clean_json_content(content)
 
     try:
-        # First attempt: direct JSON parsing on cleaned content
         return json.loads(cleaned_content)
     except json.JSONDecodeError as e:
         logger.warning(f"Failed to parse cleaned JSON: {e}")
 
-        # Second attempt: Extract individual JSON objects
+        # Extract individual JSON objects
         candidate_jsons = _extract_json_objects(cleaned_content)
 
         if len(candidate_jsons) == 1:
-            # Single JSON object - try to parse it directly
             try:
                 return json.loads(candidate_jsons[0])
             except json.JSONDecodeError:
                 pass
 
         if len(candidate_jsons) > 1:
-            # Final attempt: Merge multiple JSON objects
             merged_data: dict = {}
             for candidate in candidate_jsons:
                 try:

--- a/libs/agno/tests/unit/utils/test_string.py
+++ b/libs/agno/tests/unit/utils/test_string.py
@@ -1,8 +1,14 @@
-from typing import List, Optional
+from typing import List, Literal, Optional
 
 from pydantic import BaseModel
 
-from agno.utils.string import generate_id_from_name, parse_response_model_str, sanitize_postgres_string, url_safe_string
+from agno.utils.string import (
+    generate_id_from_name,
+    parse_response_dict_str,
+    parse_response_model_str,
+    sanitize_postgres_string,
+    url_safe_string,
+)
 
 
 def test_url_safe_string_spaces():
@@ -415,3 +421,91 @@ def test_sanitize_postgres_string_other_illegal_chars():
     assert sanitize_postgres_string("hello\x0e\x1fworld") == "helloworld"
     # Unicode replacement characters
     assert sanitize_postgres_string("hello\ufffe\uffffworld") == "helloworld"
+
+
+# =============================================================================
+# Tests for fenced code blocks inside JSON string values (issue #5901)
+# =============================================================================
+
+
+class MemoryOutput(BaseModel):
+    id: Optional[str] = None
+    content: Optional[str] = None
+    action: Literal["add", "update", "delete"]
+
+
+class AgentOutput(BaseModel):
+    answer: str
+    memories: List[MemoryOutput] = []
+
+
+def test_parse_json_with_fenced_code_block_in_value():
+    """Issue #5901: parse_response_model_str fails when JSON string contains fenced code blocks."""
+    content = '{\n    "answer": "Here is a simple Python code that prints \'Hello, World!\':\\n\\n```python\\nprint(\'Hello, World!\')\\n```",\n    "memories": []\n}'
+    result = parse_response_model_str(content, AgentOutput)
+    assert result is not None
+    assert isinstance(result, AgentOutput)
+    assert "```python" in result.answer
+    assert result.memories == []
+
+
+def test_parse_json_with_multiple_fenced_blocks():
+    """Multiple fenced code blocks inside a single string value."""
+    content = '{"answer": "First:\\n```python\\nprint(1)\\n```\\nSecond:\\n```bash\\necho hi\\n```", "memories": []}'
+    result = parse_response_model_str(content, AgentOutput)
+    assert result is not None
+    assert "```python" in result.answer
+    assert "```bash" in result.answer
+
+
+def test_parse_json_with_json_fenced_block_inside_value():
+    """A ```json code block inside a JSON string value should not confuse the parser."""
+    content = '{"answer": "Example:\\n```json\\n{\\"key\\": \\"val\\"}\\n```", "memories": []}'
+    result = parse_response_model_str(content, AgentOutput)
+    assert result is not None
+    assert "```json" in result.answer
+
+
+def test_parse_dict_with_fenced_code_block():
+    """parse_response_dict_str should also handle fenced blocks in values."""
+    content = '{"answer": "Code:\\n```python\\nx = 1\\n```", "data": 42}'
+    result = parse_response_dict_str(content)
+    assert result is not None
+    assert "```python" in result["answer"]
+    assert result["data"] == 42
+
+
+def test_parse_json_wrapped_in_markdown_still_works():
+    """Content wrapped in ```json ... ``` should still parse correctly."""
+    content = '```json\n{"answer": "hello", "memories": []}\n```'
+    result = parse_response_model_str(content, AgentOutput)
+    assert result is not None
+    assert result.answer == "hello"
+
+
+def test_parse_plain_json_no_code_blocks():
+    """Plain JSON without any code blocks should still work."""
+    content = '{"answer": "no code blocks here", "memories": []}'
+    result = parse_response_model_str(content, AgentOutput)
+    assert result is not None
+    assert result.answer == "no code blocks here"
+
+
+def test_parse_json_with_backticks_in_inline_code():
+    """Inline backticks (not fenced blocks) in values should parse fine."""
+    content = '{"answer": "Use `print()` to output text", "memories": []}'
+    result = parse_response_model_str(content, AgentOutput)
+    assert result is not None
+    assert "`print()`" in result.answer
+
+
+def test_parse_json_with_fenced_block_in_memory_content():
+    """Fenced code block inside a nested list item's string field should be preserved."""
+    memory_json = (
+        '{"answer": "See below", "memories": [{"id": "m1", "content": "```python\\nprint(42)\\n```", "action": "add"}]}'
+    )
+    result = parse_response_model_str(memory_json, AgentOutput)
+    assert result is not None
+    assert result.answer == "See below"
+    assert len(result.memories) == 1
+    assert "```python" in result.memories[0].content


### PR DESCRIPTION
## Summary

Fixes #5901

`parse_response_model_str` and `parse_response_dict_str` fail when JSON string values contain fenced code blocks (e.g. ```python```) because `_clean_json_content` aggressively strips them.

## Root Cause

`_clean_json_content` splits on ` ```json ` / ` ``` ` markers and discards parts it considers "outside" the JSON block. When the JSON itself is valid but **contains** code blocks inside string values, the splitting destroys the JSON structure:

```python
# This valid JSON gets mangled:
{"answer": "Example:\\n```python\\nprint('hi')\\n```"}
```

## Fix

Both `parse_response_model_str` and `parse_response_dict_str` now attempt direct JSON parsing on the **raw content first** (before any cleaning). Only if raw parsing fails do they fall back to the `_clean_json_content` pipeline.

This is safe because:
1. Valid JSON with fenced blocks in values parses correctly without cleaning
2. Invalid JSON (e.g. wrapped in markdown) still gets cleaned as before
3. No behavior change for any currently-working inputs

## Tests

8 new tests covering:
- Fenced code block in string value (exact repro from issue)
- Multiple fenced blocks in one value
- `\x60\x60\x60json\x60\x60\x60` block inside a value
- `parse_response_dict_str` with fenced blocks
- Markdown-wrapped JSON still works
- Plain JSON (no blocks) still works
- Inline backticks in values
- Fenced block in nested memory content field