### PR TITLE
fix: add asyncio.Lock to prevent race condition in MCP session creation with header_provider

### DIFF
--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import time
 import weakref
@@ -183,6 +184,8 @@ class MCPTools(Toolkit):
         self._run_sessions: dict[str, Tuple[ClientSession, float]] = {}
         self._run_session_contexts: dict[str, Any] = {}  # Maps run_id to session context managers
         self._session_ttl_seconds: float = 300.0  # 5 minutes TTL for MCP sessions
+        # Lock to prevent race conditions when creating sessions for the same run_id
+        self._session_creation_lock: asyncio.Lock = asyncio.Lock()
 
         def cleanup():
             """Cancel active connections"""
@@ -298,70 +301,79 @@ class MCPTools(Toolkit):
                 raise ValueError("Session is not initialized")
             return self.session
 
-        # Lazy cleanup of stale sessions
-        await self._cleanup_stale_sessions()
-
-        # Check if we already have a session for this run
         run_id = run_context.run_id
+
+        # Fast path: check without lock if session already exists
         if run_id in self._run_sessions:
             session, _ = self._run_sessions[run_id]
             return session
 
-        # Create a new session with dynamic headers for this run
-        log_debug(f"Creating new session for run_id={run_id} with dynamic headers")
+        # Serialize session creation to prevent parallel tool calls from
+        # creating duplicate sessions for the same run_id (race condition)
+        async with self._session_creation_lock:
+            # Re-check after acquiring the lock (another coroutine may have created it)
+            if run_id in self._run_sessions:
+                session, _ = self._run_sessions[run_id]
+                return session
 
-        # Generate dynamic headers from the provider
-        dynamic_headers = self._call_header_provider(run_context=run_context, agent=agent, team=team)
+            # Lazy cleanup of stale sessions
+            await self._cleanup_stale_sessions()
 
-        # Create new session with merged headers based on transport type
-        if self.transport == "sse":
-            sse_params = asdict(self.server_params) if self.server_params is not None else {}  # type: ignore
-            if "url" not in sse_params:
-                sse_params["url"] = self.url
+            # Create a new session with dynamic headers for this run
+            log_debug(f"Creating new session for run_id={run_id} with dynamic headers")
 
-            # Merge dynamic headers into existing headers
-            existing_headers = sse_params.get("headers", {})
-            sse_params["headers"] = {**existing_headers, **dynamic_headers}
+            # Generate dynamic headers from the provider
+            dynamic_headers = self._call_header_provider(run_context=run_context, agent=agent, team=team)
 
-            context = sse_client(**sse_params)  # type: ignore
-            client_timeout = min(self.timeout_seconds, sse_params.get("timeout", self.timeout_seconds))
+            # Create new session with merged headers based on transport type
+            if self.transport == "sse":
+                sse_params = asdict(self.server_params) if self.server_params is not None else {}  # type: ignore
+                if "url" not in sse_params:
+                    sse_params["url"] = self.url
 
-        elif self.transport == "streamable-http":
-            streamable_http_params = asdict(self.server_params) if self.server_params is not None else {}  # type: ignore
-            if "url" not in streamable_http_params:
-                streamable_http_params["url"] = self.url
+                # Merge dynamic headers into existing headers
+                existing_headers = sse_params.get("headers", {})
+                sse_params["headers"] = {**existing_headers, **dynamic_headers}
 
-            # Merge dynamic headers into existing headers
-            existing_headers = streamable_http_params.get("headers", {})
-            streamable_http_params["headers"] = {**existing_headers, **dynamic_headers}
+                context = sse_client(**sse_params)  # type: ignore
+                client_timeout = min(self.timeout_seconds, sse_params.get("timeout", self.timeout_seconds))
 
-            context = streamablehttp_client(**streamable_http_params)  # type: ignore
-            params_timeout = streamable_http_params.get("timeout", self.timeout_seconds)
-            if isinstance(params_timeout, timedelta):
-                params_timeout = int(params_timeout.total_seconds())
-            client_timeout = min(self.timeout_seconds, params_timeout)
-        else:
-            # stdio doesn't support headers, fall back to default session
-            log_warning(f"Cannot use dynamic headers with {self.transport} transport, using default session")
-            if self.session is None:
-                raise ValueError("Session is not initialized")
-            return self.session
+            elif self.transport == "streamable-http":
+                streamable_http_params = asdict(self.server_params) if self.server_params is not None else {}  # type: ignore
+                if "url" not in streamable_http_params:
+                    streamable_http_params["url"] = self.url
 
-        # Enter the context and create session
-        session_params = await context.__aenter__()  # type: ignore
-        read, write = session_params[0:2]
+                # Merge dynamic headers into existing headers
+                existing_headers = streamable_http_params.get("headers", {})
+                streamable_http_params["headers"] = {**existing_headers, **dynamic_headers}
 
