### PR TITLE
fix: add HITL continue support for teams

### DIFF
--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -157,6 +157,35 @@ async def agent_continue_response_streamer(
         return
 
 
+async def _team_continue_streamer(
+    team,
+    run_id: str,
+    requirements: List,
+    session_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    background_tasks: Optional[BackgroundTasks] = None,
+) -> AsyncGenerator:
+    from agno.run.team import RunErrorEvent as TeamRunErrorEvent
+
+    try:
+        continue_response = team.acontinue_run(
+            run_id=run_id,
+            requirements=requirements,
+            session_id=session_id,
+            user_id=user_id,
+            stream=True,
+            stream_events=True,
+            background_tasks=background_tasks,
+        )
+        async for chunk in continue_response:
+            yield format_sse_event(chunk)
+    except Exception as e:
+        import traceback
+
+        traceback.print_exc(limit=3)
+        yield format_sse_event(TeamRunErrorEvent(content=str(e)))
+
+
 def get_agent_router(
     os: "AgentOS",
     settings: AgnoAPISettings = AgnoAPISettings(),
@@ -510,6 +539,47 @@ def get_agent_router(
 
         agent = get_agent_by_id(agent_id=agent_id, agents=os.agents, db=os.db, registry=os.registry, create_fresh=True)
         if agent is None:
+            from agno.models.response import ToolExecution
+            from agno.os.utils import get_team_by_id
+            from agno.run.requirement import RunRequirement
+
+            team = get_team_by_id(team_id=agent_id, teams=os.teams, db=os.db, registry=os.registry, create_fresh=True)
+            if team is not None:
+                try:
+                    tools_data_for_team = json.loads(tools) if tools else []
+                except json.JSONDecodeError:
+                    raise HTTPException(status_code=400, detail="Invalid JSON in tools field")
+
+                requirements = []
+                for tool_data in tools_data_for_team:
+                    tool_exec = ToolExecution.from_dict(tool_data)
+                    req = RunRequirement(tool_execution=tool_exec)
+                    req.confirmation = tool_exec.confirmed
+                    req.confirmation_note = getattr(tool_exec, "confirmation_note", None)
+                    requirements.append(req)
+
+                if stream:
+                    return StreamingResponse(
+                        _team_continue_streamer(
+                            team,
+                            run_id=run_id,
+                            requirements=requirements,
+                            session_id=session_id,
+                            user_id=user_id,
+                            background_tasks=background_tasks,
+                        ),
+                        media_type="text/event-stream",
+                    )
+                run_response_obj = await team.acontinue_run(
+                    run_id=run_id,
+                    requirements=requirements,
+                    session_id=session_id,
+                    user_id=user_id,
+                    stream=False,
+                    background_tasks=background_tasks,
+                )
+                return run_response_obj.to_dict()
+
             raise HTTPException(status_code=404, detail="Agent not found")
 
         if session_id is None or session_id == "":

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -158,7 +158,7 @@ async def agent_continue_response_streamer(
 
 
 async def _team_continue_streamer(
-    team,
+    team: "Union[Any, Any]",
     run_id: str,
     requirements: List,
     session_id: Optional[str] = None,
@@ -166,19 +166,32 @@ async def _team_continue_streamer(
     background_tasks: Optional[BackgroundTasks] = None,
 ) -> AsyncGenerator:
     from agno.run.team import RunErrorEvent as TeamRunErrorEvent
+    from agno.team.remote import RemoteTeam
+    from agno.team.team import Team
 
     try:
-        continue_response = team.acontinue_run(
-            run_id=run_id,
-            requirements=requirements,
-            session_id=session_id,
-            user_id=user_id,
-            stream=True,
-            stream_events=True,
-            background_tasks=background_tasks,
-        )
-        async for chunk in continue_response:
-            yield format_sse_event(chunk)
+        if isinstance(team, RemoteTeam):
+            result = await team.acontinue_run(
+                run_id=run_id,
+                stream=True,
+                user_id=user_id,
+                session_id=session_id,
+            )
+            yield format_sse_event(result)  # type: ignore[arg-type]
+            return
+
+        if isinstance(team, Team):
+            continue_response = team.acontinue_run(  # type: ignore[call-overload]
+                run_id=run_id,
+                requirements=requirements,
+                session_id=session_id,
+                user_id=user_id,
+                stream=True,
+                stream_events=True,
+                background_tasks=background_tasks,
+            )
+            async for chunk in continue_response:  # type: ignore[union-attr]
+                yield format_sse_event(chunk)  # type: ignore[arg-type]
     except Exception as e:
         import traceback
 
@@ -540,8 +553,10 @@ def get_agent_router(
         agent = get_agent_by_id(agent_id=agent_id, agents=os.agents, db=os.db, registry=os.registry, create_fresh=True)
         if agent is None:
             from agno.models.response import ToolExecution
+            from agno.os.routers.teams.router import _enrich_requirements_from_session
             from agno.os.utils import get_team_by_id
-            from agno.run.requirement import RunRequirement
+            from agno.team.remote import RemoteTeam
+            from agno.team.team import Team
 
             team = get_team_by_id(team_id=agent_id, teams=os.teams, db=os.db, registry=os.registry, create_fresh=True)
             if team is not None:
@@ -550,35 +565,53 @@ def get_agent_router(
                 except json.JSONDecodeError:
                     raise HTTPException(status_code=400, detail="Invalid JSON in tools field")
 
-                requirements = []
-                for tool_data in tools_data_for_team:
-                    tool_exec = ToolExecution.from_dict(tool_data)
-                    req = RunRequirement(tool_execution=tool_exec)
-                    req.confirmation = tool_exec.confirmed
-                    req.confirmation_note = getattr(tool_exec, "confirmation_note", None)
-                    requirements.append(req)
+                incoming_tools = [ToolExecution.from_dict(td) for td in tools_data_for_team]
 
-                if stream:
-                    return StreamingResponse(
-                        _team_continue_streamer(
-                            team,
-                            run_id=run_id,
-                            requirements=requirements,
-                            session_id=session_id,
-                            user_id=user_id,
-                            background_tasks=background_tasks,
-                        ),
-                        media_type="text/event-stream",
+                if isinstance(team, RemoteTeam):
+                    if stream:
+                        return StreamingResponse(
+                            _team_continue_streamer(
+                                team,
+                                run_id=run_id,
+                                requirements=[],
+                                session_id=session_id,
+                                user_id=user_id,
+                                background_tasks=background_tasks,
+                            ),
+                            media_type="text/event-stream",
+                        )
+                    result = await team.acontinue_run(
+                        run_id=run_id,
+                        stream=False,
+                        user_id=user_id,
+                        session_id=session_id,
                     )
-                run_response_obj = await team.acontinue_run(
-                    run_id=run_id,
-                    requirements=requirements,
-                    session_id=session_id,
-                    user_id=user_id,
-                    stream=False,
-                    background_tasks=background_tasks,
-                )
-                return run_response_obj.to_dict()
+                    return result.to_dict()
+
+                if isinstance(team, Team):
+                    requirements = await _enrich_requirements_from_session(team, run_id, session_id, incoming_tools)
+
+                    if stream:
+                        return StreamingResponse(
+                            _team_continue_streamer(
+                                team,
+                                run_id=run_id,
+                                requirements=requirements,
+                                session_id=session_id,
+                                user_id=user_id,
+                                background_tasks=background_tasks,
+                            ),
+                            media_type="text/event-stream",
+                        )
+                    run_response_obj = await team.acontinue_run(  # type: ignore[misc]
+                        run_id=run_id,
+                        requirements=requirements,
+                        session_id=session_id,
+                        user_id=user_id,
+                        stream=False,
+                        background_tasks=background_tasks,
+                    )
+                    return run_response_obj.to_dict()
 
             raise HTTPException(status_code=404, detail="Agent not found")
 

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -111,6 +111,46 @@ async def team_response_streamer(
         return
 
 
+async def team_continue_response_streamer(
+    team: Union[Team, RemoteTeam],
+    run_id: str,
+    requirements: List,
+    session_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    background_tasks: Optional[BackgroundTasks] = None,
+) -> AsyncGenerator:
+    try:
+        continue_response = team.acontinue_run(
+            run_id=run_id,
+            requirements=requirements,
+            session_id=session_id,
+            user_id=user_id,
+            stream=True,
+            stream_events=True,
+            background_tasks=background_tasks,
+        )
+        async for chunk in continue_response:
+            yield format_sse_event(chunk)
+    except (InputCheckError, OutputCheckError) as e:
+        error_response = TeamRunErrorEvent(
+            content=str(e),
+            error_type=e.type,
+            error_id=e.error_id,
+        )
+        yield format_sse_event(error_response)
+    except BaseException as e:
+        import traceback
+
+        traceback.print_exc()
+        error_response = TeamRunErrorEvent(
+            content=str(e),
+            error_type=e.type if hasattr(e, "type") else None,
+            error_id=e.error_id if hasattr(e, "error_id") else None,
+        )
+        yield format_sse_event(error_response)
+        return
+
+
 def get_team_router(
     os: "AgentOS",
     settings: AgnoAPISettings = AgnoAPISettings(),
@@ -367,6 +407,96 @@ def get_team_router(
         # in cancel-before-start scenarios), so we always return success.
         await team.acancel_run(run_id=run_id)
         return JSONResponse(content={}, status_code=200)
+
+    @router.post(
+        "/teams/{team_id}/runs/{run_id}/continue",
+        tags=["Teams"],
+        operation_id="continue_team_run",
+        response_model_exclude_none=True,
+        summary="Continue Team Run",
+        description=(
+            "Continue a paused team run with updated tool results.\n\n"
+            "**Use Cases:**\n"
+            "- Resume execution after tool approval/rejection in a HITL flow\n\n"
+            "**Tools Parameter:**\n"
+            "JSON string containing array of tool execution objects with confirmation results."
+        ),
+        responses={
+            200: {
+                "description": "Team run continued successfully",
+                "content": {
+                    "text/event-stream": {
+                        "example": 'event: RunContent\ndata: {"created_at": 1757348314, "run_id": "123..."}\n\n'
+                    },
+                },
+            },
+            400: {"description": "Invalid JSON in tools field or invalid tool structure", "model": BadRequestResponse},
+            404: {"description": "Team not found", "model": NotFoundResponse},
+        },
+        dependencies=[Depends(require_resource_access("teams", "run", "team_id"))],
+    )
+    async def continue_team_run(
+        team_id: str,
+        run_id: str,
+        request: Request,
+        background_tasks: BackgroundTasks,
+        tools: str = Form(...),
+        session_id: Optional[str] = Form(None),
+        user_id: Optional[str] = Form(None),
+        stream: bool = Form(True),
+    ):
+        import json
+
+        from agno.models.response import ToolExecution
+        from agno.run.requirement import RunRequirement
+
+        if hasattr(request.state, "user_id") and request.state.user_id is not None:
+            user_id = request.state.user_id
+        if hasattr(request.state, "session_id") and request.state.session_id is not None:
+            session_id = request.state.session_id
+
+        team = get_team_by_id(team_id=team_id, teams=os.teams, db=os.db, registry=registry, create_fresh=True)
+        if team is None:
+            raise HTTPException(status_code=404, detail="Team not found")
+
+        try:
+            tools_data = json.loads(tools) if tools else []
+        except json.JSONDecodeError:
+            raise HTTPException(status_code=400, detail="Invalid JSON in tools field")
+
+        requirements = []
+        for tool_data in tools_data:
+            try:
+                tool_exec = ToolExecution.from_dict(tool_data)
+            except Exception as e:
+                raise HTTPException(status_code=400, detail=f"Invalid structure or content for tools: {str(e)}")
+            req = RunRequirement(tool_execution=tool_exec)
+            req.confirmation = tool_exec.confirmed
+            req.confirmation_note = getattr(tool_exec, "confirmation_note", None)
+            requirements.append(req)
+
+        if stream:
+            return StreamingResponse(
+                team_continue_response_streamer(
+                    team,
+                    run_id=run_id,
+                    requirements=requirements,
+                    session_id=session_id,
+                    user_id=user_id,
+                    background_tasks=background_tasks,
+                ),
+                media_type="text/event-stream",
+            )
+
+        run_response_obj = await team.acontinue_run(
+            run_id=run_id,
+            requirements=requirements,
+            session_id=session_id,
+            user_id=user_id,
+            stream=False,
+            background_tasks=background_tasks,
+        )
+        return run_response_obj.to_dict()
 
     @router.get(
         "/teams",

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -193,6 +193,12 @@ async def _enrich_requirements_from_session(
                             req.confirmation_note = getattr(incoming, "confirmation_note", None)
                             if req.tool_execution:
                                 req.tool_execution.confirmed = incoming.confirmed
+
+                        if req.member_run_id and req._member_run_response is None:
+                            member_run = team_session.get_run(req.member_run_id)
+                            if member_run is not None:
+                                req._member_run_response = member_run
+
                     return list(stored_run.requirements)
         except Exception:
             pass

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -120,7 +120,17 @@ async def team_continue_response_streamer(
     background_tasks: Optional[BackgroundTasks] = None,
 ) -> AsyncGenerator:
     try:
-        continue_response = team.acontinue_run(
+        if isinstance(team, RemoteTeam):
+            result = await team.acontinue_run(
+                run_id=run_id,
+                stream=True,
+                user_id=user_id,
+                session_id=session_id,
+            )
+            yield format_sse_event(result)  # type: ignore[arg-type]
+            return
+
+        continue_response = team.acontinue_run(  # type: ignore[call-overload]
             run_id=run_id,
             requirements=requirements,
             session_id=session_id,
@@ -129,8 +139,8 @@ async def team_continue_response_streamer(
             stream_events=True,
             background_tasks=background_tasks,
         )
-        async for chunk in continue_response:
-            yield format_sse_event(chunk)
+        async for chunk in continue_response:  # type: ignore[union-attr]
+            yield format_sse_event(chunk)  # type: ignore[arg-type]
     except (InputCheckError, OutputCheckError) as e:
         error_response = TeamRunErrorEvent(
             content=str(e),
@@ -149,6 +159,51 @@ async def team_continue_response_streamer(
         )
         yield format_sse_event(error_response)
         return
+
+
+async def _enrich_requirements_from_session(
+    team: Team,
+    run_id: str,
+    session_id: Optional[str],
+    incoming_tools: List,
+) -> List:
+    import asyncio
+
+    from agno.db.base import SessionType
+    from agno.run.requirement import RunRequirement
+
+    confirmed_map = {t.tool_call_id: t for t in incoming_tools if t.tool_call_id}
+
+    db = getattr(team, "db", None)
+    if db is not None and session_id:
+        try:
+            loop = asyncio.get_running_loop()
+            team_session = await loop.run_in_executor(
+                None,
+                lambda: db.get_session(session_id=session_id, session_type=SessionType.TEAM),
+            )
+            if team_session is not None:
+                stored_run = team_session.get_run(run_id)
+                if stored_run is not None and getattr(stored_run, "requirements", None):
+                    for req in stored_run.requirements:
+                        tcid = req.tool_execution.tool_call_id if req.tool_execution else None
+                        if tcid and tcid in confirmed_map:
+                            incoming = confirmed_map[tcid]
+                            req.confirmation = incoming.confirmed
+                            req.confirmation_note = getattr(incoming, "confirmation_note", None)
+                            if req.tool_execution:
+                                req.tool_execution.confirmed = incoming.confirmed
+                    return list(stored_run.requirements)
+        except Exception:
+            pass
+
+    requirements = []
+    for tool_exec in incoming_tools:
+        req = RunRequirement(tool_execution=tool_exec)
+        req.confirmation = tool_exec.confirmed
+        req.confirmation_note = getattr(tool_exec, "confirmation_note", None)
+        requirements.append(req)
+    return requirements
 
 
 def get_team_router(
@@ -448,7 +503,6 @@ def get_team_router(
         import json
 
         from agno.models.response import ToolExecution
-        from agno.run.requirement import RunRequirement
 
         if hasattr(request.state, "user_id") and request.state.user_id is not None:
             user_id = request.state.user_id
@@ -464,16 +518,35 @@ def get_team_router(
         except json.JSONDecodeError:
             raise HTTPException(status_code=400, detail="Invalid JSON in tools field")
 
-        requirements = []
+        incoming_tools = []
         for tool_data in tools_data:
             try:
-                tool_exec = ToolExecution.from_dict(tool_data)
+                incoming_tools.append(ToolExecution.from_dict(tool_data))
             except Exception as e:
                 raise HTTPException(status_code=400, detail=f"Invalid structure or content for tools: {str(e)}")
-            req = RunRequirement(tool_execution=tool_exec)
-            req.confirmation = tool_exec.confirmed
-            req.confirmation_note = getattr(tool_exec, "confirmation_note", None)
-            requirements.append(req)
+
+        if isinstance(team, RemoteTeam):
+            if stream:
+                return StreamingResponse(
+                    team_continue_response_streamer(
+                        team,
+                        run_id=run_id,
+                        requirements=[],
+                        session_id=session_id,
+                        user_id=user_id,
+                        background_tasks=background_tasks,
+                    ),
+                    media_type="text/event-stream",
+                )
+            result = await team.acontinue_run(
+                run_id=run_id,
+                stream=False,
+                user_id=user_id,
+                session_id=session_id,
+            )
+            return result.to_dict()
+
+        requirements = await _enrich_requirements_from_session(team, run_id, session_id, incoming_tools)
 
         if stream:
             return StreamingResponse(
@@ -488,7 +561,7 @@ def get_team_router(
                 media_type="text/event-stream",
             )
 
-        run_response_obj = await team.acontinue_run(
+        run_response_obj = await team.acontinue_run(  # type: ignore[misc]
             run_id=run_id,
             requirements=requirements,
             session_id=session_id,


### PR DESCRIPTION
## Problem

When a `Team` run is paused for HITL (human-in-the-loop), the AgentOS playground sends a `POST /agents/{team_id}/runs/{run_id}/continue` request (since teams share the agent endpoint in the UI). Two bugs prevented this from working:

**Bug 1 — 404 "Agent not found"** (fixed in first commit)
`continue_agent_run` calls `get_agent_by_id()` which only searches `os.agents`. A team ID never matches, so it raised 404 even though `get_team_by_id()` existed in `os/utils.py`.

**Bug 2 — Team coordinator summarises instead of resuming member** (fixed in this commit)
After routing to the team, the handler built *bare* `RunRequirement` objects directly from the HTTP payload. These bare objects have `member_agent_id=None` and `member_run_id=None`. When passed to `acontinue_run`, they *replace* the stored requirements:

```python
# _run.py acontinue_run_dispatch
run_response.requirements = requirements   # wipes member_agent_id
```

`_aroute_requirements_to_members` then groups requirements by `member_agent_id`. With all values `None`, `member_reqs` is empty → no member agent is resumed → the team coordinator model handles the request directly and produces a plain-text summary instead of executing the approved tool.

## Fix

### `teams/router.py`

Added `_enrich_requirements_from_session`:
1. Loads the stored `TeamSession` from `team.db` using `session_id`
2. Finds the paused `TeamRunOutput` by `run_id`
3. Retrieves the stored `RunRequirement` list (which carries `member_agent_id`, `member_run_id`, and optionally `_member_run_response`)
4. Patches `confirmation` / `confirmation_note` from the incoming HTTP payload by matching on `tool_call_id`
5. Returns the enriched list so `_aroute_requirements_to_members` can correctly route back to the paused member agent

Falls back gracefully to bare requirements if the session lookup fails (e.g. no DB configured).

Added `POST /teams/{team_id}/runs/{run_id}/continue` endpoint for REST symmetry.

### `agents/router.py`

Added team fallback: if `get_agent_by_id` returns `None`, try `get_team_by_id` and delegate using the same `_enrich_requirements_from_session` helper.

### mypy fixes

Both routers now narrow `Union[Team, RemoteTeam]` to concrete types before calling `Team`-specific overloads (e.g. `requirements=`, `stream_events=`, `background_tasks=` are not on `BaseRemote.acontinue_run`). Added targeted `# type: ignore` comments matching the pattern already used by the existing `team_response_streamer` for the unavoidable overload lie in `Team.acontinue_run`.

## Test

1. Start a team run that triggers a HITL tool (e.g. `@tool(requires_confirmation=True)`)
2. Observe `TeamRunPaused` event in the SSE stream
3. Click Approve in the AgentOS playground
4. Verify the `POST /agents/{team_id}/runs/{run_id}/continue` returns `TeamRunContinued` followed by the member agent actually executing the confirmed tool, not a coordinator summary