### PR TITLE
fix: always include content digest in file_data hash to prevent collisions

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -2163,24 +2163,24 @@ class Knowledge(RemoteKnowledge):
         elif content.url:
             hash_parts.append(content.url)
         elif content.file_data and content.file_data.content:
-            # For file_data, always add filename, type, size, or content for uniqueness
+            # For file_data, include all available metadata AND a content hash.
+            # Using if/elif previously caused all entries with the same type
+            # (e.g. "Text") to produce identical hashes regardless of content.
             if content.file_data.filename:
                 hash_parts.append(content.file_data.filename)
-            elif content.file_data.type:
+            if content.file_data.type:
                 hash_parts.append(content.file_data.type)
-            elif content.file_data.size is not None:
+            if content.file_data.size is not None:
                 hash_parts.append(str(content.file_data.size))
-            else:
-                # Fallback: use the content for uniqueness
-                # Include type information to distinguish str vs bytes
-                content_type = "str" if isinstance(content.file_data.content, str) else "bytes"
-                content_bytes = (
-                    content.file_data.content.encode()
-                    if isinstance(content.file_data.content, str)
-                    else content.file_data.content
-                )
-                content_hash = hashlib.sha256(content_bytes).hexdigest()[:16]  # Use first 16 chars
-                hash_parts.append(f"{content_type}:{content_hash}")
+            # Always include a hash of the actual content for uniqueness
+            content_type = "str" if isinstance(content.file_data.content, str) else "bytes"
+            content_bytes = (
+                content.file_data.content.encode()
+                if isinstance(content.file_data.content, str)
+                else content.file_data.content
+            )
+            content_digest = hashlib.sha256(content_bytes).hexdigest()[:16]
+            hash_parts.append(f"{content_type}:{content_digest}")
         elif content.topics and len(content.topics) > 0:
             topic = content.topics[0]
             reader = type(content.reader).__name__ if content.reader else "unknown"

--- a/libs/agno/tests/unit/knowledge/test_knowledge_content_hash.py
+++ b/libs/agno/tests/unit/knowledge/test_knowledge_content_hash.py
@@ -253,8 +253,8 @@ def test_file_data_hash_with_filename():
 
     # Different filenames should produce different hashes
     assert hash1 != hash2
-    # Same filename should produce same hash (even with different content)
-    assert hash1 == hash3
+    # Same filename but different content should produce different hashes
+    assert hash1 != hash3
 
 
 def test_file_data_hash_with_type():
@@ -270,8 +270,8 @@ def test_file_data_hash_with_type():
 
     # Different types should produce different hashes
     assert hash1 != hash2
-    # Same type should produce same hash (even with different content)
-    assert hash1 == hash3
+    # Same type but different content should produce different hashes
+    assert hash1 != hash3
 
 
 def test_file_data_hash_with_size():
@@ -287,8 +287,8 @@ def test_file_data_hash_with_size():
 
     # Different sizes should produce different hashes
     assert hash1 != hash2
-    # Same size should produce same hash (even with different content)
-    assert hash1 == hash3
+    # Same size but different content should produce different hashes
+    assert hash1 != hash3
 
 
 def test_file_data_hash_with_content_fallback():
@@ -337,8 +337,8 @@ def test_file_data_hash_with_name_and_description():
     hash3 = knowledge._build_content_hash(content3)
     hash4 = knowledge._build_content_hash(content4)
 
-    # Same name/description/filename should produce same hash (content difference ignored when filename present)
-    assert hash1 == hash2
+    # Same name/description/filename but different content should produce different hashes
+    assert hash1 != hash2
     # Different filename should produce different hash
     assert hash1 != hash3
     # Different name should produce different hash
@@ -346,7 +346,7 @@ def test_file_data_hash_with_name_and_description():
 
 
 def test_file_data_hash_priority_filename_over_type():
-    """Test that filename takes priority over type."""
+    """Test that filename and type are both included but filename differentiates."""
     knowledge = Knowledge(vector_db=MockVectorDb())
     content1 = Content(file_data=FileData(content="test", filename="file.pdf", type="application/pdf"))
     content2 = Content(file_data=FileData(content="test", filename="file.pdf", type="text/plain"))
