### PR TITLE
fix: Bedrock api_key crash, loop iteration forwarding, A2A streaming TypeError

### DIFF
--- a/libs/agno/agno/models/aws/claude.py
+++ b/libs/agno/agno/models/aws/claude.py
@@ -37,7 +37,6 @@ class Claude(AnthropicClaude):
     aws_secret_key: Optional[str] = None
     aws_session_token: Optional[str] = None
     aws_region: Optional[str] = None
-    api_key: Optional[str] = None
     session: Optional[Session] = None
 
     client: Optional[AnthropicBedrock] = None  # type: ignore
@@ -71,30 +70,21 @@ class Claude(AnthropicClaude):
                 "aws_region": self.aws_region or self.session.region_name,
             }
         else:
-            self.api_key = self.api_key or getenv("AWS_BEDROCK_API_KEY")
-            if self.api_key:
-                self.aws_region = self.aws_region or getenv("AWS_REGION")
-                client_params = {
-                    "api_key": self.api_key,
-                }
-                if self.aws_region:
-                    client_params["aws_region"] = self.aws_region
-            else:
-                self.aws_access_key = self.aws_access_key or getenv("AWS_ACCESS_KEY_ID") or getenv("AWS_ACCESS_KEY")
-                self.aws_secret_key = self.aws_secret_key or getenv("AWS_SECRET_ACCESS_KEY") or getenv("AWS_SECRET_KEY")
-                self.aws_session_token = self.aws_session_token or getenv("AWS_SESSION_TOKEN")
-                self.aws_region = self.aws_region or getenv("AWS_REGION")
+            self.aws_access_key = self.aws_access_key or getenv("AWS_ACCESS_KEY_ID") or getenv("AWS_ACCESS_KEY")
+            self.aws_secret_key = self.aws_secret_key or getenv("AWS_SECRET_ACCESS_KEY") or getenv("AWS_SECRET_KEY")
+            self.aws_session_token = self.aws_session_token or getenv("AWS_SESSION_TOKEN")
+            self.aws_region = self.aws_region or getenv("AWS_REGION")
 
-                client_params = {
-                    "aws_secret_key": self.aws_secret_key,
-                    "aws_access_key": self.aws_access_key,
-                    "aws_session_token": self.aws_session_token,
-                    "aws_region": self.aws_region,
-                }
+            client_params = {
+                "aws_secret_key": self.aws_secret_key,
+                "aws_access_key": self.aws_access_key,
+                "aws_session_token": self.aws_session_token,
+                "aws_region": self.aws_region,
+            }
 
-            if not (self.api_key or (self.aws_access_key and self.aws_secret_key)):
+            if not (self.aws_access_key and self.aws_secret_key):
                 log_warning(
-                    "AWS credentials not found. Please set AWS_BEDROCK_API_KEY or AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables or provide a boto3 session."
+                    "AWS credentials not found. Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables or provide a boto3 session."
                 )
 
         if self.timeout is not None:

