### PR TITLE
[fix] a2a stream: serialize Pydantic output_schema content before str concatenation

### DIFF
--- a/libs/agno/agno/os/interfaces/a2a/utils.py
+++ b/libs/agno/agno/os/interfaces/a2a/utils.py
@@ -348,11 +348,21 @@ async def stream_a2a_response(
 
         # Send content events
         elif isinstance(event, (RunContentEvent, TeamRunContentEvent)) and event.content:
-            accumulated_content += event.content
+            # Serialize content to str: Pydantic models (from output_schema) must be
+            # converted before str-concatenation or TextPart construction, otherwise
+            # "TypeError: can only concatenate str (not <Model>) to str" is raised.
+            raw_content = event.content
+            if hasattr(raw_content, "model_dump_json"):
+                content_str = raw_content.model_dump_json()
+            elif not isinstance(raw_content, str):
+                content_str = str(raw_content)
+            else:
+                content_str = raw_content
+            accumulated_content += content_str
             message = A2AMessage(
                 message_id=message_id,
                 role=Role.agent,
-                parts=[Part(root=TextPart(text=event.content))],
+                parts=[Part(root=TextPart(text=content_str))],
                 context_id=context_id,
                 task_id=task_id,
                 metadata={"agno_content_category": "content"},


### PR DESCRIPTION
## Problem

When an Agent has `output_schema` set to a Pydantic model, `RunContentEvent.content` is a **Pydantic BaseModel instance** rather than a plain `str`. The A2A streaming handler then crashes (closes #6850):

```
TypeError: can only concatenate str (not 'MyOutputSchema') to str
```

The failure occurs in two places inside `stream_a2a_response()`:

```python
# 1. String accumulation — fails when content is a BaseModel
accumulated_content += event.content

# 2. TextPart construction — fails if TextPart.text expects str
parts=[Part(root=TextPart(text=event.content))]
```

Note: the non-streaming `message:send` path works fine because it goes through `map_run_output_to_a2a_task()` which already calls `str(run_output.content)`.

## Fix

Before accumulating or constructing `TextPart`, detect Pydantic models and serialize them:

```python
raw_content = event.content
if hasattr(raw_content, 'model_dump_json'):
    content_str = raw_content.model_dump_json()   # Pydantic v2
elif not isinstance(raw_content, str):
    content_str = str(raw_content)                 # fallback
else:
    content_str = raw_content
```

Closes #6850