### PR TITLE
fix: use composite PK (session_id, session_type) to prevent cross-type session overwriting

### DIFF
--- a/libs/agno/agno/db/migrations/manager.py
+++ b/libs/agno/agno/db/migrations/manager.py
@@ -15,6 +15,7 @@ class MigrationManager:
         ("v2_0_0", packaging_version.parse("2.0.0")),
         ("v2_3_0", packaging_version.parse("2.3.0")),
         ("v2_5_0", packaging_version.parse("2.5.0")),
+        ("v2_6_0", packaging_version.parse("2.6.0")),
     ]
 
     def __init__(self, db: Union[AsyncBaseDb, BaseDb]):

--- a/libs/agno/agno/db/migrations/versions/v2_6_0.py
+++ b/libs/agno/agno/db/migrations/versions/v2_6_0.py
@@ -1,0 +1,450 @@
+"""Migration v2.6.0: Change session primary key to composite (session_id, session_type)
+
+Changes:
+- Replace the single-column PRIMARY KEY (session_id) with a composite
+  PRIMARY KEY (session_id, session_type) so that different session types
+  (agent, team, workflow) can share the same session_id without overwriting
+  each other.
+
+Fixes: https://github.com/agno-agi/agno/issues/6733
+"""
+
+from agno.db.base import AsyncBaseDb, BaseDb
+from agno.db.migrations.utils import quote_db_identifier
+from agno.utils.log import log_error, log_info, log_warning
+
+try:
+    from sqlalchemy import text
+except ImportError:
+    raise ImportError("`sqlalchemy` not installed. Please install it using `pip install sqlalchemy`")
+
+
+def up(db: BaseDb, table_type: str, table_name: str) -> bool:
+    """
+    Change PRIMARY KEY from (session_id) to (session_id, session_type).
+
+    Returns:
+        bool: True if any migration was applied, False otherwise.
+    """
+    db_type = type(db).__name__
+
+    try:
+        if table_type != "sessions":
+            return False
+
+        if db_type == "PostgresDb":
+            return _migrate_postgres(db, table_name)
+        elif db_type == "MySQLDb":
+            return _migrate_mysql(db, table_name)
+        elif db_type in ("SqliteDb", "SingleStoreDb"):
+            # SQLite: cannot ALTER PK; new tables use correct schema automatically.
+            # SingleStore: already uses (session_id, session_type) unique key.
+            return False
+        else:
+            log_info(f"{db_type} does not require schema migrations for v2.6.0")
+        return False
+    except Exception as e:
+        log_error(f"Error running migration v2.6.0 for {db_type} on table {table_name}: {e}")
+        raise
+
+
+async def async_up(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
+    """
+    Change PRIMARY KEY from (session_id) to (session_id, session_type).
+
+    Returns:
+        bool: True if any migration was applied, False otherwise.
+    """
+    db_type = type(db).__name__
+
+    try:
+        if table_type != "sessions":
+            return False
+
+        if db_type == "AsyncPostgresDb":
+            return await _migrate_async_postgres(db, table_name)
+        elif db_type == "AsyncMySQLDb":
+            return await _migrate_async_mysql(db, table_name)
+        elif db_type in ("AsyncSqliteDb",):
+            # SQLite: cannot ALTER PK; new tables use correct schema automatically.
+            return False
+        else:
+            log_info(f"{db_type} does not require schema migrations for v2.6.0")
+        return False
+    except Exception as e:
+        log_error(f"Error running migration v2.6.0 for {db_type} on table {table_name}: {e}")
+        raise
+
+
+def down(db: BaseDb, table_type: str, table_name: str) -> bool:
+    """
+    Revert: change PRIMARY KEY back from (session_id, session_type) to (session_id).
+
+    Returns:
+        bool: True if any migration was reverted, False otherwise.
+    """
+    db_type = type(db).__name__
+
+    try:
+        if table_type != "sessions":
+            return False
+
+        if db_type == "PostgresDb":
+            return _revert_postgres(db, table_name)
+        elif db_type == "MySQLDb":
+            return _revert_mysql(db, table_name)
+        elif db_type in ("SqliteDb", "SingleStoreDb"):
+            return False
+        else:
+            log_info(f"Revert not implemented for {db_type}")
+        return False
+    except Exception as e:
+        log_error(f"Error reverting migration v2.6.0 for {db_type} on table {table_name}: {e}")
+        raise
+
+
+async def async_down(db: AsyncBaseDb, table_type: str, table_name: str) -> bool:
+    """
+    Revert: change PRIMARY KEY back from (session_id, session_type) to (session_id).
+
+    Returns:
+        bool: True if any migration was reverted, False otherwise.
+    """
+    db_type = type(db).__name__
+
+    try:
+        if table_type != "sessions":
+            return False
+
+        if db_type == "AsyncPostgresDb":
+            return await _revert_async_postgres(db, table_name)
+        elif db_type == "AsyncMySQLDb":
+            return await _revert_async_mysql(db, table_name)
+        elif db_type in ("AsyncSqliteDb",):
+            return False
+        else:
+            log_info(f"Revert not implemented for {db_type}")
+        return False
+    except Exception as e:
+        log_error(f"Error reverting migration v2.6.0 for {db_type} on table {table_name}: {e}")
+        raise
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL (sync)
+# ---------------------------------------------------------------------------
+
+
+def _migrate_postgres(db: BaseDb, table_name: str) -> bool:
+    """Change PRIMARY KEY to (session_id, session_type) for PostgreSQL."""
+    db_schema = db.db_schema or "public"  # type: ignore
+    db_type = type(db).__name__
+    quoted_schema = quote_db_identifier(db_type, db_schema)
+    quoted_table = quote_db_identifier(db_type, table_name)
+    full_table = f"{quoted_schema}.{quoted_table}"
+
+    with db.Session() as sess, sess.begin():  # type: ignore
+        # Check if table exists
+        table_exists = sess.execute(
+            text(
+                "SELECT EXISTS ("
+                "  SELECT FROM information_schema.tables"
+                "  WHERE table_schema = :schema AND table_name = :table_name"
+                ")"
+            ),
+            {"schema": db_schema, "table_name": table_name},
+        ).scalar()
+
+        if not table_exists:
+            log_info(f"Table {table_name} does not exist, skipping migration")
+            return False
+
+        # Check if PK already includes session_type (already migrated)
+        pk_columns = _get_pk_columns_postgres(sess, db_schema, table_name)
+        if "session_type" in pk_columns:
+            log_info(f"Table {table_name} already has composite PK (session_id, session_type), skipping")
+            return False
+
+        # Drop the existing PK (session_id only)
+        pk_name = _get_pk_name_postgres(sess, db_schema, table_name)
+        if pk_name:
+            log_info(f"-- Dropping old PRIMARY KEY {pk_name} from {table_name}")
+            sess.execute(text(f"ALTER TABLE {full_table} DROP CONSTRAINT {quote_db_identifier(db_type, pk_name)}"))
+
+        # Add composite PK
+        log_info(f"-- Adding composite PRIMARY KEY (session_id, session_type) to {table_name}")
+        sess.execute(text(f"ALTER TABLE {full_table} ADD PRIMARY KEY (session_id, session_type)"))
+
+        return True
+
+
+def _revert_postgres(db: BaseDb, table_name: str) -> bool:
+    """Revert PRIMARY KEY to (session_id) for PostgreSQL."""
+    db_schema = db.db_schema or "public"  # type: ignore
+    db_type = type(db).__name__
+    quoted_schema = quote_db_identifier(db_type, db_schema)
+    quoted_table = quote_db_identifier(db_type, table_name)
+    full_table = f"{quoted_schema}.{quoted_table}"
+
+    with db.Session() as sess, sess.begin():  # type: ignore
+        table_exists = sess.execute(
+            text(
+                "SELECT EXISTS ("
+                "  SELECT FROM information_schema.tables"
+                "  WHERE table_schema = :schema AND table_name = :table_name"
+                ")"
+            ),
+            {"schema": db_schema, "table_name": table_name},
+        ).scalar()
+
+        if not table_exists:
+            return False
+
+        pk_columns = _get_pk_columns_postgres(sess, db_schema, table_name)
+        if "session_type" not in pk_columns:
+            log_info(f"Table {table_name} does not have composite PK, skipping revert")
+            return False
+
+        pk_name = _get_pk_name_postgres(sess, db_schema, table_name)
+        if pk_name:
+            sess.execute(text(f"ALTER TABLE {full_table} DROP CONSTRAINT {quote_db_identifier(db_type, pk_name)}"))
+
+        sess.execute(text(f"ALTER TABLE {full_table} ADD PRIMARY KEY (session_id)"))
+        return True
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL (async)
+# ---------------------------------------------------------------------------
+
+
+async def _migrate_async_postgres(db: AsyncBaseDb, table_name: str) -> bool:
+    """Change PRIMARY KEY to (session_id, session_type) for async PostgreSQL."""
+    db_schema = db.db_schema or "public"  # type: ignore
+    db_type = type(db).__name__
+    quoted_schema = quote_db_identifier(db_type, db_schema)
+    quoted_table = quote_db_identifier(db_type, table_name)
+    full_table = f"{quoted_schema}.{quoted_table}"
+
+    async with db.async_session_factory() as sess, sess.begin():  # type: ignore
+        result = await sess.execute(
+            text(
+                "SELECT EXISTS ("
+                "  SELECT FROM information_schema.tables"
+                "  WHERE table_schema = :schema AND table_name = :table_name"
+                ")"
+            ),
+            {"schema": db_schema, "table_name": table_name},
+        )
+        table_exists = result.scalar()
+
+        if not table_exists:
+            log_info(f"Table {table_name} does not exist, skipping migration")
+            return False
+
+        pk_columns = await _get_pk_columns_async_postgres(sess, db_schema, table_name)
+        if "session_type" in pk_columns:
+            log_info(f"Table {table_name} already has composite PK (session_id, session_type), skipping")
+            return False
+
+        pk_name = await _get_pk_name_async_postgres(sess, db_schema, table_name)
+        if pk_name:
+            log_info(f"-- Dropping old PRIMARY KEY {pk_name} from {table_name}")
+            await sess.execute(
+                text(f"ALTER TABLE {full_table} DROP CONSTRAINT {quote_db_identifier(db_type, pk_name)}")
+            )
+
+        log_info(f"-- Adding composite PRIMARY KEY (session_id, session_type) to {table_name}")
+        await sess.execute(text(f"ALTER TABLE {full_table} ADD PRIMARY KEY (session_id, session_type)"))
+
+        return True
+
+
+async def _revert_async_postgres(db: AsyncBaseDb, table_name: str) -> bool:
+    """Revert PRIMARY KEY to (session_id) for async PostgreSQL."""
+    db_schema = db.db_schema or "public"  # type: ignore
+    db_type = type(db).__name__
+    quoted_schema = quote_db_identifier(db_type, db_schema)
+    quoted_table = quote_db_identifier(db_type, table_name)
+    full_table = f"{quoted_schema}.{quoted_table}"
+
+    async with db.async_session_factory() as sess, sess.begin():  # type: ignore
+        result = await sess.execute(
+            text(
+                "SELECT EXISTS ("
+                "  SELECT FROM information_schema.tables"
+                "  WHERE table_schema = :schema AND table_name = :table_name"
+                ")"
+            ),
+            {"schema": db_schema, "table_name": table_name},
+        )
+        table_exists = result.scalar()
+
+        if not table_exists:
+            return False
+
+        pk_columns = await _get_pk_columns_async_postgres(sess, db_schema, table_name)
+        if "session_type" not in pk_columns:
+            return False
+
+        pk_name = await _get_pk_name_async_postgres(sess, db_schema, table_name)
+        if pk_name:
+            await sess.execute(
+                text(f"ALTER TABLE {full_table} DROP CONSTRAINT {quote_db_identifier(db_type, pk_name)}")
+            )
+
+        await sess.execute(text(f"ALTER TABLE {full_table} ADD PRIMARY KEY (session_id)"))
+        return True
+
+
+# ---------------------------------------------------------------------------
+# MySQL (sync)
+# ---------------------------------------------------------------------------
+
+
+def _migrate_mysql(db: BaseDb, table_name: str) -> bool:
+    """Change PRIMARY KEY to (session_id, session_type) for MySQL."""
+    db_type = type(db).__name__
+    quoted_table = quote_db_identifier(db_type, table_name)
+
+    with db.Session() as sess, sess.begin():  # type: ignore
+        # Check if table exists
+        result = sess.execute(text(f"SHOW TABLES LIKE '{table_name}'"))
+        if not result.fetchone():
+            log_info(f"Table {table_name} does not exist, skipping migration")
+            return False
+
+        # Check current PK columns
+        pk_result = sess.execute(text(f"SHOW KEYS FROM {quoted_table} WHERE Key_name = 'PRIMARY'"))
+        pk_cols = {row[4] for row in pk_result.fetchall()}
+
+        if "session_type" in pk_cols:
+            log_info(f"Table {table_name} already has composite PK, skipping")
+            return False
+
+        log_info(f"-- Changing PRIMARY KEY to (session_id, session_type) on {table_name}")
+        sess.execute(text(f"ALTER TABLE {quoted_table} DROP PRIMARY KEY, ADD PRIMARY KEY (session_id, session_type)"))
+        return True
+
+
+def _revert_mysql(db: BaseDb, table_name: str) -> bool:
+    """Revert PRIMARY KEY to (session_id) for MySQL."""
+    db_type = type(db).__name__
+    quoted_table = quote_db_identifier(db_type, table_name)
+
+    with db.Session() as sess, sess.begin():  # type: ignore
+        result = sess.execute(text(f"SHOW TABLES LIKE '{table_name}'"))
+        if not result.fetchone():
+            return False
+
+        pk_result = sess.execute(text(f"SHOW KEYS FROM {quoted_table} WHERE Key_name = 'PRIMARY'"))
+        pk_cols = {row[4] for row in pk_result.fetchall()}
+
+        if "session_type" not in pk_cols:
+            return False
+
+        sess.execute(text(f"ALTER TABLE {quoted_table} DROP PRIMARY KEY, ADD PRIMARY KEY (session_id)"))
+        return True
+
+
+# ---------------------------------------------------------------------------
+# MySQL (async)
+# ---------------------------------------------------------------------------
+
+
+async def _migrate_async_mysql(db: AsyncBaseDb, table_name: str) -> bool:
+    """Change PRIMARY KEY to (session_id, session_type) for async MySQL."""
+    db_type = type(db).__name__
+    quoted_table = quote_db_identifier(db_type, table_name)
+
+    async with db.async_session_factory() as sess, sess.begin():  # type: ignore
+        result = await sess.execute(text(f"SHOW TABLES LIKE '{table_name}'"))
+        if not result.fetchone():
+            log_info(f"Table {table_name} does not exist, skipping migration")
+            return False
+
+        pk_result = await sess.execute(text(f"SHOW KEYS FROM {quoted_table} WHERE Key_name = 'PRIMARY'"))
+        pk_cols = {row[4] for row in pk_result.fetchall()}
+
+        if "session_type" in pk_cols:
+            log_info(f"Table {table_name} already has composite PK, skipping")
+            return False
+
+        log_info(f"-- Changing PRIMARY KEY to (session_id, session_type) on {table_name}")
+        await sess.execute(
+            text(f"ALTER TABLE {quoted_table} DROP PRIMARY KEY, ADD PRIMARY KEY (session_id, session_type)")
+        )
+        return True
+
+
+async def _revert_async_mysql(db: AsyncBaseDb, table_name: str) -> bool:
+    """Revert PRIMARY KEY to (session_id) for async MySQL."""
+    db_type = type(db).__name__
+    quoted_table = quote_db_identifier(db_type, table_name)
+
+    async with db.async_session_factory() as sess, sess.begin():  # type: ignore
+        result = await sess.execute(text(f"SHOW TABLES LIKE '{table_name}'"))
+        if not result.fetchone():
+            return False
+
+        pk_result = await sess.execute(text(f"SHOW KEYS FROM {quoted_table} WHERE Key_name = 'PRIMARY'"))
+        pk_cols = {row[4] for row in pk_result.fetchall()}
+
+        if "session_type" not in pk_cols:
+            return False
+
+        await sess.execute(text(f"ALTER TABLE {quoted_table} DROP PRIMARY KEY, ADD PRIMARY KEY (session_id)"))
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def _get_pk_columns_postgres(sess, db_schema: str, table_name: str) -> set:
+    """Get the column names of the primary key for a PostgreSQL table."""
+    result = sess.execute(
+        text(
+            "SELECT a.attname "
+            "FROM pg_index i "
+            "JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) "
+            "WHERE i.indrelid = :full_name::regclass AND i.indisprimary"
+        ),
+        {"full_name": f"{db_schema}.{table_name}"},
+    )
+    return {row[0] for row in result.fetchall()}
+
+
+def _get_pk_name_postgres(sess, db_schema: str, table_name: str) -> str:
+    """Get the name of the primary key constraint for a PostgreSQL table."""
+    result = sess.execute(
+        text("SELECT conname FROM pg_constraint WHERE conrelid = :full_name::regclass AND contype = 'p'"),
+        {"full_name": f"{db_schema}.{table_name}"},
+    )
+    row = result.fetchone()
+    return row[0] if row else ""
+
+
+async def _get_pk_columns_async_postgres(sess, db_schema: str, table_name: str) -> set:
+    """Get the column names of the primary key for an async PostgreSQL table."""
+    result = await sess.execute(
+        text(
+            "SELECT a.attname "
+            "FROM pg_index i "
+            "JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) "
+            "WHERE i.indrelid = :full_name::regclass AND i.indisprimary"
+        ),
+        {"full_name": f"{db_schema}.{table_name}"},
+    )
+    return {row[0] for row in result.fetchall()}
+
+
+async def _get_pk_name_async_postgres(sess, db_schema: str, table_name: str) -> str:
+    """Get the name of the primary key constraint for an async PostgreSQL table."""
+    result = await sess.execute(
+        text("SELECT conname FROM pg_constraint WHERE conrelid = :full_name::regclass AND contype = 'p'"),
+        {"full_name": f"{db_schema}.{table_name}"},
+    )
+    row = result.fetchone()
+    return row[0] if row else ""

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -598,11 +598,10 @@ class AsyncMongoDb(AsyncBaseDb):
             if collection is None:
                 return None
 
-            query = {"session_id": session_id}
+            session_type_value = session_type.value if isinstance(session_type, SessionType) else session_type
+            query = {"session_id": session_id, "session_type": session_type_value}
             if user_id is not None:
                 query["user_id"] = user_id
-            if session_type is not None:
-                query["session_type"] = session_type
 
             result = await collection.find_one(query)
             if result is None:
@@ -825,14 +824,28 @@ class AsyncMongoDb(AsyncBaseDb):
 
             session_dict = session.to_dict()
 
-            existing = await collection.find_one({"session_id": session_dict.get("session_id")}, {"user_id": 1})
+            # Determine session_type from session class
+            if isinstance(session, AgentSession):
+                session_type_value = SessionType.AGENT.value
+            elif isinstance(session, TeamSession):
+                session_type_value = SessionType.TEAM.value
+            else:
+                session_type_value = SessionType.WORKFLOW.value
+
+            existing = await collection.find_one(
+                {"session_id": session_dict.get("session_id"), "session_type": session_type_value},
+                {"user_id": 1},
+            )
             if existing:
                 existing_uid = existing.get("user_id")
                 if existing_uid is not None and existing_uid != session_dict.get("user_id"):
                     return None
 
             incoming_uid = session_dict.get("user_id")
-            upsert_filter: Dict[str, Any] = {"session_id": session_dict.get("session_id")}
+            upsert_filter: Dict[str, Any] = {
+                "session_id": session_dict.get("session_id"),
+                "session_type": session_type_value,
+            }
             if incoming_uid is not None:
                 upsert_filter["$or"] = [{"user_id": incoming_uid}, {"user_id": None}, {"user_id": {"$exists": False}}]
             else:

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -383,7 +383,8 @@ class MongoDb(BaseDb):
             if collection is None:
                 return None
 
-            query = {"session_id": session_id}
+            session_type_value = session_type.value if isinstance(session_type, SessionType) else session_type
+            query = {"session_id": session_id, "session_type": session_type_value}
             if user_id is not None:
                 query["user_id"] = user_id
 
@@ -608,14 +609,28 @@ class MongoDb(BaseDb):
 
             session_dict = session.to_dict()
 
-            existing = collection.find_one({"session_id": session_dict.get("session_id")}, {"user_id": 1})
+            # Determine session_type from session class
+            if isinstance(session, AgentSession):
+                session_type_value = SessionType.AGENT.value
+            elif isinstance(session, TeamSession):
+                session_type_value = SessionType.TEAM.value
+            else:
+                session_type_value = SessionType.WORKFLOW.value
+
+            existing = collection.find_one(
+                {"session_id": session_dict.get("session_id"), "session_type": session_type_value},
+                {"user_id": 1},
+            )
             if existing:
                 existing_uid = existing.get("user_id")
                 if existing_uid is not None and existing_uid != session_dict.get("user_id"):
                     return None
 
             incoming_uid = session_dict.get("user_id")
-            upsert_filter: Dict[str, Any] = {"session_id": session_dict.get("session_id")}
+            upsert_filter: Dict[str, Any] = {
+                "session_id": session_dict.get("session_id"),
+                "session_type": session_type_value,
+            }
             if incoming_uid is not None:
                 upsert_filter["$or"] = [{"user_id": incoming_uid}, {"user_id": None}, {"user_id": {"$exists": False}}]
             else:

--- a/libs/agno/agno/db/mongo/schemas.py
+++ b/libs/agno/agno/db/mongo/schemas.py
@@ -3,7 +3,7 @@
 from typing import Any, Dict, List
 
 SESSION_COLLECTION_SCHEMA = [
-    {"key": "session_id", "unique": True},
+    {"key": [("session_id", 1), ("session_type", 1)], "unique": True},
     {"key": "user_id"},
     {"key": "session_type"},
     {"key": "agent_id"},

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -849,7 +849,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                         updated_at=session_dict.get("created_at"),
                     )
                     stmt = stmt.on_conflict_do_update(  # type: ignore
-                        index_elements=["session_id"],
+                        index_elements=["session_id", "session_type"],
                         set_=dict(
                             agent_id=session_dict.get("agent_id"),
                             user_id=session_dict.get("user_id"),
@@ -890,7 +890,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                         updated_at=session_dict.get("created_at"),
                     )
                     stmt = stmt.on_conflict_do_update(  # type: ignore
-                        index_elements=["session_id"],
+                        index_elements=["session_id", "session_type"],
                         set_=dict(
                             team_id=session_dict.get("team_id"),
                             user_id=session_dict.get("user_id"),
@@ -931,7 +931,7 @@ class AsyncPostgresDb(AsyncBaseDb):
                         updated_at=session_dict.get("created_at"),
                     )
                     stmt = stmt.on_conflict_do_update(  # type: ignore
-                        index_elements=["session_id"],
+                        index_elements=["session_id", "session_type"],
                         set_=dict(
                             workflow_id=session_dict.get("workflow_id"),
                             user_id=session_dict.get("user_id"),

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -1018,7 +1018,7 @@ class PostgresDb(BaseDb):
                         updated_at=session_dict.get("created_at"),
                     )
                     stmt = stmt.on_conflict_do_update(  # type: ignore
-                        index_elements=["session_id"],
+                        index_elements=["session_id", "session_type"],
                         set_=dict(
                             agent_id=session_dict.get("agent_id"),
                             user_id=session_dict.get("user_id"),
@@ -1057,7 +1057,7 @@ class PostgresDb(BaseDb):
                         updated_at=session_dict.get("created_at"),
                     )
                     stmt = stmt.on_conflict_do_update(  # type: ignore
-                        index_elements=["session_id"],
+                        index_elements=["session_id", "session_type"],
                         set_=dict(
                             team_id=session_dict.get("team_id"),
                             user_id=session_dict.get("user_id"),
@@ -1096,7 +1096,7 @@ class PostgresDb(BaseDb):
                         updated_at=session_dict.get("created_at"),
                     )
                     stmt = stmt.on_conflict_do_update(  # type: ignore
-                        index_elements=["session_id"],
+                        index_elements=["session_id", "session_type"],
                         set_=dict(
                             workflow_id=session_dict.get("workflow_id"),
                             user_id=session_dict.get("user_id"),
@@ -1198,10 +1198,10 @@ class PostgresDb(BaseDb):
                     update_columns = {
                         col.name: stmt.excluded[col.name]
                         for col in table.columns
-                        if col.name not in ["id", "session_id", "created_at"]
+                        if col.name not in ["id", "session_id", "session_type", "created_at"]
                     }
                     stmt = stmt.on_conflict_do_update(
-                        index_elements=["session_id"],
+                        index_elements=["session_id", "session_type"],
                         set_=update_columns,
                         where=(table.c.user_id == stmt.excluded.user_id) | (table.c.user_id.is_(None)),
                     ).returning(table)
@@ -1257,10 +1257,10 @@ class PostgresDb(BaseDb):
                     update_columns = {
                         col.name: stmt.excluded[col.name]
                         for col in table.columns
-                        if col.name not in ["id", "session_id", "created_at"]
+                        if col.name not in ["id", "session_id", "session_type", "created_at"]
                     }
                     stmt = stmt.on_conflict_do_update(
-                        index_elements=["session_id"],
+                        index_elements=["session_id", "session_type"],
                         set_=update_columns,
                         where=(table.c.user_id == stmt.excluded.user_id) | (table.c.user_id.is_(None)),
                     ).returning(table)
@@ -1316,10 +1316,10 @@ class PostgresDb(BaseDb):
                     update_columns = {
                         col.name: stmt.excluded[col.name]
                         for col in table.columns
-                        if col.name not in ["id", "session_id", "created_at"]
+                        if col.name not in ["id", "session_id", "session_type", "created_at"]
                     }
                     stmt = stmt.on_conflict_do_update(
-                        index_elements=["session_id"],
+                        index_elements=["session_id", "session_type"],
                         set_=update_columns,
                         where=(table.c.user_id == stmt.excluded.user_id) | (table.c.user_id.is_(None)),
                     ).returning(table)

--- a/libs/agno/agno/db/postgres/schemas.py
+++ b/libs/agno/agno/db/postgres/schemas.py
@@ -9,7 +9,7 @@ except ImportError:
     raise ImportError("`sqlalchemy` not installed. Please install it using `pip install sqlalchemy`")
 
 SESSION_TABLE_SCHEMA = {
-    "session_id": {"type": String, "primary_key": True, "nullable": False},
+    "session_id": {"type": String, "nullable": False},
     "session_type": {"type": String, "nullable": False, "index": True},
     "agent_id": {"type": String, "nullable": True},
     "team_id": {"type": String, "nullable": True},
@@ -24,6 +24,7 @@ SESSION_TABLE_SCHEMA = {
     "summary": {"type": JSONB, "nullable": True},
     "created_at": {"type": BigInteger, "nullable": False, "index": True},
     "updated_at": {"type": BigInteger, "nullable": True},
+    "__primary_key__": ["session_id", "session_type"],
 }
 
 MEMORY_TABLE_SCHEMA = {

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -571,7 +571,9 @@ class AsyncSqliteDb(AsyncBaseDb):
                 return None
 
             async with self.async_session_factory() as sess, sess.begin():
+                session_type_value = session_type.value if isinstance(session_type, SessionType) else session_type
                 stmt = select(table).where(table.c.session_id == session_id)
+                stmt = stmt.where(table.c.session_type == session_type_value)
 
                 # Filtering
                 if user_id is not None:
@@ -787,7 +789,7 @@ class AsyncSqliteDb(AsyncBaseDb):
                         updated_at=serialized_session.get("created_at"),
                     )
                     stmt = stmt.on_conflict_do_update(
-                        index_elements=["session_id"],
+                        index_elements=["session_id", "session_type"],
                         set_=dict(
                             agent_id=serialized_session.get("agent_id"),
                             user_id=serialized_session.get("user_id"),
@@ -826,7 +828,7 @@ class AsyncSqliteDb(AsyncBaseDb):
                     )
 
                     stmt = stmt.on_conflict_do_update(
-                        index_elements=["session_id"],
+                        index_elements=["session_id", "session_type"],
                         set_=dict(
                             team_id=serialized_session.get("team_id"),
                             user_id=serialized_session.get("user_id"),
@@ -864,7 +866,7 @@ class AsyncSqliteDb(AsyncBaseDb):
                         metadata=serialized_session.get("metadata"),
                     )
                     stmt = stmt.on_conflict_do_update(
-                        index_elements=["session_id"],
+                        index_elements=["session_id", "session_type"],
                         set_=dict(
                             workflow_id=serialized_session.get("workflow_id"),
                             user_id=serialized_session.get("user_id"),
@@ -967,7 +969,7 @@ class AsyncSqliteDb(AsyncBaseDb):
                     if agent_data:
                         stmt = sqlite.insert(table)
                         stmt = stmt.on_conflict_do_update(
-                            index_elements=["session_id"],
+                            index_elements=["session_id", "session_type"],
                             set_=dict(
                                 agent_id=stmt.excluded.agent_id,
                                 user_id=stmt.excluded.user_id,
@@ -1022,7 +1024,7 @@ class AsyncSqliteDb(AsyncBaseDb):
                     if team_data:
                         stmt = sqlite.insert(table)
                         stmt = stmt.on_conflict_do_update(
-                            index_elements=["session_id"],
+                            index_elements=["session_id", "session_type"],
                             set_=dict(
                                 team_id=stmt.excluded.team_id,
                                 user_id=stmt.excluded.user_id,
@@ -1077,7 +1079,7 @@ class AsyncSqliteDb(AsyncBaseDb):
                     if workflow_data:
                         stmt = sqlite.insert(table)
                         stmt = stmt.on_conflict_do_update(
-                            index_elements=["session_id"],
+                            index_elements=["session_id", "session_type"],
                             set_=dict(
                                 workflow_id=stmt.excluded.workflow_id,
                                 user_id=stmt.excluded.user_id,

--- a/libs/agno/agno/db/sqlite/schemas.py
+++ b/libs/agno/agno/db/sqlite/schemas.py
@@ -9,7 +9,7 @@ except ImportError:
 
 
 SESSION_TABLE_SCHEMA = {
-    "session_id": {"type": String, "primary_key": True, "nullable": False},
+    "session_id": {"type": String, "nullable": False},
     "session_type": {"type": String, "nullable": False, "index": True},
     "agent_id": {"type": String, "nullable": True},
     "team_id": {"type": String, "nullable": True},
@@ -24,6 +24,7 @@ SESSION_TABLE_SCHEMA = {
     "summary": {"type": JSON, "nullable": True},
     "created_at": {"type": BigInteger, "nullable": False, "index": True},
     "updated_at": {"type": BigInteger, "nullable": True},
+    "__primary_key__": ["session_id", "session_type"],
 }
 
 USER_MEMORY_TABLE_SCHEMA = {

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -740,7 +740,9 @@ class SqliteDb(BaseDb):
                 return None
 
             with self.Session() as sess, sess.begin():
+                session_type_value = session_type.value if isinstance(session_type, SessionType) else session_type
                 stmt = select(table).where(table.c.session_id == session_id)
+                stmt = stmt.where(table.c.session_type == session_type_value)
 
                 # Filtering
                 if user_id is not None:
@@ -955,7 +957,7 @@ class SqliteDb(BaseDb):
                         updated_at=serialized_session.get("created_at"),
                     )
                     stmt = stmt.on_conflict_do_update(
-                        index_elements=["session_id"],
+                        index_elements=["session_id", "session_type"],
                         set_=dict(
                             agent_id=serialized_session.get("agent_id"),
                             user_id=serialized_session.get("user_id"),
@@ -994,7 +996,7 @@ class SqliteDb(BaseDb):
                     )
 
                     stmt = stmt.on_conflict_do_update(
-                        index_elements=["session_id"],
+                        index_elements=["session_id", "session_type"],
                         set_=dict(
                             team_id=serialized_session.get("team_id"),
                             user_id=serialized_session.get("user_id"),
@@ -1032,7 +1034,7 @@ class SqliteDb(BaseDb):
                         metadata=serialized_session.get("metadata"),
                     )
                     stmt = stmt.on_conflict_do_update(
-                        index_elements=["session_id"],
+                        index_elements=["session_id", "session_type"],
                         set_=dict(
                             workflow_id=serialized_session.get("workflow_id"),
                             user_id=serialized_session.get("user_id"),
@@ -1135,7 +1137,7 @@ class SqliteDb(BaseDb):
                     if agent_data:
                         stmt = sqlite.insert(table)
                         stmt = stmt.on_conflict_do_update(
-                            index_elements=["session_id"],
+                            index_elements=["session_id", "session_type"],
                             set_=dict(
                                 agent_id=stmt.excluded.agent_id,
                                 user_id=stmt.excluded.user_id,
@@ -1190,7 +1192,7 @@ class SqliteDb(BaseDb):
                     if team_data:
                         stmt = sqlite.insert(table)
                         stmt = stmt.on_conflict_do_update(
-                            index_elements=["session_id"],
+                            index_elements=["session_id", "session_type"],
                             set_=dict(
                                 team_id=stmt.excluded.team_id,
                                 user_id=stmt.excluded.user_id,
@@ -1245,7 +1247,7 @@ class SqliteDb(BaseDb):
                     if workflow_data:
                         stmt = sqlite.insert(table)
                         stmt = stmt.on_conflict_do_update(
-                            index_elements=["session_id"],
+                            index_elements=["session_id", "session_type"],
                             set_=dict(
                                 workflow_id=stmt.excluded.workflow_id,
                                 user_id=stmt.excluded.user_id,

--- a/libs/agno/tests/unit/db/test_postgres.py
+++ b/libs/agno/tests/unit/db/test_postgres.py
@@ -375,7 +375,7 @@ def test_get_table_schema_definition_sessions():
     assert schema == SESSION_TABLE_SCHEMA
     assert "session_id" in schema
     assert schema["session_id"]["nullable"] is False
-    assert schema["session_id"]["primary_key"] is True
+    assert schema["__primary_key__"] == ["session_id", "session_type"]
 
 
 def test_get_table_schema_definition_memories():

--- a/libs/agno/tests/unit/db/test_session_type_isolation.py
+++ b/libs/agno/tests/unit/db/test_session_type_isolation.py
@@ -1,0 +1,170 @@
+"""Tests that sessions with the same session_id but different session_types
+are stored independently and do not overwrite each other.
+
+Regression tests for https://github.com/agno-agi/agno/issues/6733
+"""
+
+import time
+
+import pytest
+
+from agno.db.base import SessionType
+from agno.db.sqlite.sqlite import SqliteDb
+from agno.session.agent import AgentSession
+from agno.session.team import TeamSession
+from agno.session.workflow import WorkflowSession
+
+
+@pytest.fixture
+def db(tmp_path):
+    """Create a SQLite database in a temporary directory."""
+    db = SqliteDb(db_url=f"sqlite:///{tmp_path}/test.db")
+    return db
+
+
+def _now():
+    return int(time.time())
+
+
+class TestSessionTypeIsolation:
+    """Verify that Agent, Team, and Workflow sessions with the same
+    session_id coexist independently in the database."""
+
+    def test_agent_and_team_same_session_id(self, db):
+        """An AgentSession upsert must NOT overwrite an existing TeamSession
+        that has the same session_id."""
+        shared_id = "shared-session-001"
+
+        # 1. Upsert a TeamSession
+        team_session = TeamSession(
+            session_id=shared_id,
+            team_id="team-alpha",
+            session_data={"note": "team data"},
+            created_at=_now(),
+        )
+        result = db.upsert_session(team_session)
+        assert result is not None
+        assert isinstance(result, TeamSession)
+        assert result.team_id == "team-alpha"
+
+        # 2. Upsert an AgentSession with the SAME session_id
+        agent_session = AgentSession(
+            session_id=shared_id,
+            agent_id="agent-beta",
+            session_data={"note": "agent data"},
+            created_at=_now(),
+        )
+        result = db.upsert_session(agent_session)
+        assert result is not None
+        assert isinstance(result, AgentSession)
+        assert result.agent_id == "agent-beta"
+
+        # 3. Verify the TeamSession is still intact
+        team_result = db.get_session(shared_id, SessionType.TEAM)
+        assert team_result is not None
+        assert isinstance(team_result, TeamSession)
+        assert team_result.team_id == "team-alpha"
+        assert team_result.session_data["note"] == "team data"
+
+        # 4. Verify the AgentSession is also intact
+        agent_result = db.get_session(shared_id, SessionType.AGENT)
+        assert agent_result is not None
+        assert isinstance(agent_result, AgentSession)
+        assert agent_result.agent_id == "agent-beta"
+        assert agent_result.session_data["note"] == "agent data"
+
+    def test_all_three_types_same_session_id(self, db):
+        """Agent, Team, and Workflow sessions should all coexist with
+        the same session_id."""
+        shared_id = "shared-session-002"
+        ts = _now()
+
+        db.upsert_session(AgentSession(session_id=shared_id, agent_id="a1", created_at=ts))
+        db.upsert_session(TeamSession(session_id=shared_id, team_id="t1", created_at=ts))
+        db.upsert_session(WorkflowSession(session_id=shared_id, workflow_id="w1", created_at=ts))
+
+        agent_result = db.get_session(shared_id, SessionType.AGENT)
+        team_result = db.get_session(shared_id, SessionType.TEAM)
+        workflow_result = db.get_session(shared_id, SessionType.WORKFLOW)
+
+        assert isinstance(agent_result, AgentSession)
+        assert agent_result.agent_id == "a1"
+
+        assert isinstance(team_result, TeamSession)
+        assert team_result.team_id == "t1"
+
+        assert isinstance(workflow_result, WorkflowSession)
+        assert workflow_result.workflow_id == "w1"
+
+    def test_upsert_updates_correct_session_type(self, db):
+        """Updating an AgentSession should not affect a TeamSession with
+        the same session_id."""
+        shared_id = "shared-session-003"
+        ts = _now()
+
+        # Create both
+        db.upsert_session(
+            TeamSession(
+                session_id=shared_id,
+                team_id="t1",
+                session_data={"note": "original team"},
+                created_at=ts,
+            )
+        )
+        db.upsert_session(
+            AgentSession(
+                session_id=shared_id,
+                agent_id="a1",
+                session_data={"note": "original agent"},
+                created_at=ts,
+            )
+        )
+
+        # Update only the AgentSession
+        db.upsert_session(
+            AgentSession(
+                session_id=shared_id,
+                agent_id="a1",
+                session_data={"note": "updated agent"},
+                created_at=ts,
+            )
+        )
+
+        # Team session must be unchanged
+        team_result = db.get_session(shared_id, SessionType.TEAM)
+        assert isinstance(team_result, TeamSession)
+        assert team_result.session_data["note"] == "original team"
+
+        # Agent session must be updated
+        agent_result = db.get_session(shared_id, SessionType.AGENT)
+        assert isinstance(agent_result, AgentSession)
+        assert agent_result.session_data["note"] == "updated agent"
+
+    def test_bulk_upsert_preserves_isolation(self, db):
+        """Bulk upsert of agent sessions should not overwrite team sessions
+        with the same session_ids."""
+        shared_id = "shared-session-005"
+        ts = _now()
+
+        # Create a team session first
+        db.upsert_session(
+            TeamSession(
+                session_id=shared_id,
+                team_id="t1",
+                session_data={"note": "team data"},
+                created_at=ts,
+            )
+        )
+
+        # Bulk upsert agent sessions including one with the same session_id
+        agent_sessions = [
+            AgentSession(session_id=shared_id, agent_id="a1", created_at=ts),
+            AgentSession(session_id="unique-agent-session", agent_id="a2", created_at=ts),
+        ]
+        db.upsert_sessions(agent_sessions)
+
+        # Team session must be preserved
+        team_result = db.get_session(shared_id, SessionType.TEAM)
+        assert team_result is not None
+        assert isinstance(team_result, TeamSession)
+        assert team_result.session_data["note"] == "team data"


### PR DESCRIPTION
## Summary

When a standalone Agent uses the same `session_id` as a Team, the Agent's upsert overwrites the Team's entire session history because the database uniqueness constraint (and primary key) is based solely on `session_id`, ignoring `session_type`.

This is the exact scenario described in #6733: a Team creates a session with `session_id="abc"`, then an independent Agent also uses `session_id="abc"`. The Agent's `ON CONFLICT (session_id) DO UPDATE` hits the Team's row and replaces all Team data (runs, team_data, session_type) with Agent data.

**Root cause:** The primary key / unique constraint on the sessions table only covers `session_id`, but the system stores Agent, Team, and Workflow sessions in the same table with a `session_type` discriminator column.

**Fix:** Change the primary key to a composite `(session_id, session_type)` so that different session types with the same `session_id` are stored as independent rows.

Note: SingleStore already had the correct `UNIQUE KEY (session_id, session_type)` constraint — this fix aligns all other backends with that pattern.

Fixes #6733

## Changes

### Schema
- **PostgreSQL** (`postgres/schemas.py`): Replace `primary_key: True` on `session_id` with `__primary_key__: ["session_id", "session_type"]`
- **SQLite** (`sqlite/schemas.py`): Same change
- **MongoDB** (`mongo/schemas.py`): Change unique index from `{"key": "session_id"}` to `{"key": [("session_id", 1), ("session_type", 1)]}`

### Upserts (all backends, sync + async)
- Update all `on_conflict_do_update(index_elements=["session_id"])` to `index_elements=["session_id", "session_type"]` (PostgreSQL, SQLite)
- Update MongoDB `upsert_filter` and `find_one` to include `session_type`
- Exclude `session_type` from bulk upsert update columns in PostgreSQL

### Reads
- Add `session_type` filter to `get_session()` in SQLite (sync + async) and MongoDB (sync) where it was missing
  - PostgreSQL already had this filter

### Migration
- Add `v2_6_0.py` migration to alter the primary key from `(session_id)` to `(session_id, session_type)` for PostgreSQL (sync + async) and MySQL (sync + async)
- Register migration in `MigrationManager`

### Tests
- Add `test_session_type_isolation.py` with 4 regression tests using SQLite:
  - Agent and Team sessions coexist with same session_id
  - All three types (Agent, Team, Workflow) coexist
  - Updating one type doesn't affect others
  - Bulk upsert preserves cross-type isolation

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: N/A
- [x] Tested in clean environment
- [x] Tests added/updated

---

## Additional Notes

- **Backward compatibility**: The migration script handles existing databases by altering the primary key constraint. Existing data is preserved since session_id values are typically unique UUIDs.
- **Backends covered**: PostgreSQL, SQLite, MongoDB (sync + async for all). MySQL migration is included but not tested locally.
- **SingleStore**: Already had the correct composite unique key — no changes needed.
- **Other backends** (Redis, DynamoDB, Firestore, SurrealDB, GCS JSON, JSON file): May need similar fixes in follow-up PRs if they use session_id-only constraints.