--- a/libs/agno/agno/os/interfaces/a2a/utils.py
+++ b/libs/agno/agno/os/interfaces/a2a/utils.py
@@ -348,11 +348,14 @@ async def stream_a2a_response(
 
         # Send content events
         elif isinstance(event, (RunContentEvent, TeamRunContentEvent)) and event.content:
-            accumulated_content += event.content
+            from pydantic import BaseModel as _BaseModel
+
+            content_str = event.content.model_dump_json() if isinstance(event.content, _BaseModel) else str(event.content)
+            accumulated_content += content_str
             message = A2AMessage(
                 message_id=message_id,
                 role=Role.agent,
-                parts=[Part(root=TextPart(text=event.content))],
+                parts=[Part(root=TextPart(text=content_str))],
                 context_id=context_id,
                 task_id=task_id,
                 metadata={"agno_content_category": "content"},

--- a/libs/agno/agno/workflow/loop.py
+++ b/libs/agno/agno/workflow/loop.py
@@ -365,7 +365,8 @@ class Loop:
         while iteration < self.max_iterations:
             # Execute all steps in this iteration - mirroring workflow logic
             iteration_results: List[StepOutput] = []
-            current_step_input = step_input
+            if iteration == 0:
+                current_step_input = step_input
             loop_step_outputs = {}  # Track outputs within this loop iteration
 
             for i, step in enumerate(self.steps):
@@ -504,7 +505,8 @@ class Loop:
 
             # Execute all steps in this iteration - mirroring workflow logic
             iteration_results = []
-            current_step_input = step_input
+            if iteration == 0:
+                current_step_input = step_input
             loop_step_outputs = {}
 
             for i, step in enumerate(self.steps):
@@ -666,7 +668,8 @@ class Loop:
         while iteration < self.max_iterations:
             # Execute all steps in this iteration - mirroring workflow logic
             iteration_results: List[StepOutput] = []
-            current_step_input = step_input
+            if iteration == 0:
+                current_step_input = step_input
             loop_step_outputs = {}  # Track outputs within this loop iteration
 
             for i, step in enumerate(self.steps):
@@ -805,7 +808,8 @@ class Loop:
 
             # Execute all steps in this iteration - mirroring workflow logic
             iteration_results = []
-            current_step_input = step_input
+            if iteration == 0:
+                current_step_input = step_input
             loop_step_outputs = {}  # Track outputs within this loop iteration
 
             for i, step in enumerate(self.steps):

--- a/libs/agno/tests/unit/models/aws/test_claude_client.py
+++ b/libs/agno/tests/unit/models/aws/test_claude_client.py
@@ -222,8 +222,23 @@ class TestSessionTokenEnv:
 
 
 class TestApiKeyPath:
-    def test_api_key_client_cached(self, monkeypatch):
-        monkeypatch.setenv("AWS_BEDROCK_API_KEY", "br-api-key-123")
+    def test_no_api_key_in_params(self, monkeypatch):
+        """api_key is not a valid AnthropicBedrock param; ensure it is never passed."""
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKID123")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret456")
+        monkeypatch.setenv("AWS_REGION", "us-west-2")
+
+        model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0")
+        params = model._get_client_params()
+
+        assert "api_key" not in params
+        assert params["aws_access_key"] == "AKID123"
+        assert params["aws_secret_key"] == "secret456"
+        assert params["aws_region"] == "us-west-2"
+
+    def test_aws_creds_client_cached(self, monkeypatch):
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKID123")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret456")
         monkeypatch.setenv("AWS_REGION", "us-west-2")
 
         model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0")
@@ -238,17 +253,6 @@ class TestApiKeyPath:
 
             assert MockBedrock.call_count == 1
             assert client1 is client2
-
-    def test_api_key_params(self, monkeypatch):
-        monkeypatch.setenv("AWS_BEDROCK_API_KEY", "br-api-key-123")
-        monkeypatch.setenv("AWS_REGION", "us-west-2")
-
-        model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0")
-        params = model._get_client_params()
-
-        assert params["api_key"] == "br-api-key-123"
-        assert params["aws_region"] == "us-west-2"
-        assert "aws_session_token" not in params
 
 
 class TestSessionNullCredentials:


### PR DESCRIPTION
## Summary
Fixes 3 independent bugs:

- **Bedrock `api_key` crash (#6852):** `AnthropicBedrock()` does not accept `api_key` — only AWS-native credentials (`aws_access_key`, `aws_secret_key`, etc.). When `AWS_BEDROCK_API_KEY` env var was set, the client constructor crashed with `TypeError`. Removed the invalid code path; users should use standard AWS credentials instead.

- **Loop iteration output not forwarded (#6862):** Each loop iteration reset `current_step_input = step_input` (the original input), discarding the output from the previous iteration. Iteration N+1 now receives the output from iteration N's last step, enabling iterative refinement workflows. Fixed in all 4 execution paths (sync, sync-stream, async, async-stream).

- **A2A streaming TypeError with `output_schema` (#6850):** When `output_schema` is set, `event.content` is a Pydantic `BaseModel` instance. `accumulated_content += event.content` raised `TypeError` (str + BaseModel). Now serializes to JSON string before concatenation.

## Changes
- `libs/agno/agno/models/aws/claude.py` — Remove `api_key` field and invalid code path
- `libs/agno/agno/workflow/loop.py` — Only reset `current_step_input` on first iteration (4 locations)
- `libs/agno/agno/os/interfaces/a2a/utils.py` — Serialize BaseModel content before string ops
- `libs/agno/tests/unit/models/aws/test_claude_client.py` — Update tests to verify correct behavior

## Test plan
- [x] 500 unit tests pass, 0 regressions
- [x] `_get_client_params()` never includes `api_key` key
- [x] Test validates `api_key` is absent (was previously asserting the broken behavior)