-        session_context = ClientSession(read, write, read_timeout_seconds=timedelta(seconds=client_timeout))  # type: ignore
-        session = await session_context.__aenter__()  # type: ignore
+                context = streamablehttp_client(**streamable_http_params)  # type: ignore
+                params_timeout = streamable_http_params.get("timeout", self.timeout_seconds)
+                if isinstance(params_timeout, timedelta):
+                    params_timeout = int(params_timeout.total_seconds())
+                client_timeout = min(self.timeout_seconds, params_timeout)
+            else:
+                # stdio doesn't support headers, fall back to default session
+                log_warning(f"Cannot use dynamic headers with {self.transport} transport, using default session")
+                if self.session is None:
+                    raise ValueError("Session is not initialized")
+                return self.session
 
-        # Initialize the session
-        await session.initialize()
+            # Enter the context and create session
+            session_params = await context.__aenter__()  # type: ignore
+            read, write = session_params[0:2]
 
-        # Store the session with timestamp and context for cleanup
-        self._run_sessions[run_id] = (session, time.time())
-        self._run_session_contexts[run_id] = (context, session_context)
+            session_context = ClientSession(read, write, read_timeout_seconds=timedelta(seconds=client_timeout))  # type: ignore
+            session = await session_context.__aenter__()  # type: ignore
 
