### PR TITLE
fix: return 503 instead of 404 for disabled AgentOS features

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -171,8 +171,8 @@ def _get_disabled_feature_router(prefix: str, tag: str, requires: str) -> APIRou
     for path in [prefix, f"{prefix}/{{path:path}}"]:
 
         @router.api_route(path, methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
-        async def _disabled(_detail: str = detail) -> None:
-            raise HTTPException(status_code=503, detail=_detail)
+        async def _disabled() -> None:
+            raise HTTPException(status_code=503, detail=detail)
 
     return router
 
@@ -390,16 +390,22 @@ class AgentOS:
             get_traces_router(dbs=self.dbs),
             get_database_router(self, settings=self.settings),
         ]
-        # Add component and registry routers only if a sync db (BaseDb) is available
-        # Component routes require sync database operations
-        if self.db is not None and isinstance(self.db, BaseDb):
-            updated_routers.append(get_components_router(os_db=self.db, registry=self.registry))
-        if self.registry is not None:
-            updated_routers.append(get_registry_router(registry=self.registry))
-        # Add schedule and approval routers if a db is available
+        # Routes that require a database
         if self.db is not None:
+            if isinstance(self.db, BaseDb):
+                updated_routers.append(get_components_router(os_db=self.db, registry=self.registry))
+            else:
+                updated_routers.append(_get_disabled_feature_router("/components", "Components", "sync db (BaseDb)"))
             updated_routers.append(get_schedule_router(os_db=self.db, settings=self.settings))
             updated_routers.append(get_approval_router(os_db=self.db, settings=self.settings))
+        else:
+            for prefix, tag in [("/components", "Components"), ("/schedules", "Schedules"), ("/approvals", "Approvals")]:
+                updated_routers.append(_get_disabled_feature_router(prefix, tag, "db"))
+        # Registry router
+        if self.registry is not None:
+            updated_routers.append(get_registry_router(registry=self.registry))
+        else:
+            updated_routers.append(_get_disabled_feature_router("/registry", "Registry", "registry"))
 
         # Clear all previously existing routes
         app.router.routes = [


### PR DESCRIPTION
## Summary

When `db` or `registry` is not passed to `AgentOS(...)`, the `/components`, `/approvals`, `/schedules`, and `/registry` endpoints were never registered with FastAPI, resulting in generic `404 Not Found` errors. The frontend then shows a confusing "Not Found" page state.

This PR registers stub routers that return `503 Service Unavailable` with a clear message like:
> "Components not available: pass a `db` to AgentOS to enable this feature."

This lets the frontend distinguish between "resource not found" (404) and "feature not configured" (503) and show appropriate UI states.

## Type of change

- [x] Bug fix
- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

**Before:** `GET /components` → `404 {"detail": "Not Found"}`
**After:** `GET /components` → `503 {"detail": "Components not available: pass a \`db\` to AgentOS to enable this feature."}`

Changes are in a single file: `libs/agno/agno/os/app.py`. A small `_get_disabled_feature_router()` helper creates catch-all stub routers, keeping the call sites to one-liners. Consistent with the existing 503 pattern already used inside the approval and schedule routers.