### PR TITLE
[fix] parse_tool_calls: replace shared dict refs from list multiplication with independent dicts

### DIFF
--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -720,7 +720,7 @@ class OpenAIChat(Model):
             _function_arguments = _tool_call.function.arguments if _tool_call.function else None
 
             if len(tool_calls) <= _index:
-                tool_calls.extend([{}] * (_index - len(tool_calls) + 1))
+                tool_calls.extend([{} for _ in range(_index - len(tool_calls) + 1)])
             tool_call_entry = tool_calls[_index]
             if not tool_call_entry:
                 tool_call_entry["id"] = _tool_call_id


### PR DESCRIPTION
## Problem

`parse_tool_calls` in `libs/agno/agno/models/openai/chat.py` uses:

```python
tool_calls.extend([{}] * (_index - len(tool_calls) + 1))
```

This is a classic Python pitfall — `[{}] * N` creates **N references to the same dict object**, not N independent dicts. When any element is mutated (e.g. `tool_call_entry["id"] = ...`), **all N elements change simultaneously** through the shared reference.

This causes **every tool call to be executed twice** (or more) when the model returns a non-zero-based `tool_call.index` (e.g., Claude via OpenRouter), because multiple slots in the list end up sharing the same dict and all get updated together.

## Fix

Replace `[{}] * N` with a list comprehension:

```python
# Before (buggy)
tool_calls.extend([{}] * (_index - len(tool_calls) + 1))

# After (fixed)
tool_calls.extend([{} for _ in range(_index - len(tool_calls) + 1)])
```

Each slot now gets its own independent empty dict, so mutations to one slot do not affect others.

## Verification

```python
# Demonstrates the bug
shared = [{}] * 3
shared[0]['key'] = 'value'
assert shared[1]['key'] == 'value'  # all 3 are mutated!

# Correct
independent = [{} for _ in range(3)]
independent[0]['key'] = 'value'
assert 'key' not in independent[1]  # only index 0 is mutated ✅
```

Closes #6542