### PR TITLE
fix: remove invalid api_key from Bedrock client params

### DIFF
--- a/libs/agno/agno/models/aws/claude.py
+++ b/libs/agno/agno/models/aws/claude.py
@@ -71,30 +71,34 @@ class Claude(AnthropicClaude):
                 "aws_region": self.aws_region or self.session.region_name,
             }
         else:
-            self.api_key = self.api_key or getenv("AWS_BEDROCK_API_KEY")
-            if self.api_key:
-                self.aws_region = self.aws_region or getenv("AWS_REGION")
-                client_params = {
-                    "api_key": self.api_key,
-                }
-                if self.aws_region:
-                    client_params["aws_region"] = self.aws_region
-            else:
-                self.aws_access_key = self.aws_access_key or getenv("AWS_ACCESS_KEY_ID") or getenv("AWS_ACCESS_KEY")
-                self.aws_secret_key = self.aws_secret_key or getenv("AWS_SECRET_ACCESS_KEY") or getenv("AWS_SECRET_KEY")
-                self.aws_session_token = self.aws_session_token or getenv("AWS_SESSION_TOKEN")
-                self.aws_region = self.aws_region or getenv("AWS_REGION")
+            # AnthropicBedrock does not accept an api_key parameter.
+            # Fail fast if the caller set one explicitly or via the env var.
+            _bedrock_api_key = self.api_key or getenv("AWS_BEDROCK_API_KEY")
+            if _bedrock_api_key:
+                raise ValueError(
+                    "AnthropicBedrock does not support the 'api_key' parameter. "
+                    "AWS Bedrock API keys (bearer tokens) are not supported by the "
+                    "underlying anthropic library. Please use IAM credentials instead: "
+                    "set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment "
+                    "variables, or pass a boto3 Session."
+                )
 
-                client_params = {
-                    "aws_secret_key": self.aws_secret_key,
-                    "aws_access_key": self.aws_access_key,
-                    "aws_session_token": self.aws_session_token,
-                    "aws_region": self.aws_region,
-                }
+            self.aws_access_key = self.aws_access_key or getenv("AWS_ACCESS_KEY_ID") or getenv("AWS_ACCESS_KEY")
+            self.aws_secret_key = self.aws_secret_key or getenv("AWS_SECRET_ACCESS_KEY") or getenv("AWS_SECRET_KEY")
+            self.aws_session_token = self.aws_session_token or getenv("AWS_SESSION_TOKEN")
+            self.aws_region = self.aws_region or getenv("AWS_REGION")
 
-            if not (self.api_key or (self.aws_access_key and self.aws_secret_key)):
+            client_params = {
+                "aws_secret_key": self.aws_secret_key,
+                "aws_access_key": self.aws_access_key,
+                "aws_session_token": self.aws_session_token,
+                "aws_region": self.aws_region,
+            }
+
+            if not (self.aws_access_key and self.aws_secret_key):
                 log_warning(
-                    "AWS credentials not found. Please set AWS_BEDROCK_API_KEY or AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY environment variables or provide a boto3 session."
+                    "AWS credentials not found. Please set AWS_ACCESS_KEY_ID and "
+                    "AWS_SECRET_ACCESS_KEY environment variables or provide a boto3 session."
                 )
 
         if self.timeout is not None:

--- a/libs/agno/tests/unit/models/aws/test_claude_client.py
+++ b/libs/agno/tests/unit/models/aws/test_claude_client.py
@@ -222,33 +222,26 @@ class TestSessionTokenEnv:
 
 
 class TestApiKeyPath:
-    def test_api_key_client_cached(self, monkeypatch):
+    def test_api_key_env_raises_value_error(self, monkeypatch):
+        """AWS_BEDROCK_API_KEY is not supported by AnthropicBedrock; must raise."""
         monkeypatch.setenv("AWS_BEDROCK_API_KEY", "br-api-key-123")
         monkeypatch.setenv("AWS_REGION", "us-west-2")
 
         model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0")
 
-        with patch("agno.models.aws.claude.AnthropicBedrock") as MockBedrock:
-            mock_client = MagicMock()
-            mock_client.is_closed.return_value = False
-            MockBedrock.return_value = mock_client
+        with pytest.raises(ValueError, match="AnthropicBedrock does not support the 'api_key' parameter"):
+            model._get_client_params()
 
-            client1 = model.get_client()
-            client2 = model.get_client()
+    def test_api_key_explicit_raises_value_error(self):
+        """Passing api_key directly must also raise."""
+        model = Claude(
+            id="anthropic.claude-3-sonnet-20240229-v1:0",
+            api_key="br-api-key-123",
+            aws_region="us-west-2",
+        )
 
-            assert MockBedrock.call_count == 1
-            assert client1 is client2
-
-    def test_api_key_params(self, monkeypatch):
-        monkeypatch.setenv("AWS_BEDROCK_API_KEY", "br-api-key-123")
-        monkeypatch.setenv("AWS_REGION", "us-west-2")
-
-        model = Claude(id="anthropic.claude-3-sonnet-20240229-v1:0")
-        params = model._get_client_params()
-
-        assert params["api_key"] == "br-api-key-123"
-        assert params["aws_region"] == "us-west-2"
-        assert "aws_session_token" not in params
+        with pytest.raises(ValueError, match="AnthropicBedrock does not support the 'api_key' parameter"):
+            model._get_client_params()
 
 
 class TestSessionNullCredentials:


### PR DESCRIPTION
## Problem

When using `agno.models.aws.Claude` with `AWS_BEDROCK_API_KEY` (or passing `api_key` directly), the agent crashes with:

```
AnthropicBedrock.__init__() got an unexpected keyword argument 'api_key'
```

The `AnthropicBedrock` client from the `anthropic` library does **not** accept an `api_key` parameter — it only supports IAM credentials (`aws_access_key`, `aws_secret_key`, etc.) or a boto3 Session.

## Fix

Replace the broken `api_key` code path in `_get_client_params()` with a clear `ValueError` that fires immediately when `api_key` or `AWS_BEDROCK_API_KEY` is detected, guiding users to use IAM credentials or a boto3 Session instead.

## Changes

- **`libs/agno/agno/models/aws/claude.py`**: Removed the `api_key` branch that passed an unsupported parameter to `AnthropicBedrock()`. Added early `ValueError` with actionable guidance.
- **`libs/agno/tests/unit/models/aws/test_claude_client.py`**: Updated tests to verify the new `ValueError` is raised for both env-var and explicit `api_key` usage.

## Test results

All 14 unit tests pass:

```
tests/unit/models/aws/test_claude_client.py   14 passed
```

Closes #6852