### PR TITLE
[fix] Carry forward previous iteration output in Loop step

### DIFF
--- a/libs/agno/agno/workflow/loop.py
+++ b/libs/agno/agno/workflow/loop.py
@@ -412,6 +412,12 @@ class Loop:
                 )
 
             all_results.append(iteration_results)
+
+            # Carry forward the last iteration's output so the next iteration
+            # sees it via get_last_step_content() instead of the pre-loop input.
+            if iteration_results:
+                step_input = self._update_step_input_from_outputs(step_input, iteration_results[-1], loop_step_outputs)
+
             iteration += 1
 
             # Check end condition
@@ -571,6 +577,12 @@ class Loop:
                         )
 
             all_results.append(iteration_results)
+
+            # Carry forward the last iteration's output so the next iteration
+            # sees it via get_last_step_content() instead of the pre-loop input.
+            if iteration_results:
+                step_input = self._update_step_input_from_outputs(step_input, iteration_results[-1], loop_step_outputs)
+
             iteration += 1
 
             # Check end condition
@@ -713,6 +725,12 @@ class Loop:
                 )
 
             all_results.append(iteration_results)
+
+            # Carry forward the last iteration's output so the next iteration
+            # sees it via get_last_step_content() instead of the pre-loop input.
+            if iteration_results:
+                step_input = self._update_step_input_from_outputs(step_input, iteration_results[-1], loop_step_outputs)
+
             iteration += 1
 
             # Check end condition
@@ -872,6 +890,12 @@ class Loop:
                         )
 
             all_results.append(iteration_results)
+
+            # Carry forward the last iteration's output so the next iteration
+            # sees it via get_last_step_content() instead of the pre-loop input.
+            if iteration_results:
+                step_input = self._update_step_input_from_outputs(step_input, iteration_results[-1], loop_step_outputs)
+
             iteration += 1
 
             # Check end condition

