### PR TITLE
fix: replace [{}]*N with list comprehension in parse_tool_calls

### DIFF
--- a/libs/agno/agno/models/groq/groq.py
+++ b/libs/agno/agno/models/groq/groq.py
@@ -455,7 +455,7 @@ class Groq(Model):
             _function_arguments = _tool_call.function.arguments if _tool_call.function else None
 
             if len(tool_calls) <= _index:
-                tool_calls.extend([{}] * (_index - len(tool_calls) + 1))
+                tool_calls.extend([{} for _ in range(_index - len(tool_calls) + 1)])
             tool_call_entry = tool_calls[_index]
             if not tool_call_entry:
                 tool_call_entry["id"] = _tool_call_id

--- a/libs/agno/agno/models/huggingface/huggingface.py
+++ b/libs/agno/agno/models/huggingface/huggingface.py
@@ -390,7 +390,7 @@ class HuggingFace(Model):
             _function_arguments = _tool_call.function.arguments if _tool_call.function else None
 
             if len(tool_calls) <= _index:
-                tool_calls.extend([{}] * (_index - len(tool_calls) + 1))
+                tool_calls.extend([{} for _ in range(_index - len(tool_calls) + 1)])
             tool_call_entry = tool_calls[_index]
             if not tool_call_entry:
                 tool_call_entry["id"] = _tool_call_id

--- a/libs/agno/agno/models/ibm/watsonx.py
+++ b/libs/agno/agno/models/ibm/watsonx.py
@@ -312,7 +312,7 @@ class WatsonX(Model):
             _function_arguments = _tool_call.get("function", {}).get("arguments")
 
             if len(tool_calls) <= _index:
-                tool_calls.extend([{}] * (_index - len(tool_calls) + 1))
+                tool_calls.extend([{} for _ in range(_index - len(tool_calls) + 1)])
             tool_call_entry = tool_calls[_index]
             if not tool_call_entry:
                 tool_call_entry["id"] = _tool_call_id

--- a/libs/agno/agno/models/openai/chat.py
+++ b/libs/agno/agno/models/openai/chat.py
@@ -720,7 +720,7 @@ class OpenAIChat(Model):
             _function_arguments = _tool_call.function.arguments if _tool_call.function else None
 
             if len(tool_calls) <= _index:
-                tool_calls.extend([{}] * (_index - len(tool_calls) + 1))
+                tool_calls.extend([{} for _ in range(_index - len(tool_calls) + 1)])
             tool_call_entry = tool_calls[_index]
             if not tool_call_entry:
                 tool_call_entry["id"] = _tool_call_id


### PR DESCRIPTION
## Problem

`parse_tool_calls` uses `[{}] * N` to extend the tool_calls list. This is a classic Python pitfall — list multiplication with mutable objects creates N references to the **same** dict, not N independent dicts. When one entry is mutated, all entries change simultaneously, causing **every tool call to be executed twice** when the provider returns non-zero-based indices.

Closes #6542

## Root Cause

```python
# Buggy: creates N references to the SAME dict
tool_calls.extend([{}] * (_index - len(tool_calls) + 1))
```

When Claude via LiteLLM Proxy returns `index=1`, the code extends with 2 dicts — but they're the same object. Mutating `tool_calls[1]` also mutates `tool_calls[0]`, causing double-execution.

## Solution

```python
# Fixed: creates N independent dicts
tool_calls.extend([{} for _ in range(_index - len(tool_calls) + 1)])
```

Fixed across **all four** model files that had the same pattern:
- `libs/agno/agno/models/openai/chat.py`
- `libs/agno/agno/models/groq/groq.py`
- `libs/agno/agno/models/ibm/watsonx.py`
- `libs/agno/agno/models/huggingface/huggingface.py`