### PR TITLE
fix(tracing): propagate session/run metadata to OTel span in continue_run

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -2721,6 +2721,33 @@ def continue_run_dispatch(
         session_id=session_id,
         user_id=user_id,
     )
+
+    # Propagate trace metadata to the current OTel span so that
+    # instrumentation (e.g. OpenInference) can attach session_id,
+    # run_id and user_id to the trace — even when continue_run
+    # is called from a new context (e.g. after HITL pause).
+    try:
+        from opentelemetry import trace as _trace_api
+
+        _current_span = _trace_api.get_current_span()
+        if _current_span and _current_span.is_recording():
+            if run_id:
+                _current_span.set_attribute("run_id", run_id)
+                _current_span.set_attribute("agno.run.id", run_id)
+            if session_id:
+                _current_span.set_attribute("session_id", session_id)
+                _current_span.set_attribute("agno.session.id", session_id)
+                _current_span.set_attribute("session.id", session_id)
+            if user_id:
+                _current_span.set_attribute("user_id", user_id)
+                _current_span.set_attribute("agno.user.id", user_id)
+                _current_span.set_attribute("user.id", user_id)
+            if agent.agent_id:
+                _current_span.set_attribute("agent_id", agent.agent_id)
+                _current_span.set_attribute("agno.agent.id", agent.agent_id)
+    except ImportError:
+        pass
+
     # Initialize the Agent
     agent.initialize_agent(debug_mode=debug_mode)
 
@@ -3450,6 +3477,32 @@ def acontinue_run_dispatch(  # type: ignore
         session_id=session_id,
         user_id=user_id,
     )
+
+    # Propagate trace metadata to the current OTel span so that
+    # instrumentation (e.g. OpenInference) can attach session_id,
+    # run_id and user_id to the trace — even when acontinue_run
+    # is called from a new async context (e.g. after HITL pause).
+    try:
+        from opentelemetry import trace as _trace_api
+
+        _current_span = _trace_api.get_current_span()
+        if _current_span and _current_span.is_recording():
+            if run_id:
+                _current_span.set_attribute("run_id", run_id)
+                _current_span.set_attribute("agno.run.id", run_id)
+            if session_id:
+                _current_span.set_attribute("session_id", session_id)
+                _current_span.set_attribute("agno.session.id", session_id)
+                _current_span.set_attribute("session.id", session_id)
+            if user_id:
+                _current_span.set_attribute("user_id", user_id)
+                _current_span.set_attribute("agno.user.id", user_id)
+                _current_span.set_attribute("user.id", user_id)
+            if agent.agent_id:
+                _current_span.set_attribute("agent_id", agent.agent_id)
+                _current_span.set_attribute("agno.agent.id", agent.agent_id)
+    except ImportError:
+        pass
 
     # Initialize the Agent
     agent.initialize_agent(debug_mode=debug_mode)


### PR DESCRIPTION
## Problem

When `acontinue_run` (or `continue_run`) is called from a new async context after a HITL (human-in-the-loop) pause, the OpenTelemetry span created by instrumentation (e.g. OpenInference + Langfuse) lacks `session_id`, `run_id`, and `user_id` attributes.

This happens because the original OTel context from `arun` is lost when execution resumes in a different async context (e.g. a new FastAPI request handler).

**Impact:** Langfuse traces for continued HITL runs show missing metadata, making it impossible to correlate resumed runs with the original session.

## Root Cause

`acontinue_run_dispatch` correctly extracts `session_id`, `run_id`, and `user_id` from the `RunResponse`, but never sets them as attributes on the current OTel span. The `create_trace_from_spans` function in `tracing/schemas.py` reads these from the root span's attributes, so if they're not set, the trace is incomplete.

## Fix

After extracting IDs from `RunResponse` and `initialize_session`, explicitly call `set_attribute()` on the current recording span with all relevant identifiers (`run_id`, `session_id`, `user_id`, `agent_id`) using both the canonical Agno attribute keys and the OpenInference-compatible keys.

Applied to both sync (`continue_run_dispatch`) and async (`acontinue_run_dispatch`) paths.

The import is wrapped in `try/except ImportError` so there's zero impact when OpenTelemetry is not installed.

## Testing

The fix is safe and backward-compatible:
- If OTel is not installed → `ImportError` is caught, no-op
- If no span is active → `get_current_span()` returns a non-recording span, no-op
- If span is recording → attributes are set, traces are complete

Closes #6939