### PR TITLE
fix: use valid Telegram bot token format in system tests

### DIFF
--- a/libs/agno/tests/system/docker-compose.yaml
+++ b/libs/agno/tests/system/docker-compose.yaml
@@ -116,7 +116,7 @@ services:
       ENABLE_AUTHORIZATION: ${ENABLE_AUTHORIZATION:-true}
       SLACK_SIGNING_SECRET: ${SLACK_SIGNING_SECRET:-test-signing-secret}
       SLACK_TOKEN: ${SLACK_TOKEN:-test-token}
-      TELEGRAM_TOKEN: ${TELEGRAM_TOKEN:-test-telegram-token}
+      TELEGRAM_TOKEN: ${TELEGRAM_TOKEN:-0000000000:test-telegram-token}
       TELEGRAM_WEBHOOK_SECRET_TOKEN: ${TELEGRAM_WEBHOOK_SECRET_TOKEN:-test-webhook-secret}
     ports:
       - "7001:7001"


### PR DESCRIPTION
## Summary

The dummy `TELEGRAM_TOKEN` in docker-compose (`test-telegram-token`) crashes the gateway because `AsyncTeleBot` validates that tokens contain a colon (Telegram format: `ID:SECRET`).

Changes `test-telegram-token` → `0000000000:test-telegram-token`.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Tested in clean environment

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)