### PR TITLE
feat: add Olostep toolkit for web scraping, crawling, search and AI a…

### DIFF
--- a/cookbook/91_tools/olostep_tools.py
+++ b/cookbook/91_tools/olostep_tools.py
@@ -1,0 +1,42 @@
+"""
+Olostep Tools - Examples
+
+pip install agno olostep openai
+export OLOSTEP_API_KEY=***
+export OPENAI_API_KEY=***
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools.olostep import OlostepTools
+
+# Example 1: Scrape a single URL
+scrape_agent = Agent(
+    model=OpenAIChat(id="gpt-4o-mini"),
+    tools=[OlostepTools(scrape_url=True)],
+    markdown=True,
+)
+scrape_agent.print_response(
+    "Summarize the key features described at https://docs.olostep.com/get-started/welcome"
+)
+
+# Example 2: Web search + AI-powered answers
+research_agent = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    tools=[OlostepTools(search_web=True, answer_question=True)],
+    markdown=True,
+)
+research_agent.print_response(
+    "What are the top web scraping APIs in 2025 and how do they compare on pricing?"
+)
+
+# Example 3: Map a site then batch scrape all discovered pages
+batch_agent = Agent(
+    model=OpenAIChat(id="gpt-4o"),
+    tools=[OlostepTools(map_website=True, batch_scrape=True)],
+    markdown=True,
+)
+batch_agent.print_response(
+    "Map https://docs.olostep.com, find all feature pages, "
+    "then batch scrape them and give me a summary of every feature."
+)

--- a/libs/agno/agno/tools/olostep.py
+++ b/libs/agno/agno/tools/olostep.py
@@ -1,0 +1,450 @@
+"""Olostep toolkit for Agno agents."""
+
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+from agno.tools import Toolkit
+from agno.utils.log import log_error
+
+try:
+    from olostep import Olostep, Olostep_BaseError
+except ImportError:
+    raise ImportError("`olostep` not installed. Please install using `pip install olostep`")
+
+
+class OlostepTools(Toolkit):
+    """
+    Olostep is a toolkit for web scraping, crawling, mapping, search,
+    and AI-powered answers for use in Agno agents.
+
+    Args:
+        api_key (Optional[str]): Olostep API key. Falls back to OLOSTEP_API_KEY env var.
+        scrape_url (bool): Enable single-URL scraping. Default: True.
+        crawl_website (bool): Enable website crawling. Default: False.
+        map_website (bool): Enable URL discovery / site mapping. Default: False.
+        search_web (bool): Enable web search returning structured links. Default: False.
+        answer_question (bool): Enable AI-powered answers grounded in live web data. Default: False.
+        batch_scrape (bool): Enable concurrent batch scraping of multiple URLs. Default: False.
+        all_tools (bool): Enable all tools at once. Default: False.
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        scrape_url: bool = True,
+        crawl_website: bool = False,
+        map_website: bool = False,
+        search_web: bool = False,
+        answer_question: bool = False,
+        batch_scrape: bool = False,
+        all_tools: bool = False,
+    ) -> None:
+        super().__init__(name="olostep")
+
+        self.api_key = api_key or os.getenv("OLOSTEP_API_KEY")
+        if not self.api_key:
+            log_error("OLOSTEP_API_KEY not set. Please set the OLOSTEP_API_KEY environment variable.")
+
+        self.client = Olostep(api_key=self.api_key)
+
+        if all_tools:
+            scrape_url = crawl_website = map_website = True
+            search_web = answer_question = batch_scrape = True
+
+        if scrape_url:
+            self.register(self.scrape_url)
+        if crawl_website:
+            self.register(self.crawl_website)
+        if map_website:
+            self.register(self.map_website)
+        if search_web:
+            self.register(self.search_web)
+        if answer_question:
+            self.register(self.answer_question)
+        if batch_scrape:
+            self.register(self.batch_scrape)
+
+    def scrape_url(
+        self,
+        url: str,
+        formats: str = "markdown",
+        wait_before_scraping: int = 0,
+        remove_images: bool = False,
+        country: Optional[str] = None,
+        parser_id: Optional[str] = None,
+        llm_extract_prompt: Optional[str] = None,
+        llm_extract_schema: Optional[str] = None,
+    ) -> str:
+        """
+        Scrape a single URL and return its content.
+
+        Use this to extract the text, markdown, HTML, or structured JSON from any webpage.
+        Supports JS-rendered sites. For structured extraction, use parser_id (efficient,
+        for known sites) or llm_extract_prompt/llm_extract_schema (flexible, costs more).
+
+        Args:
+            url: The full URL to scrape (e.g. "https://example.com/page").
+            formats: Comma-separated output formats. Options: "markdown" (default,
+                     LLM-friendly), "html" (cleaned HTML), "text" (plain text),
+                     "json" (structured — requires parser_id or llm_extract_schema/prompt).
+            wait_before_scraping: Milliseconds to wait after page load before extracting.
+                                  Useful for JS-heavy or dynamic pages.
+            remove_images: Strip image tags from the output. Default: False.
+            country: Two-letter country code for geo-location simulation (e.g. "us", "gb").
+            parser_id: Olostep pre-built parser ID for structured JSON extraction.
+                       Available parsers: "@olostep/google-search", "@olostep/amazon-it-product",
+                       "@olostep/extract-emails", "@olostep/extract-socials",
+                       "@olostep/extract-calendars". Include "json" in formats when using this.
+            llm_extract_prompt: Natural language instruction for LLM-based structured
+                                extraction (e.g. "Extract the event title, date, and venue").
+                                Costs 20 credits. Include "json" in formats.
+            llm_extract_schema: JSON string schema for LLM extraction
+                                (e.g. '{"title": "", "date": "", "venue": ""}').
+                                Takes precedence over llm_extract_prompt if both provided.
+
+        Returns:
+            Scraped content as a string. Returns markdown/text/html directly.
+            Returns JSON string when using parser or llm_extract.
+            Returns an error message string on failure.
+        """
+        try:
+            fmt_list = [f.strip() for f in formats.split(",")]
+
+            kwargs: Dict[str, Any] = {
+                "url_to_scrape": url,
+                "formats": fmt_list,
+                "wait_before_scraping": wait_before_scraping,
+                "remove_images": remove_images,
+            }
+
+            if country:
+                kwargs["country"] = country.lower()
+
+            if parser_id:
+                kwargs["parser"] = {"id": parser_id}
+
+            if llm_extract_schema:
+                try:
+                    schema = json.loads(llm_extract_schema)
+                except json.JSONDecodeError:
+                    return "Error: llm_extract_schema must be a valid JSON string."
+                kwargs["llm_extract"] = {"schema": schema}
+            elif llm_extract_prompt:
+                kwargs["llm_extract"] = {"prompt": llm_extract_prompt}
+
+            result = self.client.scrapes.create(**kwargs)
+
+            if "json" in fmt_list and result.json_content:
+                return result.json_content
+            if "markdown" in fmt_list and result.markdown_content:
+                return result.markdown_content
+            if "text" in fmt_list and result.text_content:
+                return result.text_content
+            if "html" in fmt_list and result.html_content:
+                return result.html_content
+
+            return "No content returned for the requested formats."
+
+        except Olostep_BaseError as e:
+            return f"Olostep API error scraping {url}: {type(e).__name__}: {e}"
+        except Exception as e:
+            return f"Unexpected error scraping {url}: {e}"
+
+    def crawl_website(
+        self,
+        url: str,
+        max_pages: int = 20,
+        max_depth: Optional[int] = None,
+        include_urls: Optional[str] = None,
+        exclude_urls: Optional[str] = None,
+        search_query: Optional[str] = None,
+        top_n: Optional[int] = None,
+    ) -> str:
+        """
+        Crawl a website starting from a URL and return content from all crawled pages.
+
+        Use this to gather content from an entire website or a section of it — for example,
+        all blog posts, all docs pages, or all product listings. Supports URL glob filtering
+        and relevance-based filtering via search_query.
+
+        Args:
+            url: The starting URL for the crawl (e.g. "https://docs.example.com").
+            max_pages: Maximum number of pages to crawl. Default: 20. Max: 1000.
+            max_depth: Maximum link depth from the start URL. None means no depth limit.
+            include_urls: Comma-separated glob patterns for paths to include
+                          (e.g. "/blog/**, /articles/**"). Only matching URLs are crawled.
+            exclude_urls: Comma-separated glob patterns for paths to exclude
+                          (e.g. "/admin/**, /login/**").
+            search_query: Filter crawled pages by relevance to this query
+                          (e.g. "pricing information"). Returns most relevant pages first.
+            top_n: When combined with search_query, limits to top N most relevant pages.
+
+        Returns:
+            JSON string — a list of objects with "url" and "markdown_content" fields.
+            Returns an error message string on failure.
+        """
+        try:
+            kwargs: Dict[str, Any] = {
+                "start_url": url,
+                "max_pages": max_pages,
+            }
+
+            if max_depth is not None:
+                kwargs["max_depth"] = max_depth
+            if include_urls:
+                kwargs["include_urls"] = [p.strip() for p in include_urls.split(",")]
+            if exclude_urls:
+                kwargs["exclude_urls"] = [p.strip() for p in exclude_urls.split(",")]
+            if search_query:
+                kwargs["search_query"] = search_query
+            if top_n is not None:
+                kwargs["top_n"] = top_n
+
+            crawl = self.client.crawls.create(**kwargs)
+
+            pages: List[Dict[str, str]] = []
+            for page in crawl.pages():
+                try:
+                    content = page.retrieve(["markdown"])
+                    pages.append({
+                        "url": page.url,
+                        "markdown_content": content.markdown_content or "",
+                    })
+                except Exception as page_err:
+                    log_error(f"Failed to retrieve content for {page.url}: {page_err}")
+                    pages.append({"url": page.url, "markdown_content": ""})
+
+            return json.dumps(pages, ensure_ascii=False)
+
+        except Olostep_BaseError as e:
+            return f"Olostep API error crawling {url}: {type(e).__name__}: {e}"
+        except Exception as e:
+            return f"Unexpected error crawling {url}: {e}"
+
+    def map_website(
+        self,
+        url: str,
+        include_urls: Optional[str] = None,
+        exclude_urls: Optional[str] = None,
+        include_subdomain: bool = False,
+        top_n: Optional[int] = None,
+    ) -> str:
+        """
+        Discover and return all URLs found on a website.
+
+        Use this to explore a site's structure before scraping, or to prepare a URL
+        list for batch_scrape. Returns URLs from sitemaps and discovered links.
+        Ideal for SEO analysis, content discovery, and understanding site structure.
+
+        Args:
+            url: The website URL to map (e.g. "https://www.example.com").
+            include_urls: Comma-separated glob path patterns to include
+                          (e.g. "/product, /product/**").
+            exclude_urls: Comma-separated glob path patterns to exclude
+                          (e.g. "/ads/**, /tracking/**").
+            include_subdomain: Also include URLs from subdomains (e.g. blog.example.com).
+                               Default: False.
+            top_n: Limit number of URLs returned. Default: all (up to ~100k).
+
+        Returns:
+            JSON string — a list of URL strings.
+            Returns an error message string on failure.
+        """
+        try:
+            kwargs: Dict[str, Any] = {"url": url}
+
+            if include_urls:
+                kwargs["include_urls"] = [p.strip() for p in include_urls.split(",")]
+            if exclude_urls:
+                kwargs["exclude_urls"] = [p.strip() for p in exclude_urls.split(",")]
+            if include_subdomain:
+                kwargs["include_subdomain"] = True
+            if top_n is not None:
+                kwargs["top_n"] = top_n
+
+            maps = self.client.maps.create(**kwargs)
+
+            urls: List[str] = []
+            for u in maps.urls():
+                urls.append(u)
+
+            return json.dumps(urls, ensure_ascii=False)
+
+        except Olostep_BaseError as e:
+            return f"Olostep API error mapping {url}: {type(e).__name__}: {e}"
+        except Exception as e:
+            return f"Unexpected error mapping {url}: {e}"
+
+    def search_web(self, query: str) -> str:
+        """
+        Search the web with a natural language query and return relevant links.
+
+        Use this to find web pages on a topic before scraping them, or when you need a
+        list of sources. Unlike answer_question (which returns a synthesized AI answer),
+        this returns raw links for further investigation.
+
+        Args:
+            query: Natural language search query
+                   (e.g. "best open source vector databases 2025").
+
+        Returns:
+            JSON string — a list of objects each with "url", "title", and "description".
+            Returns an error message string on failure.
+        """
+        try:
+            result = self.client.searches.create(query=query)
+
+            links: List[Dict[str, str]] = []
+            if result.result and result.result.links:
+                for link in result.result.links:
+                    links.append({
+                        "url": link.url or "",
+                        "title": link.title or "",
+                        "description": link.description or "",
+                    })
+
+            return json.dumps(links, ensure_ascii=False)
+
+        except Olostep_BaseError as e:
+            return f"Olostep API error searching '{query}': {type(e).__name__}: {e}"
+        except Exception as e:
+            return f"Unexpected error searching '{query}': {e}"
+
+    def answer_question(
+        self,
+        task: str,
+        json_schema: Optional[str] = None,
+    ) -> str:
+        """
+        Search the web and return an AI-powered answer grounded in live data.
+
+        Use this for research tasks, fact-checking, or data enrichment where you need a
+        synthesized answer with sources — not just raw links. Olostep searches the web,
+        validates sources, and returns a structured answer. If data cannot be verified,
+        it returns "NOT_FOUND" for that field.
+
+        Args:
+            task: The question or research task in natural language. Can reference
+                  specific URLs (e.g. "What is the pricing at https://example.com?")
+                  or ask general questions (e.g. "What is the current valuation of OpenAI?").
+            json_schema: Optional JSON string defining the structure of the answer.
+                         Provide an object with empty string values as a template
+                         (e.g. '{"company_name": "", "valuation": "", "founded": ""}').
+                         If omitted, returns a plain text answer.
+
+        Returns:
+            If json_schema provided: JSON string with structured answer plus "_sources" list.
+            Otherwise: JSON string with "answer" (text) and "sources" (list of URLs).
+            Returns an error message string on failure.
+        """
+        try:
+            kwargs: Dict[str, Any] = {"task": task}
+
+            if json_schema:
+                try:
+                    schema = json.loads(json_schema)
+                    kwargs["json"] = schema
+                except json.JSONDecodeError:
+                    return "Error: json_schema must be a valid JSON string."
+
+            answer = self.client.answers.create(**kwargs)
+
+            if json_schema and answer.result and answer.result.json_content:
+                try:
+                    data = json.loads(answer.result.json_content)
+                    json_sources = answer.result.sources if answer.result.sources else []
+                    data["_sources"] = json_sources
+                    return json.dumps(data, ensure_ascii=False)
+                except json.JSONDecodeError:
+                    return answer.result.json_content
+
+            plain = answer.answer or ""
+            sources: List[str] = []
+            if answer.result and answer.result.sources:
+                sources = answer.result.sources
+
+            return json.dumps({"answer": plain, "sources": sources}, ensure_ascii=False)
+
+        except Olostep_BaseError as e:
+            return f"Olostep API error for task '{task}': {type(e).__name__}: {e}"
+        except Exception as e:
+            return f"Unexpected error for task '{task}': {e}"
+
+    def batch_scrape(
+        self,
+        urls: str,
+        formats: str = "markdown",
+        parser_id: Optional[str] = None,
+        country: Optional[str] = None,
+    ) -> str:
+        """
+        Scrape multiple URLs concurrently in a single batch job.
+
+        Use this when you have a list of URLs (50–10,000) to scrape at once. Processing
+        takes ~5–8 minutes regardless of batch size, making it far more efficient than
+        individual scrapes for large lists. Best combined with map_website to first
+        discover URLs then scrape them all.
+
+        Args:
+            urls: Comma-separated list of URLs to scrape
+                  (e.g. "https://a.com, https://b.com, https://c.com").
+            formats: Comma-separated output formats: "markdown", "html", "text", "json".
+                     Default: "markdown". Use "json" with parser_id for structured output.
+            parser_id: Olostep parser ID to extract structured JSON from each URL
+                       (e.g. "@olostep/google-search", "@olostep/extract-emails").
+            country: Two-letter country code for geo-targeting all URLs (e.g. "us").
+
+        Returns:
+            JSON string — a list of objects, each with:
+              "url": the scraped URL,
+              "custom_id": internal hash ID,
+              "content": the scraped content string.
+            Returns an error message string on failure.
+        """
+        try:
+            url_list = [u.strip() for u in urls.split(",") if u.strip()]
+            if not url_list:
+                return "Error: no valid URLs provided."
+
+            fmt_list = [f.strip() for f in formats.split(",")]
+
+            batch_kwargs: Dict[str, Any] = {"urls": url_list}
+
+            if parser_id:
+                batch_kwargs["parser"] = {"id": parser_id}
+            if country:
+                batch_kwargs["country"] = country.lower()
+
+            batch = self.client.batches.create(**batch_kwargs)
+
+            results: List[Dict[str, str]] = []
+            for item in batch.items():
+                try:
+                    content_obj = item.retrieve(fmt_list)
+                    if "json" in fmt_list and content_obj.json_content:
+                        content = content_obj.json_content
+                    elif "markdown" in fmt_list and content_obj.markdown_content:
+                        content = content_obj.markdown_content
+                    elif "text" in fmt_list and content_obj.text_content:
+                        content = content_obj.text_content
+                    elif "html" in fmt_list and content_obj.html_content:
+                        content = content_obj.html_content
+                    else:
+                        content = ""
+                except Exception as item_err:
+                    log_error(f"Failed to retrieve batch item {item.url}: {item_err}")
+                    content = ""
+
+                results.append({
+                    "url": item.url,
+                    "custom_id": item.custom_id,
+                    "content": content,
+                })
+
+            return json.dumps(results, ensure_ascii=False)
+
+        except Olostep_BaseError as e:
+            return f"Olostep API error in batch scrape: {type(e).__name__}: {e}"
+        except Exception as e:
+            return f"Unexpected error in batch scrape: {e}"

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -127,6 +127,7 @@ mem0 = ["mem0ai"]
 memori = ["memori>=3.0.5"]
 newspaper = ["newspaper4k", "lxml_html_clean"]
 notion = ["notion-client"]
