### PR TITLE
fix: skip structured output check for opus, sonnet 4.6

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -189,10 +189,14 @@ class Claude(Model):
         # Check for legacy model patterns which don't support structured outputs
         if self.id.startswith("claude-3-"):
             return False
-        if self.id.startswith("claude-sonnet-4-") and not self.id.startswith("claude-sonnet-4-5"):
+        if self.id.startswith("claude-sonnet-4-") and not (
+            self.id.startswith("claude-sonnet-4-5") or self.id.startswith("claude-sonnet-4-6")
+        ):
             return False
         if self.id.startswith("claude-opus-4-") and not (
-            self.id.startswith("claude-opus-4-1") or self.id.startswith("claude-opus-4-5")
+          self.id.startswith("claude-opus-4-1")
+          or self.id.startswith("claude-opus-4-5")
+          or self.id.startswith("claude-opus-4-6")
         ):
             return False
 


### PR DESCRIPTION
## Summary

Resolves recurring `Unexpected error calling Claude API: Model 'claude-sonnet-4-6' does not support structured outputs.`

This occurs when using Anthropic models via AzureAI.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
