### PR TITLE
fix: resolve output_schema and reasoning conflict for Anthropic (fixes #5582)

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -331,6 +331,38 @@ class Claude(Model):
 
         return None
 
+    def _strip_trailing_assistant_for_output_format(
+        self,
+        chat_messages: List[Dict[str, Any]],
+        response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
+    ) -> List[Dict[str, Any]]:
+        """
+        Remove trailing assistant messages when output_format is used.
+
+        Anthropic's API does not allow pre-filling (assistant message in the final
+        position) when ``output_format`` is specified.  This typically surfaces when
+        ``reasoning=True`` is combined with ``output_schema`` because the reasoning
+        loop may leave an assistant message at the end of the message history.
+
+        See: https://github.com/agno-agi/agno/issues/5582
+        """
+        if response_format is None or not self._supports_structured_outputs():
+            return chat_messages
+
+        # Only strip when response_format actually produces an output_format
+        # for the API call.  json_object format is ignored by _build_output_format
+        # (returns None), so the pre-filling restriction does not apply.
+        if self._build_output_format(response_format) is None:
+            return chat_messages
+
+        if chat_messages and chat_messages[-1].get("role") == "assistant":
+            log_debug(
+                "Stripping trailing assistant message to avoid pre-filling conflict with output_format"
+            )
+            return chat_messages[:-1]
+
+        return chat_messages
+
     def _validate_structured_outputs_usage(
         self,
         response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
@@ -594,6 +626,7 @@ class Claude(Model):
         """
         try:
             chat_messages, system_message = format_messages(messages, compress_tool_results=compress_tool_results)
+            chat_messages = self._strip_trailing_assistant_for_output_format(chat_messages, response_format)
             request_kwargs = self._prepare_request_kwargs(system_message, tools=tools, response_format=response_format)
 
             if self._has_beta_features(response_format=response_format, tools=tools):
@@ -658,6 +691,7 @@ class Claude(Model):
             APIStatusError: For other API-related errors
         """
         chat_messages, system_message = format_messages(messages, compress_tool_results=compress_tool_results)
+        chat_messages = self._strip_trailing_assistant_for_output_format(chat_messages, response_format)
         request_kwargs = self._prepare_request_kwargs(system_message, tools=tools, response_format=response_format)
 
         try:
@@ -713,6 +747,7 @@ class Claude(Model):
         """
         try:
             chat_messages, system_message = format_messages(messages, compress_tool_results=compress_tool_results)
+            chat_messages = self._strip_trailing_assistant_for_output_format(chat_messages, response_format)
             request_kwargs = self._prepare_request_kwargs(system_message, tools=tools, response_format=response_format)
 
             # Beta features
@@ -776,6 +811,7 @@ class Claude(Model):
         """
         try:
             chat_messages, system_message = format_messages(messages, compress_tool_results=compress_tool_results)
+            chat_messages = self._strip_trailing_assistant_for_output_format(chat_messages, response_format)
             request_kwargs = self._prepare_request_kwargs(system_message, tools=tools, response_format=response_format)
 
             if self._has_beta_features(response_format=response_format, tools=tools):

--- a/libs/agno/tests/unit/models/anthropic/test_strip_trailing_assistant.py
+++ b/libs/agno/tests/unit/models/anthropic/test_strip_trailing_assistant.py
@@ -1,0 +1,179 @@
+"""
+Tests for _strip_trailing_assistant_for_output_format.
+
+Verifies that when output_format is active (i.e. response_format is set
+on a model that supports structured outputs), trailing assistant messages
+are stripped to avoid Anthropic's "pre-filling not supported" error.
+
+See: https://github.com/agno-agi/agno/issues/5582
+"""
+
+from pydantic import BaseModel
+
+from agno.models.anthropic.claude import Claude
+
+
+class _DummySchema(BaseModel):
+    answer: str
+    confidence: float
+
+
+def _make_model(model_id: str = "claude-sonnet-4-5-20250929") -> Claude:
+    """Create a Claude instance without needing an API key."""
+    return Claude(id=model_id, api_key="test-key")
+
+
+# ── output_schema alone (no trailing assistant) ────────────────────────
+class TestOutputSchemaWithoutTrailingAssistant:
+    """output_schema should work fine when the last message is a user message."""
+
+    def test_user_last_message_unchanged(self):
+        model = _make_model()
+        messages = [
+            {"role": "user", "content": "Hello"},
+        ]
+        result = model._strip_trailing_assistant_for_output_format(
+            messages, response_format=_DummySchema
+        )
+        assert result == messages
+
+    def test_tool_result_last_message_unchanged(self):
+        """Tool results map to role 'user' in Anthropic API, should be kept."""
+        model = _make_model()
+        messages = [
+            {"role": "user", "content": "Search for X"},
+            {"role": "assistant", "content": [{"type": "tool_use", "id": "t1", "input": {}, "name": "search"}]},
+            {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "result"}]},
+        ]
+        result = model._strip_trailing_assistant_for_output_format(
+            messages, response_format=_DummySchema
+        )
+        assert result == messages
+
+
+# ── reasoning alone (no output_schema) ─────────────────────────────────
+class TestReasoningWithoutOutputSchema:
+    """Trailing assistant messages should be kept when output_schema is not set."""
+
+    def test_trailing_assistant_kept_when_no_response_format(self):
+        model = _make_model()
+        messages = [
+            {"role": "user", "content": "Think about this"},
+            {"role": "assistant", "content": "I'm thinking..."},
+        ]
+        result = model._strip_trailing_assistant_for_output_format(
+            messages, response_format=None
+        )
+        assert result == messages
+        assert len(result) == 2
+
+
+# ── both output_schema + reasoning (the bug scenario) ─────────────────
+class TestOutputSchemaWithReasoning:
+    """When both are active, trailing assistant must be stripped."""
+
+    def test_trailing_assistant_stripped(self):
+        model = _make_model()
+        messages = [
+            {"role": "user", "content": "Research this topic"},
+            {"role": "assistant", "content": "Here are my findings from the tools..."},
+        ]
+        result = model._strip_trailing_assistant_for_output_format(
+            messages, response_format=_DummySchema
+        )
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+
+    def test_multi_turn_trailing_assistant_stripped(self):
+        """Simulates a full tool-call cycle ending with assistant."""
+        model = _make_model()
+        messages = [
+            {"role": "user", "content": "Search for X"},
+            {"role": "assistant", "content": [{"type": "tool_use", "id": "t1", "input": {}, "name": "search"}]},
+            {"role": "user", "content": [{"type": "tool_result", "tool_use_id": "t1", "content": "result"}]},
+            {"role": "assistant", "content": "Based on the search results..."},
+        ]
+        result = model._strip_trailing_assistant_for_output_format(
+            messages, response_format=_DummySchema
+        )
+        assert len(result) == 3
+        assert result[-1]["role"] == "user"
+
+    def test_empty_messages_unchanged(self):
+        model = _make_model()
+        result = model._strip_trailing_assistant_for_output_format(
+            [], response_format=_DummySchema
+        )
+        assert result == []
+
+
+# ── non-structured-output models ───────────────────────────────────────
+class TestNonStructuredOutputModel:
+    """Models that don't support structured outputs should not strip."""
+
+    def test_unsupported_model_keeps_trailing_assistant(self):
+        model = _make_model(model_id="claude-3-haiku-20240307")
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Thinking..."},
+        ]
+        result = model._strip_trailing_assistant_for_output_format(
+            messages, response_format=_DummySchema
+        )
+        assert len(result) == 2
+        assert result[-1]["role"] == "assistant"
+
+
+# ── dict response_format ───────────────────────────────────────────────
+class TestDictResponseFormat:
+    """Ensure dict-based response_format also triggers stripping."""
+
+    def test_dict_response_format_strips_trailing_assistant(self):
+        model = _make_model()
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "response"},
+        ]
+        result = model._strip_trailing_assistant_for_output_format(
+            messages,
+            response_format={"type": "json_schema", "schema": {"type": "object"}},
+        )
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+
+    def test_json_object_response_format_keeps_trailing_assistant(self):
+        """json_object response_format should not trigger stripping.
+
+        _build_output_format() returns None for {"type": "json_object"},
+        so trailing assistant messages must be preserved.
+        """
+        model = _make_model()
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "response"},
+        ]
+        result = model._strip_trailing_assistant_for_output_format(
+            messages,
+            response_format={"type": "json_object"},
+        )
+        assert result == messages
+        assert len(result) == 2
+        assert result[-1]["role"] == "assistant"
+
+
+# ── json_object response_format (no stripping) ────────────────────────
+class TestJsonObjectResponseFormat:
+    """json_object format does not produce output_format — should not strip."""
+
+    def test_json_object_format_keeps_trailing_assistant(self):
+        model = _make_model()
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "response"},
+        ]
+        result = model._strip_trailing_assistant_for_output_format(
+            messages,
+            response_format={"type": "json_object"},
+        )
+        assert len(result) == 2
+        assert result[-1]["role"] == "assistant"


### PR DESCRIPTION
## Summary
Fixes #5582 — `output_schema` incompatible with `reasoning=True` on Claude Sonnet 4.5.

## Root Cause
When reasoning is enabled, agno's tool-call cycle may leave an assistant message at the end of the message history. Anthropic's `output_format` (used for structured output via `output_schema`) forbids pre-filling — i.e. having an assistant message in the final position.

## Changes
- Added `_strip_trailing_assistant_for_output_format()` method to `Claude` model
- Applied in all 4 invoke methods (`invoke`, `invoke_stream`, `ainvoke`, `ainvoke_stream`)
- Only activates when `response_format` is set **and** the model supports structured outputs
- Non-structured-output models are unaffected

## Tests
8 new unit tests covering:
- output_schema without trailing assistant (no change)
- reasoning without output_schema (no change)
- Both together — trailing assistant stripped (**the fix**)
- Multi-turn tool-call cycles
- Non-structured-output models (no stripping)
- Dict-based response_format
- Empty message lists

Fixes #5582