### PR TITLE
[fix] Filter user_input_schema by user_input_fields to exclude agent-owned params

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -489,15 +489,21 @@ class Function(BaseModel):
                         param_descriptions[param_name] = f"({param_type}) {param.description}"
                         param_descriptions_clean[param_name] = param.description
 
-            # If the function requires user input, we should set the user_input_schema to all parameters. The arguments provided by the model are filled in later.
+            # If the function requires user input, build the user_input_schema.
+            # When user_input_fields is specified and non-empty, only include those fields
+            # so that defaulted parameters owned by the agent are not surfaced for user input.
             if self.requires_user_input:
+                if self.user_input_fields:
+                    schema_param_names = [name for name in sig.parameters if name in self.user_input_fields]
+                else:
+                    schema_param_names = list(sig.parameters)
                 self.user_input_schema = [
                     UserInputField(
                         name=name,
                         description=param_descriptions_clean.get(name),
                         field_type=type_hints.get(name, str),
                     )
-                    for name in sig.parameters
+                    for name in schema_param_names
                 ]
 
             # Get JSON schema for parameters only

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -184,12 +184,11 @@ def test_function_process_entrypoint_with_user_input():
     func.process_entrypoint()
 
     assert func.user_input_schema is not None
-    assert len(func.user_input_schema) == 2
+    # Only fields in user_input_fields should appear in user_input_schema
+    assert len(func.user_input_schema) == 1
 
     assert func.user_input_schema[0].name == "param1"
     assert func.user_input_schema[0].field_type is str
-    assert func.user_input_schema[1].name == "param2"
-    assert func.user_input_schema[1].field_type is int
 
 
 def test_function_process_entrypoint_skip_processing():
@@ -598,11 +597,10 @@ def test_tool_decorator_with_user_input():
     assert user_input_func.user_input_fields == ["param1"]
     user_input_func.process_entrypoint()
     assert user_input_func.user_input_schema is not None
-    assert len(user_input_func.user_input_schema) == 2
+    # Only fields in user_input_fields should appear in user_input_schema
+    assert len(user_input_func.user_input_schema) == 1
     assert user_input_func.user_input_schema[0].name == "param1"
     assert user_input_func.user_input_schema[0].field_type is str
-    assert user_input_func.user_input_schema[1].name == "param2"
-    assert user_input_func.user_input_schema[1].field_type is int
 
 
 def test_tool_decorator_with_hooks():
@@ -811,3 +809,106 @@ def test_function_cache_pydantic_model_nested(tmp_path):
 
     retrieved_result = func._get_cached_result(cache_file)
     assert retrieved_result == {"name": "John", "address": {"street": "123 Main St", "city": "Springfield"}}
