### PR TITLE
fix(serialization): add ensure_ascii=False to prevent Unicode escaping for non-ASCII text

### DIFF
--- a/libs/agno/agno/agent/_default_tools.py
+++ b/libs/agno/agno/agent/_default_tools.py
@@ -121,7 +121,7 @@ def create_knowledge_search_tool(
         if agent.references_format == "json":
             import json
 
-            return json.dumps(docs, indent=2, default=str)
+            return json.dumps(docs, indent=2, default=str, ensure_ascii=False)
         else:
             import yaml
 

--- a/libs/agno/agno/agent/_response.py
+++ b/libs/agno/agno/agent/_response.py
@@ -1723,7 +1723,7 @@ def _build_followup_messages(
     elif isinstance(response_content, BaseModel):
         content_str = response_content.model_dump_json()
     elif isinstance(response_content, dict):
-        content_str = json.dumps(response_content)
+        content_str = json.dumps(response_content, ensure_ascii=False)
     else:
         content_str = str(response_content)
 

--- a/libs/agno/agno/agent/_utils.py
+++ b/libs/agno/agno/agent/_utils.py
@@ -83,7 +83,7 @@ def convert_dependencies_to_string(agent: Agent, context: Dict[str, Any]) -> str
         return ""
 
     try:
-        return json.dumps(context, indent=2, default=str)
+        return json.dumps(context, indent=2, default=str, ensure_ascii=False)
     except (TypeError, ValueError, OverflowError) as e:
         log_warning(f"Failed to convert context to JSON: {e}")
         # Attempt a fallback conversion for non-serializable objects
@@ -91,14 +91,14 @@ def convert_dependencies_to_string(agent: Agent, context: Dict[str, Any]) -> str
         for key, value in context.items():
             try:
                 # Try to serialize each value individually
-                json.dumps({key: value}, default=str)
+                json.dumps({key: value}, default=str, ensure_ascii=False)
                 sanitized_context[key] = value
             except Exception:
                 # If serialization fails, convert to string representation
                 sanitized_context[key] = str(value)
 
         try:
-            return json.dumps(sanitized_context, indent=2)
+            return json.dumps(sanitized_context, indent=2, ensure_ascii=False)
         except Exception as e:
             log_error(f"Failed to convert sanitized context to JSON: {e}")
             return str(context)

--- a/libs/agno/agno/knowledge/reader/docling_reader.py
+++ b/libs/agno/agno/knowledge/reader/docling_reader.py
@@ -210,7 +210,7 @@ class DoclingReader(Reader):
             if self.output_format == OutputFormat.TEXT:
                 doc_content = result.document.export_to_text()
             elif self.output_format == OutputFormat.JSON:
-                doc_content = json.dumps(result.document.export_to_dict())
+                doc_content = json.dumps(result.document.export_to_dict(), ensure_ascii=False)
             elif self.output_format == OutputFormat.YAML:
                 import yaml
 

--- a/libs/agno/agno/knowledge/reader/json_reader.py
+++ b/libs/agno/agno/knowledge/reader/json_reader.py
@@ -60,7 +60,7 @@ class JSONReader(Reader):
                     name=json_name,
                     id=str(uuid4()),
                     meta_data={"page": page_number},
-                    content=json.dumps(content),
+                    content=json.dumps(content, ensure_ascii=False),
                 )
                 for page_number, content in enumerate(json_contents, start=1)
             ]

--- a/libs/agno/agno/team/_utils.py
+++ b/libs/agno/agno/team/_utils.py
@@ -64,7 +64,7 @@ def _convert_documents_to_string(team: Team, docs: List[Union[Dict[str, Any], st
 
         return yaml.dump(docs)
 
-    return json.dumps(docs, indent=2)
+    return json.dumps(docs, indent=2, ensure_ascii=False)
 
 
 def _convert_dependencies_to_string(team: Team, context: Dict[str, Any]) -> str:
@@ -81,7 +81,7 @@ def _convert_dependencies_to_string(team: Team, context: Dict[str, Any]) -> str:
         return ""
 
     try:
-        return json.dumps(context, indent=2, default=str)
+        return json.dumps(context, indent=2, default=str, ensure_ascii=False)
     except (TypeError, ValueError, OverflowError) as e:
         log_warning(f"Failed to convert context to JSON: {e}")
         # Attempt a fallback conversion for non-serializable objects
@@ -89,7 +89,7 @@ def _convert_dependencies_to_string(team: Team, context: Dict[str, Any]) -> str:
         for key, value in context.items():
             try:
                 # Try to serialize each value individually
-                json.dumps({key: value}, default=str)
+                json.dumps({key: value}, default=str, ensure_ascii=False)
                 sanitized_context[key] = value
             except Exception as e:
                 log_error(f"Failed to serialize to JSON: {e}")
@@ -97,7 +97,7 @@ def _convert_dependencies_to_string(team: Team, context: Dict[str, Any]) -> str:
                 sanitized_context[key] = str(value)
 
         try:
-            return json.dumps(sanitized_context, indent=2)
+            return json.dumps(sanitized_context, indent=2, ensure_ascii=False)
         except Exception as e:
             log_error(f"Failed to convert sanitized context to JSON: {e}")
             return str(context)


### PR DESCRIPTION
## Summary

Fixes #7036

When using Agno with non-ASCII languages (Chinese, Russian, Arabic, etc.) on Linux/Docker, `json.dumps()` default `ensure_ascii=True` escapes characters to `\u`-sequences.

This breaks LLM context quality and causes hallucinations.

## Changes

Added `ensure_ascii=False` to `json.dumps()` calls in knowledge base and agent serialization paths.

## Testing

```python
import json
text = "赵箭"
assert json.dumps(text, ensure_ascii=False) == "\"赵箭\""
```