### PR TITLE
fix: break agent loop when all tool calls are blocked by tool_call_limit

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -813,7 +813,7 @@ class Model(ABC):
                     if (
                         tool_call_limit is not None
                         and function_call_results
-                        and all(m.tool_call_error for m in function_call_results)
+                        and all(m.tool_call_limit_reached for m in function_call_results)
                     ):
                         break
 
@@ -1045,7 +1045,7 @@ class Model(ABC):
                     if (
                         tool_call_limit is not None
                         and function_call_results
-                        and all(m.tool_call_error for m in function_call_results)
+                        and all(m.tool_call_limit_reached for m in function_call_results)
                     ):
                         break
 
@@ -1541,7 +1541,7 @@ class Model(ABC):
                     if (
                         tool_call_limit is not None
                         and function_call_results
-                        and all(m.tool_call_error for m in function_call_results)
+                        and all(m.tool_call_limit_reached for m in function_call_results)
                     ):
                         break
 
@@ -1828,7 +1828,7 @@ class Model(ABC):
                     if (
                         tool_call_limit is not None
                         and function_call_results
-                        and all(m.tool_call_error for m in function_call_results)
+                        and all(m.tool_call_limit_reached for m in function_call_results)
                     ):
                         break
 
@@ -2107,6 +2107,7 @@ class Model(ABC):
             tool_name=function_call.function.name,
             tool_args=function_call.arguments,
             tool_call_error=True,
+            tool_call_limit_reached=True,
         )
 
     def run_function_call(

--- a/libs/agno/agno/models/message.py
+++ b/libs/agno/agno/models/message.py
@@ -103,6 +103,9 @@ class Message(BaseModel):
     tool_args: Optional[Any] = None
     # The error of the tool call
     tool_call_error: Optional[bool] = None
+    # True when the tool call was blocked specifically because the tool_call_limit was reached.
+    # Distinct from tool_call_error which is also set for runtime execution errors.
+    tool_call_limit_reached: bool = False
     # If True, the agent will stop executing after this tool call.
     stop_after_tool_call: bool = False
     # When True, the message will be added to the agent's memory.

--- a/libs/agno/tests/unit/models/test_tool_call_limit_loop.py
+++ b/libs/agno/tests/unit/models/test_tool_call_limit_loop.py
@@ -215,7 +215,7 @@ class TestRunFunctionCallsLimit:
     results consumed by the loop-break guard."""
 
     def test_calls_blocked_when_limit_exceeded(self):
-        """run_function_calls() must create tool_call_error=True results for
+        """run_function_calls() must create tool_call_limit_reached=True results for
         every FunctionCall that exceeds the limit, without executing them."""
         from agno.tools.function import Function, FunctionCall
 
@@ -240,15 +240,15 @@ class TestRunFunctionCallsLimit:
             )
         )
 
-        ok_results = [m for m in results if not m.tool_call_error]
-        error_results = [m for m in results if m.tool_call_error]
+        ok_results = [m for m in results if not m.tool_call_limit_reached]
+        error_results = [m for m in results if m.tool_call_limit_reached]
 
         assert len(ok_results) == 1, f"Expected 1 successful result, got {len(ok_results)}"
         assert len(error_results) == 1, f"Expected 1 blocked result, got {len(error_results)}"
         assert len(executed) == 1, f"Expected the tool executed once, got {len(executed)}"
 
     def test_all_calls_blocked_when_limit_zero(self):
-        """With tool_call_limit=0, ALL calls must produce tool_call_error=True
+        """With tool_call_limit=0, ALL calls must produce tool_call_limit_reached=True
         results — this is the condition that triggers the loop-break guard."""
         from agno.tools.function import Function, FunctionCall
 
@@ -274,12 +274,12 @@ class TestRunFunctionCallsLimit:
         )
 
         assert results, "Expected at least one result message"
-        assert all(m.tool_call_error for m in results), "All results must have tool_call_error=True when limit=0"
+        assert all(m.tool_call_limit_reached for m in results), "All results must have tool_call_limit_reached=True when limit=0"
         assert len(executed) == 0, f"No tool should have been executed, but got {len(executed)} executions"
 
     def test_guard_condition_all_errors(self):
         """Verify the exact boolean expression used in response():
-        ``all(m.tool_call_error for m in function_call_results)`` must be True
+        ``all(m.tool_call_limit_reached for m in function_call_results)`` must be True
         when every result is an error (i.e. all calls were blocked)."""
         from agno.tools.function import Function, FunctionCall
 
@@ -303,6 +303,6 @@ class TestRunFunctionCallsLimit:
         should_break = (
             tool_call_limit is not None  # 0 is a valid limit, not None
             and bool(results)  # function_call_results is non-empty
-            and all(m.tool_call_error for m in results)  # every result is an error
+            and all(m.tool_call_limit_reached for m in results)  # every result is an error
         )
         assert should_break, "The loop-break guard must evaluate to True when all calls are blocked"


### PR DESCRIPTION
## Summary

When `tool_call_limit` was set and the model exceeded it, every subsequent tool call got a `"Tool call limit reached. Do not try again."` error message added to the conversation. The model ignored the instruction, immediately requested the same tool again, and the loop never terminated — burning tokens indefinitely.

## Root cause

After the tool-call batch the loop unconditionally called `continue` (line ~833), which sent all the "limit reached" errors back to the model and restarted the agentic cycle. The model received strings like:

```
Tool call limit reached. Tool call glob_file not executed. Don't try to execute it again.
```

and responded with another `glob_file` tool call anyway.

## Fix

After logging function-call results, check whether **every** result in the batch has `tool_call_error=True`. If so, the entire batch was blocked by the limit — there is no useful work left — so we break out of the loop immediately:

```python
# If every tool call in this batch was blocked by the tool-call limit, stop
# iterating immediately. Without this guard the model receives only "limit reached"
# error messages, ignores them, and calls the same tools again — creating an
# infinite loop.
if (
    tool_call_limit is not None
    and function_call_results
    and all(m.tool_call_error for m in function_call_results)
):
    break
```

This guard is added to all four affected code paths in `base.py`:
- sync response (`generate`)
- async response (`agenerate`)
- sync stream (`stream`)
- async stream (`astream`)

## Testing

Reproduce with any agent whose `tool_call_limit` is set to a small value and where the model attempts to call the same tool multiple times:

```python
from agno.agent import Agent
from agno.models.openai import OpenAI
from agno.tools.file import FileTools

agent = Agent(
    model=OpenAI(id="gpt-4o"),
    tools=[FileTools()],
    tool_call_limit=1,  # allow only 1 tool call
)

# Before fix: runs forever
# After fix:  stops after 1 tool call and returns a response
agent.run("List all .py files recursively")
```

Fixes #6984