### PR TITLE
fix: normalize model provider identifiers across model parsing and AgentOS schemas

### DIFF
--- a/libs/agno/agno/models/utils.py
+++ b/libs/agno/agno/models/utils.py
@@ -1,6 +1,78 @@
+﻿import re
 from typing import Optional, Union
 
 from agno.models.base import Model
+
+
+def _normalize_provider_token(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.strip().lower())
+
+
+def normalize_model_provider(model_provider: Optional[str], model_name: Optional[str] = None) -> Optional[str]:
+    alias_map = {
+        "aimlapi": "aimlapi",
+        "anthropic": "anthropic",
+        "awsbedrock": "aws-bedrock",
+        "awsclaude": "aws-claude",
+        "azure": "azure-openai",
+        "azureaifoundry": "azure-ai-foundry",
+        "azureopenai": "azure-openai",
+        "cerebras": "cerebras",
+        "cerebrasopenai": "cerebras-openai",
+        "cohere": "cohere",
+        "cometapi": "cometapi",
+        "dashscope": "dashscope",
+        "deepinfra": "deepinfra",
+        "deepseek": "deepseek",
+        "fireworks": "fireworks",
+        "google": "google",
+        "groq": "groq",
+        "huggingface": "huggingface",
+        "ibm": "ibm",
+        "internlm": "internlm",
+        "langdb": "langdb",
+        "litellm": "litellm",
+        "litellmopenai": "litellm-openai",
+        "llamacpp": "llama-cpp",
+        "llamaopenai": "llama-openai",
+        "lmstudio": "lmstudio",
+        "meta": "meta",
+        "mistral": "mistral",
+        "moonshot": "moonshot",
+        "nebius": "nebius",
+        "neosantara": "neosantara",
+        "nexus": "nexus",
+        "nvidia": "nvidia",
+        "ollama": "ollama",
+        "openai": "openai",
+        "openaichat": "openai",
+        "openairesponses": "openai-responses",
+        "openrouter": "openrouter",
+        "perplexity": "perplexity",
+        "portkey": "portkey",
+        "requesty": "requesty",
+        "sambanova": "sambanova",
+        "siliconflow": "siliconflow",
+        "together": "together",
+        "vercel": "vercel",
+        "vertexaiclaude": "vertexai-claude",
+        "vllm": "vllm",
+        "xai": "xai",
+    }
+
+    provider_token = _normalize_provider_token(model_provider) if model_provider else None
+    name_token = _normalize_provider_token(model_name) if model_name else None
+
+    if provider_token == "openai" and name_token == "openairesponses":
+        return "openai-responses"
+
+    for token in (provider_token, name_token):
+        if token and token in alias_map:
+            return alias_map[token]
+
+    if model_provider:
+        return model_provider.strip().lower().replace("_", "-").replace(" ", "-")
+    return None
 
 
 def _get_model_class(model_id: str, model_provider: str) -> Model:
@@ -254,7 +326,7 @@ def _parse_model_string(model_string: str) -> Model:
         )
 
     model_provider, model_id = parts
-    model_provider = model_provider.strip().lower()
+    model_provider = normalize_model_provider(model_provider) or model_provider.strip().lower()
     model_id = model_id.strip()
 
     if not model_provider or not model_id:
@@ -274,3 +346,8 @@ def get_model(model: Union[Model, str, None]) -> Optional[Model]:
         return _parse_model_string(model)
     else:
         raise ValueError("Model must be a Model instance, string, or None")
