### PR TITLE
fix: mongo validation

### DIFF
--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -264,7 +264,11 @@ class AsyncMongoDb(AsyncBaseDb):
         all database connections.
         """
         if self._client is not None:
-            self._client.close()
+            import inspect
+
+            close_result = self._client.close()
+            if inspect.isawaitable(close_result):
+                await close_result
             self._client = None
             self._database = None
 

--- a/libs/agno/tests/unit/db/test_async_mongo.py
+++ b/libs/agno/tests/unit/db/test_async_mongo.py
@@ -111,6 +111,9 @@ async def test_initialization_flags_cleared_on_event_loop_change():
     initialized_flags_before = [attr for attr in vars(db).keys() if attr.endswith("_initialized")]
     assert len(initialized_flags_before) >= 2, "Should have initialized flags"
 
+    # Close old client before simulating event loop change
+    await db.close()
+
     # Manually simulate event loop change (what _ensure_client does)
     db._event_loop = None  # Force it to detect a "new" loop next time
     _ = db.db_client  # This should trigger cleanup
@@ -124,6 +127,8 @@ async def test_initialization_flags_cleared_on_event_loop_change():
     assert len(initialized_flags_after) == 0, (
         f"All _initialized flags should be cleared, but found: {initialized_flags_after}"
     )
+
+    await db.close()
 
 
 @pytest.mark.asyncio
@@ -140,12 +145,24 @@ async def test_indexes_awaited_properly():
     collection = await db._get_collection("sessions", create_collection_if_not_found=True)
     assert collection is not None
 
-    # Verify no pending tasks (excluding current task)
-    pending = [task for task in asyncio.all_tasks() if not task.done()]
+    # Verify no pending tasks from our code (exclude current task and PyMongo/Motor internals)
     current_task = asyncio.current_task()
-    pending = [task for task in pending if task != current_task]
+
+    def _is_pymongo_internal(task: asyncio.Task) -> bool:
+        """Check if a task belongs to PyMongo/Motor internals."""
+        coro = task.get_coro()
+        code_file = getattr(getattr(coro, "cr_code", None), "co_filename", "")
+        return "pymongo" in code_file or "motor" in code_file
+
+    pending = [
+        task
+        for task in asyncio.all_tasks()
+        if not task.done() and task != current_task and not _is_pymongo_internal(task)
+    ]
 
     assert len(pending) == 0, f"Should have no pending tasks, but found: {pending}"
+
+    await db.close()
 
 
 @pytest.mark.asyncio
@@ -162,6 +179,9 @@ async def test_collection_cache_reset_on_event_loop_change():
     collections_before = [attr for attr in vars(db).keys() if attr.endswith("_collection")]
     assert len(collections_before) >= 3
 
+    # Close the current client before simulating event loop change
+    await db.close()
+
     # Force event loop change
     db._event_loop = None
     _ = db.db_client
@@ -169,6 +189,8 @@ async def test_collection_cache_reset_on_event_loop_change():
     # All collections should be cleared
     collections_after = [attr for attr in vars(db).keys() if attr.endswith("_collection")]
     assert len(collections_after) == 0, f"All collections should be cleared, found: {collections_after}"
+
+    await db.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Fix `AsyncMongoDb.close()` to await `AsyncMongoClient.close()` which is a coroutine in PyMongo async (unlike Motor's sync close())
- Fix unit tests to properly close MongoDB clients before simulating event loop changes, preventing orphaned background tasks
- Filter PyMongo internal tasks in test_indexes_awaited_properly to avoid false failures from PyMongo's background monitor/RTT/cursor tasks

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
