### PR TITLE
fix: pass agent metadata to OpenInference tracing spans

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -366,11 +366,15 @@ def _run(
         update_run_response,
     )
     from agno.agent._storage import load_session_state, read_or_create_session, update_metadata
-    from agno.agent._telemetry import log_agent_telemetry
+    from agno.agent._telemetry import log_agent_telemetry, set_tracing_metadata
     from agno.agent._tools import determine_tools_for_model
 
     register_run(run_context.run_id)
     log_debug(f"Agent Run Start: {run_response.run_id}", center=True)
+
+    # Propagate agent metadata to the active OpenTelemetry span so that
+    # observability backends (e.g. Langfuse via OpenInference) can display it.
+    set_tracing_metadata(agent)
 
     memory_future = None
     learning_future = None
@@ -750,11 +754,15 @@ def _run_stream(
         parse_response_with_parser_model_stream,
     )
     from agno.agent._storage import load_session_state, read_or_create_session, update_metadata
-    from agno.agent._telemetry import log_agent_telemetry
+    from agno.agent._telemetry import log_agent_telemetry, set_tracing_metadata
     from agno.agent._tools import determine_tools_for_model
 
     register_run(run_context.run_id)
     log_debug(f"Agent Run Start: {run_response.run_id}", center=True)
+
+    # Propagate agent metadata to the active OpenTelemetry span so that
+    # observability backends (e.g. Langfuse via OpenInference) can display it.
+    set_tracing_metadata(agent)
 
     memory_future = None
     learning_future = None
@@ -1430,11 +1438,15 @@ async def _arun(
         update_run_response,
     )
     from agno.agent._storage import aread_or_create_session, load_session_state, update_metadata
-    from agno.agent._telemetry import alog_agent_telemetry
+    from agno.agent._telemetry import alog_agent_telemetry, set_tracing_metadata
     from agno.agent._tools import determine_tools_for_model
 
     await aregister_run(run_context.run_id)
     log_debug(f"Agent Run Start: {run_response.run_id}", center=True)
+
+    # Propagate agent metadata to the active OpenTelemetry span so that
+    # observability backends (e.g. Langfuse via OpenInference) can display it.
+    set_tracing_metadata(agent)
 
     memory_task = None
     learning_task = None
@@ -1928,11 +1940,15 @@ async def _arun_stream(
         aparse_response_with_parser_model_stream,
     )
     from agno.agent._storage import aread_or_create_session, load_session_state, update_metadata
-    from agno.agent._telemetry import alog_agent_telemetry
+    from agno.agent._telemetry import alog_agent_telemetry, set_tracing_metadata
     from agno.agent._tools import determine_tools_for_model
 
     await aregister_run(run_context.run_id)
     log_debug(f"Agent Run Start: {run_response.run_id}", center=True)
+
+    # Propagate agent metadata to the active OpenTelemetry span so that
+    # observability backends (e.g. Langfuse via OpenInference) can display it.
+    set_tracing_metadata(agent)
 
     memory_task = None
     cultural_knowledge_task = None

--- a/libs/agno/agno/agent/_telemetry.py
+++ b/libs/agno/agno/agent/_telemetry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 if TYPE_CHECKING:
@@ -56,6 +57,40 @@ def log_agent_telemetry(agent: Agent, session_id: str, run_id: Optional[str] = N
         )
     except Exception as e:
         log_debug(f"Could not create Agent run telemetry event: {e}")
+
+
+def set_tracing_metadata(agent: Agent) -> None:
+    """Propagate agent metadata to the active OpenTelemetry span.
+
+    When OpenInference instrumentation wraps the agent run functions, it creates
+    a span and makes it the active span via ``trace_api.use_span``.  The
+    instrumentation already extracts several agent attributes (name, tools, etc.)
+    but does **not** read ``agent.metadata``.  This helper bridges the gap by
+    writing the metadata dict to the current span so that it appears in
+    observability backends such as Langfuse.
+
+    The function is a no-op when:
+    - ``agent.metadata`` is empty/None
+    - OpenTelemetry is not installed
+    - There is no active valid span (i.e. the agent is not being traced)
+    """
+    if not agent.metadata:
+        return
+
+    try:
+        from opentelemetry import trace as trace_api  # type: ignore[import-not-found]
+    except ImportError:
+        return
+
+    span = trace_api.get_current_span()
+    if span is None or not span.is_recording():
+        return
+
+    try:
+        span.set_attribute("metadata", json.dumps(agent.metadata, ensure_ascii=False))
+    except Exception:
+        # Never let tracing metadata propagation break the agent run.
+        pass
 
 
 async def alog_agent_telemetry(agent: Agent, session_id: str, run_id: Optional[str] = None) -> None:

--- a/libs/agno/tests/unit/telemetry/test_tracing_metadata.py
+++ b/libs/agno/tests/unit/telemetry/test_tracing_metadata.py
@@ -1,0 +1,121 @@
+"""Tests for set_tracing_metadata: agent metadata propagation to OTel spans."""
+
+import json
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+from agno.agent._telemetry import set_tracing_metadata
+
+
+def _make_agent(metadata=None):
+    """Create a minimal Agent-like object with a metadata attribute."""
+    agent = MagicMock()
+    agent.metadata = metadata
+    return agent
+
+
+def _install_fake_otel():
+    """Install a fake opentelemetry.trace module into sys.modules and return the mock span getter."""
+    fake_trace = ModuleType("opentelemetry.trace")
+    fake_otel = ModuleType("opentelemetry")
+    fake_otel.trace = fake_trace  # type: ignore[attr-defined]
+
+    mock_get_current_span = MagicMock()
+    fake_trace.get_current_span = mock_get_current_span  # type: ignore[attr-defined]
+
+    sys.modules["opentelemetry"] = fake_otel
+    sys.modules["opentelemetry.trace"] = fake_trace
+
+    return mock_get_current_span
+
+
+def _uninstall_fake_otel():
+    """Remove fake opentelemetry modules from sys.modules."""
+    sys.modules.pop("opentelemetry.trace", None)
+    sys.modules.pop("opentelemetry", None)
+
+
+class TestSetTracingMetadata:
+    """Unit tests for set_tracing_metadata."""
+
+    def test_noop_when_metadata_is_none(self):
+        """Should not touch OTel when metadata is None."""
+        agent = _make_agent(metadata=None)
+        # set_tracing_metadata should return early without importing opentelemetry
+        set_tracing_metadata(agent)
+
+    def test_noop_when_metadata_is_empty(self):
+        """Should not touch OTel when metadata is an empty dict."""
+        agent = _make_agent(metadata={})
+        set_tracing_metadata(agent)
+
+    def test_noop_when_opentelemetry_not_installed(self):
+        """Should silently skip when opentelemetry is not installed."""
+        agent = _make_agent(metadata={"key": "value"})
+        # Ensure opentelemetry is NOT available
+        _uninstall_fake_otel()
+        # Should not raise
+        set_tracing_metadata(agent)
+
+    def test_sets_metadata_on_active_span(self):
+        """Should set serialized metadata on the active recording span."""
+        agent = _make_agent(metadata={"department": "finance", "cost_center": "dept_123"})
+
+        mock_span = MagicMock()
+        mock_span.is_recording.return_value = True
+
+        mock_get = _install_fake_otel()
+        mock_get.return_value = mock_span
+        try:
+            set_tracing_metadata(agent)
+
+            expected = json.dumps(
+                {"department": "finance", "cost_center": "dept_123"},
+                ensure_ascii=False,
+            )
+            mock_span.set_attribute.assert_called_once_with("metadata", expected)
+        finally:
+            _uninstall_fake_otel()
+
+    def test_noop_when_span_not_recording(self):
+        """Should not set attributes on a non-recording span."""
+        agent = _make_agent(metadata={"key": "value"})
+
+        mock_span = MagicMock()
+        mock_span.is_recording.return_value = False
+
+        mock_get = _install_fake_otel()
+        mock_get.return_value = mock_span
+        try:
+            set_tracing_metadata(agent)
+            mock_span.set_attribute.assert_not_called()
+        finally:
+            _uninstall_fake_otel()
+
+    def test_noop_when_no_active_span(self):
+        """Should not raise when get_current_span returns None."""
+        agent = _make_agent(metadata={"key": "value"})
+
+        mock_get = _install_fake_otel()
+        mock_get.return_value = None
+        try:
+            set_tracing_metadata(agent)
+        finally:
+            _uninstall_fake_otel()
+
+    def test_exception_in_set_attribute_is_swallowed(self):
+        """Should never let tracing errors break the agent run."""
+        agent = _make_agent(metadata={"key": "value"})
+
+        mock_span = MagicMock()
+        mock_span.is_recording.return_value = True
+        mock_span.set_attribute.side_effect = RuntimeError("boom")
+
+        mock_get = _install_fake_otel()
+        mock_get.return_value = mock_span
+        try:
+            # Should not raise
+            set_tracing_metadata(agent)
+        finally:
+            _uninstall_fake_otel()


### PR DESCRIPTION
## Summary

Agent's custom `metadata` dict was not being propagated to OpenInference tracing spans, so it never appeared in observability backends like Langfuse.

Added a `set_tracing_metadata()` helper in `agno/agent/_telemetry.py` that writes `agent.metadata` as a JSON-serialized `"metadata"` attribute on the active OpenTelemetry span. It is called from all four agent run entry points (`_run`, `_run_stream`, `_arun`, `_arun_stream`).

The function is a safe no-op when:
- `agent.metadata` is `None` or empty
- OpenTelemetry is not installed
- There is no active recording span

Closes #6859

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

The OpenInference instrumentation wrapper (`openinference-instrumentation-agno`) already extracts agent name, tools, knowledge, etc. via `_agent_run_attributes()`, but it does not read `agent.metadata`. Rather than waiting for an upstream fix in the external package, this PR bridges the gap from the agno side by writing metadata to the active span inside the wrapped `_run` functions, where the span is already active via `trace_api.use_span()`.

The `"metadata"` attribute key follows the [OpenInference semantic convention](https://github.com/Arize-ai/openinference/blob/main/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py#L216) (`SpanAttributes.METADATA = "metadata"`).

### Test plan

- [x] 7 unit tests added in `tests/unit/telemetry/test_tracing_metadata.py` covering:
  - No-op when metadata is None/empty
  - No-op when OpenTelemetry is not installed
  - Correct serialization on active recording span
  - No-op on non-recording span
  - No-op when no active span
  - Exception swallowing (tracing never breaks agent run)
- [x] All 19 existing telemetry tests continue to pass