--- a/libs/agno/tests/unit/workflow/test_loop_carry_forward.py
+++ b/libs/agno/tests/unit/workflow/test_loop_carry_forward.py
@@ -1,0 +1,215 @@
+"""
+Unit tests for Loop carry-forward behavior.
+
+Verifies that get_last_step_content() returns the previous iteration's
+output rather than the pre-loop step output, fixing issue #6862.
+"""
+
+from typing import List
+
+import pytest
+
+from agno.workflow.loop import Loop
+from agno.workflow.step import Step
+from agno.workflow.types import StepInput, StepOutput
+
+# =============================================================================
+# Executor helpers
+# =============================================================================
+
+
+def increment_executor(step_input: StepInput) -> StepOutput:
+    """Increment the numeric content from the previous step by 10."""
+    last_content = step_input.get_last_step_content()
+    if last_content is not None and str(last_content).isdigit():
+        new_value = int(last_content) + 10
+        return StepOutput(content=str(new_value))
+    return StepOutput(content="0")
+
+
+def accumulate_executor(step_input: StepInput) -> StepOutput:
+    """Append iteration marker to previous content to track carry-forward."""
+    last_content = step_input.get_last_step_content() or ""
+    return StepOutput(content=f"{last_content}+iter")
+
+
+def _make_initial_input(value: str) -> StepInput:
+    """Create a StepInput that mimics what a workflow passes to a Loop.
+
+    In a real workflow, the step preceding the Loop produces a StepOutput
+    and the workflow engine sets both ``previous_step_content`` and
+    ``previous_step_outputs`` on the StepInput handed to the Loop.
+    """
+    return StepInput(
+        input=value,
+        previous_step_content=value,
+        previous_step_outputs={
+            "Initial Step": StepOutput(step_name="Initial Step", content=value),
+        },
+    )
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+class TestLoopCarryForward:
+    """Tests that Loop carries forward previous iteration output."""
+
+    def test_execute_carries_forward_output(self):
+        """Loop.execute should pass previous iteration output to next iteration."""
+        loop = Loop(
+            name="increment-loop",
+            steps=[
+                Step(
+                    name="increment",
+                    description="Increment by 10",
+                    executor=increment_executor,
+                ),
+            ],
+            max_iterations=3,
+        )
+
+        result = loop.execute(_make_initial_input("35"))
+
+        # After 3 iterations: 35 -> 45 -> 55 -> 65
+        assert result.steps is not None
+        assert len(result.steps) == 3
+        assert result.steps[0].content == "45"  # iteration 1: 35 + 10
+        assert result.steps[1].content == "55"  # iteration 2: 45 + 10
+        assert result.steps[2].content == "65"  # iteration 3: 55 + 10
+
+    def test_execute_end_condition_with_carry_forward(self):
+        """Loop should terminate early when end_condition is met with carried-forward output."""
+
+        def end_when_ge_50(results: List[StepOutput]) -> bool:
+            return int(results[-1].content) >= 50
+
+        loop = Loop(
+            name="end-condition-loop",
+            steps=[
+                Step(
+                    name="increment",
+                    description="Increment by 10",
+                    executor=increment_executor,
+                ),
+            ],
+            max_iterations=10,
+            end_condition=end_when_ge_50,
+        )
+
+        result = loop.execute(_make_initial_input("35"))
+
+        # iteration 1: 35 + 10 = 45 (not >= 50, continue)
+        # iteration 2: 45 + 10 = 55 (>= 50, stop)
+        assert result.steps is not None
+        assert len(result.steps) == 2
+        assert result.steps[0].content == "45"
+        assert result.steps[1].content == "55"
+
+    def test_execute_accumulate_carry_forward(self):
+        """Loop should accumulate content across iterations via carry-forward."""
+        loop = Loop(
+            name="accumulate-loop",
+            steps=[
+                Step(
+                    name="accumulate",
+                    description="Append iteration marker",
+                    executor=accumulate_executor,
+                ),
+            ],
+            max_iterations=3,
+        )
+
+        result = loop.execute(_make_initial_input("start"))
+
+        assert result.steps is not None
+        assert len(result.steps) == 3
+        assert result.steps[0].content == "start+iter"
+        assert result.steps[1].content == "start+iter+iter"
+        assert result.steps[2].content == "start+iter+iter+iter"
+
+    def test_execute_stream_carries_forward_output(self):
+        """Loop.execute_stream should carry forward previous iteration output."""
+        from agno.workflow.types import StepType
+
+        loop = Loop(
+            name="stream-increment-loop",
+            steps=[
+                Step(
+                    name="increment",
+                    description="Increment by 10",
+                    executor=increment_executor,
+                ),
+            ],
+            max_iterations=3,
+        )
+
+        events = list(loop.execute_stream(_make_initial_input("35")))
+
+        # In streaming mode, child StepOutputs are collected internally;
+        # only the final Loop StepOutput is yielded with nested steps.
+        loop_outputs = [e for e in events if isinstance(e, StepOutput) and e.step_type == StepType.LOOP]
+        assert len(loop_outputs) == 1
+        result = loop_outputs[0]
+
+        assert result.steps is not None
+        assert len(result.steps) == 3
+        assert result.steps[0].content == "45"
+        assert result.steps[1].content == "55"
+        assert result.steps[2].content == "65"
+
+    @pytest.mark.asyncio
+    async def test_aexecute_carries_forward_output(self):
+        """Loop.aexecute should carry forward previous iteration output."""
+        loop = Loop(
+            name="async-increment-loop",
+            steps=[
+                Step(
+                    name="increment",
+                    description="Increment by 10",
+                    executor=increment_executor,
+                ),
+            ],
+            max_iterations=3,
+        )
+
+        result = await loop.aexecute(_make_initial_input("35"))
+
+        assert result.steps is not None
+        assert len(result.steps) == 3
+        assert result.steps[0].content == "45"
+        assert result.steps[1].content == "55"
+        assert result.steps[2].content == "65"
+
+    @pytest.mark.asyncio
+    async def test_aexecute_stream_carries_forward_output(self):
+        """Loop.aexecute_stream should carry forward previous iteration output."""
+        from agno.workflow.types import StepType
+
+        loop = Loop(
+            name="async-stream-increment-loop",
+            steps=[
+                Step(
+                    name="increment",
+                    description="Increment by 10",
+                    executor=increment_executor,
+                ),
+            ],
+            max_iterations=3,
+        )
+
+        events = []
+        async for event in loop.aexecute_stream(_make_initial_input("35")):
+            events.append(event)
+
+        loop_outputs = [e for e in events if isinstance(e, StepOutput) and e.step_type == StepType.LOOP]
+        assert len(loop_outputs) == 1
+        result = loop_outputs[0]
+
+        assert result.steps is not None
+        assert len(result.steps) == 3
+        assert result.steps[0].content == "45"
+        assert result.steps[1].content == "55"
+        assert result.steps[2].content == "65"


### PR DESCRIPTION
## Summary

Fix Loop to carry forward previous iteration's output to `get_last_step_content()`.

When a `Loop` runs multiple iterations, each iteration's step receives the **same input** (the output from the step before the Loop) rather than the output from the previous loop iteration. This makes it impossible to build iterative workflows where each iteration builds on the previous one.

The fix updates `step_input` at the end of each iteration using `_update_step_input_from_outputs()`, so the next iteration sees the previous iteration's output via `get_last_step_content()`. This is applied consistently across all four execution methods: `execute`, `execute_stream`, `aexecute`, and `aexecute_stream`.

Fixes #6862

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

**Root cause**: In `Loop.execute()` (and its stream/async variants), `current_step_input` is reset to the original `step_input` at the start of each iteration. Since `step_input` is never updated between iterations, every iteration receives the same pre-loop input.

**Fix**: After each iteration completes, update `step_input` with the last iteration's output using `_update_step_input_from_outputs()`. This way, when the next iteration sets `current_step_input = step_input`, it correctly receives the previous iteration's output.

**Tests**: Added 6 unit tests covering all execution paths (sync, async, stream, async-stream) plus end-condition and accumulation scenarios.