### PR TITLE
feat: emit StateSnapshot and StateDelta events in AG-UI streaming

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -11,6 +11,7 @@ try:
         RunAgentInput,
         RunErrorEvent,
         RunStartedEvent,
+        StateSnapshotEvent,
     )
     from ag_ui.encoder import EventEncoder
 except ImportError as e:
@@ -49,6 +50,10 @@ async def run_agent(agent: Union[Agent, RemoteAgent], run_input: RunAgentInput) 
         # Validating the session state is of the expected type (dict)
         session_state = validate_agui_state(run_input.state, run_input.thread_id)
 
+        # Emit initial state snapshot if state is provided
+        if session_state is not None:
+            yield StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot=session_state)
+
         # Request streaming response from agent
         response_stream = agent.arun(  # type: ignore
             input=messages,
@@ -65,6 +70,7 @@ async def run_agent(agent: Union[Agent, RemoteAgent], run_input: RunAgentInput) 
             response_stream=response_stream,  # type: ignore
             thread_id=run_input.thread_id,
             run_id=run_id,
+            run_state=session_state,
         ):
             yield event
 
@@ -90,6 +96,10 @@ async def run_team(team: Union[Team, RemoteTeam], input: RunAgentInput) -> Async
         # Validating the session state is of the expected type (dict)
         session_state = validate_agui_state(input.state, input.thread_id)
 