+olostep = ["olostep>=0.1.0"]
 opencv = ["opencv-python"]
 parallel = ["parallel-web"]
 psycopg = ["psycopg-binary", "psycopg"]
@@ -241,6 +242,7 @@ tools = [
   "agno[ddg]",
   "agno[duckdb]",
   "agno[newspaper]",
+  "agno[olostep]",
   "agno[youtube]",
   "agno[firecrawl]",
   "agno[tavily]",
@@ -506,6 +508,7 @@ module = [
   "newspaper.*",
   "numpy.*",
   "ollama.*",
+  "olostep.*",
   "openpyxl.*",
   "openai.*",
   "cv2.*",

--- a/libs/agno/tests/unit/tools/test_olostep.py
+++ b/libs/agno/tests/unit/tools/test_olostep.py
@@ -1,0 +1,417 @@
+"""Unit tests for OlostepTools class."""
+
+import json
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+
+# Skip all tests in this module if olostep is not installed
+pytest.importorskip("olostep")
+
+from olostep import Olostep, Olostep_BaseError  # noqa
+
+from agno.tools.olostep import OlostepTools
+
+
+@pytest.fixture
+def mock_olostep_client():
+    """Create a mock Olostep client."""
+    mock_client = Mock()
+
+    # Mock scrape response
+    mock_scrape_result = Mock()
+    mock_scrape_result.markdown_content = "# Test Page\n\nTest content"
+    mock_scrape_result.text_content = "Test Page\n\nTest content"
+    mock_scrape_result.html_content = "<html><body>Test content</body></html>"
+    mock_scrape_result.json_content = '{"title": "Test Page"}'
+    mock_client.scrapes.create.return_value = mock_scrape_result
+
+    # Mock crawl response
+    mock_page = Mock()
+    mock_page.url = "https://example.com/page1"
+    mock_page_content = Mock()
+    mock_page_content.markdown_content = "# Page 1"
+    mock_page.retrieve.return_value = mock_page_content
+
+    mock_crawl_result = Mock()
+    mock_crawl_result.pages.return_value = [mock_page]
+    mock_client.crawls.create.return_value = mock_crawl_result
+
+    # Mock map response
+    mock_map_result = Mock()
+    mock_map_result.urls.return_value = ["https://example.com/page1", "https://example.com/page2"]
+    mock_client.maps.create.return_value = mock_map_result
+
+    # Mock search response
+    mock_link = Mock()
+    mock_link.url = "https://example.com"
+    mock_link.title = "Example Site"
+    mock_link.description = "Example description"
+    mock_search_result = Mock()
+    mock_search_result.result = Mock()
+    mock_search_result.result.links = [mock_link]
+    mock_client.searches.create.return_value = mock_search_result
+
+    # Mock answer response
+    mock_answer_result = Mock()
+    mock_answer_result.answer = "The answer to your question is..."
+    mock_answer_result.result = Mock()
+    mock_answer_result.result.sources = ["https://example.com", "https://other.com"]
+    mock_answer_result.result.json_content = None
+    mock_client.answers.create.return_value = mock_answer_result
+
+    # Mock batch response
+    mock_batch_item = Mock()
+    mock_batch_item.url = "https://example.com"
+    mock_batch_item.custom_id = "batch_123"
+    mock_batch_content = Mock()
+    mock_batch_content.markdown_content = "# Batch Result"
+    mock_batch_content.text_content = "Batch Result"
+    mock_batch_content.html_content = "<html>Batch</html>"
+    mock_batch_content.json_content = None
+    mock_batch_item.retrieve.return_value = mock_batch_content
+
+    mock_batch_result = Mock()
+    mock_batch_result.items.return_value = [mock_batch_item]
+    mock_client.batches.create.return_value = mock_batch_result
+
+    return mock_client
+
+
+def test_init_with_api_key():
+    """Test initialization with explicit API key."""
+    with patch("agno.tools.olostep.Olostep") as mock_olostep_class:
+        tools = OlostepTools(api_key="test_key", scrape_url=True)
+        assert tools.api_key == "test_key"
+        mock_olostep_class.assert_called_once_with(api_key="test_key")
+
+
+def test_init_with_env_api_key():
+    """Test initialization with environment API key."""
+    with (
+        patch("agno.tools.olostep.Olostep") as mock_olostep_class,
+        patch.dict(os.environ, {"OLOSTEP_API_KEY": "env_key"}),
+    ):
+        tools = OlostepTools(scrape_url=True)
+        assert tools.api_key == "env_key"
+        mock_olostep_class.assert_called_once_with(api_key="env_key")
+
+
+def test_init_without_api_key(caplog):
+    """Test initialization without API key logs error."""
+    with (
+        patch("agno.tools.olostep.Olostep"),
+        patch.dict(os.environ, {}, clear=True),
+        patch("agno.tools.olostep.log_error") as mock_log_error,
+    ):
+        OlostepTools(scrape_url=True)
+        mock_log_error.assert_called_once()
+
+
+def test_init_with_all_tools():
+    """Test initialization with all_tools=True enables all methods."""
+    with patch("agno.tools.olostep.Olostep"):
+        with patch.dict(os.environ, {"OLOSTEP_API_KEY": "test_key"}):
+            tools = OlostepTools(all_tools=True)
+            # Verify that the toolkit was created with all tools registered
+            assert tools is not None
+            assert hasattr(tools, "scrape_url")
+            assert hasattr(tools, "crawl_website")
+            assert hasattr(tools, "map_website")
+            assert hasattr(tools, "search_web")
+            assert hasattr(tools, "answer_question")
+            assert hasattr(tools, "batch_scrape")
+
+
+def test_init_with_selective_tools():
+    """Test initialization with selective tool enabling."""
+    with patch("agno.tools.olostep.Olostep"):
+        with patch.dict(os.environ, {"OLOSTEP_API_KEY": "test_key"}):
+            tools = OlostepTools(scrape_url=True, search_web=True, crawl_website=False)
+            # Verify selective tools are registered
+            assert hasattr(tools, "scrape_url")
+            assert hasattr(tools, "search_web")
+            # crawl_website should still exist as a method, but wasn't registered
+            assert hasattr(tools, "crawl_website")
+
+
+def test_scrape_url_markdown(mock_olostep_client):
+    """Test scrape_url with markdown format."""
+    with (
+        patch("agno.tools.olostep.Olostep") as mock_olostep_class,
+        patch.dict(os.environ, {"OLOSTEP_API_KEY": "test_key"}),
+    ):
+        mock_olostep_class.return_value = mock_olostep_client
+        tools = OlostepTools(scrape_url=True)
+        result = tools.scrape_url("https://example.com")
+
+        assert result == "# Test Page\n\nTest content"
+        mock_olostep_client.scrapes.create.assert_called_once()
+        call_args = mock_olostep_client.scrapes.create.call_args
+        assert call_args[1]["url_to_scrape"] == "https://example.com"
+        assert "markdown" in call_args[1]["formats"]
+
+
+def test_scrape_url_json_format(mock_olostep_client):
+    """Test scrape_url with JSON format and parser_id."""
+    with (
+        patch("agno.tools.olostep.Olostep") as mock_olostep_class,
+        patch.dict(os.environ, {"OLOSTEP_API_KEY": "test_key"}),
+    ):
+        mock_olostep_client.scrapes.create.return_value.markdown_content = None
+        mock_olostep_client.scrapes.create.return_value.json_content = '{"extracted": "data"}'
+        mock_olostep_class.return_value = mock_olostep_client
+
+        tools = OlostepTools(scrape_url=True)
+        result = tools.scrape_url(
+            "https://example.com",
+            formats="json",
+            parser_id="@olostep/google-search"
+        )
+
+        assert result == '{"extracted": "data"}'
+        call_args = mock_olostep_client.scrapes.create.call_args
+        assert call_args[1]["parser"] == {"id": "@olostep/google-search"}
+
+
+def test_scrape_url_with_llm_extract_schema(mock_olostep_client):
+    """Test scrape_url with LLM extraction schema."""
+    with (
+        patch("agno.tools.olostep.Olostep") as mock_olostep_class,
+        patch.dict(os.environ, {"OLOSTEP_API_KEY": "test_key"}),
+    ):
+        mock_olostep_class.return_value = mock_olostep_client
+        tools = OlostepTools(scrape_url=True)
+        schema = '{"title": "", "price": ""}'
+        tools.scrape_url(
+            "https://example.com",
+            formats="json",
+            llm_extract_schema=schema
+        )
+
+        call_args = mock_olostep_client.scrapes.create.call_args
+        assert call_args[1]["llm_extract"]["schema"] == {"title": "", "price": ""}
+
+
+def test_scrape_url_invalid_schema():
+    """Test scrape_url with invalid JSON schema."""
+    with (
+        patch("agno.tools.olostep.Olostep"),
+        patch.dict(os.environ, {"OLOSTEP_API_KEY": "test_key"}),
+    ):
+        tools = OlostepTools(scrape_url=True)
+        result = tools.scrape_url(
+            "https://example.com",
+            llm_extract_schema="invalid json"
+        )
+
+        assert "Error: llm_extract_schema must be a valid JSON string" in result
+
+
+def test_scrape_url_error_handling(mock_olostep_client):
+    """Test scrape_url error handling."""
+    with (
+        patch("agno.tools.olostep.Olostep") as mock_olostep_class,
+        patch.dict(os.environ, {"OLOSTEP_API_KEY": "test_key"}),
+    ):
+        mock_olostep_client.scrapes.create.side_effect = Olostep_BaseError("API Error")
+        mock_olostep_class.return_value = mock_olostep_client
+
+        tools = OlostepTools(scrape_url=True)
+        result = tools.scrape_url("https://example.com")
+
+        assert "Olostep API error" in result
+        assert "API Error" in result
+
+
+def test_crawl_website(mock_olostep_client):
+    """Test crawl_website method."""
+    with (
+        patch("agno.tools.olostep.Olostep") as mock_olostep_class,
+        patch.dict(os.environ, {"OLOSTEP_API_KEY": "test_key"}),
+    ):
+        mock_olostep_class.return_value = mock_olostep_client
+        tools = OlostepTools(crawl_website=True)
+        result = tools.crawl_website("https://example.com")
+
+        result_data = json.loads(result)
+        assert len(result_data) == 1
+        assert result_data[0]["url"] == "https://example.com/page1"
+        assert result_data[0]["markdown_content"] == "# Page 1"
+
+
+def test_crawl_website_with_filters(mock_olostep_client):
+    """Test crawl_website with URL filters."""
+    with (
+        patch("agno.tools.olostep.Olostep") as mock_olostep_class,
+        patch.dict(os.environ, {"OLOSTEP_API_KEY": "test_key"}),
+    ):
+        mock_olostep_class.return_value = mock_olostep_client
+        tools = OlostepTools(crawl_website=True)
+        tools.crawl_website(
+            "https://example.com",
+            max_pages=50,
+            max_depth=2,
+            include_urls="/blog/**, /articles/**",
+            exclude_urls="/admin/**"
+        )
+
+        call_args = mock_olostep_client.crawls.create.call_args
+        assert call_args[1]["max_pages"] == 50
+        assert call_args[1]["max_depth"] == 2
+        assert "/blog/**" in call_args[1]["include_urls"]
+        assert "/admin/**" in call_args[1]["exclude_urls"]
+
+
+def test_map_website(mock_olostep_client):
+    """Test map_website method."""
+    with (
+        patch("agno.tools.olostep.Olostep") as mock_olostep_class,
+        patch.dict(os.environ, {"OLOSTEP_API_KEY": "test_key"}),
+    ):
+        mock_olostep_class.return_value = mock_olostep_client
+        tools = OlostepTools(map_website=True)
+        result = tools.map_website("https://example.com")
+
+        result_data = json.loads(result)
+        assert len(result_data) == 2
+        assert "https://example.com/page1" in result_data
+        assert "https://example.com/page2" in result_data
+
+
+def test_search_web(mock_olostep_client):
+    """Test search_web method."""
+    with (
+        patch("agno.tools.olostep.Olostep") as mock_olostep_class,
+        patch.dict(os.environ, {"OLOSTEP_API_KEY": "test_key"}),
+    ):
+        mock_olostep_class.return_value = mock_olostep_client
+        tools = OlostepTools(search_web=True)
+        result = tools.search_web("best vector databases 2025")
+
+        result_data = json.loads(result)
+        assert len(result_data) == 1
+        assert result_data[0]["url"] == "https://example.com"
+        assert result_data[0]["title"] == "Example Site"
+        assert result_data[0]["description"] == "Example description"
+
+
+def test_answer_question(mock_olostep_client):
+    """Test answer_question method."""
+    with (
+        patch("agno.tools.olostep.Olostep") as mock_olostep_class,
+        patch.dict(os.environ, {"OLOSTEP_API_KEY": "test_key"}),
+    ):
+        mock_olostep_class.return_value = mock_olostep_client
+        tools = OlostepTools(answer_question=True)
+        result = tools.answer_question("What is the best web scraping tool?")
+
+        result_data = json.loads(result)
+        assert "answer" in result_data
+        assert "sources" in result_data
+        assert result_data["answer"] == "The answer to your question is..."
+        assert len(result_data["sources"]) == 2
+
+
+def test_answer_question_with_schema(mock_olostep_client):
+    """Test answer_question with JSON schema."""
+    with (
+        patch("agno.tools.olostep.Olostep") as mock_olostep_class,
+        patch.dict(os.environ, {"OLOSTEP_API_KEY": "test_key"}),
+    ):
+        mock_answer = Mock()
+        mock_answer.answer = "Answer text"
+        mock_answer.result = Mock()
+        mock_answer.result.json_content = '{"company": "Agno", "founded": "2025"}'
+        mock_answer.result.sources = ["https://example.com"]
+        mock_olostep_client.answers.create.return_value = mock_answer
+        mock_olostep_class.return_value = mock_olostep_client
+
+        tools = OlostepTools(answer_question=True)
+        schema = '{"company": "", "founded": ""}'
+        result = tools.answer_question("What is Agno?", json_schema=schema)
+
+        result_data = json.loads(result)
+        assert result_data["company"] == "Agno"
+        assert result_data["founded"] == "2025"
+        assert "_sources" in result_data
+
+
+def test_batch_scrape(mock_olostep_client):
+    """Test batch_scrape method."""
+    with (
+        patch("agno.tools.olostep.Olostep") as mock_olostep_class,
+        patch.dict(os.environ, {"OLOSTEP_API_KEY": "test_key"}),
+    ):
+        mock_olostep_class.return_value = mock_olostep_client
+        tools = OlostepTools(batch_scrape=True)
+        urls = "https://example.com, https://example.com/page2"
+        result = tools.batch_scrape(urls)
+
+        result_data = json.loads(result)
+        assert len(result_data) == 1
+        assert result_data[0]["url"] == "https://example.com"
+        assert result_data[0]["custom_id"] == "batch_123"
+        assert "Batch Result" in result_data[0]["content"]
+
+
+def test_batch_scrape_empty_urls():
+    """Test batch_scrape with no valid URLs."""
+    with (
+        patch("agno.tools.olostep.Olostep"),
+        patch.dict(os.environ, {"OLOSTEP_API_KEY": "test_key"}),
+    ):
+        tools = OlostepTools(batch_scrape=True)
+        result = tools.batch_scrape("")
+
+        assert "Error: no valid URLs provided" in result
+
+
+def test_batch_scrape_with_parser(mock_olostep_client):
+    """Test batch_scrape with parser_id."""
+    with (
+        patch("agno.tools.olostep.Olostep") as mock_olostep_class,
+        patch.dict(os.environ, {"OLOSTEP_API_KEY": "test_key"}),
+    ):
+        mock_olostep_class.return_value = mock_olostep_client
+        tools = OlostepTools(batch_scrape=True)
+        urls = "https://example.com, https://example2.com"
+        tools.batch_scrape(urls, parser_id="@olostep/extract-emails")
+
+        call_args = mock_olostep_client.batches.create.call_args
+        assert call_args[1]["parser"] == {"id": "@olostep/extract-emails"}
+
+
+def test_all_tools_enabled():
+    """Test that multiple tools can be registered simultaneously."""
+    with patch("agno.tools.olostep.Olostep"):
+        with patch.dict(os.environ, {"OLOSTEP_API_KEY": "test_key"}):
+            tools = OlostepTools(
+                scrape_url=True,
+                crawl_website=True,
+                map_website=True,
+                search_web=True,
+                answer_question=True,
+                batch_scrape=True,
+            )
+
+            # Verify all methods are present
+            assert all(
+                hasattr(tools, name)
+                for name in ["scrape_url", "crawl_website", "map_website", "search_web", "answer_question", "batch_scrape"]
+            )
+
+
+def test_country_parameter(mock_olostep_client):
+    """Test that country parameter is lowercased."""
+    with (
+        patch("agno.tools.olostep.Olostep") as mock_olostep_class,
+        patch.dict(os.environ, {"OLOSTEP_API_KEY": "test_key"}),
+    ):
+        mock_olostep_class.return_value = mock_olostep_client
+        tools = OlostepTools(scrape_url=True)
+        tools.scrape_url("https://example.com", country="US")
+
+        call_args = mock_olostep_client.scrapes.create.call_args
+        assert call_args[1]["country"] == "us"


### PR DESCRIPTION
## Summary

Closes #7048 

Adds `OlostepTools` which is an Agno toolkit wrapping the [Olostep](https://www.olostep.com/) web data API.

Olostep is a web scraping, crawling, and AI-powered data extraction API used by leading AI startups. This toolkit gives Agno agents access to all of Olostep's core capabilities through a clean, consistent interface.

**Tools added:**
- `scrape_url`: scrape any URL to markdown/html/text/json, with support for parsers and LLM extraction
- `crawl_website`: recursively crawl a site with URL glob filtering and relevance-based search
- `map_website`: discover all URLs on a site (sitemaps + discovered links)
- `search_web`: web search returning structured links with titles and descriptions
- `answer_question`: AI-synthesized answers grounded in live web data, with optional JSON schema output
- `batch_scrape`: concurrent scraping of up to 10,000 URLs in a single job

**Files changed:**
- `libs/agno/agno/tools/olostep.py`: toolkit implementation
- `libs/agno/pyproject.toml`: added `olostep` optional dependency and mypy override
- `cookbook/91_tools/olostep_tools.py`: three working example agents

## Type of change
- [x] New feature

---
## Checklist
- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check
- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---
## Additional Notes

Tested end-to-end locally with live API keys. All three cookbook examples ran successfully:
- Single URL scrape returning clean markdown
- Parallel `search_web` + `answer_question` tool calls
- `map_website` → `batch_scrape` pipeline (mapped 12 feature pages, batch scraped all in one job, returned structured summaries)

Install: `pip install agno[olostep]`
Olostep API key required: https://www.olostep.com/dashboard/api-keys