### PR TITLE
fix: lazy-load mistralai to avoid startup errors when not installed

### DIFF
--- a/libs/agno/agno/knowledge/embedder/mistral.py
+++ b/libs/agno/agno/knowledge/embedder/mistral.py
@@ -4,8 +4,6 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from agno.knowledge.embedder.base import Embedder
 from agno.utils.log import log_info, log_warning
-from agno.utils.models._mistral_compat import EmbeddingResponse
-from agno.utils.models._mistral_compat import MistralClient as Mistral
 
 
 @dataclass
@@ -21,12 +19,14 @@ class MistralEmbedder(Embedder):
     timeout: Optional[int] = None
     client_params: Optional[Dict[str, Any]] = None
     # -*- Provide the Mistral Client manually
-    mistral_client: Optional[Mistral] = None
+    mistral_client: Optional[Any] = None
 
     @property
-    def client(self) -> Mistral:
+    def client(self) -> Any:
         if self.mistral_client:
             return self.mistral_client
+
+        from agno.utils.models._mistral_compat import MistralClient as Mistral
 
         _client_params: Dict[str, Any] = {
             "api_key": self.api_key,
@@ -43,7 +43,7 @@ class MistralEmbedder(Embedder):
 
         return self.mistral_client
 
-    def _response(self, text: str) -> EmbeddingResponse:
+    def _response(self, text: str) -> Any:
         _request_params: Dict[str, Any] = {
             "inputs": [text],  # Mistral API expects a list
             "model": self.id,
@@ -57,7 +57,7 @@ class MistralEmbedder(Embedder):
 
     def get_embedding(self, text: str) -> List[float]:
         try:
-            response: EmbeddingResponse = self._response(text=text)
+            response = self._response(text=text)
             if response.data and response.data[0].embedding:
                 return response.data[0].embedding
             return []
@@ -67,7 +67,7 @@ class MistralEmbedder(Embedder):
 
     def get_embedding_and_usage(self, text: str) -> Tuple[List[float], Dict[str, Any]]:
         try:
-            response: EmbeddingResponse = self._response(text=text)
+            response = self._response(text=text)
             embedding: List[float] = (
                 response.data[0].embedding if (response.data and response.data[0].embedding) else []
             )
@@ -82,7 +82,7 @@ class MistralEmbedder(Embedder):
         try:
             # Check if the client has an async version of embeddings.create
             if hasattr(self.client.embeddings, "create_async"):
-                response: EmbeddingResponse = await self.client.embeddings.create_async(
+                response = await self.client.embeddings.create_async(
                     inputs=[text], model=self.id, **self.request_params if self.request_params else {}
                 )
             else:
@@ -90,7 +90,7 @@ class MistralEmbedder(Embedder):
                 import asyncio
 
                 loop = asyncio.get_running_loop()
-                response: EmbeddingResponse = await loop.run_in_executor(  # type: ignore
+                response = await loop.run_in_executor(
                     None,
                     lambda: self.client.embeddings.create(
                         inputs=[text], model=self.id, **self.request_params if self.request_params else {}
@@ -109,7 +109,7 @@ class MistralEmbedder(Embedder):
         try:
             # Check if the client has an async version of embeddings.create
             if hasattr(self.client.embeddings, "create_async"):
-                response: EmbeddingResponse = await self.client.embeddings.create_async(
+                response = await self.client.embeddings.create_async(
                     inputs=[text], model=self.id, **self.request_params if self.request_params else {}
                 )
             else:
@@ -117,7 +117,7 @@ class MistralEmbedder(Embedder):
                 import asyncio
 
                 loop = asyncio.get_running_loop()
-                response: EmbeddingResponse = await loop.run_in_executor(  # type: ignore
+                response = await loop.run_in_executor(
                     None,
                     lambda: self.client.embeddings.create(
                         inputs=[text], model=self.id, **self.request_params if self.request_params else {}
@@ -162,13 +162,13 @@ class MistralEmbedder(Embedder):
             try:
                 # Check if the client has an async version of embeddings.create
                 if hasattr(self.client.embeddings, "create_async"):
-                    response: EmbeddingResponse = await self.client.embeddings.create_async(**_request_params)
+                    response = await self.client.embeddings.create_async(**_request_params)
                 else:
                     # Fallback to running sync method in thread executor
                     import asyncio
 
                     loop = asyncio.get_running_loop()
-                    response: EmbeddingResponse = await loop.run_in_executor(  # type: ignore
+                    response = await loop.run_in_executor(
                         None, lambda: self.client.embeddings.create(**_request_params)
                     )
 

--- a/libs/agno/agno/models/mistral/mistral.py
+++ b/libs/agno/agno/models/mistral/mistral.py
@@ -11,24 +11,6 @@ from agno.models.metrics import MessageMetrics
 from agno.models.response import ModelResponse
 from agno.run.agent import RunOutput
 from agno.utils.log import log_debug, log_error
-from agno.utils.models._mistral_compat import (
-    AssistantMessage,
-    ChatCompletionResponse,
-    CompletionEvent,
-    DeltaMessage,
-    HTTPValidationError,
-    MistralClient,
-    ParsedChatCompletionResponse,
-    SDKError,
-    SystemMessage,
-    ToolMessage,
-    Unset,
-    UserMessage,
-    response_format_from_pydantic_model,
-)
-from agno.utils.models.mistral import format_messages
-
-MistralMessage = Union[UserMessage, AssistantMessage, SystemMessage, ToolMessage]
 
 
 @dataclass
@@ -60,9 +42,9 @@ class MistralChat(Model):
     timeout: Optional[int] = None
     client_params: Optional[Dict[str, Any]] = None
     # -*- Provide the Mistral Client manually
-    mistral_client: Optional[MistralClient] = None
+    mistral_client: Optional[Any] = None
 
-    def get_client(self) -> MistralClient:
+    def get_client(self) -> Any:
         """
         Get the Mistral client.
 
@@ -71,6 +53,8 @@ class MistralChat(Model):
         """
         if self.mistral_client:
             return self.mistral_client
+
+        from agno.utils.models._mistral_compat import MistralClient
 
         _client_params = self._get_client_params()
         self.mistral_client = MistralClient(**_client_params)
@@ -172,6 +156,15 @@ class MistralChat(Model):
         """
         Send a chat completion request to the Mistral model.
         """
+        from agno.utils.models._mistral_compat import (
+            ChatCompletionResponse,
+            HTTPValidationError,
+            ParsedChatCompletionResponse,
+            SDKError,
+            response_format_from_pydantic_model,
+        )
+        from agno.utils.models.mistral import format_messages
+
         mistral_messages = format_messages(messages, compress_tool_results)
         try:
             response: Union[ChatCompletionResponse, ParsedChatCompletionResponse]
@@ -222,6 +215,9 @@ class MistralChat(Model):
         """
         Stream the response from the Mistral model.
         """
+        from agno.utils.models._mistral_compat import HTTPValidationError, SDKError
+        from agno.utils.models.mistral import format_messages
+
         mistral_messages = format_messages(messages, compress_tool_results)
 
         assistant_message.metrics.start_timer()
@@ -256,6 +252,15 @@ class MistralChat(Model):
         """
         Send an asynchronous chat completion request to the Mistral API.
         """
+        from agno.utils.models._mistral_compat import (
+            ChatCompletionResponse,
+            HTTPValidationError,
+            ParsedChatCompletionResponse,
+            SDKError,
+            response_format_from_pydantic_model,
+        )
+        from agno.utils.models.mistral import format_messages
+
         mistral_messages = format_messages(messages, compress_tool_results)
         try:
             response: Union[ChatCompletionResponse, ParsedChatCompletionResponse]
@@ -304,6 +309,9 @@ class MistralChat(Model):
         """
         Stream an asynchronous response from the Mistral API.
         """
+        from agno.utils.models._mistral_compat import HTTPValidationError, SDKError
+        from agno.utils.models.mistral import format_messages
+
         mistral_messages = format_messages(messages, compress_tool_results)
         try:
             assistant_message.metrics.start_timer()
@@ -324,16 +332,16 @@ class MistralChat(Model):
             log_error(f"SDKError from Mistral: {e}")
             raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
 
-    def _parse_provider_response(self, response: ChatCompletionResponse, **kwargs) -> ModelResponse:
+    def _parse_provider_response(self, response: Any, **kwargs: Any) -> ModelResponse:
         """
         Parse the response from the Mistral model.
 
         Args:
-            response (ChatCompletionResponse): The response from the model.
+            response: The response from the model.
         """
         model_response = ModelResponse()
         if response.choices is not None and len(response.choices) > 0:
-            response_message: AssistantMessage = response.choices[0].message
+            response_message = response.choices[0].message
 
             # -*- Set content
             model_response.content = response_message.content  # type: ignore
@@ -358,13 +366,15 @@ class MistralChat(Model):
 
         return model_response
 
-    def _parse_provider_response_delta(self, response_delta: CompletionEvent) -> ModelResponse:
+    def _parse_provider_response_delta(self, response_delta: Any) -> ModelResponse:
         """
         Parse the response delta from the Mistral model.
         """
+        from agno.utils.models._mistral_compat import Unset
+
         model_response = ModelResponse()
 
-        delta_message: DeltaMessage = response_delta.data.choices[0].delta
+        delta_message = response_delta.data.choices[0].delta
         if delta_message.role is not None and not isinstance(delta_message.role, Unset):
             model_response.role = delta_message.role  # type: ignore
 

--- a/libs/agno/agno/utils/models/_mistral_compat.py
+++ b/libs/agno/agno/utils/models/_mistral_compat.py
@@ -4,63 +4,116 @@ Compatibility layer for mistralai v1 (<2.0.0) and v2 (>=2.0.0).
 Centralizes version detection and conditional imports so consumer modules
 can simply do:
     from agno.utils.models._mistral_compat import MistralClient, AssistantMessage, ...
+
+All imports from ``mistralai`` are deferred until first access so that
+applications which do not use Mistral never pay the cost of (or see errors
+about) the optional ``mistralai`` dependency.
 """
 
 import importlib.metadata
+from typing import Any, Dict, Optional
 
 from agno.utils.log import log_debug, log_error
 
-try:
-    _mistral_version = int(importlib.metadata.version("mistralai").split(".")[0])
-except importlib.metadata.PackageNotFoundError:
-    log_error("`mistralai` not installed. Please install using `pip install mistralai`")
-    raise ImportError("`mistralai` not installed. Please install using `pip install mistralai`")
+# ---------------------------------------------------------------------------
+# Lazy-loading machinery
+# ---------------------------------------------------------------------------
+
+_MISTRAL_SDK_VERSION: Optional[int] = None
+_resolved: Dict[str, Any] = {}
 
 
-if _mistral_version >= 2:
-    # v2: mistralai >= 2.0.0
-    from mistralai.client import Mistral as MistralClient  # type: ignore[attr-defined]
-    from mistralai.client.errors import HTTPValidationError, SDKError  # type: ignore[attr-defined]
-    from mistralai.client.models import (  # type: ignore[attr-defined]
-        AssistantMessage,
-        ChatCompletionResponse,
-        CompletionEvent,
-        DeltaMessage,
-        EmbeddingResponse,
-        ImageURLChunk,
-        SystemMessage,
-        TextChunk,
-        ToolMessage,
-        UserMessage,
+def _resolve() -> None:
+    """Run the version check and conditional imports exactly once."""
+    global _MISTRAL_SDK_VERSION
+
+    if _MISTRAL_SDK_VERSION is not None:
+        return  # already resolved
+
+    try:
+        _MISTRAL_SDK_VERSION = int(importlib.metadata.version("mistralai").split(".")[0])
+    except importlib.metadata.PackageNotFoundError:
+        log_error("`mistralai` not installed. Please install using `pip install mistralai`")
+        raise ImportError("`mistralai` not installed. Please install using `pip install mistralai`")
+
+    if _MISTRAL_SDK_VERSION >= 2:
+        # v2: mistralai >= 2.0.0
+        from mistralai.client import Mistral as _MistralClient  # type: ignore[attr-defined]
+        from mistralai.client.errors import HTTPValidationError as _HTTPValidationError, SDKError as _SDKError  # type: ignore[attr-defined]
+        from mistralai.client.models import (  # type: ignore[attr-defined]
+            AssistantMessage as _AssistantMessage,
+            ChatCompletionResponse as _ChatCompletionResponse,
+            CompletionEvent as _CompletionEvent,
+            DeltaMessage as _DeltaMessage,
+            EmbeddingResponse as _EmbeddingResponse,
+            ImageURLChunk as _ImageURLChunk,
+            SystemMessage as _SystemMessage,
+            TextChunk as _TextChunk,
+            ToolMessage as _ToolMessage,
+            UserMessage as _UserMessage,
+        )
+        from mistralai.client.types.basemodel import Unset as _Unset  # type: ignore[attr-defined]
+    else:
+        # v1: mistralai < 2.0.0
+        log_debug(
+            f"mistralai v{_MISTRAL_SDK_VERSION} detected. v1 support will be deprecated, please consider upgrading: `pip install -U mistralai`"
+        )
+        from mistralai import CompletionEvent as _CompletionEvent  # type: ignore[attr-defined,no-redef]
+        from mistralai import Mistral as _MistralClient  # type: ignore[attr-defined,no-redef]
+        from mistralai.models import (  # type: ignore[no-redef]
+            AssistantMessage as _AssistantMessage,
+            HTTPValidationError as _HTTPValidationError,
+            ImageURLChunk as _ImageURLChunk,
+            SDKError as _SDKError,
+            SystemMessage as _SystemMessage,
+            TextChunk as _TextChunk,
+            ToolMessage as _ToolMessage,
+            UserMessage as _UserMessage,
+        )
+        from mistralai.models.chatcompletionresponse import ChatCompletionResponse as _ChatCompletionResponse  # type: ignore[no-redef]
+        from mistralai.models.deltamessage import DeltaMessage as _DeltaMessage  # type: ignore[no-redef]
+        from mistralai.models.embeddingresponse import EmbeddingResponse as _EmbeddingResponse  # type: ignore[no-redef]
+        from mistralai.types.basemodel import Unset as _Unset  # type: ignore[no-redef]
+
+    # These paths are the same in both v1 and v2
+    from mistralai.extra import response_format_from_pydantic_model as _response_format_from_pydantic_model
+    from mistralai.extra.struct_chat import ParsedChatCompletionResponse as _ParsedChatCompletionResponse
+
+    _resolved.update(
+        {
+            "AssistantMessage": _AssistantMessage,
+            "ChatCompletionResponse": _ChatCompletionResponse,
+            "CompletionEvent": _CompletionEvent,
+            "DeltaMessage": _DeltaMessage,
+            "EmbeddingResponse": _EmbeddingResponse,
+            "HTTPValidationError": _HTTPValidationError,
+            "ImageURLChunk": _ImageURLChunk,
+            "MistralClient": _MistralClient,
+            "ParsedChatCompletionResponse": _ParsedChatCompletionResponse,
+            "SDKError": _SDKError,
+            "SystemMessage": _SystemMessage,
+            "TextChunk": _TextChunk,
+            "ToolMessage": _ToolMessage,
+            "Unset": _Unset,
+            "UserMessage": _UserMessage,
+            "response_format_from_pydantic_model": _response_format_from_pydantic_model,
+            "MISTRAL_SDK_VERSION": _MISTRAL_SDK_VERSION,
+        }
     )
-    from mistralai.client.types.basemodel import Unset  # type: ignore[attr-defined]
-else:
-    # v1: mistralai < 2.0.0
-    log_debug(
-        f"mistralai v{_mistral_version} detected. v1 support will be deprecated, please consider upgrading: `pip install -U mistralai`"
-    )
-    from mistralai import CompletionEvent  # type: ignore[attr-defined,no-redef]
-    from mistralai import Mistral as MistralClient  # type: ignore[attr-defined,no-redef]
-    from mistralai.models import (  # type: ignore[no-redef]
-        AssistantMessage,
-        HTTPValidationError,
-        ImageURLChunk,
-        SDKError,
-        SystemMessage,
-        TextChunk,
-        ToolMessage,
-        UserMessage,
-    )
-    from mistralai.models.chatcompletionresponse import ChatCompletionResponse  # type: ignore[no-redef]
-    from mistralai.models.deltamessage import DeltaMessage  # type: ignore[no-redef]
-    from mistralai.models.embeddingresponse import EmbeddingResponse  # type: ignore[no-redef]
-    from mistralai.types.basemodel import Unset  # type: ignore[no-redef]
 
-# These paths are the same in both v1 and v2
-from mistralai.extra import response_format_from_pydantic_model
-from mistralai.extra.struct_chat import ParsedChatCompletionResponse
 
-MISTRAL_SDK_VERSION = _mistral_version
+def __getattr__(name: str) -> Any:
+    """Lazy module-level attribute access — triggers import on first use."""
+    if name in _resolved:
+        return _resolved[name]
+
+    if name in __all__:
+        _resolve()
+        if name in _resolved:
+            return _resolved[name]
+
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "AssistantMessage",

--- a/libs/agno/agno/utils/models/mistral.py
+++ b/libs/agno/agno/utils/models/mistral.py
@@ -3,19 +3,11 @@ from typing import Any, List, Optional, Union
 from agno.media import Image
 from agno.models.message import Message
 from agno.utils.log import log_error, log_warning
-from agno.utils.models._mistral_compat import (
-    AssistantMessage,
-    ImageURLChunk,
-    SystemMessage,
-    TextChunk,
-    ToolMessage,
-    UserMessage,
-)
-
-MistralMessage = Union[UserMessage, AssistantMessage, SystemMessage, ToolMessage]
 
 
-def _format_image_for_message(image: Image) -> Optional[ImageURLChunk]:
+def _format_image_for_message(image: Image) -> Optional[Any]:
+    from agno.utils.models._mistral_compat import ImageURLChunk
+
     # Case 1: Image is a URL
     if image.url is not None:
         return ImageURLChunk(image_url=image.url)
@@ -42,7 +34,14 @@ def _format_image_for_message(image: Image) -> Optional[ImageURLChunk]:
     return None
 
 
-def format_messages(messages: List[Message], compress_tool_results: bool = False) -> List[MistralMessage]:
+def format_messages(messages: List[Message], compress_tool_results: bool = False) -> List[Any]:
+    from agno.utils.models._mistral_compat import (
+        AssistantMessage,
+        SystemMessage,
+        TextChunk,
+        ToolMessage,
+        UserMessage,
+    )
     from agno.utils.message import normalize_tool_messages, reformat_tool_call_ids
 
     # Backwards compat: expand old Gemini combined tool messages into individual canonical messages
@@ -50,10 +49,10 @@ def format_messages(messages: List[Message], compress_tool_results: bool = False
     # Mistral requires alphanumeric tool call IDs (a-z, A-Z, 0-9) with length 9
     messages = reformat_tool_call_ids(messages, provider="mistral")
 
-    mistral_messages: List[MistralMessage] = []
+    mistral_messages: List[Any] = []
 
     for message in messages:
-        mistral_message: MistralMessage
+        mistral_message: Any
         if message.role == "user":
             if message.audio is not None and len(message.audio) > 0:
                 log_warning("Audio input is currently unsupported.")


### PR DESCRIPTION
## Summary

Fixes #7056

When starting an Agent-OS app that does **not** use Mistral, the process logs `ERROR mistralai not installed` at startup because `_mistral_compat.py` eagerly checks for the `mistralai` package and imports from it at module level.

This PR defers all `mistralai` imports and version detection to first actual use:

- **`_mistral_compat.py`**: Replace eager top-level imports with a `_resolve()` helper that runs on first attribute access via module-level `__getattr__`. The version check and all `from mistralai ...` imports only execute when a consumer first accesses any exported name (e.g. `MistralClient`, `AssistantMessage`).
- **`models/mistral/mistral.py`**: Move `_mistral_compat` and `format_messages` imports from module level into each method body (`invoke`, `invoke_stream`, `ainvoke`, `ainvoke_stream`, `_parse_provider_response_delta`). Change type annotations that referenced mistralai types to `Any`.
- **`knowledge/embedder/mistral.py`**: Move `MistralClient` and `EmbeddingResponse` imports from module level into the `client` property and method bodies.
- **`utils/models/mistral.py`**: Move message-type imports (`AssistantMessage`, `UserMessage`, etc.) from module level into function bodies.

**Behavior after this change:**
- Apps that do not use Mistral: no `mistralai` check, no ERROR logs, no `ImportError` at startup.
- Apps that use Mistral without installing `mistralai`: a clear `ImportError` is raised on first actual use of `MistralChat` or `MistralEmbedder`.
- Apps that use Mistral with `mistralai` installed: no change in behavior; imports are resolved once on first use and cached.

## Test plan

- [ ] Start an app using only non-Mistral models (e.g. OpenAI) without `mistralai` installed — verify no ERROR logs at startup
- [ ] Start an app using `MistralChat` without `mistralai` installed — verify clear `ImportError` on first use
- [ ] Start an app using `MistralChat` with `mistralai` installed — verify normal operation
- [ ] Run existing Mistral integration tests with `mistralai` installed — verify no regressions