### PR TITLE
fix(os): read knowledge_table from contents_db instead of agent.db

### DIFF
--- a/libs/agno/agno/os/routers/agents/schema.py
+++ b/libs/agno/agno/os/routers/agents/schema.py
@@ -140,7 +140,16 @@ class AgentResponse(BaseModel):
             _agent_model_data["provider"] = model_provider
 
         session_table = agent.db.session_table_name if agent.db else None
-        knowledge_table = agent.db.knowledge_table_name if agent.db and agent.knowledge else None
+        # Read knowledge_table from the knowledge's own contents_db, not agent.db.
+        # agent.db is the session/state database; when the user configures a
+        # separate contents_db with a custom knowledge_table the config must
+        # reflect that custom table name, not the agent-level default.
+        _contents_db = getattr(agent.knowledge, "contents_db", None) if agent.knowledge else None
+        knowledge_table = (
+            _contents_db.knowledge_table_name
+            if _contents_db is not None
+            else (agent.db.knowledge_table_name if agent.db and agent.knowledge else None)
+        )
 
         tools_info = {
             "tools": formatted_tools,
@@ -159,9 +168,8 @@ class AgentResponse(BaseModel):
             "cache_session": agent.cache_session,
         }
 
-        contents_db = getattr(agent.knowledge, "contents_db", None) if agent.knowledge else None
         knowledge_info = {
-            "db_id": contents_db.id if contents_db else None,
+            "db_id": _contents_db.id if _contents_db else None,
             "knowledge_table": knowledge_table,
             "enable_agentic_knowledge_filters": agent.enable_agentic_knowledge_filters,
             "knowledge_filters": (


### PR DESCRIPTION
## Problem

`AgentResponse.from_agent()` reads `knowledge_table_name` from `agent.db` (the session/state database):

```python
knowledge_table = agent.db.knowledge_table_name if agent.db and agent.knowledge else None
```

When a user configures a **separate** `PostgresDb` with a custom `knowledge_table` for their `Knowledge` object's `contents_db`, the AgentOS "See Config" view always shows the `agent.db` default table name (`agno_knowledge`), ignoring the user's custom setting.

### Example

```python
# User sets a custom knowledge table on the Knowledge's contents_db
KNOWLEDGE_DB = PostgresDb(
    id="my_knowledge_db",
    db_url=DB_URL,
    knowledge_table="presenter_knowledge_contents"  # <-- ignored in config
)

agent = Agent(
    knowledge=Knowledge(contents_db=KNOWLEDGE_DB, ...),
    db=PostgresDb(id="session_db", ...),  # agent.db has default table name
)
# AgentOS "See Config" always shows "agno_knowledge" instead of
# "presenter_knowledge_contents"
```

## Fix

Read `knowledge_table_name` from `knowledge.contents_db` first, falling back to `agent.db` only when no dedicated `contents_db` exists. This matches how `db_id` is already derived (line 172 reads from `contents_db.id`).

## Changes

- `libs/agno/agno/os/routers/agents/schema.py`: Extract `_contents_db` earlier and use it for both `knowledge_table` and `db_id` in the knowledge config block.

Closes #6975