### PR TITLE
fix: always include content hash in _build_content_hash for file_data

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -2163,24 +2163,22 @@ class Knowledge(RemoteKnowledge):
         elif content.url:
             hash_parts.append(content.url)
         elif content.file_data and content.file_data.content:
-            # For file_data, always add filename, type, size, or content for uniqueness
+            # For file_data, always include a hash of the actual content for uniqueness.
+            # A filename or type alone is not sufficient because multiple distinct text
+            # entries can share the same type (e.g. "Text") when inserted via text_content,
+            # causing them to produce identical hashes and overwrite each other in the store.
+            content_type = "str" if isinstance(content.file_data.content, str) else "bytes"
+            content_bytes = (
+                content.file_data.content.encode()
+                if isinstance(content.file_data.content, str)
+                else content.file_data.content
+            )
+            content_digest = hashlib.sha256(content_bytes).hexdigest()[:16]
             if content.file_data.filename:
                 hash_parts.append(content.file_data.filename)
-            elif content.file_data.type:
+            if content.file_data.type:
                 hash_parts.append(content.file_data.type)
-            elif content.file_data.size is not None:
-                hash_parts.append(str(content.file_data.size))
-            else:
-                # Fallback: use the content for uniqueness
-                # Include type information to distinguish str vs bytes
-                content_type = "str" if isinstance(content.file_data.content, str) else "bytes"
-                content_bytes = (
-                    content.file_data.content.encode()
-                    if isinstance(content.file_data.content, str)
-                    else content.file_data.content
-                )
-                content_hash = hashlib.sha256(content_bytes).hexdigest()[:16]  # Use first 16 chars
-                hash_parts.append(f"{content_type}:{content_hash}")
+            hash_parts.append(f"{content_type}:{content_digest}")
         elif content.topics and len(content.topics) > 0:
             topic = content.topics[0]
             reader = type(content.reader).__name__ if content.reader else "unknown"


### PR DESCRIPTION
## Problem

When `text_content` is inserted via `knowledge.insert()` / `knowledge.ainsert()`, a `FileData` object is created with `type="Text"` but **no filename**. The `_build_content_hash` method then uses `file_data.type` as the unique identifier, but since all `text_content` insertions share the same type string `"Text"`, every distinct entry produces the **same content hash**. New data silently overwrites existing records instead of being added as unique entries.

## Fix

Always compute and include a SHA-256 digest of the actual content bytes alongside any filename/type metadata. Distinct text entries now produce distinct hashes regardless of whether a filename is present.

**Before:**
```python
# All text_content entries hash to hash("Text") — same result every time!
elif content.file_data.type:
    hash_parts.append(content.file_data.type)
```

**After:**
```python
# Always include a content-derived digest for uniqueness
content_digest = hashlib.sha256(content_bytes).hexdigest()[:16]
hash_parts.append(f"{content_type}:{content_digest}")
```

Fixes #6952