### PR TITLE
fix: prevent content hash collisions in text_content insertions

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -2163,24 +2163,23 @@ class Knowledge(RemoteKnowledge):
         elif content.url:
             hash_parts.append(content.url)
         elif content.file_data and content.file_data.content:
-            # For file_data, always add filename, type, size, or content for uniqueness
+            # For file_data, always hash the actual content for uniqueness.
+            # Metadata (filename, type, size) is additive context, not a replacement.
             if content.file_data.filename:
                 hash_parts.append(content.file_data.filename)
-            elif content.file_data.type:
+            if content.file_data.type:
                 hash_parts.append(content.file_data.type)
-            elif content.file_data.size is not None:
+            if content.file_data.size is not None:
                 hash_parts.append(str(content.file_data.size))
-            else:
-                # Fallback: use the content for uniqueness
-                # Include type information to distinguish str vs bytes
-                content_type = "str" if isinstance(content.file_data.content, str) else "bytes"
-                content_bytes = (
-                    content.file_data.content.encode()
-                    if isinstance(content.file_data.content, str)
-                    else content.file_data.content
-                )
-                content_hash = hashlib.sha256(content_bytes).hexdigest()[:16]  # Use first 16 chars
-                hash_parts.append(f"{content_type}:{content_hash}")
+            # Always include a hash of the actual content
+            content_type = "str" if isinstance(content.file_data.content, str) else "bytes"
+            content_bytes = (
+                content.file_data.content.encode()
+                if isinstance(content.file_data.content, str)
+                else content.file_data.content
+            )
+            content_hash = hashlib.sha256(content_bytes).hexdigest()[:16]
+            hash_parts.append(f"{content_type}:{content_hash}")
         elif content.topics and len(content.topics) > 0:
             topic = content.topics[0]
             reader = type(content.reader).__name__ if content.reader else "unknown"

--- a/libs/agno/tests/unit/knowledge/test_knowledge_content_hash.py
+++ b/libs/agno/tests/unit/knowledge/test_knowledge_content_hash.py
@@ -241,7 +241,7 @@ def test_hash_with_only_description():
 
 
 def test_file_data_hash_with_filename():
-    """Test that file_data hash uses filename when available."""
+    """Test that file_data hash uses filename AND content."""
     knowledge = Knowledge(vector_db=MockVectorDb())
     content1 = Content(file_data=FileData(content="test content", filename="file1.pdf"))
     content2 = Content(file_data=FileData(content="test content", filename="file2.pdf"))
@@ -253,12 +253,12 @@ def test_file_data_hash_with_filename():
 
     # Different filenames should produce different hashes
     assert hash1 != hash2
-    # Same filename should produce same hash (even with different content)
-    assert hash1 == hash3
+    # Same filename but different content should produce different hashes
+    assert hash1 != hash3
 
 
 def test_file_data_hash_with_type():
-    """Test that file_data hash uses type when filename is not available."""
+    """Test that file_data hash uses type AND content for uniqueness."""
     knowledge = Knowledge(vector_db=MockVectorDb())
     content1 = Content(file_data=FileData(content="test content", type="application/pdf"))
     content2 = Content(file_data=FileData(content="test content", type="text/plain"))
@@ -270,12 +270,12 @@ def test_file_data_hash_with_type():
 
     # Different types should produce different hashes
     assert hash1 != hash2
-    # Same type should produce same hash (even with different content)
-    assert hash1 == hash3
+    # Same type but different content should produce different hashes
+    assert hash1 != hash3
 
 
 def test_file_data_hash_with_size():
-    """Test that file_data hash uses size when filename and type are not available."""
+    """Test that file_data hash uses size AND content for uniqueness."""
     knowledge = Knowledge(vector_db=MockVectorDb())
     content1 = Content(file_data=FileData(content="test content", size=1024))
     content2 = Content(file_data=FileData(content="test content", size=2048))
@@ -287,8 +287,8 @@ def test_file_data_hash_with_size():
 
     # Different sizes should produce different hashes
     assert hash1 != hash2
-    # Same size should produce same hash (even with different content)
-    assert hash1 == hash3
+    # Same size but different content should produce different hashes
+    assert hash1 != hash3
 
 
 def test_file_data_hash_with_content_fallback():
@@ -309,7 +309,7 @@ def test_file_data_hash_with_content_fallback():
 
 
 def test_file_data_hash_with_name_and_description():
