### PR TITLE
fix: pass Bedrock API key as bearer token instead of invalid api_key param

### DIFF
--- a/libs/agno/agno/models/aws/claude.py
+++ b/libs/agno/agno/models/aws/claude.py
@@ -74,8 +74,11 @@ class Claude(AnthropicClaude):
             self.api_key = self.api_key or getenv("AWS_BEDROCK_API_KEY")
             if self.api_key:
                 self.aws_region = self.aws_region or getenv("AWS_REGION")
+                # Bedrock API keys are bearer tokens — pass via Authorization
+                # header, not as a constructor parameter (AnthropicBedrock
+                # does not accept an `api_key` kwarg).
                 client_params = {
-                    "api_key": self.api_key,
+                    "default_headers": {"Authorization": f"Bearer {self.api_key}"},
                 }
                 if self.aws_region:
                     client_params["aws_region"] = self.aws_region

--- a/libs/agno/tests/unit/models/aws/test_claude_client.py
+++ b/libs/agno/tests/unit/models/aws/test_claude_client.py
@@ -246,9 +246,10 @@ class TestApiKeyPath:
         model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0")
         params = model._get_client_params()
 
-        assert params["api_key"] == "br-api-key-123"
+        assert params["default_headers"]["Authorization"] == "Bearer br-api-key-123"
         assert params["aws_region"] == "us-west-2"
         assert "aws_session_token" not in params
+        assert "api_key" not in params
 
 
 class TestSessionNullCredentials:


### PR DESCRIPTION
## Summary

Fixes #6852 — `AnthropicBedrock.__init__() got an unexpected keyword argument 'api_key'` when using `AWS_BEDROCK_API_KEY`.

## Root Cause

`_get_client_params()` in `agno/models/aws/claude.py` constructs `{"api_key": self.api_key}` and passes it to `AnthropicBedrock(**client_params)`. However, the `anthropic` library's `AnthropicBedrock` class **does not accept** an `api_key` parameter — it only accepts `aws_access_key`, `aws_secret_key`, `aws_session_token`, `aws_region`, `default_headers`, etc.

## Fix

Bedrock API keys are bearer tokens. Pass them via the `default_headers` parameter:

```python
# Before (broken):
client_params = {"api_key": self.api_key}

# After (fixed):
client_params = {"default_headers": {"Authorization": f"Bearer {self.api_key}"}}
```

This uses `AnthropicBedrock`'s `default_headers` parameter, which attaches the `Authorization: Bearer <token>` header to every request.

## Tests

- Updated `TestApiKeyPath::test_api_key_params` to verify:
  - `default_headers["Authorization"]` contains the bearer token
  - No `api_key` key exists in the params
- All 14 existing AWS Claude client tests pass (zero regression)

## Reproducer

```python
from agno.agent import Agent
from agno.models.aws import Claude
import os

os.environ["AWS_BEDROCK_API_KEY"] = "your-key"
os.environ["AWS_REGION"] = "us-east-2"

agent = Agent(model=Claude(id="anthropic.claude-opus-4-6-v1"))
# Before fix: crashes with TypeError
# After fix: initializes correctly with bearer token auth
```
