### PR TITLE
fix: reject Claude 4.6 assistant prefills

### DIFF
--- a/cookbook/90_models/anthropic/sonnet_4_6_assistant_prefill_repro.py
+++ b/cookbook/90_models/anthropic/sonnet_4_6_assistant_prefill_repro.py
@@ -1,0 +1,83 @@
+"""
+Claude Sonnet 4.6 assistant-prefill migration example.
+
+Run:
+    python cookbook/90_models/anthropic/sonnet_4_6_assistant_prefill_repro.py
+
+What this shows:
+1. The old Claude 4.5-style assistant-prefill pattern is now rejected early by Agno.
+2. The Claude 4.6-safe pattern ends with a user message and succeeds.
+"""
+
+from os import getenv
+from pathlib import Path
+
+from agno.models.anthropic import Claude
+from agno.models.message import Message
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[3] / ".env")
+
+
+MODEL_ID = "claude-sonnet-4-6"
+
+SYSTEM_PROMPT = (
+    "You are a customer support triage assistant. "
+    "Return a compact JSON object with the keys: "
+    "priority, category, customer_sentiment, and needs_human_agent."
+)
+
+USER_TICKET = (
+    "Ticket ID: CS-18427\n"
+    "Customer: Our production checkout is failing for multiple users after today's deploy. "
+    "Payments are being authorized, but the order confirmation page crashes and no receipt is sent. "
+    "This is affecting revenue and we need an urgent response.\n\n"
+    "Classify this ticket and return only JSON."
+)
+
+
+def run_invalid_prefill_example(model: Claude) -> None:
+    print("\n=== Invalid Claude 4.6 Pattern ===")
+    invalid_messages = [
+        Message(role="system", content=SYSTEM_PROMPT),
+        Message(role="user", content=USER_TICKET),
+        Message(role="assistant", content='{"priority":'),
+    ]
+
+    try:
+        model.response(messages=invalid_messages)
+    except ValueError as exc:
+        print(exc)
+
+
+def run_valid_migrated_example(model: Claude) -> None:
+    print("\n=== Valid Claude 4.6 Pattern ===")
+    valid_messages = [
+        Message(role="system", content=SYSTEM_PROMPT),
+        Message(
+            role="user",
+            content=(
+                f"{USER_TICKET}\n\n"
+                "Start your response directly with a JSON object. "
+                'The JSON must include the keys "priority", "category", '
+                '"customer_sentiment", and "needs_human_agent".'
+            ),
+        ),
+    ]
+
+    response = model.response(messages=valid_messages)
+    print(response.content)
+
+
+def main() -> None:
+    if not getenv("ANTHROPIC_API_KEY"):
+        raise SystemExit("Set ANTHROPIC_API_KEY before running this example.")
+
+    model = Claude(id=MODEL_ID, max_tokens=128)
+
+    run_invalid_prefill_example(model)
+    run_valid_migrated_example(model)
+
+
+if __name__ == "__main__":
+    main()

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -16,7 +16,12 @@ from agno.run.agent import RunOutput
 from agno.tools.function import Function
 from agno.utils.http import get_default_async_client, get_default_sync_client
 from agno.utils.log import log_debug, log_error, log_warning
-from agno.utils.models.claude import MCPServerConfiguration, format_messages, format_tools_for_model
+from agno.utils.models.claude import (
+    MCPServerConfiguration,
+    format_messages,
+    format_tools_for_model,
+    validate_messages_for_claude_model,
+)
 from agno.utils.tokens import count_schema_tokens
 
 try:
@@ -417,7 +422,7 @@ class Claude(Model):
         tools: Optional[List[Union[Function, Dict[str, Any]]]] = None,
         response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
     ) -> int:
-        anthropic_messages, system_prompt = format_messages(messages, compress_tool_results=True)
+        anthropic_messages, system_prompt = self._format_messages_for_request(messages, compress_tool_results=True)
         anthropic_tools = None
         if tools:
             formatted_tools = self._format_tools(tools)
@@ -438,7 +443,7 @@ class Claude(Model):
         tools: Optional[List[Union[Function, Dict[str, Any]]]] = None,
         response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
     ) -> int:
-        anthropic_messages, system_prompt = format_messages(messages, compress_tool_results=True)
+        anthropic_messages, system_prompt = self._format_messages_for_request(messages, compress_tool_results=True)
         anthropic_tools = None
         if tools:
             formatted_tools = self._format_tools(tools)
@@ -560,6 +565,12 @@ class Claude(Model):
             log_debug(f"Calling {self.provider} with request parameters: {request_kwargs}", log_level=2)
         return request_kwargs
 
