### PR TITLE
fix: treat .html/.htm/.xhtml URLs as web content, not binary files

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -27,6 +27,9 @@ from agno.utils.http import async_fetch_with_retry
 from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.string import generate_id
 
+# Web extensions that should not be treated as binary files
+_WEB_EXTENSIONS = {".html", ".htm", ".xhtml"}
+
 ContentDict = Dict[str, Union[str, Dict[str, str]]]
 
 
@@ -1183,6 +1186,8 @@ class Knowledge(RemoteKnowledge):
             return self.markdown_reader, ""
         elif file_extension in [".xlsx", ".xls"]:
             return self.excel_reader, ""
+        elif file_extension in [".html", ".htm", ".xhtml"]:
+            return self.website_reader, ""
         else:
             return self.text_reader, ""
 
@@ -1564,7 +1569,7 @@ class Knowledge(RemoteKnowledge):
         file_extension = url_path.suffix.lower()
 
         bytes_content = None
-        if file_extension:
+        if file_extension and file_extension not in _WEB_EXTENSIONS:
             async with AsyncClient() as client:
                 response = await async_fetch_with_retry(content.url, client=client)
             bytes_content = BytesIO(response.content)
@@ -1716,7 +1721,7 @@ class Knowledge(RemoteKnowledge):
         file_extension = url_path.suffix.lower()
 
         bytes_content = None
-        if file_extension:
+        if file_extension and file_extension not in _WEB_EXTENSIONS:
             response = fetch_with_retry(content.url)
             bytes_content = BytesIO(response.content)
 


### PR DESCRIPTION
## Problem

URLs ending with `.html`, `.htm`, or `.xhtml` were incorrectly treated as binary files in `_load_from_url` and `_aload_from_url` methods. This caused `BytesIO` to be passed to `WebsiteReader` which expects a URL string, resulting in:

```
AttributeError: '_io.BytesIO' object has no attribute 'decode'
```

## Solution

This fix includes two changes:

1. **Add `_WEB_EXTENSIONS` constant** - Define web extensions that should not be treated as binary files
2. **Fix `_select_reader_by_extension`** - Return `website_reader` for `.html`, `.htm`, `.xhtml` extensions

## Changes

- Added `_WEB_EXTENSIONS = {".html", ".htm", ".xhtml"}` constant
- Modified condition in `_load_from_url` and `_aload_from_url` to exclude web extensions from binary download
- Added html/htm/xhtml handling in `_select_reader_by_extension` to return `website_reader`

## Testing

```python
# Test 1: _WEB_EXTENSIONS constant
from agno.knowledge.knowledge import _WEB_EXTENSIONS
assert ".html" in _WEB_EXTENSIONS  # ✅

# Test 2: _select_reader_by_extension returns WebsiteReader for .html
from agno.knowledge.knowledge import Knowledge
from agno.knowledge.reader.website_reader import WebsiteReader
kb = Knowledge(vector_db=MockVectorDb())
reader, _ = kb._select_reader_by_extension(".html")
assert isinstance(reader, WebsiteReader)  # ✅

# Test 3: .html URLs are not downloaded to BytesIO
file_extension = ".html"
should_download = file_extension and file_extension not in _WEB_EXTENSIONS
assert should_download == False  # ✅
```

Fixes #6985