### PR TITLE
fix(openai): exclude optional fields from required in sanitize_response_schema()

### DIFF
--- a/libs/agno/agno/utils/models/openai_responses.py
+++ b/libs/agno/agno/utils/models/openai_responses.py
@@ -122,7 +122,8 @@ def sanitize_response_schema(schema: dict):
                 required_fields = []
                 for prop_name, prop_schema in schema["properties"].items():
                     # Use the utility function to check if this is a Dict field
-                    if not is_dict_field(prop_schema):
+                    # Also skip fields that have a default value (optional fields)
+                    if not is_dict_field(prop_schema) and "default" not in prop_schema:
                         required_fields.append(prop_name)
 
                 schema["required"] = required_fields


### PR DESCRIPTION
The `sanitize_response_schema()` function unconditionally adds every property to the `required` array, even when fields have `default: null` (i.e. Optional fields with a default of None).

This fix skips fields that already have a `default` key in their schema, so Optional fields with defaults are not marked as required.

Closes #7066