### PR TITLE
[fix] knowledge: hash actual file_data content bytes for uniqueness, not just type

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -2163,24 +2163,21 @@ class Knowledge(RemoteKnowledge):
         elif content.url:
             hash_parts.append(content.url)
         elif content.file_data and content.file_data.content:
-            # For file_data, always add filename, type, size, or content for uniqueness
+            # For file_data, include the filename when present to give a human-readable
+            # component, but ALWAYS also hash the actual content bytes for uniqueness.
+            # Previously only file_data.type (e.g. "Text") was used when filename was
+            # absent, causing every text_content entry to produce the same hash.
             if content.file_data.filename:
                 hash_parts.append(content.file_data.filename)
-            elif content.file_data.type:
-                hash_parts.append(content.file_data.type)
-            elif content.file_data.size is not None:
-                hash_parts.append(str(content.file_data.size))
-            else:
-                # Fallback: use the content for uniqueness
-                # Include type information to distinguish str vs bytes
-                content_type = "str" if isinstance(content.file_data.content, str) else "bytes"
-                content_bytes = (
-                    content.file_data.content.encode()
-                    if isinstance(content.file_data.content, str)
-                    else content.file_data.content
-                )
-                content_hash = hashlib.sha256(content_bytes).hexdigest()[:16]  # Use first 16 chars
-                hash_parts.append(f"{content_type}:{content_hash}")
+            # Always hash the raw content for uniqueness regardless of filename presence
+            content_type = "str" if isinstance(content.file_data.content, str) else "bytes"
+            content_bytes = (
+                content.file_data.content.encode()
+                if isinstance(content.file_data.content, str)
+                else content.file_data.content
+            )
+            content_hash_hex = hashlib.sha256(content_bytes).hexdigest()[:16]
+            hash_parts.append(f"{content_type}:{content_hash_hex}")
         elif content.topics and len(content.topics) > 0:
             topic = content.topics[0]
             reader = type(content.reader).__name__ if content.reader else "unknown"


### PR DESCRIPTION
## Root cause

`_build_content_hash()` in `knowledge.py` chose the hash input for `file_data` in this priority order:

1. `filename` → unique ✅  
2. **`type`** → always `'Text'` for `text_content` entries ❌  
3. `size` → collides for entries of the same length  
4. content bytes → unique ✅ (only reached when 1-3 are all `None`)

When `knowledge.insert(text_content='...')` is called (without a filename), it creates `FileData(content='<text>', type='Text')`. Since `filename is None`, the hash falls to branch 2 and uses the literal string `'Text'` for ALL entries — producing the **same hash regardless of content** (closes #6952):

```python
# Before: all text_content entries produce hash('Text') ❌
if content.file_data.filename:
    hash_parts.append(content.file_data.filename)
elif content.file_data.type:        # ← 'Text' for every entry
    hash_parts.append(content.file_data.type)
```

## Fix

Always hash the raw content bytes and use the filename only as an optional readable prefix:

```python
if content.file_data.filename:
    hash_parts.append(content.file_data.filename)
# Always add a content hash — guarantees uniqueness regardless of filename
hash_parts.append(f'str:{sha256(content.encode()).hexdigest()[:16]}')
```

Closes #6952