### PR TITLE
fix: treat .html/.htm URLs as web content instead of fetching as BytesIO

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -1562,16 +1562,17 @@ class Knowledge(RemoteKnowledge):
         # 3. Fetch and load content if file has an extension
         url_path = Path(parsed_url.path)
         file_extension = url_path.suffix.lower()
+        web_extensions = {".html", ".htm"}
 
         bytes_content = None
-        if file_extension:
+        if file_extension and file_extension not in web_extensions:
             async with AsyncClient() as client:
                 response = await async_fetch_with_retry(content.url, client=client)
             bytes_content = BytesIO(response.content)
 
         # 4. Select reader
         name = content.name if content.name else content.url
-        if file_extension:
+        if file_extension and file_extension not in web_extensions:
             reader, default_name = self._select_reader_by_extension(file_extension, content.reader)
             if default_name and file_extension == ".csv":
                 name = basename(parsed_url.path) or default_name
@@ -1714,15 +1715,16 @@ class Knowledge(RemoteKnowledge):
         # 3. Fetch and load content if file has an extension
         url_path = Path(parsed_url.path)
         file_extension = url_path.suffix.lower()
+        web_extensions = {".html", ".htm"}
 
         bytes_content = None
-        if file_extension:
+        if file_extension and file_extension not in web_extensions:
             response = fetch_with_retry(content.url)
             bytes_content = BytesIO(response.content)
 
         # 4. Select reader
         name = content.name if content.name else content.url
-        if file_extension:
+        if file_extension and file_extension not in web_extensions:
             reader, default_name = self._select_reader_by_extension(file_extension, content.reader)
             if default_name and file_extension == ".csv":
                 name = basename(parsed_url.path) or default_name


### PR DESCRIPTION
## Summary
Fixes #6985.

**Root cause:** `_load_from_url()` and `_aload_from_url()` fetch any URL with a file extension into `BytesIO` and pass it to a file reader. For `.html`/`.htm` URLs, this means `BytesIO` is passed to `WebsiteReader.read()`, which expects a URL string, causing `AttributeError: '_io.BytesIO' object has no attribute 'decode'`.

**Fix:** Exclude `.html` and `.htm` from the file-extension fetch path so they are treated as web content and routed to `WebsiteReader` with the original URL string.

## Changes
- `libs/agno/agno/knowledge/knowledge.py`: Added `web_extensions = {".html", ".htm"}` exclusion set to both sync `_load_from_url()` and async `_aload_from_url()`, preventing BytesIO fetch for HTML URLs.

## Testing
- Verified that `.html` URLs now bypass BytesIO fetch and use WebsiteReader with URL string
- Non-HTML file URLs (`.pdf`, `.csv`, etc.) continue to work as before
- Change is minimal and backward-compatible

Made with [Cursor](https://cursor.com)