### PR TITLE
[fix] agent._tools: call knowledge.get_tools() / aget_tools() to expose knowledge-specific tools

### DIFF
--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -198,6 +198,16 @@ def get_tools(
     if resolved_knowledge is not None and agent.update_knowledge:
         agent_tools.append(agent.add_to_knowledge)
 
+    # If the knowledge object exposes additional tools (e.g. FileSystemKnowledge
+    # provides grep_file / list_files / get_file), add them to the agent.
+    if resolved_knowledge is not None and hasattr(resolved_knowledge, "get_tools"):
+        try:
+            knowledge_tools = resolved_knowledge.get_tools()
+            if knowledge_tools:
+                agent_tools.extend(knowledge_tools)
+        except Exception:
+            pass
+
     # Add tools for accessing skills
     if agent.skills is not None:
         agent_tools.extend(agent.skills.get_tools())
@@ -329,6 +339,23 @@ async def aget_tools(
 
     if resolved_knowledge is not None and agent.update_knowledge:
         agent_tools.append(agent.add_to_knowledge)
+
+    # If the knowledge object exposes additional tools (e.g. FileSystemKnowledge
+    # provides grep_file / list_files / get_file), add them to the agent.
+    if resolved_knowledge is not None and hasattr(resolved_knowledge, "aget_tools"):
+        try:
+            knowledge_tools = await resolved_knowledge.aget_tools()
+            if knowledge_tools:
+                agent_tools.extend(knowledge_tools)
+        except Exception:
+            pass
+    elif resolved_knowledge is not None and hasattr(resolved_knowledge, "get_tools"):
+        try:
+            knowledge_tools = resolved_knowledge.get_tools()
+            if knowledge_tools:
+                agent_tools.extend(knowledge_tools)
+        except Exception:
+            pass
 
     # Add tools for accessing skills
     if agent.skills is not None:


### PR DESCRIPTION
## Problem

`KnowledgeBase` subclasses that override `get_tools()` / `aget_tools()` (e.g. `FileSystemKnowledge`, which provides `grep_file` / `list_files` / `get_file`) are never called from `agent._tools.get_tools()` / `aget_tools()`.

Only the generic `search_knowledge_base` tool is injected, so the docstring example is non-functional (closes #6937):

```python
# Docstring says:
# Agent automatically gets grep_file, list_files, get_file tools
agent = Agent(knowledge=fs_knowledge, search_knowledge=True)
# Actual: only search_knowledge_base is added; grep_file etc. are missing
```

## Root cause

In `libs/agno/agno/agent/_tools.py`, after adding the search / update tools, the code never calls `resolved_knowledge.get_tools()` even though the protocol defines it.

## Fix

After the `update_knowledge` block, call `knowledge.get_tools()` (sync) or `knowledge.aget_tools()` (async) when the knowledge object defines them, and extend `agent_tools` with the result:

```python
if resolved_knowledge is not None and hasattr(resolved_knowledge, 'get_tools'):
    knowledge_tools = resolved_knowledge.get_tools()
    if knowledge_tools:
        agent_tools.extend(knowledge_tools)
```

Both sync (`get_tools`) and async (`aget_tools`) paths are covered.

Closes #6937