+
+
+def test_user_input_fields_filters_defaulted_params():
+    """Test that user_input_schema only contains fields in user_input_fields,
+    excluding defaulted parameters owned by the agent (issue #6870)."""
+
+    @tool(requires_user_input=True, user_input_fields=["to_address"])
+    def send_email(
+        subject: str,
+        body: str,
+        to_address: str,
+        priority: str = "normal",
+        cc: Optional[str] = None,
+    ) -> str:
+        """Send an email.
+
+        Args:
+            subject: Email subject
+            body: Email body
+            to_address: Recipient address
+            priority: Email priority
+            cc: CC address
+        """
+        return "sent"
+
+    assert isinstance(send_email, Function)
+    send_email.process_entrypoint()
+
+    # user_input_schema should only contain 'to_address'
+    assert send_email.user_input_schema is not None
+    schema_names = [f.name for f in send_email.user_input_schema]
+    assert schema_names == ["to_address"]
+    assert send_email.user_input_schema[0].field_type is str
+
+    # Defaulted parameters should NOT appear in user_input_schema
+    assert "priority" not in schema_names
+    assert "cc" not in schema_names
+    # Agent-provided params should also NOT appear
+    assert "subject" not in schema_names
+    assert "body" not in schema_names
+
+
+def test_user_input_fields_empty_list_includes_all_params():
+    """Test that an empty user_input_fields list results in all params in user_input_schema."""
+
+    @tool(requires_user_input=True, user_input_fields=[])
+    def my_tool(param1: str, param2: int = 10) -> str:
+        """A tool."""
+        return "done"
+
+    assert isinstance(my_tool, Function)
+    my_tool.process_entrypoint()
+
+    # Empty user_input_fields means all fields should be in the schema
+    assert my_tool.user_input_schema is not None
+    schema_names = [f.name for f in my_tool.user_input_schema]
+    assert "param1" in schema_names
+    assert "param2" in schema_names
+
+
+def test_user_input_no_fields_specified_includes_all_params():
+    """Test that when user_input_fields is None, all params appear in user_input_schema."""
+
+    @tool(requires_user_input=True)
+    def my_tool(param1: str, param2: int = 10) -> str:
+        """A tool."""
+        return "done"
+
+    assert isinstance(my_tool, Function)
+    my_tool.process_entrypoint()
+
+    # No user_input_fields means all fields should be in the schema
+    assert my_tool.user_input_schema is not None
+    schema_names = [f.name for f in my_tool.user_input_schema]
+    assert "param1" in schema_names
+    assert "param2" in schema_names
+
+
+def test_user_input_fields_multiple_fields():
+    """Test user_input_fields with multiple specified fields."""
+
+    @tool(requires_user_input=True, user_input_fields=["to_address", "subject"])
+    def send_email(
+        subject: str,
+        body: str,
+        to_address: str,
+        priority: str = "normal",
+        cc: Optional[str] = None,
+    ) -> str:
+        """Send an email."""
+        return "sent"
+
+    assert isinstance(send_email, Function)
+    send_email.process_entrypoint()
+
+    assert send_email.user_input_schema is not None
+    schema_names = [f.name for f in send_email.user_input_schema]
+    assert len(schema_names) == 2
+    assert "subject" in schema_names
+    assert "to_address" in schema_names
+    assert "body" not in schema_names
+    assert "priority" not in schema_names
+    assert "cc" not in schema_names


### PR DESCRIPTION
## Summary

When `user_input_fields` is specified, `user_input_schema` should only contain those fields. Previously, `user_input_schema` included **all** function parameters regardless of `user_input_fields`, causing defaulted agent-owned parameters (e.g. `priority="normal"`, `cc=None`) to appear in the schema with `value=None` when the agent omitted them during the tool call.

This led to validation errors during `continue_run` because `handle_user_input_update` would copy all schema field values (including `None`) into `tool_args`, overwriting the function's default values.

Fixes #6870

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

---

## Additional Notes

### Root Cause

In `libs/agno/agno/tools/function.py` line 492-501, `user_input_schema` was built from `sig.parameters` (all params) without filtering by `user_input_fields`. When the agent called a tool without providing a defaulted parameter, the schema entry for that parameter had `value=None`. Later, `handle_user_input_update` in `libs/agno/agno/agent/_tools.py` copied all schema values into `tool_args`, overwriting defaults with `None` and causing Pydantic validation failures.

### Fix

When `self.user_input_fields` is set and non-empty, only include parameters whose names are in `user_input_fields` when building `user_input_schema`. When `user_input_fields` is `None` or empty, the previous behavior (include all params) is preserved.

### Tests

- Updated 2 existing tests to match corrected behavior
- Added 4 new test cases:
  - `test_user_input_fields_filters_defaulted_params` — reproduces the exact issue scenario from #6870
  - `test_user_input_fields_empty_list_includes_all_params` — empty list preserves all-params behavior
  - `test_user_input_no_fields_specified_includes_all_params` — None preserves all-params behavior
  - `test_user_input_fields_multiple_fields` — multiple fields in user_input_fields