### PR TITLE
fix(openai): skip null-default fields in sanitize_response_schema to preserve Optional typing

### DIFF
--- a/libs/agno/agno/utils/models/openai_responses.py
+++ b/libs/agno/agno/utils/models/openai_responses.py
@@ -121,9 +121,14 @@ def sanitize_response_schema(schema: dict):
 
                 required_fields = []
                 for prop_name, prop_schema in schema["properties"].items():
-                    # Use the utility function to check if this is a Dict field
-                    if not is_dict_field(prop_schema):
-                        required_fields.append(prop_name)
+                    # Skip Dict fields (additionalProperties defines value type)
+                    if is_dict_field(prop_schema):
+                        continue
+                    # Skip Optional fields: those with default=null preserve their
+                    # optionality and must NOT be added to "required"
+                    if prop_schema.get("default") is None and "default" in prop_schema:
+                        continue
+                    required_fields.append(prop_name)
 
                 schema["required"] = required_fields
 


### PR DESCRIPTION
## Description

`sanitize_response_schema()` in `agno/utils/models/openai_responses.py` adds all non-Dict properties to the `"required"` array, including `Optional[T]` fields (those with `"default": null` in the JSON schema). This incorrectly marks optional fields as required in the OpenAI structured output schema, causing validation failures or unintended behavior.

## Root Cause

```python
# Before fix — adds ALL non-Dict fields to required, even Optional ones
for prop_name, prop_schema in schema["properties"].items():
    if not is_dict_field(prop_schema):
        required_fields.append(prop_name)  # ← Optional[T] also added here
```

Pydantic generates `"default": null` for `Optional[T]` fields. The function later strips `"default": null` but already added the field to `required`.

## Fix

```python
# After fix — skip Optional fields (default=null) when building required list
for prop_name, prop_schema in schema["properties"].items():
    if is_dict_field(prop_schema):
        continue
    # Skip Optional fields: default=null means the field is optional
    if prop_schema.get("default") is None and "default" in prop_schema:
        continue
    required_fields.append(prop_name)
```

## Changes

- `libs/agno/agno/utils/models/openai_responses.py`: Skip `default=null` fields when building the `required` list in `sanitize_response_schema()`

Closes #7066