+
+
+
+
+

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -1,4 +1,4 @@
-import json
+﻿import json
 from typing import TYPE_CHECKING, List, cast
 
 from fastapi import (
@@ -27,6 +27,7 @@ from agno.os.schema import (
 )
 from agno.os.settings import AgnoAPISettings
 from agno.utils.log import logger
+from agno.models.utils import normalize_model_provider
 
 if TYPE_CHECKING:
     from agno.os.app import AgentOS
@@ -217,18 +218,24 @@ def get_base_router(
             for agent in os.agents:
                 model = cast(Model, agent.model)
                 if model and model.id is not None and model.provider is not None:
-                    key = (model.id, model.provider)
+                    normalized_provider = normalize_model_provider(model.provider, model.name)
+                    if normalized_provider is None:
+                        continue
+                    key = (model.id, normalized_provider)
                     if key not in unique_models:
-                        unique_models[key] = Model(id=model.id, provider=model.provider)
+                        unique_models[key] = Model(id=model.id, provider=normalized_provider)
 
         # Collect models from local teams
         if os.teams:
             for team in os.teams:
                 model = cast(Model, team.model)
                 if model and model.id is not None and model.provider is not None:
-                    key = (model.id, model.provider)
+                    normalized_provider = normalize_model_provider(model.provider, model.name)
+                    if normalized_provider is None:
+                        continue
+                    key = (model.id, normalized_provider)
                     if key not in unique_models:
-                        unique_models[key] = Model(id=model.id, provider=model.provider)
+                        unique_models[key] = Model(id=model.id, provider=normalized_provider)
 
         return list(unique_models.values())
 
@@ -308,3 +315,4 @@ def get_websocket_router(
             await websocket_manager.disconnect_websocket(websocket)
 
     return ws_router
+

--- a/libs/agno/agno/os/routers/agents/schema.py
+++ b/libs/agno/agno/os/routers/agents/schema.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+﻿from typing import Any, Dict, Optional
 from uuid import uuid4
 
 from pydantic import BaseModel
@@ -13,6 +13,7 @@ from agno.run import RunContext
 from agno.run.agent import RunOutput
 from agno.session import AgentSession
 from agno.utils.agent import aexecute_instructions, aexecute_system_message
+from agno.models.utils import normalize_model_provider
 
 
 class AgentResponse(BaseModel):
@@ -129,7 +130,14 @@ class AgentResponse(BaseModel):
 
         # Build model only if it has at least one non-null field
         model_name = agent.model.name if (agent.model and agent.model.name) else None
-        model_provider = agent.model.provider if (agent.model and agent.model.provider) else None
+        model_provider = (
+            normalize_model_provider(
+                agent.model.provider if agent.model else None,
+                agent.model.name if agent.model else None,
+            )
+            if agent.model
+            else None
+        )
         model_id = agent.model.id if (agent.model and agent.model.id) else None
         _agent_model_data: Dict[str, Any] = {}
         if model_name is not None:
@@ -186,7 +194,9 @@ class AgentResponse(BaseModel):
                 memory_info["model"] = ModelResponse(
                     name=agent.memory_manager.model.name,
                     model=agent.memory_manager.model.id,
-                    provider=agent.memory_manager.model.provider,
+                    provider=normalize_model_provider(
+                        agent.memory_manager.model.provider, agent.memory_manager.model.name
+                    ),
                 ).model_dump()
 
         reasoning_info: Dict[str, Any] = {
@@ -200,7 +210,7 @@ class AgentResponse(BaseModel):
             reasoning_info["reasoning_model"] = ModelResponse(
                 name=agent.reasoning_model.name,
                 model=agent.reasoning_model.id,
-                provider=agent.reasoning_model.provider,
+                provider=normalize_model_provider(agent.reasoning_model.provider, agent.reasoning_model.name),
             ).model_dump()
 
         default_tools_info = {
@@ -269,7 +279,7 @@ class AgentResponse(BaseModel):
             response_settings_info["parser_model"] = ModelResponse(
                 name=agent.parser_model.name,
                 model=agent.parser_model.id,
-                provider=agent.parser_model.provider,
+                provider=normalize_model_provider(agent.parser_model.provider, agent.parser_model.name),
             ).model_dump()
 
         streaming_info = {
@@ -301,3 +311,4 @@ class AgentResponse(BaseModel):
             current_version=getattr(agent, "_version", None),
             stage=getattr(agent, "_stage", None),
         )
+

--- a/libs/agno/agno/os/routers/teams/schema.py
+++ b/libs/agno/agno/os/routers/teams/schema.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union
+﻿from typing import Any, Dict, List, Optional, Union
 from uuid import uuid4
 
 from pydantic import BaseModel
@@ -14,6 +14,7 @@ from agno.run.team import TeamRunOutput
 from agno.session import TeamSession
 from agno.team.team import Team
 from agno.utils.agent import aexecute_instructions, aexecute_system_message
+from agno.models.utils import normalize_model_provider
 
 
 class TeamResponse(BaseModel):
@@ -172,7 +173,7 @@ class TeamResponse(BaseModel):
                 memory_info["model"] = ModelResponse(
                     name=team.memory_manager.model.name,
                     model=team.memory_manager.model.id,
-                    provider=team.memory_manager.model.provider,
+                    provider=normalize_model_provider(team.memory_manager.model.provider, team.memory_manager.model.name),
                 ).model_dump()
 
         reasoning_info: Dict[str, Any] = {
@@ -186,7 +187,7 @@ class TeamResponse(BaseModel):
             reasoning_info["reasoning_model"] = ModelResponse(
                 name=team.reasoning_model.name,
                 model=team.reasoning_model.id,
-                provider=team.reasoning_model.provider,
+                provider=normalize_model_provider(team.reasoning_model.provider, team.reasoning_model.name),
             ).model_dump()
 
         default_tools_info = {
@@ -242,7 +243,7 @@ class TeamResponse(BaseModel):
             response_settings_info["parser_model"] = ModelResponse(
                 name=team.parser_model.name,
                 model=team.parser_model.id,
-                provider=team.parser_model.provider,
+                provider=normalize_model_provider(team.parser_model.provider, team.parser_model.name),
             ).model_dump()
 
         streaming_info = {
@@ -258,7 +259,7 @@ class TeamResponse(BaseModel):
         if team.model and team.model.id is not None:
             _team_model_data["model"] = team.model.id
         if team.model and team.model.provider is not None:
-            _team_model_data["provider"] = team.model.provider
+            _team_model_data["provider"] = normalize_model_provider(team.model.provider, team.model.name)
 
         members: List[Union[AgentResponse, TeamResponse]] = []
         for member in team.members if isinstance(team.members, list) else []:
@@ -294,3 +295,4 @@ class TeamResponse(BaseModel):
             current_version=getattr(team, "_version", None),
             stage=getattr(team, "_stage", None),
         )
+

--- a/libs/agno/tests/unit/os/test_model_provider_normalization.py
+++ b/libs/agno/tests/unit/os/test_model_provider_normalization.py
@@ -1,0 +1,58 @@
+﻿import pytest
+from fastapi.testclient import TestClient
+
+from agno.agent.agent import Agent
+from agno.models.azure import AzureOpenAI
+from agno.models.openai import OpenAIChat
+from agno.models.openai.responses import OpenAIResponses
+from agno.os import AgentOS
+from agno.os.routers.agents.schema import AgentResponse
+from agno.team.team import Team
+
+
+@pytest.mark.asyncio
+async def test_agent_response_normalizes_openai_chat_provider():
+    agent = Agent(id="agent-chat", name="agent-chat", model=OpenAIChat(id="gpt-4o"))
+
+    response = await AgentResponse.from_agent(agent)
+
+    assert response.model is not None
+    assert response.model.provider == "openai"
+
+
+@pytest.mark.asyncio
+async def test_agent_response_normalizes_openai_responses_provider():
+    agent = Agent(id="agent-responses", name="agent-responses", model=OpenAIResponses(id="gpt-4.1"))
+
+    response = await AgentResponse.from_agent(agent)
+
+    assert response.model is not None
+    assert response.model.provider == "openai-responses"
+
+
+@pytest.mark.asyncio
+async def test_agent_response_normalizes_azure_provider():
+    agent = Agent(id="agent-azure", name="agent-azure", model=AzureOpenAI(id="gpt-4o"))
+
+    response = await AgentResponse.from_agent(agent)
+
+    assert response.model is not None
+    assert response.model.provider == "azure-openai"
+
+
+def test_models_endpoint_normalizes_provider_keys():
+    agent = Agent(id="agent-chat", name="agent-chat", model=OpenAIChat(id="gpt-4o"))
+    team = Team(id="team-azure", name="team-azure", members=[agent], model=AzureOpenAI(id="gpt-4o"))
+    agent_os = AgentOS(
+        agents=[agent, Agent(id="agent-responses", name="agent-responses", model=OpenAIResponses(id="gpt-4.1"))],
+        teams=[team],
+    )
+
+    client = TestClient(agent_os.get_app())
+    response = client.get("/models")
+
+    assert response.status_code == 200
+    models = response.json()
+    assert {"id": "gpt-4o", "provider": "openai"} in models
+    assert {"id": "gpt-4.1", "provider": "openai-responses"} in models
+    assert {"id": "gpt-4o", "provider": "azure-openai"} in models

--- a/libs/agno/tests/unit/utils/test_model_string.py
+++ b/libs/agno/tests/unit/utils/test_model_string.py
@@ -1,13 +1,17 @@
-import pytest
+﻿import pytest
 
 from agno.agent import Agent
 from agno.culture.manager import CultureManager
 from agno.knowledge.chunking.agentic import AgenticChunking
 from agno.memory.manager import MemoryManager
 from agno.models.anthropic import Claude
+from agno.models.azure import AzureOpenAI
 from agno.models.google import Gemini
 from agno.models.groq import Groq
+from agno.models.lmstudio import LMStudio
 from agno.models.openai import OpenAIChat
+from agno.models.openai.responses import OpenAIResponses
+from agno.models.siliconflow import Siliconflow
 from agno.models.utils import get_model
 from agno.team import Team
 
@@ -76,6 +80,40 @@ def test_get_model_unknown_provider():
     with pytest.raises(ValueError, match="not supported"):
         get_model("unknown-provider:model-123")
 
+
+def test_get_model_normalizes_openai_chat_provider_alias():
+    """Test get_model() accepts the OpenAIChat class/provider name."""
+    model = get_model("OpenAIChat:gpt-4o")
+    assert isinstance(model, OpenAIChat)
+    assert model.id == "gpt-4o"
+
+
+def test_get_model_normalizes_openai_responses_provider_alias():
+    """Test get_model() accepts the OpenAIResponses class/provider name."""
+    model = get_model("OpenAIResponses:gpt-4.1")
+    assert isinstance(model, OpenAIResponses)
+    assert model.id == "gpt-4.1"
+
+
+def test_get_model_normalizes_azure_provider_alias():
+    """Test get_model() accepts the Azure provider label used by model classes."""
+    model = get_model("Azure:gpt-4o")
+    assert isinstance(model, AzureOpenAI)
+    assert model.id == "gpt-4o"
+
+
+def test_get_model_normalizes_lmstudio_provider_casing():
+    """Test get_model() accepts the LMStudio provider label."""
+    model = get_model("LMStudio:qwen2.5")
+    assert isinstance(model, LMStudio)
+    assert model.id == "qwen2.5"
+
+
+def test_get_model_normalizes_siliconflow_provider_casing():
+    """Test get_model() accepts Siliconflow casing from model.provider."""
+    model = get_model("Siliconflow:Qwen/Qwen3-32B")
+    assert isinstance(model, Siliconflow)
+    assert model.id == "Qwen/Qwen3-32B"
 
 def test_agent_with_model_string():
     """Test creating Agent with model string."""
@@ -164,3 +202,4 @@ def test_agentic_chunking_with_model_instance():
     """Test AgenticChunking accepts Model instance."""
     chunking = AgenticChunking(model=OpenAIChat(id="gpt-4o"))
     assert isinstance(chunking.model, OpenAIChat)
+


### PR DESCRIPTION
Closes #7093 


  ## Summary

  This PR normalizes model provider identifiers across the model parsing path and AgentOS response schemas.

  Today the framework uses different provider strings in different parts of the stack. For example, runtime model
  instances may expose values such as `OpenAI`, `Azure`, `LMStudio`, or `Siliconflow`, while `get_model()` expects
  canonical provider keys such as `openai`, `azure-openai`, `lmstudio`, and `siliconflow`.

  This mismatch makes some model configurations non-round-trippable across AgentOS / Studio style flows.

  ## What changed

  - added a provider normalization helper in `agno.models.utils`
  - applied normalization in `_parse_model_string()`
  - applied the same normalization when serializing AgentOS agent/team model metadata
  - normalized `/models` endpoint output as well
  - added regression tests for provider aliases and AgentOS output normalization

  ## Examples fixed

  The following inputs / outputs now consistently resolve to canonical provider identifiers:

  - `OpenAIChat` -> `openai`
  - `OpenAIResponses` -> `openai-responses`
  - `Azure` -> `azure-openai`
  - `LMStudio` -> `lmstudio`
  - `Siliconflow` -> `siliconflow`

  ## Scope

  It does not redesign full model serialization or configuration round-tripping. It only fixes provider identifier
  normalization at the parsing boundary and AgentOS output boundary.

  ## Tests

  Added regression coverage for:

  - model string parsing aliases
  - AgentOS agent response provider normalization
  - `/models` endpoint provider normalization