### PR TITLE
[fix] Read knowledge_table from Knowledge's contents_db

### DIFF
--- a/libs/agno/agno/os/routers/agents/schema.py
+++ b/libs/agno/agno/os/routers/agents/schema.py
@@ -140,7 +140,6 @@ class AgentResponse(BaseModel):
             _agent_model_data["provider"] = model_provider
 
         session_table = agent.db.session_table_name if agent.db else None
-        knowledge_table = agent.db.knowledge_table_name if agent.db and agent.knowledge else None
 
         tools_info = {
             "tools": formatted_tools,
@@ -160,6 +159,14 @@ class AgentResponse(BaseModel):
         }
 
         contents_db = getattr(agent.knowledge, "contents_db", None) if agent.knowledge else None
+        # Use the knowledge's own contents_db table name when available,
+        # falling back to agent.db for agents without a custom Knowledge config.
+        if contents_db and hasattr(contents_db, "knowledge_table_name"):
+            knowledge_table = contents_db.knowledge_table_name
+        elif agent.db and agent.knowledge:
+            knowledge_table = agent.db.knowledge_table_name
+        else:
+            knowledge_table = None
         knowledge_info = {
             "db_id": contents_db.id if contents_db else None,
             "knowledge_table": knowledge_table,

--- a/libs/agno/tests/unit/os/test_knowledge_table_config.py
+++ b/libs/agno/tests/unit/os/test_knowledge_table_config.py
@@ -1,0 +1,85 @@
+"""Tests that knowledge_table reflects the Knowledge's contents_db config in AgentResponse.
+
+Covers the fix for https://github.com/agno-agi/agno/issues/6975 where
+AgnoOS always displayed knowledge_table as 'agno_knowledge' regardless
+of the user's custom Knowledge contents_db configuration.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from agno.agent import Agent
+from agno.os.routers.agents.schema import AgentResponse
+
+
+def _make_db(knowledge_table="agno_knowledge", **kwargs):
+    """Create a minimal db-like object with knowledge_table_name."""
+    return SimpleNamespace(
+        id="test-db",
+        knowledge_table_name=knowledge_table,
+        session_table_name=kwargs.get("session_table", "agno_sessions"),
+        memory_table_name=kwargs.get("memory_table", "agno_memories"),
+    )
+
+
+def _make_knowledge(contents_db=None):
+    """Create a minimal knowledge-like object."""
+    return SimpleNamespace(contents_db=contents_db)
+
+
+@pytest.mark.asyncio
+async def test_knowledge_table_from_custom_contents_db():
+    """When Knowledge has a contents_db with a custom knowledge_table,
+    AgentResponse should report that table name, not the agent.db default."""
+    custom_db = _make_db(knowledge_table="my_custom_knowledge")
+    agent = Agent(name="test-agent")
+    agent.knowledge = _make_knowledge(contents_db=custom_db)
+    agent.db = _make_db()  # default: "agno_knowledge"
+
+    resp = await AgentResponse.from_agent(agent)
+
+    assert resp.knowledge is not None
+    assert resp.knowledge["knowledge_table"] == "my_custom_knowledge"
+
+
+@pytest.mark.asyncio
+async def test_knowledge_table_falls_back_to_agent_db():
+    """When Knowledge exists but has no contents_db, fall back to agent.db."""
+    agent = Agent(name="test-agent")
+    agent.knowledge = _make_knowledge(contents_db=None)
+    agent.db = _make_db(knowledge_table="agent_level_table")
+
+    resp = await AgentResponse.from_agent(agent)
+
+    assert resp.knowledge is not None
+    assert resp.knowledge["knowledge_table"] == "agent_level_table"
+
+
+@pytest.mark.asyncio
+async def test_knowledge_table_none_without_knowledge():
+    """When agent has no knowledge, knowledge_table should be None."""
+    agent = Agent(name="test-agent")
+    agent.knowledge = None
+    agent.db = _make_db(knowledge_table="should_not_appear")
+
+    resp = await AgentResponse.from_agent(agent)
+
+    # knowledge section should either be None or have knowledge_table=None
+    if resp.knowledge is not None:
+        assert resp.knowledge["knowledge_table"] is None
+
+
+@pytest.mark.asyncio
+async def test_knowledge_table_default_when_no_custom_config():
+    """When Knowledge has a contents_db with default config, the default table name
+    should still be reported correctly (not silently dropped)."""
+    default_db = _make_db()  # knowledge_table defaults to "agno_knowledge"
+    agent = Agent(name="test-agent")
+    agent.knowledge = _make_knowledge(contents_db=default_db)
+    agent.db = _make_db()
+
+    resp = await AgentResponse.from_agent(agent)
+
+    assert resp.knowledge is not None
+    assert resp.knowledge["knowledge_table"] == "agno_knowledge"


### PR DESCRIPTION
## Summary

Fixes #6975

`AgentResponse.from_agent()` reads `knowledge_table` from `agent.db.knowledge_table_name` (line 143 of `schema.py`), which always returns the default `"agno_knowledge"`. When a user configures a custom `Knowledge` with its own `contents_db` (e.g., `PostgresDb(knowledge_table="my_custom_table")`), that custom table name is ignored in the AgnoOS config display.

This PR changes the logic to read `knowledge_table_name` from the Knowledge's own `contents_db` first, falling back to `agent.db` only when the Knowledge has no custom `contents_db`.

## Changes

- `libs/agno/agno/os/routers/agents/schema.py`: Read `knowledge_table_name` from `agent.knowledge.contents_db` when available, fall back to `agent.db`
- `libs/agno/tests/unit/os/test_knowledge_table_config.py`: 4 test cases covering custom table name, fallback to agent.db, no-knowledge case, and default config

## Testing

- `test_knowledge_table_from_custom_contents_db` — custom contents_db table name is reported correctly
- `test_knowledge_table_falls_back_to_agent_db` — falls back to agent.db when contents_db is None
- `test_knowledge_table_none_without_knowledge` — returns None when agent has no knowledge
- `test_knowledge_table_default_when_no_custom_config` — default table name still works

All existing tests pass (`test_knowledge_filters_serialization.py`). Linter and formatter clean.