-        return session
+            # Initialize the session
+            await session.initialize()
+
+            # Store the session with timestamp and context for cleanup
+            self._run_sessions[run_id] = (session, time.time())
+            self._run_session_contexts[run_id] = (context, session_context)
+
+            return session
 
     async def cleanup_run_session(self, run_id: str) -> None:
         """

--- a/libs/agno/agno/tools/mcp/multi_mcp.py
+++ b/libs/agno/agno/tools/mcp/multi_mcp.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import time
 import warnings
@@ -164,6 +165,8 @@ class MultiMCPTools(Toolkit):
         self._run_sessions: Dict[Tuple[str, int], Tuple[ClientSession, float]] = {}
         self._run_session_contexts: Dict[Tuple[str, int], Any] = {}  # Maps (run_id, server_idx) to context managers
         self._session_ttl_seconds: float = 300.0  # 5 minutes default TTL
+        # Lock to prevent race conditions when creating sessions for the same (run_id, server_idx)
+        self._session_creation_lock: asyncio.Lock = asyncio.Lock()
 
         self.allow_partial_failure = allow_partial_failure
 
@@ -292,71 +295,80 @@ class MultiMCPTools(Toolkit):
                 return self._sessions[server_idx]
             raise ValueError(f"Server index {server_idx} out of range")
 
-        # Lazy cleanup of stale sessions
-        await self._cleanup_stale_sessions()
-
-        # Check if we already have a session for this (run_id, server_idx)
         run_id = run_context.run_id
         cache_key = (run_id, server_idx)
+
+        # Fast path: check without lock if session already exists
         if cache_key in self._run_sessions:
             session, _ = self._run_sessions[cache_key]
             return session
 
-        # Create a new session with dynamic headers for this run and server
-        log_debug(f"Creating new session for run_id={run_id}, server_idx={server_idx} with dynamic headers")
+        # Serialize session creation to prevent parallel tool calls from
+        # creating duplicate sessions for the same (run_id, server_idx) (race condition)
+        async with self._session_creation_lock:
+            # Re-check after acquiring the lock (another coroutine may have created it)
+            if cache_key in self._run_sessions:
+                session, _ = self._run_sessions[cache_key]
+                return session
 
-        # Generate dynamic headers from the provider
-        dynamic_headers = self._call_header_provider(run_context=run_context, agent=agent, team=team)
+            # Lazy cleanup of stale sessions
+            await self._cleanup_stale_sessions()
 
-        # Get the server params for this server index
-        if server_idx >= len(self.server_params_list):
-            raise ValueError(f"Server index {server_idx} out of range")
+            # Create a new session with dynamic headers for this run and server
+            log_debug(f"Creating new session for run_id={run_id}, server_idx={server_idx} with dynamic headers")
 
-        server_params = self.server_params_list[server_idx]
+            # Generate dynamic headers from the provider
+            dynamic_headers = self._call_header_provider(run_context=run_context, agent=agent, team=team)
 
-        # Create new session with merged headers based on transport type
-        if isinstance(server_params, SSEClientParams):
-            params_dict = asdict(server_params)
-            existing_headers = params_dict.get("headers") or {}
-            params_dict["headers"] = {**existing_headers, **dynamic_headers}
+            # Get the server params for this server index
+            if server_idx >= len(self.server_params_list):
+                raise ValueError(f"Server index {server_idx} out of range")
 
-            context = sse_client(**params_dict)  # type: ignore
-            client_timeout = min(self.timeout_seconds, params_dict.get("timeout", self.timeout_seconds))
+            server_params = self.server_params_list[server_idx]
 
-        elif isinstance(server_params, StreamableHTTPClientParams):
-            params_dict = asdict(server_params)
-            existing_headers = params_dict.get("headers") or {}
-            params_dict["headers"] = {**existing_headers, **dynamic_headers}
+            # Create new session with merged headers based on transport type
+            if isinstance(server_params, SSEClientParams):
+                params_dict = asdict(server_params)
+                existing_headers = params_dict.get("headers") or {}
+                params_dict["headers"] = {**existing_headers, **dynamic_headers}
 
-            context = streamablehttp_client(**params_dict)  # type: ignore
-            params_timeout = params_dict.get("timeout", self.timeout_seconds)
-            if isinstance(params_timeout, timedelta):
-                params_timeout = int(params_timeout.total_seconds())
-            client_timeout = min(self.timeout_seconds, params_timeout)
-        else:
-            # stdio doesn't support headers, fall back to default session
-            log_warning(
-                f"Cannot use dynamic headers with stdio transport for server {server_idx}, using default session"
-            )
-            if server_idx < len(self._sessions):
-                return self._sessions[server_idx]
-            raise ValueError(f"Server index {server_idx} out of range")
+                context = sse_client(**params_dict)  # type: ignore
+                client_timeout = min(self.timeout_seconds, params_dict.get("timeout", self.timeout_seconds))
 
-        # Enter the context and create session
-        session_params = await context.__aenter__()  # type: ignore
-        read, write = session_params[0:2]
+            elif isinstance(server_params, StreamableHTTPClientParams):
+                params_dict = asdict(server_params)
+                existing_headers = params_dict.get("headers") or {}
+                params_dict["headers"] = {**existing_headers, **dynamic_headers}
 
-        session_context = ClientSession(read, write, read_timeout_seconds=timedelta(seconds=client_timeout))  # type: ignore
-        session = await session_context.__aenter__()  # type: ignore
+                context = streamablehttp_client(**params_dict)  # type: ignore
+                params_timeout = params_dict.get("timeout", self.timeout_seconds)
+                if isinstance(params_timeout, timedelta):
+                    params_timeout = int(params_timeout.total_seconds())
+                client_timeout = min(self.timeout_seconds, params_timeout)
+            else:
+                # stdio doesn't support headers, fall back to default session
+                log_warning(
+                    f"Cannot use dynamic headers with stdio transport for server {server_idx}, using default session"
+                )
+                if server_idx < len(self._sessions):
+                    return self._sessions[server_idx]
+                raise ValueError(f"Server index {server_idx} out of range")
 
-        # Initialize the session
-        await session.initialize()
+            # Enter the context and create session
+            session_params = await context.__aenter__()  # type: ignore
+            read, write = session_params[0:2]
 
-        # Store the session with timestamp and context for cleanup
-        self._run_sessions[cache_key] = (session, time.time())
-        self._run_session_contexts[cache_key] = (context, session_context)
+            session_context = ClientSession(read, write, read_timeout_seconds=timedelta(seconds=client_timeout))  # type: ignore
+            session = await session_context.__aenter__()  # type: ignore
 
-        return session
+            # Initialize the session
+            await session.initialize()
+
+            # Store the session with timestamp and context for cleanup
+            self._run_sessions[cache_key] = (session, time.time())
+            self._run_session_contexts[cache_key] = (context, session_context)
+
+            return session
 
     async def cleanup_run_session(self, run_id: str, server_idx: int) -> None:
         """Clean up a per-run session."""


### PR DESCRIPTION
## Summary

Fixes a race condition in `MCPTools` and `MultiMCPTools` that causes parallel tool calls to hang indefinitely when `header_provider` is set.

When `header_provider` is configured, `get_session_for_run()` creates a new per-run session with dynamic headers. However, when multiple tool calls execute in parallel (via `asyncio.gather()`), they all check `if run_id in self._run_sessions` simultaneously, all see `False`, and each proceeds to create a duplicate session against the same MCP server — causing the connection to deadlock.

The fix adds an `asyncio.Lock` with a double-checked locking pattern:
1. **Fast path (no lock):** If a session already exists for the run_id, return it immediately
2. **Slow path (with lock):** Acquire the lock, re-check if another coroutine created the session while waiting, then create it if needed

Fixes #6094

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Both `MCPTools.get_session_for_run()` and `MultiMCPTools.get_session_for_run()` had the same TOCTOU (time-of-check-time-of-use) race condition. The fix is applied to both classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)