+        # Emit initial state snapshot if state is provided
+        if session_state is not None:
+            yield StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot=session_state)
+
         # Request streaming response from team
         response_stream = team.arun(  # type: ignore
             input=messages,
@@ -103,7 +113,7 @@ async def run_team(team: Union[Team, RemoteTeam], input: RunAgentInput) -> Async
 
         # Stream the response content in AG-UI format
         async for event in async_stream_agno_response_as_agui_events(
-            response_stream=response_stream, thread_id=input.thread_id, run_id=run_id
+            response_stream=response_stream, thread_id=input.thread_id, run_id=run_id, run_state=session_state
         ):
             yield event
 

--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -1,9 +1,10 @@
 """Logic used by the AG-UI router."""
 
+import copy
 import json
 import uuid
 from collections.abc import Iterator
-from dataclasses import asdict, dataclass, is_dataclass
+from dataclasses import asdict, dataclass, field, is_dataclass
 from typing import Any, AsyncIterator, Dict, List, Optional, Set, Tuple, Union
 
 from ag_ui.core import (
@@ -11,6 +12,8 @@ from ag_ui.core import (
     CustomEvent,
     EventType,
     RunFinishedEvent,
+    StateDeltaEvent,
+    StateSnapshotEvent,
     StepFinishedEvent,
     StepStartedEvent,
     TextMessageContentEvent,
@@ -73,6 +76,7 @@ class EventBuffer:
     current_text_message_id: str = ""  # ID of the current text message context (for tool call parenting)
     next_text_message_id: str = ""  # Pre-generated ID for the next text message
     pending_tool_calls_parent_id: str = ""  # Parent message ID for pending tool calls
+    _last_snapshot: Optional[Dict[str, Any]] = field(default=None, repr=False)
 
     def __init__(self):
         self.active_tool_call_ids = set()
@@ -80,6 +84,7 @@ class EventBuffer:
         self.current_text_message_id = ""
         self.next_text_message_id = str(uuid.uuid4())
         self.pending_tool_calls_parent_id = ""
+        self._last_snapshot = None
 
     def start_tool_call(self, tool_call_id: str) -> None:
         """Start a new tool call."""
@@ -112,6 +117,29 @@ class EventBuffer:
     def clear_pending_tool_calls_parent_id(self) -> None:
         """Clear the pending parent ID when a new text message starts."""
         self.pending_tool_calls_parent_id = ""
+
+    def set_state_snapshot(self, state: Dict[str, Any]) -> None:
+        """Store deep copy of current state for delta computation."""
+        self._last_snapshot = copy.deepcopy(state)
+
+    def compute_state_delta(self, current_state: Dict[str, Any]) -> Optional[List[Any]]:
+        """Compute JSON Patch delta between last snapshot and current state.
+
+        Returns a list of JSON Patch ops (RFC 6902) or None if unchanged/error.
+        """
+        if self._last_snapshot is None:
+            return None
+        try:
+            import jsonpatch
+
+            patch = jsonpatch.make_patch(self._last_snapshot, current_state)
+            ops = patch.patch
+            if not ops:
+                return None
+            return ops
+        except Exception as e:
+            log_warning(f"Failed to compute state delta: {e}")
+            return None
 
 
 def convert_agui_messages_to_agno_messages(messages: List[AGUIMessage]) -> List[Message]:
@@ -192,11 +220,27 @@ def extract_response_chunk_content(response: RunContentEvent) -> str:
     return get_text_from_message(response.content) if response.content is not None else ""
 
 
+def _create_state_delta_events(
+    run_state: Optional[Dict[str, Any]],
+    event_buffer: EventBuffer,
+) -> List[BaseEvent]:
+    """Compute state delta and return StateDeltaEvent if state changed."""
+    if run_state is None:
+        return []
+    ops = event_buffer.compute_state_delta(run_state)
+    if ops is None:
+        return []
+    # Update the snapshot to current state for next delta computation
+    event_buffer.set_state_snapshot(run_state)
+    return [StateDeltaEvent(type=EventType.STATE_DELTA, delta=ops)]
+
+
 def _create_events_from_chunk(
     chunk: Union[RunOutputEvent, TeamRunOutputEvent],
     message_id: str,
     message_started: bool,
     event_buffer: EventBuffer,
+    run_state: Optional[Dict[str, Any]] = None,
 ) -> Tuple[List[BaseEvent], bool, str]:
     """
     Process a single chunk and return events to emit + updated message_started state.
@@ -206,6 +250,7 @@ def _create_events_from_chunk(
         message_id: Current message identifier
         message_started: Whether a message is currently active
         event_buffer: Event buffer for tracking tool call state
+        run_state: Mutable dict reference to the agent's session state (for delta tracking)
 
     Returns:
         Tuple of (events_to_emit, new_message_started_state, message_id)
@@ -326,6 +371,9 @@ def _create_events_from_chunk(
                     )
                     events_to_emit.append(result_event)
 
+                # Emit state delta after tool call completion (state may have been mutated by the tool)
+                events_to_emit.extend(_create_state_delta_events(run_state, event_buffer))
+
     # Handle reasoning
     elif chunk.event == RunEvent.reasoning_started:
         step_started_event = StepStartedEvent(type=EventType.STEP_STARTED, step_name="reasoning")
@@ -361,6 +409,7 @@ def _create_completion_events(
     message_id: str,
     thread_id: str,
     run_id: str,
+    run_state: Optional[Dict[str, Any]] = None,
 ) -> List[BaseEvent]:
     """Create events for run completion."""
     events_to_emit: List[BaseEvent] = []
@@ -434,6 +483,13 @@ def _create_completion_events(
                 )
                 events_to_emit.append(end_event)
 
+    # Emit final state snapshot before finishing the run (only if frontend opted into state tracking)
+    if run_state is not None:
+        # Use session_state from RunCompletedEvent (authoritative) if available, otherwise fall back to run_state
+        final_state = getattr(chunk, "session_state", None) or run_state
+        snapshot_event = StateSnapshotEvent(type=EventType.STATE_SNAPSHOT, snapshot=final_state)
+        events_to_emit.append(snapshot_event)
+
     run_finished_event = RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id=thread_id, run_id=run_id)
     events_to_emit.append(run_finished_event)
 
@@ -458,13 +514,20 @@ def _emit_event_logic(event: BaseEvent, event_buffer: EventBuffer) -> List[BaseE
 
 
 def stream_agno_response_as_agui_events(
-    response_stream: Iterator[Union[RunOutputEvent, TeamRunOutputEvent]], thread_id: str, run_id: str
+    response_stream: Iterator[Union[RunOutputEvent, TeamRunOutputEvent]],
+    thread_id: str,
+    run_id: str,
+    run_state: Optional[Dict[str, Any]] = None,
 ) -> Iterator[BaseEvent]:
     """Map the Agno response stream to AG-UI format, handling event ordering constraints."""
     message_id = ""  # Will be set by EventBuffer when text message starts
     message_started = False
     event_buffer = EventBuffer()
     stream_completed = False
+
+    # Establish baseline state snapshot for delta tracking
+    if run_state is not None:
+        event_buffer.set_state_snapshot(run_state)
 
     completion_chunk = None
 
@@ -481,7 +544,7 @@ def stream_agno_response_as_agui_events(
         else:
             # Process regular chunk immediately
             events_from_chunk, message_started, message_id = _create_events_from_chunk(
-                chunk, message_id, message_started, event_buffer
+                chunk, message_id, message_started, event_buffer, run_state=run_state
             )
 
             for event in events_from_chunk:
@@ -492,7 +555,7 @@ def stream_agno_response_as_agui_events(
     # Process ONLY completion cleanup events, not content from completion chunk
     if completion_chunk:
         completion_events = _create_completion_events(
-            completion_chunk, event_buffer, message_started, message_id, thread_id, run_id
+            completion_chunk, event_buffer, message_started, message_id, thread_id, run_id, run_state=run_state
         )
         for event in completion_events:
             events_to_emit = _emit_event_logic(event_buffer=event_buffer, event=event)
@@ -506,7 +569,7 @@ def stream_agno_response_as_agui_events(
 
         synthetic_completion = RunCompletedEvent()
         completion_events = _create_completion_events(
-            synthetic_completion, event_buffer, message_started, message_id, thread_id, run_id
+            synthetic_completion, event_buffer, message_started, message_id, thread_id, run_id, run_state=run_state
         )
         for event in completion_events:
             events_to_emit = _emit_event_logic(event_buffer=event_buffer, event=event)
@@ -519,12 +582,17 @@ async def async_stream_agno_response_as_agui_events(
     response_stream: AsyncIterator[Union[RunOutputEvent, TeamRunOutputEvent]],
     thread_id: str,
     run_id: str,
+    run_state: Optional[Dict[str, Any]] = None,
 ) -> AsyncIterator[BaseEvent]:
     """Map the Agno response stream to AG-UI format, handling event ordering constraints."""
     message_id = ""  # Will be set by EventBuffer when text message starts
     message_started = False
     event_buffer = EventBuffer()
     stream_completed = False
+
+    # Establish baseline state snapshot for delta tracking
+    if run_state is not None:
+        event_buffer.set_state_snapshot(run_state)
 
     completion_chunk = None
 
@@ -541,7 +609,7 @@ async def async_stream_agno_response_as_agui_events(
         else:
             # Process regular chunk immediately
             events_from_chunk, message_started, message_id = _create_events_from_chunk(
-                chunk, message_id, message_started, event_buffer
+                chunk, message_id, message_started, event_buffer, run_state=run_state
             )
 
             for event in events_from_chunk:
@@ -552,7 +620,7 @@ async def async_stream_agno_response_as_agui_events(
     # Process ONLY completion cleanup events, not content from completion chunk
     if completion_chunk:
         completion_events = _create_completion_events(
-            completion_chunk, event_buffer, message_started, message_id, thread_id, run_id
+            completion_chunk, event_buffer, message_started, message_id, thread_id, run_id, run_state=run_state
         )
         for event in completion_events:
             events_to_emit = _emit_event_logic(event_buffer=event_buffer, event=event)
@@ -566,7 +634,7 @@ async def async_stream_agno_response_as_agui_events(
 
         synthetic_completion = RunCompletedEvent()
         completion_events = _create_completion_events(
-            synthetic_completion, event_buffer, message_started, message_id, thread_id, run_id
+            synthetic_completion, event_buffer, message_started, message_id, thread_id, run_id, run_state=run_state
         )
         for event in completion_events:
             events_to_emit = _emit_event_logic(event_buffer=event_buffer, event=event)

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -181,7 +181,7 @@ markdown = ["unstructured<0.18.31", "markdown", "aiofiles"]
 chonkie = ["chonkie[semantic]", "chonkie[code]", "chonkie"]
 
 # Dependencies for AG-UI integration
-agui = ["ag-ui-protocol"]
+agui = ["ag-ui-protocol", "jsonpatch"]
 
 # Dependencies for A2A integration
 a2a = ["a2a-sdk"]
@@ -476,6 +476,7 @@ module = [
   "imghdr.*",
   "infinity_client.*",
   "jira.*",
+  "jsonpatch.*",
   "jwt.*",
   "kubernetes.*",
   "lancedb.*",

--- a/libs/agno/tests/unit/app/test_agui_app.py
+++ b/libs/agno/tests/unit/app/test_agui_app.py
@@ -1358,3 +1358,211 @@ def test_validate_agui_state_with_invalid_to_dict():
     obj = TestClass()
     result = validate_agui_state(obj, "test_thread")
     assert result is None
+
+
+# --- State Events Tests ---
+
+
+def test_event_buffer_state_snapshot_deep_copy():
+    """Test EventBuffer state snapshot stores a deep copy and computes deltas correctly."""
+    buffer = EventBuffer()
+
+    state = {"score": 0, "items": ["a"]}
+    buffer.set_state_snapshot(state)
+
+    # Verify deep copy: mutating original dict should not affect snapshot
+    state["score"] = 10
+    state["items"].append("b")
+
+    delta = buffer.compute_state_delta(state)
+    assert delta is not None
+    # Should have ops for score change and items change
+    ops_paths = [op["path"] for op in delta]
+    assert "/score" in ops_paths
+
+    # No change should return None
+    buffer.set_state_snapshot(state)
+    delta = buffer.compute_state_delta(state)
+    assert delta is None
+
+
+def test_event_buffer_compute_delta_no_snapshot():
+    """Test compute_state_delta returns None when no snapshot has been set."""
+    buffer = EventBuffer()
+    result = buffer.compute_state_delta({"key": "value"})
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_final_state_snapshot_at_completion():
+    """Test that a StateSnapshotEvent is emitted before RUN_FINISHED when state is provided."""
+    from agno.run.agent import RunCompletedEvent, RunEvent
+
+    final_state = {"score": 42, "done": True}
+
+    async def mock_stream():
+        text_response = RunContentEvent()
+        text_response.event = RunEvent.run_content
+        text_response.content = "Done"
+        yield text_response
+
+        completed = RunCompletedEvent()
+        completed.event = RunEvent.run_completed
+        completed.content = ""
+        completed.session_state = final_state
+        yield completed
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(
+        mock_stream(), "thread_1", "run_1", run_state={"score": 0}
+    ):
+        events.append(event)
+
+    event_types = [e.type for e in events]
+    assert EventType.STATE_SNAPSHOT in event_types
+    assert EventType.RUN_FINISHED in event_types
+
+    # StateSnapshotEvent must come before RUN_FINISHED
+    snapshot_idx = event_types.index(EventType.STATE_SNAPSHOT)
+    finished_idx = event_types.index(EventType.RUN_FINISHED)
+    assert snapshot_idx < finished_idx
+
+    # The snapshot should use the authoritative session_state from RunCompletedEvent
+    snapshot_event = events[snapshot_idx]
+    assert snapshot_event.snapshot == final_state
+
+
+@pytest.mark.asyncio
+async def test_state_delta_after_tool_call():
+    """Test that a StateDeltaEvent is emitted when state changes during a tool call."""
+    from agno.run.agent import RunEvent
+
+    # Shared mutable state dict (same reference the agent would use)
+    run_state = {"counter": 0, "status": "idle"}
+
+    async def mock_stream():
+        text_response = RunContentEvent()
+        text_response.event = RunEvent.run_content
+        text_response.content = "Processing"
+        yield text_response
+
+        tool_start = ToolCallStartedEvent()
+        tool_start.event = RunEvent.tool_call_started
+        tool_start.content = ""
+        tool = MagicMock()
+        tool.tool_call_id = "tool_1"
+        tool.tool_name = "increment"
+        tool.tool_args = {}
+        tool_start.tool = tool
+        yield tool_start
+
+        # Simulate agent mutating state during tool execution (before tool_call_completed)
+        run_state["counter"] = 1
+        run_state["status"] = "active"
+
+        tool_end = ToolCallCompletedEvent()
+        tool_end.event = RunEvent.tool_call_completed
+        tool_end.content = ""
+        tool.result = "incremented"
+        tool_end.tool = tool
+        yield tool_end
+
+        completed = RunContentEvent()
+        completed.event = RunEvent.run_completed
+        completed.content = ""
+        yield completed
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(
+        mock_stream(), "thread_1", "run_1", run_state=run_state
+    ):
+        events.append(event)
+
+    event_types = [e.type for e in events]
+    assert EventType.STATE_DELTA in event_types
+
+    # StateDelta should come after ToolCallResult
+    delta_idx = event_types.index(EventType.STATE_DELTA)
+    result_idx = event_types.index(EventType.TOOL_CALL_RESULT)
+    assert delta_idx > result_idx
+
+    # Verify the delta contains the right operations
+    delta_event = events[delta_idx]
+    delta_paths = [op["path"] for op in delta_event.delta]
+    assert "/counter" in delta_paths
+    assert "/status" in delta_paths
+
+
+@pytest.mark.asyncio
+async def test_no_state_events_when_no_state():
+    """Test backward compatibility: no state events when run_state is None."""
+    from agno.run.agent import RunEvent
+
+    async def mock_stream():
+        text_response = RunContentEvent()
+        text_response.event = RunEvent.run_content
+        text_response.content = "Hello"
+        yield text_response
+
+        completed = RunContentEvent()
+        completed.event = RunEvent.run_completed
+        completed.content = ""
+        yield completed
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream(), "thread_1", "run_1"):
+        events.append(event)
+
+    event_types = [e.type for e in events]
+    assert EventType.STATE_SNAPSHOT not in event_types
+    assert EventType.STATE_DELTA not in event_types
+
+
+@pytest.mark.asyncio
+async def test_no_delta_when_state_unchanged():
+    """Test that no StateDeltaEvent is emitted when a tool call does not mutate state."""
+    from agno.run.agent import RunEvent
+
+    run_state = {"counter": 0}
+
+    async def mock_stream():
+        text_response = RunContentEvent()
+        text_response.event = RunEvent.run_content
+        text_response.content = "Processing"
+        yield text_response
+
+        tool_start = ToolCallStartedEvent()
+        tool_start.event = RunEvent.tool_call_started
+        tool_start.content = ""
+        tool = MagicMock()
+        tool.tool_call_id = "tool_1"
+        tool.tool_name = "noop"
+        tool.tool_args = {}
+        tool_start.tool = tool
+        yield tool_start
+
+        # State is NOT mutated here
+
+        tool_end = ToolCallCompletedEvent()
+        tool_end.event = RunEvent.tool_call_completed
+        tool_end.content = ""
+        tool.result = "done"
+        tool_end.tool = tool
+        yield tool_end
+
+        completed = RunContentEvent()
+        completed.event = RunEvent.run_completed
+        completed.content = ""
+        yield completed
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(
+        mock_stream(), "thread_1", "run_1", run_state=run_state
+    ):
+        events.append(event)
+
+    event_types = [e.type for e in events]
+    # No delta should be emitted since state was not changed
+    assert EventType.STATE_DELTA not in event_types
+    # But a final snapshot should still be emitted (run_state fallback)
+    assert EventType.STATE_SNAPSHOT in event_types

--- a/libs/agno/tests/unit/app/test_agui_state_e2e.py
+++ b/libs/agno/tests/unit/app/test_agui_state_e2e.py
@@ -1,0 +1,314 @@
+"""End-to-end integration test for AG-UI state events (StateSnapshot + StateDelta).
+
+Tests the full pipeline: router -> streaming -> event emission, using mock agent responses.
+Also includes real API tests that run when OPENAI_API_KEY is set.
+"""
+
+import json
+import os
+import uuid
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import APIRouter, FastAPI
+
+from agno.agent.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.os.interfaces.agui.router import attach_routes
+from agno.run.agent import (
+    RunCompletedEvent,
+    RunContentEvent,
+    RunEvent,
+    ToolCallCompletedEvent,
+    ToolCallStartedEvent,
+)
+from agno.tools import tool
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+
+def make_agui_payload(messages, state=None):
+    """Build a valid RunAgentInput payload with all required fields."""
+    return {
+        "threadId": str(uuid.uuid4()),
+        "runId": str(uuid.uuid4()),
+        "state": state,
+        "messages": [{"id": str(uuid.uuid4()), "role": m["role"], "content": m["content"]} for m in messages],
+        "tools": [],
+        "context": [],
+        "forwardedProps": {},
+    }
+
+
+@tool
+def increment_counter(amount: int = 1) -> str:
+    """Increment the counter in session state by the given amount."""
+    return f"Counter incremented by {amount}"
+
+
+@pytest.fixture
+def agent():
+    return Agent(
+        name="StateTestAgent",
+        model=OpenAIChat(id="gpt-4o-mini"),
+        tools=[increment_counter],
+        instructions="You are a test agent.",
+        markdown=False,
+    )
+
+
+@pytest.fixture
+def app(agent):
+    test_app = FastAPI()
+    router = APIRouter()
+    attach_routes(router, agent=agent)
+    test_app.include_router(router)
+    return test_app
+
+
+def parse_sse_events(raw: str) -> list:
+    """Parse SSE text into a list of event dicts."""
+    events = []
+    for block in raw.strip().split("\n\n"):
+        event_data = {}
+        for line in block.split("\n"):
+            if line.startswith("event:"):
+                event_data["event"] = line[len("event:") :].strip()
+            elif line.startswith("data:"):
+                data_str = line[len("data:") :].strip()
+                try:
+                    event_data["data"] = json.loads(data_str)
+                except json.JSONDecodeError:
+                    event_data["data"] = data_str
+        if event_data:
+            events.append(event_data)
+    return events
+
+
+def get_event_types(events):
+    """Extract event types from parsed SSE events."""
+    return [e.get("data", {}).get("type") if isinstance(e.get("data"), dict) else None for e in events]
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (mocked agent, real router + streaming pipeline)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_router_emits_state_snapshot_with_state(app, agent):
+    """Integration test: router emits initial StateSnapshot when state is provided."""
+    from httpx import ASGITransport
+
+    async def mock_arun_stream(*args, **kwargs):
+        text = RunContentEvent()
+        text.event = RunEvent.run_content
+        text.content = "Hello"
+        yield text
+
+        completed = RunCompletedEvent()
+        completed.event = RunEvent.run_completed
+        completed.content = ""
+        completed.session_state = {"counter": 0, "label": "test"}
+        yield completed
+
+    with patch.object(agent, "arun", side_effect=mock_arun_stream):
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            response = await client.post(
+                "/agui",
+                json=make_agui_payload(
+                    messages=[{"role": "user", "content": "Hi"}],
+                    state={"counter": 0, "label": "test"},
+                ),
+                timeout=30.0,
+            )
+
+    assert response.status_code == 200
+    events = parse_sse_events(response.text)
+    event_types = get_event_types(events)
+
+    # Must have RUN_STARTED, STATE_SNAPSHOT (initial + final), RUN_FINISHED
+    assert "RUN_STARTED" in event_types
+    assert event_types.count("STATE_SNAPSHOT") >= 2, f"Expected >= 2 snapshots, got: {event_types}"
+    assert "RUN_FINISHED" in event_types
+
+    # Initial snapshot right after RUN_STARTED
+    run_started_idx = event_types.index("RUN_STARTED")
+    first_snapshot_idx = event_types.index("STATE_SNAPSHOT")
+    assert first_snapshot_idx == run_started_idx + 1
+
+    # Final snapshot right before RUN_FINISHED
+    run_finished_idx = event_types.index("RUN_FINISHED")
+    last_snapshot_idx = len(event_types) - 1 - event_types[::-1].index("STATE_SNAPSHOT")
+    assert last_snapshot_idx == run_finished_idx - 1
+
+    # Verify initial snapshot content
+    first_snapshot_data = events[first_snapshot_idx]["data"]
+    assert first_snapshot_data["snapshot"] == {"counter": 0, "label": "test"}
+
+
+@pytest.mark.asyncio
+async def test_router_no_state_events_without_state(app, agent):
+    """Integration test: no state events when state is not provided."""
+    from httpx import ASGITransport
+
+    async def mock_arun_stream(*args, **kwargs):
+        text = RunContentEvent()
+        text.event = RunEvent.run_content
+        text.content = "Hello"
+        yield text
+
+        completed = RunCompletedEvent()
+        completed.event = RunEvent.run_completed
+        completed.content = ""
+        yield completed
+
+    with patch.object(agent, "arun", side_effect=mock_arun_stream):
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            response = await client.post(
+                "/agui",
+                json=make_agui_payload(
+                    messages=[{"role": "user", "content": "Hi"}],
+                    state=None,
+                ),
+                timeout=30.0,
+            )
+
+    assert response.status_code == 200
+    events = parse_sse_events(response.text)
+    event_types = get_event_types(events)
+
+    assert "STATE_SNAPSHOT" not in event_types
+    assert "STATE_DELTA" not in event_types
+    assert "RUN_FINISHED" in event_types
+
+
+@pytest.mark.asyncio
+async def test_router_state_delta_after_tool_mutation(app, agent):
+    """Integration test: StateDelta emitted when tool mutates state."""
+    from httpx import ASGITransport
+
+    # The mutable state dict passed through the pipeline
+    mutable_state = {"counter": 0}
+
+    async def mock_arun_stream(*args, **kwargs):
+        text = RunContentEvent()
+        text.event = RunEvent.run_content
+        text.content = "Let me increment"
+        yield text
+
+        tool_start = ToolCallStartedEvent()
+        tool_start.event = RunEvent.tool_call_started
+        tool_start.content = ""
+        tool_mock = MagicMock()
+        tool_mock.tool_call_id = "tc_1"
+        tool_mock.tool_name = "increment_counter"
+        tool_mock.tool_args = {"amount": 1}
+        tool_start.tool = tool_mock
+        yield tool_start
+
+        # Simulate state mutation that happens during tool execution
+        mutable_state["counter"] = 5
+
+        tool_end = ToolCallCompletedEvent()
+        tool_end.event = RunEvent.tool_call_completed
+        tool_end.content = ""
+        tool_mock.result = "Counter incremented"
+        tool_end.tool = tool_mock
+        yield tool_end
+
+        completed = RunCompletedEvent()
+        completed.event = RunEvent.run_completed
+        completed.content = ""
+        completed.session_state = {"counter": 5}
+        yield completed
+
+    # Intercept validate_agui_state to return our mutable_state
+    def mock_validate(state, thread_id):
+        if state is not None:
+            mutable_state["counter"] = 0  # Reset to initial
+            return mutable_state
+        return None
+
+    with (
+        patch.object(agent, "arun", side_effect=mock_arun_stream),
+        patch("agno.os.interfaces.agui.router.validate_agui_state", side_effect=mock_validate),
+    ):
+        async with httpx.AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            response = await client.post(
+                "/agui",
+                json=make_agui_payload(
+                    messages=[{"role": "user", "content": "Increment counter"}],
+                    state={"counter": 0},
+                ),
+                timeout=30.0,
+            )
+
+    assert response.status_code == 200
+    events = parse_sse_events(response.text)
+    event_types = get_event_types(events)
+
+    # Should have STATE_DELTA after tool call
+    assert "STATE_DELTA" in event_types, f"Missing STATE_DELTA. Events: {event_types}"
+
+    # STATE_DELTA should come after TOOL_CALL_RESULT
+    delta_idx = event_types.index("STATE_DELTA")
+    result_idx = event_types.index("TOOL_CALL_RESULT")
+    assert delta_idx > result_idx
+
+    # Verify delta content
+    delta_event = events[delta_idx]["data"]
+    delta_ops = delta_event["delta"]
+    paths = [op["path"] for op in delta_ops]
+    assert "/counter" in paths
+
+    # Should also have final STATE_SNAPSHOT
+    assert "STATE_SNAPSHOT" in event_types
+
+
+# ---------------------------------------------------------------------------
+# Real API tests (require OPENAI_API_KEY)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"),
+    reason="OPENAI_API_KEY not set",
+)
+@pytest.mark.asyncio
+async def test_agui_state_events_real_api(app):
+    """Real API test: AG-UI agent emits StateSnapshot events when state is provided."""
+    from httpx import ASGITransport
+
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://testserver",
+    ) as client:
+        response = await client.post(
+            "/agui",
+            json=make_agui_payload(
+                messages=[{"role": "user", "content": "Say hello in one sentence."}],
+                state={"counter": 0, "label": "test"},
+            ),
+            timeout=60.0,
+        )
+
+    assert response.status_code == 200
+    events = parse_sse_events(response.text)
+    event_types = get_event_types(events)
+
+    assert "RUN_STARTED" in event_types
+    assert event_types.count("STATE_SNAPSHOT") >= 2
+    assert "RUN_FINISHED" in event_types


### PR DESCRIPTION
## Summary

Completes the outbound half of AG-UI state synchronization. The AG-UI interface now emits `StateSnapshotEvent` and `StateDeltaEvent` events during streaming, enabling frontend clients (e.g. CopilotKit) to receive real-time state updates from the agent.

Previously, agno accepted state from the frontend (`run_input.state` -> `agent.arun(session_state=...)`) but never sent updated state back. This PR closes that loop.

Closes #6136

### What changed

- **`pyproject.toml`**: Added `jsonpatch` to `agui` extras and mypy overrides
- **`utils.py`**: Extended `EventBuffer` with state tracking (`set_state_snapshot`, `compute_state_delta`), added `_create_state_delta_events()` helper, threaded `run_state` through both streaming functions and event creation
- **`router.py`**: Emit initial `StateSnapshotEvent` after `RunStartedEvent`, pass `run_state` to streaming functions (both `run_agent()` and `run_team()`)
- **Tests**: 6 new unit tests + integration test file with mocked and real API tests

### Event sequence (run with state + tools)

```
RUN_STARTED
STATE_SNAPSHOT          <- initial state
TEXT_MESSAGE_START/CONTENT/END
TOOL_CALL_START/ARGS/END
TOOL_CALL_RESULT
STATE_DELTA             <- JSON Patch ops (RFC 6902) if state changed
TEXT_MESSAGE_START/CONTENT/END
STATE_SNAPSHOT          <- final authoritative state
RUN_FINISHED
```

### Design decisions

- **Deep-copy isolation**: `_last_snapshot` stores a deep copy so in-place mutations to the agent's state dict are detectable via `jsonpatch.make_patch()`
- **Mutable dict reference chain**: `session_state` (the validated dict) is passed as `run_state` through the entire pipeline, so tool-induced mutations are visible at delta computation time
- **Backward compatible**: All state event emission is gated on `run_state is not None` - when the frontend sends no state, zero state events are emitted
- **Final snapshot uses authoritative source**: Uses `RunCompletedEvent.session_state` when available, falls back to `run_state`

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

- All 39 existing AG-UI tests pass (backward compatible)
- 6 new state-specific unit tests cover: deep-copy isolation, delta computation, final snapshot at completion, delta after tool call, no state events without state, no delta when unchanged
- Integration tests verify the full router pipeline with mocked agents
- Tested end-to-end with a live CopilotKit frontend against the real OpenAI API
