### PR TITLE
fix(lancedb): deduplicate search results to prevent duplicate documents

### DIFF
--- a/libs/agno/agno/vectordb/lancedb/lance_db.py
+++ b/libs/agno/agno/vectordb/lancedb/lance_db.py
@@ -521,6 +521,17 @@ class LanceDb(VectorDb):
 
         search_results = self._build_search_results(results)
 
+        # Secondary deduplication by content to catch duplicates with different DB IDs
+        seen_content: set = set()
+        unique_results: List[Document] = []
+        for doc in search_results:
+            content_key = doc.content_id if doc.content_id else (doc.content[:100] if doc.content else None)
+            if content_key is None or content_key not in seen_content:
+                if content_key is not None:
+                    seen_content.add(content_key)
+                unique_results.append(doc)
+        search_results = unique_results
+
         # Filter results based on metadata if filters are provided
         if filters and search_results:
             filtered_results = []
@@ -639,8 +650,18 @@ class LanceDb(VectorDb):
 
     def _build_search_results(self, results: List[Dict[str, Any]]) -> List[Document]:
         search_results: List[Document] = []
+        seen_ids: set = set()
         try:
             for item in results:
+                # Deduplicate by document ID to prevent returning duplicate documents
+                # This can occur with hybrid search or when multiple indexes overlap
+                doc_id = item.get("id")
+                if doc_id is not None:
+                    if doc_id in seen_ids:
+                        log_debug(f"Skipping duplicate document with id: {doc_id}")
+                        continue
+                    seen_ids.add(doc_id)
+
                 payload = json.loads(item["payload"])
                 search_results.append(
                     Document(


### PR DESCRIPTION
Fixes #7047

## Problem
LanceDB `search()` method returns duplicate documents in results, causing knowledge retrieval to return repeated information. This happens because:
- Hybrid search queries both vector and FTS indexes, which can return the same document twice
- In some edge cases, the same content may be stored with different internal IDs

## Fix
Added two-level deduplication in the LanceDB search pipeline:

**Level 1** — in `_build_search_results()`: deduplicates raw DB rows by document `id` before constructing `Document` objects. This efficiently handles overlapping results from hybrid search indexes.

**Level 2** — in `search()`: secondary deduplication by `content_id` (falling back to first 100 chars of content) after building results. This catches duplicates that may have been stored with different internal DB IDs.

Both deduplication layers are O(n) using sets, adding negligible overhead.

## Changes
- `libs/agno/agno/vectordb/lancedb/lance_db.py`
  - `_build_search_results()`: track seen document IDs, skip duplicates with debug logging
  - `search()`: secondary deduplication pass by `content_id` / content prefix