@@ -354,12 +354,13 @@ def test_file_data_hash_priority_filename_over_type():
     hash1 = knowledge._build_content_hash(content1)
     hash2 = knowledge._build_content_hash(content2)
 
-    # Same filename should produce same hash regardless of type
-    assert hash1 == hash2
+    # Same filename and content but different type should produce different hashes
+    # (all fields are now included)
+    assert hash1 != hash2
 
 
 def test_file_data_hash_priority_type_over_size():
-    """Test that type takes priority over size."""
+    """Test that type and size are both included."""
     knowledge = Knowledge(vector_db=MockVectorDb())
     content1 = Content(file_data=FileData(content="test", type="application/pdf", size=1024))
     content2 = Content(file_data=FileData(content="test", type="application/pdf", size=2048))
@@ -367,8 +368,8 @@ def test_file_data_hash_priority_type_over_size():
     hash1 = knowledge._build_content_hash(content1)
     hash2 = knowledge._build_content_hash(content2)
 
-    # Same type should produce same hash regardless of size
-    assert hash1 == hash2
+    # Same type and content but different size should produce different hashes
+    assert hash1 != hash2
 
 
 def test_file_data_hash_with_name_only():
@@ -458,8 +459,8 @@ def test_file_data_hash_all_fields_present():
     hash2 = knowledge._build_content_hash(content2)
     hash3 = knowledge._build_content_hash(content3)
 
-    # Same name/description/filename should produce same hash (content/type/size differences ignored when filename present)
-    assert hash1 == hash2
+    # Same name/description/filename but different content should produce different hashes
+    assert hash1 != hash2
     # Different filename should produce different hash
     assert hash1 != hash3
 
@@ -584,3 +585,28 @@ def test_document_content_hash_fallback_to_content_hash():
     assert hash1 != hash2
     # Same content should produce same hash
     assert hash1 == hash3
+
+
+def test_text_content_with_same_type_produces_unique_hashes():
+    """Regression test for #6952: text_content inserts with type='Text' must produce
+    unique hashes for different content. Previously the if/elif chain would short-circuit
+    on type='Text' and ignore the actual content, causing all text_content inserts to
+    collide to the same hash."""
+    knowledge = Knowledge(vector_db=MockVectorDb())
+
+    content1 = Content(file_data=FileData(content="first text", type="Text"))
+    content2 = Content(file_data=FileData(content="second text", type="Text"))
+    content3 = Content(file_data=FileData(content="third text", type="Text"))
+    content4 = Content(file_data=FileData(content="first text", type="Text"))
+
+    hash1 = knowledge._build_content_hash(content1)
+    hash2 = knowledge._build_content_hash(content2)
+    hash3 = knowledge._build_content_hash(content3)
+    hash4 = knowledge._build_content_hash(content4)
+
+    # Different content must produce different hashes, even with the same type
+    assert hash1 != hash2
+    assert hash1 != hash3
+    assert hash2 != hash3
+    # Identical content must produce the same hash
+    assert hash1 == hash4


### PR DESCRIPTION
## Problem

`Knowledge._build_content_hash()` uses an `if/elif/elif/else` chain to pick **one** metadata field (filename → type → size → content digest) as the hash input. When `text_content` is passed to `ainsert()`, it wraps the text in `FileData(content=text_content, type="Text")`. Because `type` is always truthy, the `elif file_data.type:` branch fires and the hash is based solely on `"Text"` — the actual content is never hashed.

**Result:** every `text_content` insert with the same `type` produces an identical hash, so:
- `content_hash_exists()` returns `True` for brand-new content
- Stale data is never replaced on re-insert

## Solution

Replace the exclusive `if/elif/elif/else` chain with non-exclusive `if/if/if` checks that **accumulate all available metadata fields**, plus **always append a SHA-256 digest of the actual content bytes**.

This ensures:
- Different content always produces a different hash, even when metadata fields are identical
- Metadata fields (filename, type, size) still contribute to hash differentiation
- Backward compatibility is preserved for URL-based and path-based content (those code paths are unchanged)

## Tests

- Updated 6 existing tests whose assertions expected the old (buggy) behaviour where same metadata → same hash regardless of content
- Added `test_text_content_with_same_type_produces_unique_hashes` regression test that directly reproduces the bug scenario from #6952
- All 30 content-hash tests pass

Closes #6952