### PR TITLE
fix: user_input_schema only includes user_input_fields when specified (fixes #6870)

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -490,15 +490,25 @@ class Function(BaseModel):
                             param_descriptions[param_name] = param.description or ""
                         param_descriptions_clean[param_name] = param.description or ""
 
-            # If the function requires user input, we should set the user_input_schema to all parameters. The arguments provided by the model are filled in later.
+            # If the function requires user input, build user_input_schema.
+            # When user_input_fields is specified, only include those fields
+            # so that agent-owned defaulted params (e.g. priority="normal")
+            # are not exposed to the user and don't get overwritten with None.
             if self.requires_user_input:
+                if self.user_input_fields:
+                    schema_params = [
+                        name for name in sig.parameters if name in self.user_input_fields
+                    ]
+                else:
+                    schema_params = list(sig.parameters.keys())
                 self.user_input_schema = [
                     UserInputField(
                         name=name,
                         description=param_descriptions_clean.get(name),
                         field_type=type_hints.get(name, str),
                     )
-                    for name in sig.parameters
+                    for name in schema_params
+                    if name not in excluded_params or name in (self.user_input_fields or [])
                 ]
 
             # Get JSON schema for parameters only

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -186,12 +186,42 @@ def test_function_process_entrypoint_with_user_input():
     func.process_entrypoint()
 
     assert func.user_input_schema is not None
-    assert len(func.user_input_schema) == 2
+    assert len(func.user_input_schema) == 1
 
     assert func.user_input_schema[0].name == "param1"
     assert func.user_input_schema[0].field_type is str
-    assert func.user_input_schema[1].name == "param2"
-    assert func.user_input_schema[1].field_type is int
+
+
+def test_function_user_input_schema_excludes_agent_owned_defaults():
+    """Test that user_input_schema only contains user_input_fields,
+    so agent-owned defaulted params don't leak with value=None."""
+
+    def send_email(
+        subject: str,
+        body: str,
+        to_address: str,
+        priority: str = "normal",
+        cc: str = "",
+    ) -> str:
+        """Send an email."""
+        return "sent"
+
+    func = Function(
+        name="send_email",
+        entrypoint=send_email,
+        requires_user_input=True,
+        user_input_fields=["to_address"],
+    )
+    func.process_entrypoint()
+
+    assert func.user_input_schema is not None
+    schema_names = [f.name for f in func.user_input_schema]
+    assert schema_names == ["to_address"]
+    # Agent-owned params must NOT appear in the schema
+    assert "priority" not in schema_names
+    assert "cc" not in schema_names
+    assert "subject" not in schema_names
+    assert "body" not in schema_names
 
 
 def test_function_process_entrypoint_skip_processing():
@@ -600,11 +630,10 @@ def test_tool_decorator_with_user_input():
     assert user_input_func.user_input_fields == ["param1"]
     user_input_func.process_entrypoint()
     assert user_input_func.user_input_schema is not None
-    assert len(user_input_func.user_input_schema) == 2
+    # With user_input_fields=["param1"], only param1 should be in schema
+    assert len(user_input_func.user_input_schema) == 1
     assert user_input_func.user_input_schema[0].name == "param1"
     assert user_input_func.user_input_schema[0].field_type is str
-    assert user_input_func.user_input_schema[1].name == "param2"
-    assert user_input_func.user_input_schema[1].field_type is int
 
 
 def test_tool_decorator_with_hooks():


### PR DESCRIPTION
## Summary

Fixes #6870 — When `user_input_fields` is specified on a `@tool`, agent-owned parameters with defaults (e.g. `priority: str = "normal"`) leaked into `user_input_schema` with `value=None`, causing validation errors on `continue_run`.

## Problem

```python
@tool(requires_user_input=True, user_input_fields=["to_address"])
def send_email(subject: str, body: str, to_address: str, priority: str = "normal", cc: str | None = None):
    ...
```

`user_input_schema` was built from **all** `sig.parameters`, so it included `subject`, `body`, `priority`, and `cc` alongside the intended `to_address`. When the agent omitted defaulted params (e.g., `priority`), those fields stayed `value=None` in the schema. Then `handle_user_input_update` set `tool_args["priority"] = None`, overwriting the default and causing validation failure.

## Fix

In `Function.process_entrypoint()`, when `user_input_fields` is specified, `user_input_schema` now only includes those specific fields:

```python
if self.user_input_fields:
    schema_params = [name for name in sig.parameters if name in self.user_input_fields]
else:
    schema_params = list(sig.parameters.keys())  # backward-compatible: all params
```

This ensures agent-owned params keep their function-signature defaults and are never overwritten with `None`.

## Testing

- Updated existing test `test_function_process_entrypoint_with_user_input` to verify only user-input fields appear in schema
- Added new test `test_function_user_input_schema_excludes_agent_owned_defaults` that mirrors the exact scenario from #6870
- All 40 unit tests pass
