### PR TITLE
fix: strip <think> tags from streaming accumulated content

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1846,7 +1846,20 @@ class Model(ABC):
         if stream_data.response_metrics is not None:
             assistant_message.metrics = stream_data.response_metrics
         if stream_data.response_content:
-            assistant_message.content = stream_data.response_content
+            # Extract thinking content from accumulated stream if present (e.g. DeepSeek <think> tags)
+            if "<think>" in stream_data.response_content or "</think>" in stream_data.response_content:
+                from agno.utils.reasoning import extract_thinking_content
+
+                reasoning_content, clean_content = extract_thinking_content(stream_data.response_content)
+                if reasoning_content:
+                    assistant_message.content = clean_content
+                    # Only set reasoning_content if not already populated by native reasoning
+                    if not stream_data.response_reasoning_content:
+                        assistant_message.reasoning_content = reasoning_content
+                else:
+                    assistant_message.content = stream_data.response_content
+            else:
+                assistant_message.content = stream_data.response_content
         if stream_data.response_reasoning_content:
             assistant_message.reasoning_content = stream_data.response_reasoning_content
         if stream_data.response_redacted_reasoning_content:

--- a/libs/agno/agno/utils/reasoning.py
+++ b/libs/agno/agno/utils/reasoning.py
@@ -10,22 +10,29 @@ if TYPE_CHECKING:
 
 
 def extract_thinking_content(content: str) -> Tuple[Optional[str], str]:
-    """Extract thinking content from response text between <think> tags."""
+    """Extract thinking content from response text between <think> tags.
+
+    Handles multiple <think>...</think> blocks (common in multi-step agent loops).
+    """
     if not content or "</think>" not in content:
         return None, content
 
-    # Find the end of thinking content
-    end_idx = content.find("</think>")
+    import re
 
-    # Look for opening <think> tag, if not found, assume thinking starts at beginning
-    start_idx = content.find("<think>")
-    if start_idx == -1:
+    pattern = re.compile(r"<think>(.*?)</think>", re.DOTALL)
+    matches = pattern.findall(content)
+
+    if not matches:
+        # Handle case where </think> exists but no opening <think>
+        end_idx = content.find("</think>")
         reasoning_content = content[:end_idx].strip()
-    else:
-        start_idx = start_idx + len("<think>")
-        reasoning_content = content[start_idx:end_idx].strip()
+        output_content = content[end_idx + len("</think>") :].strip()
+        return reasoning_content, output_content
 
-    output_content = content[end_idx + len("</think>") :].strip()
+    reasoning_parts = [m.strip() for m in matches if m.strip()]
+    reasoning_content = "\n\n".join(reasoning_parts) if reasoning_parts else None
+
+    output_content = pattern.sub("", content).strip()
 
     return reasoning_content, output_content
 

--- a/libs/agno/tests/unit/reasoning/test_extract_thinking.py
+++ b/libs/agno/tests/unit/reasoning/test_extract_thinking.py
@@ -1,0 +1,83 @@
+"""Tests for extract_thinking_content in agno.utils.reasoning."""
+
+from agno.utils.reasoning import extract_thinking_content
+
+
+def test_no_think_tags_returns_none():
+    content = "Just a regular response with no thinking."
+    reasoning, output = extract_thinking_content(content)
+    assert reasoning is None
+    assert output == content
+
+
+def test_empty_string():
+    reasoning, output = extract_thinking_content("")
+    assert reasoning is None
+    assert output == ""
+
+
+def test_single_think_block():
+    content = "<think>Let me reason about this.</think>The answer is 42."
+    reasoning, output = extract_thinking_content(content)
+    assert reasoning == "Let me reason about this."
+    assert output == "The answer is 42."
+
+
+def test_think_block_with_newlines():
+    content = "<think>\nStep 1: analyze\nStep 2: solve\n</think>\nHere is the result."
+    reasoning, output = extract_thinking_content(content)
+    assert reasoning == "Step 1: analyze\nStep 2: solve"
+    assert output == "Here is the result."
+
+
+def test_multiple_think_blocks():
+    content = (
+        "<think>First round of thinking.</think>"
+        "Intermediate response. "
+        "<think>Second round after tool call.</think>"
+        "Final answer."
+    )
+    reasoning, output = extract_thinking_content(content)
+    assert "First round of thinking." in reasoning
+    assert "Second round after tool call." in reasoning
+    assert "Intermediate response." in output
+    assert "Final answer." in output
+    assert "<think>" not in output
+    assert "</think>" not in output
+
+
+def test_three_think_blocks():
+    content = "<think>Block 1</think>Response 1. <think>Block 2</think>Response 2. <think>Block 3</think>Response 3."
+    reasoning, output = extract_thinking_content(content)
+    assert "Block 1" in reasoning
+    assert "Block 2" in reasoning
+    assert "Block 3" in reasoning
+    assert "<think>" not in output
+
+
+def test_missing_open_tag():
+    content = "Some leaked thinking</think>Actual response."
+    reasoning, output = extract_thinking_content(content)
+    assert reasoning == "Some leaked thinking"
+    assert output == "Actual response."
+
+
+def test_empty_think_block():
+    content = "<think></think>Response only."
+    reasoning, output = extract_thinking_content(content)
+    # Empty block should not contribute reasoning
+    assert output == "Response only."
+
+
+def test_think_block_only_no_output():
+    content = "<think>Only reasoning, no visible response.</think>"
+    reasoning, output = extract_thinking_content(content)
+    assert reasoning == "Only reasoning, no visible response."
+    assert output == ""
+
+
+def test_whitespace_around_tags():
+    content = "  <think>  padded reasoning  </think>  padded output  "
+    reasoning, output = extract_thinking_content(content)
+    assert reasoning == "padded reasoning"
+    assert "padded output" in output


### PR DESCRIPTION
## Summary

Fixes streaming responses from models using `<think>` tags (DeepSeek, Qwen3 via OpenAI-compatible APIs) leaking raw think tags into assistant message content. This causes token inflation and infinite thinking loops in multi-step agent runs.

The non-streaming path already calls `extract_thinking_content`, but streaming accumulated chunks without post-processing.

## What changed

- Added think-tag extraction in `_populate_assistant_message_from_stream_data` after chunks accumulate, matching non-streaming behavior
- Upgraded `extract_thinking_content` to handle multiple `<think>` blocks (common in multi-step agent loops with tool calls)
- Added 10 unit tests covering single blocks, multiple blocks, missing open tags, empty blocks, and edge cases
- Only activates when think tags are detected - models with native reasoning are unaffected

## How I found this

Traced the streaming flow: chunks arrive via `_parse_provider_response_delta`, accumulate in `stream_data.response_content` (base.py:1890), then get assigned to `assistant_message.content` (base.py:1849). The non-streaming equivalent in Ollama's `_parse_provider_response` (chat.py:351) calls `extract_thinking_content` on the full response, but no equivalent existed for streaming finalization.

The multi-block issue came from issue #6878 - agent loops with tool calls produce multiple accumulated `<think>` blocks, but the old `extract_thinking_content` only handled the first one.

## Test plan

- [x] 10 unit tests for `extract_thinking_content` (single, multi-block, edge cases)
- [x] 90/90 existing reasoning tests still pass
- [x] ruff format + ruff check clean
- [ ] Manual test with DeepSeek streaming - think tags stripped, moved to reasoning_content

Fixes #6878