### PR TITLE
fix(models): replace += with = for assistant content in _process_model_response

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -1111,11 +1111,11 @@ class Model(ABC):
         self._populate_assistant_message(assistant_message=assistant_message, provider_response=provider_response)
 
         # Update model response with assistant message content and audio
+        # Use assignment (not +=) so RunOutput.content reflects only the last
+        # assistant message, not a concatenation of all intermediate responses
+        # (e.g. tool-call preambles). Full message history is in RunOutput.messages.
         if assistant_message.content is not None:
-            if model_response.content is None:
-                model_response.content = assistant_message.get_content_string()
-            else:
-                model_response.content += assistant_message.get_content_string()
+            model_response.content = assistant_message.get_content_string()
         if assistant_message.reasoning_content is not None:
             model_response.reasoning_content = assistant_message.reasoning_content
         if assistant_message.redacted_reasoning_content is not None:
@@ -1174,11 +1174,11 @@ class Model(ABC):
         self._populate_assistant_message(assistant_message=assistant_message, provider_response=provider_response)
 
         # Update model response with assistant message content and audio
+        # Use assignment (not +=) so RunOutput.content reflects only the last
+        # assistant message, not a concatenation of all intermediate responses
+        # (e.g. tool-call preambles). Full message history is in RunOutput.messages.
         if assistant_message.content is not None:
-            if model_response.content is None:
-                model_response.content = assistant_message.get_content_string()
-            else:
-                model_response.content += assistant_message.get_content_string()
+            model_response.content = assistant_message.get_content_string()
         if assistant_message.reasoning_content is not None:
             model_response.reasoning_content = assistant_message.reasoning_content
         if assistant_message.redacted_reasoning_content is not None:


### PR DESCRIPTION
## Summary

`RunOutput.content` was accumulating every assistant message in a tool-call loop — including intermediate "thinking" preambles — instead of reflecting only the **last** assistant message (the final answer).

**Root cause**: Both `_process_model_response` and `_aprocess_model_response` used `+=` to build `model_response.content`, which concatenated all intermediate assistant responses:

```python
# Before (broken — accumulates preamble + final answer):
if assistant_message.content is not None:
    if model_response.content is None:
        model_response.content = assistant_message.get_content_string()
    else:
        model_response.content += assistant_message.get_content_string()
```

**Example** — a typical tool-calling flow:
1. Assistant: "Analyzing: need to check logs…" + `tool_calls`
2. Tool executes
3. Assistant: "### Final conclusion…"

`RunOutput.content` was `"Analyzing: need to check logs…### Final conclusion…"` instead of just `"### Final conclusion…"`.

## Fix

Switch to a simple assignment so `RunOutput.content` always reflects only the last assistant message:

```python
# After (correct — only the last assistant message):
if assistant_message.content is not None:
    model_response.content = assistant_message.get_content_string()
```

All history is preserved in `RunOutput.messages`, so no information is lost.

Fixes #6986