-    """Test that file_data hash includes both name/description and file_data fields."""
+    """Test that file_data hash includes name, description, metadata, AND content."""
     knowledge = Knowledge(vector_db=MockVectorDb())
     content1 = Content(
         name="Document 1",
@@ -337,8 +337,8 @@ def test_file_data_hash_with_name_and_description():
     hash3 = knowledge._build_content_hash(content3)
     hash4 = knowledge._build_content_hash(content4)
 
-    # Same name/description/filename should produce same hash (content difference ignored when filename present)
-    assert hash1 == hash2
+    # Different content should produce different hash even with same filename
+    assert hash1 != hash2
     # Different filename should produce different hash
     assert hash1 != hash3
     # Different name should produce different hash
@@ -346,7 +346,7 @@ def test_file_data_hash_with_name_and_description():
 
 
 def test_file_data_hash_priority_filename_over_type():
-    """Test that filename takes priority over type."""
+    """Test that both filename and type contribute to the hash."""
     knowledge = Knowledge(vector_db=MockVectorDb())
     content1 = Content(file_data=FileData(content="test", filename="file.pdf", type="application/pdf"))
     content2 = Content(file_data=FileData(content="test", filename="file.pdf", type="text/plain"))
@@ -354,12 +354,12 @@ def test_file_data_hash_priority_filename_over_type():
     hash1 = knowledge._build_content_hash(content1)
     hash2 = knowledge._build_content_hash(content2)
 
-    # Same filename should produce same hash regardless of type
-    assert hash1 == hash2
+    # Different type should produce different hash even with same filename
+    assert hash1 != hash2
 
 
 def test_file_data_hash_priority_type_over_size():
-    """Test that type takes priority over size."""
+    """Test that both type and size contribute to the hash."""
     knowledge = Knowledge(vector_db=MockVectorDb())
     content1 = Content(file_data=FileData(content="test", type="application/pdf", size=1024))
     content2 = Content(file_data=FileData(content="test", type="application/pdf", size=2048))
@@ -367,8 +367,8 @@ def test_file_data_hash_priority_type_over_size():
     hash1 = knowledge._build_content_hash(content1)
     hash2 = knowledge._build_content_hash(content2)
 
-    # Same type should produce same hash regardless of size
-    assert hash1 == hash2
+    # Different size should produce different hash even with same type
+    assert hash1 != hash2
 
 
 def test_file_data_hash_with_name_only():
@@ -436,7 +436,7 @@ def test_file_data_hash_string_vs_bytes_same_content():
 
 
 def test_file_data_hash_all_fields_present():
-    """Test file_data hash when all fields are present."""
+    """Test file_data hash when all fields are present — all contribute."""
     knowledge = Knowledge(vector_db=MockVectorDb())
     content1 = Content(
         name="Doc 1",
@@ -458,8 +458,8 @@ def test_file_data_hash_all_fields_present():
     hash2 = knowledge._build_content_hash(content2)
     hash3 = knowledge._build_content_hash(content3)
 
-    # Same name/description/filename should produce same hash (content/type/size differences ignored when filename present)
-    assert hash1 == hash2
+    # Different content should produce different hash
+    assert hash1 != hash2
     # Different filename should produce different hash
     assert hash1 != hash3
 
@@ -584,3 +584,31 @@ def test_document_content_hash_fallback_to_content_hash():
     assert hash1 != hash2
     # Same content should produce same hash
     assert hash1 == hash3
+
+
+def test_text_content_produces_unique_hashes():
+    """Regression test for #6952: text_content insertions must produce unique hashes.
+
+    When calling knowledge.insert(text_content="..."), a FileData is created
+    with type="Text". Previously, the if-elif chain in _build_content_hash
+    would match on type="Text" and skip the actual content hash, causing all
+    text_content insertions to collide on sha256("Text").
+    """
+    knowledge = Knowledge(vector_db=MockVectorDb())
+
+    content1 = Content(file_data=FileData(content="First document about AI safety", type="Text"))
+    content2 = Content(file_data=FileData(content="Second document about quantum computing", type="Text"))
+    content3 = Content(file_data=FileData(content="Third document about climate change", type="Text"))
+    content4 = Content(file_data=FileData(content="First document about AI safety", type="Text"))
+
+    hash1 = knowledge._build_content_hash(content1)
+    hash2 = knowledge._build_content_hash(content2)
+    hash3 = knowledge._build_content_hash(content3)
+    hash4 = knowledge._build_content_hash(content4)
+
+    # All different content must produce different hashes
+    assert hash1 != hash2, "Different text_content produced identical hashes"
+    assert hash1 != hash3, "Different text_content produced identical hashes"
+    assert hash2 != hash3, "Different text_content produced identical hashes"
+    # Same content must produce same hash (deterministic)
+    assert hash1 == hash4, "Same text_content produced different hashes"


### PR DESCRIPTION
## Problem

When calling `knowledge.insert(text_content="...")`, a `FileData` object is created with `type="Text"`. The `_build_content_hash()` method uses an `if-elif` chain to build the hash from metadata fields. Because it matches on `type="Text"` and **stops** (due to `elif`), the actual content is never included in the hash.

**Result:** Every `text_content` insertion produces the identical hash `sha256("Text")`, regardless of actual content. This causes:
- Silent data loss (only the first document is stored, subsequent ones are treated as duplicates)
- Knowledge base corruption (different documents mapped to the same hash)

## Root Cause

In `knowledge.py`, `_build_content_hash()` (line ~2165):

```python
# BEFORE (buggy): elif chain — only first matching field is hashed
if content.file_data.filename:
    hash_parts.append(content.file_data.filename)
elif content.file_data.type:          # ← matches "Text", stops here
    hash_parts.append(content.file_data.type)
elif content.file_data.size:
    hash_parts.append(str(content.file_data.size))
```

When `text_content="anything"` creates `FileData(content="anything", type="Text")`, the `elif` hits `type="Text"` and never reaches the content hash. All text insertions collide.

## Fix

Changed the `if-elif` chain to **additive `if` statements**. Now all present metadata (filename, type, size) AND the actual content hash are always included:

```python
# AFTER (fixed): additive — all fields contribute to hash
if content.file_data.filename:
    hash_parts.append(content.file_data.filename)
if content.file_data.type:
    hash_parts.append(content.file_data.type)
if content.file_data.size:
    hash_parts.append(str(content.file_data.size))
# Content hash is ALWAYS included
```

## Tests

- Updated 7 existing tests that were asserting the old (buggy) behavior where content differences were ignored
- Added regression test `test_text_content_produces_unique_hashes` that reproduces the exact scenario from #6952
- All 30 tests pass

Fixes #6952