+    def _format_messages_for_request(
+        self, messages: List[Message], compress_tool_results: bool = False
+    ) -> tuple[List[Dict[str, Union[str, list]]], str]:
+        validate_messages_for_claude_model(messages, self.id)
+        return format_messages(messages, compress_tool_results=compress_tool_results)
+
     def invoke(
         self,
         messages: List[Message],
@@ -573,10 +584,12 @@ class Claude(Model):
         """
         Send a request to the Anthropic API to generate a response.
         """
-        try:
-            chat_messages, system_message = format_messages(messages, compress_tool_results=compress_tool_results)
-            request_kwargs = self._prepare_request_kwargs(system_message, tools=tools, response_format=response_format)
+        chat_messages, system_message = self._format_messages_for_request(
+            messages, compress_tool_results=compress_tool_results
+        )
+        request_kwargs = self._prepare_request_kwargs(system_message, tools=tools, response_format=response_format)
 
+        try:
             if self._has_beta_features(response_format=response_format, tools=tools):
                 assistant_message.metrics.start_timer()
                 provider_response = self.get_client().beta.messages.create(
@@ -638,7 +651,9 @@ class Claude(Model):
             RateLimitError: If the API rate limit is exceeded
             APIStatusError: For other API-related errors
         """
-        chat_messages, system_message = format_messages(messages, compress_tool_results=compress_tool_results)
+        chat_messages, system_message = self._format_messages_for_request(
+            messages, compress_tool_results=compress_tool_results
+        )
         request_kwargs = self._prepare_request_kwargs(system_message, tools=tools, response_format=response_format)
 
         try:
@@ -692,10 +707,12 @@ class Claude(Model):
         """
         Send an asynchronous request to the Anthropic API to generate a response.
         """
-        try:
-            chat_messages, system_message = format_messages(messages, compress_tool_results=compress_tool_results)
-            request_kwargs = self._prepare_request_kwargs(system_message, tools=tools, response_format=response_format)
+        chat_messages, system_message = self._format_messages_for_request(
+            messages, compress_tool_results=compress_tool_results
+        )
+        request_kwargs = self._prepare_request_kwargs(system_message, tools=tools, response_format=response_format)
 
+        try:
             # Beta features
             if self._has_beta_features(response_format=response_format, tools=tools):
                 assistant_message.metrics.start_timer()
@@ -755,10 +772,12 @@ class Claude(Model):
             RateLimitError: If the API rate limit is exceeded
             APIStatusError: For other API-related errors
         """
-        try:
-            chat_messages, system_message = format_messages(messages, compress_tool_results=compress_tool_results)
-            request_kwargs = self._prepare_request_kwargs(system_message, tools=tools, response_format=response_format)
+        chat_messages, system_message = self._format_messages_for_request(
+            messages, compress_tool_results=compress_tool_results
+        )
+        request_kwargs = self._prepare_request_kwargs(system_message, tools=tools, response_format=response_format)
 
+        try:
             if self._has_beta_features(response_format=response_format, tools=tools):
                 assistant_message.metrics.start_timer()
                 async with self.get_async_client().beta.messages.stream(

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -38,6 +38,48 @@ ROLE_MAP = {
     "tool": "user",
 }
 
+NO_ASSISTANT_PREFILL_PREFIXES = (
+    "claude-sonnet-4-6",
+    "claude-opus-4-6",
+)
+
+
+def supports_assistant_prefill(model_id: str) -> bool:
+    """Return True when the Claude model still supports final assistant prefills."""
+    return not model_id.startswith(NO_ASSISTANT_PREFILL_PREFIXES)
+
+
+def validate_messages_for_claude_model(messages: List[Message], model_id: str) -> None:
+    """
+    Validate message ordering against Claude model constraints.
+
+    Claude Sonnet/Opus 4.6 no longer allow conversations to end with an
+    assistant message. This helper raises early with migration guidance rather
+    than sending an invalid request to Anthropic.
+    """
+    if supports_assistant_prefill(model_id):
+        return
+
+    last_conversation_idx: Optional[int] = None
+    for idx in range(len(messages) - 1, -1, -1):
+        if messages[idx].role not in ("system", "developer"):
+            last_conversation_idx = idx
+            break
+
+    if last_conversation_idx is None:
+        return
+
+    last_message = messages[last_conversation_idx]
+    if last_message.role != "assistant":
+        return
+
+    raise ValueError(
+        f"Model '{model_id}' does not support assistant message prefills or a conversation ending with an "
+        "assistant message. End the conversation with a user message instead. "
+        "For JSON output, use Agno output_schema/structured outputs. "
+        "For continuations, move the previous assistant prefix into the user message."
+    )
+
 
 def _format_image_for_message(image: Image) -> Optional[Dict[str, Any]]:
     """

--- a/libs/agno/tests/integration/models/anthropic/test_betas.py
+++ b/libs/agno/tests/integration/models/anthropic/test_betas.py
@@ -6,6 +6,7 @@ import pytest
 
 from agno.agent import Agent
 from agno.models.anthropic import Claude
+from agno.models.message import Message
 
 
 def _create_mock_response():
@@ -134,6 +135,22 @@ def test_regular_client_used_without_betas(mock_anthropic_client):
     # Verify that betas parameter was not passed
     call_kwargs = mock_anthropic_client.messages.create.call_args[1]
     assert "betas" not in call_kwargs
+
+
+def test_final_assistant_prefill_is_rejected_for_claude_46(mock_anthropic_client):
+    """Claude 4.6 should fail fast before calling the Anthropic client."""
+    model = Claude(id="claude-sonnet-4-6")
+
+    with pytest.raises(ValueError, match="does not support assistant message prefills"):
+        model.response(
+            messages=[
+                Message(role="system", content="You return compact JSON."),
+                Message(role="user", content="Classify this support ticket."),
+                Message(role="assistant", content='{"priority":'),
+            ]
+        )
+
+    mock_anthropic_client.messages.create.assert_not_called()
 
 
 def test_multiple_betas():

--- a/libs/agno/tests/unit/utils/test_claude.py
+++ b/libs/agno/tests/unit/utils/test_claude.py
@@ -3,7 +3,8 @@ import base64
 import pytest
 
 from agno.media import File
-from agno.utils.models.claude import _format_file_for_message
+from agno.models.message import Message
+from agno.utils.models.claude import _format_file_for_message, validate_messages_for_claude_model
 
 
 class TestFormatFileForMessage:
@@ -86,3 +87,48 @@ class TestFormatFileForMessage:
 
         assert result["source"]["data"] == csv_content
         assert result["source"]["data"] != base64.standard_b64encode(csv_content.encode()).decode()
+
+
+class TestValidateMessagesForClaudeModel:
+    def test_raises_for_final_assistant_prefill_on_claude_46(self):
+        messages = [
+            Message(role="system", content="You return compact JSON."),
+            Message(role="user", content="Classify the ticket."),
+            Message(role="assistant", content='{"priority":'),
+        ]
+
+        with pytest.raises(ValueError, match="does not support assistant message prefills"):
+            validate_messages_for_claude_model(messages, "claude-sonnet-4-6")
+
+    def test_allows_final_assistant_prefill_for_claude_45(self):
+        messages = [
+            Message(role="user", content="Classify the ticket."),
+            Message(role="assistant", content='{"priority":'),
+        ]
+
+        validate_messages_for_claude_model(messages, "claude-sonnet-4-5-20250929")
+
+    def test_allows_valid_user_final_message_for_claude_46(self):
+        messages = [
+            Message(role="assistant", content="Previous answer."),
+            Message(role="user", content="Please continue with more detail."),
+        ]
+
+        validate_messages_for_claude_model(messages, "claude-sonnet-4-6")
+
+    def test_raises_for_non_text_final_assistant_message_on_claude_46(self):
+        messages = [
+            Message(
+                role="assistant",
+                tool_calls=[
+                    {
+                        "id": "tool_1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }
+                ],
+            )
+        ]
+
+        with pytest.raises(ValueError, match="does not support assistant message prefills"):
+            validate_messages_for_claude_model(messages, "claude-sonnet-4-6")


### PR DESCRIPTION
## Summary

Fixes Claude 4.6 assistant-prefill failures in Anthropic requests by rejecting unsupported request shapes early in Agno.

Related issue: #7015

Root cause:
Claude 4.6 no longer supports assistant message prefills. Agno was still allowing Anthropic conversations to end with a final `assistant` message, which caused runtime `400` errors such as:

`This model does not support assistant message prefill. The conversation must end with a user message.`

What changed:
- Added Anthropic Claude 4.6-specific message validation in `libs/agno/agno/utils/models/claude.py`
- Wired validation into the Anthropic request path in `libs/agno/agno/models/anthropic/claude.py`
- Added tests covering:
  - rejection of final assistant-prefill messages on Claude 4.6
  - continued support for Claude 4.5 behavior
  - acceptance of Claude 4.6 requests that end with a user message
  - failure before the Anthropic client is called
- Added a cookbook example demonstrating:
  - the invalid Claude 4.6 pattern
  - the valid migrated Claude 4.6 pattern

This PR intentionally does not silently rewrite assistant-prefill requests. Instead, it fails fast locally with migration guidance, which is the safer long-term behavior and aligns with Anthropic’s Claude 4.6 migration guide.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Tested locally with:
- `python -m pytest libs/agno/tests/unit/utils/test_claude.py libs/agno/tests/integration/models/anthropic/test_betas.py -q`
- `python cookbook/90_models/anthropic/sonnet_4_6_assistant_prefill_repro.py`
- `./scripts/format.sh`
- `./scripts/validate.sh`

Behavior after this change:
- Claude 4.5: final assistant-prefill behavior remains unchanged
- Claude 4.6+: requests ending in `assistant` are rejected locally with a clear error and migration guidance

Cookbook added:
- `cookbook/90_models/anthropic/sonnet_4_6_assistant_prefill_repro.py`

Reference:
- Issue: https://github.com/agno-agi/agno/issues/7015
- Anthropic migration guide: https://platform.claude.com/docs/en/about-claude/models/migration-guide
