### PR TITLE
fix(mistral): lazy-load mistralai to suppress import errors when not installed

### DIFF
--- a/libs/agno/agno/utils/models/_mistral_compat.py
+++ b/libs/agno/agno/utils/models/_mistral_compat.py
@@ -8,13 +8,16 @@ can simply do:
 
 import importlib.metadata
 
-from agno.utils.log import log_debug, log_error
+from agno.utils.log import log_debug
 
 try:
     _mistral_version = int(importlib.metadata.version("mistralai").split(".")[0])
 except importlib.metadata.PackageNotFoundError:
-    log_error("`mistralai` not installed. Please install using `pip install mistralai`")
-    raise ImportError("`mistralai` not installed. Please install using `pip install mistralai`")
+    raise ImportError(
+        "`mistralai` not installed. Please install it with: pip install mistralai
+"
+        "Or install agno with the mistral extra: pip install agno[mistral]"
+    )
 
 
 if _mistral_version >= 2:

--- a/libs/agno/agno/utils/models/mistral.py
+++ b/libs/agno/agno/utils/models/mistral.py
@@ -1,21 +1,27 @@
-from typing import Any, List, Optional, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from agno.media import Image
 from agno.models.message import Message
 from agno.utils.log import log_error, log_warning
-from agno.utils.models._mistral_compat import (
-    AssistantMessage,
-    ImageURLChunk,
-    SystemMessage,
-    TextChunk,
-    ToolMessage,
-    UserMessage,
-)
 
-MistralMessage = Union[UserMessage, AssistantMessage, SystemMessage, ToolMessage]
+if TYPE_CHECKING:
+    from agno.utils.models._mistral_compat import (
+        AssistantMessage,
+        ImageURLChunk,
+        SystemMessage,
+        TextChunk,
+        ToolMessage,
+        UserMessage,
+    )
+
+MistralMessage = Any  # resolved to Union[UserMessage, AssistantMessage, SystemMessage, ToolMessage] at runtime
 
 
-def _format_image_for_message(image: Image) -> Optional[ImageURLChunk]:
+def _format_image_for_message(image: Image) -> Optional[Any]:
+    from agno.utils.models._mistral_compat import ImageURLChunk
+
     # Case 1: Image is a URL
     if image.url is not None:
         return ImageURLChunk(image_url=image.url)
@@ -42,8 +48,15 @@ def _format_image_for_message(image: Image) -> Optional[ImageURLChunk]:
     return None
 
 
-def format_messages(messages: List[Message], compress_tool_results: bool = False) -> List[MistralMessage]:
+def format_messages(messages: List[Message], compress_tool_results: bool = False) -> List[Any]:
     from agno.utils.message import normalize_tool_messages, reformat_tool_call_ids
+    from agno.utils.models._mistral_compat import (
+        AssistantMessage,
+        SystemMessage,
+        TextChunk,
+        ToolMessage,
+        UserMessage,
+    )
 
     # Backwards compat: expand old Gemini combined tool messages into individual canonical messages
     messages = normalize_tool_messages(messages)


### PR DESCRIPTION
## Description

When an app does **not** use Mistral (e.g. only uses OpenAI or DeepSeek models), importing `agno` still logs two `ERROR` messages and may raise `ImportError` at startup:

```
ERROR  `mistralai` not installed. Please install using `pip install mistralai`
ERROR  `mistralai` not installed. Please install using `pip install mistralai`
```

This happens because `_mistral_compat.py` calls `log_error()` at module-import time when `mistralai` is not installed, and `utils/models/mistral.py` imports from `_mistral_compat` at top level.

## Root Cause

```python
# _mistral_compat.py — runs at import time even if Mistral is never used
except importlib.metadata.PackageNotFoundError:
    log_error("`mistralai` not installed...")  # ← triggers ERROR log on every import
    raise ImportError(...)
```

## Fix

1. **`_mistral_compat.py`**: Remove `log_error()` call — let `ImportError` propagate silently. The error is meaningful only when someone actually tries to use Mistral.

2. **`utils/models/mistral.py`**: Guard compat imports with `TYPE_CHECKING` and move runtime instantiations inside the functions that need them, so the module can be imported without triggering `ImportError`.

## Changes

- `libs/agno/agno/utils/models/_mistral_compat.py`: Remove `log_error` on `PackageNotFoundError`
- `libs/agno/agno/utils/models/mistral.py`: Lazy-load `_mistral_compat` symbols inside functions

Closes #7056
