### PR TITLE
fix(knowledge): use ensure_ascii=False in json.dumps to preserve non-ASCII characters

### DIFF
--- a/libs/agno/agno/agent/_default_tools.py
+++ b/libs/agno/agno/agent/_default_tools.py
@@ -121,7 +121,7 @@ def create_knowledge_search_tool(
         if agent.references_format == "json":
             import json
 
-            return json.dumps(docs, indent=2, default=str)
+            return json.dumps(docs, indent=2, default=str, ensure_ascii=False)
         else:
             import yaml
 

--- a/libs/agno/agno/agent/_utils.py
+++ b/libs/agno/agno/agent/_utils.py
@@ -83,7 +83,7 @@ def convert_dependencies_to_string(agent: Agent, context: Dict[str, Any]) -> str
         return ""
 
     try:
-        return json.dumps(context, indent=2, default=str)
+        return json.dumps(context, indent=2, default=str, ensure_ascii=False)
     except (TypeError, ValueError, OverflowError) as e:
         log_warning(f"Failed to convert context to JSON: {e}")
         # Attempt a fallback conversion for non-serializable objects
@@ -91,14 +91,14 @@ def convert_dependencies_to_string(agent: Agent, context: Dict[str, Any]) -> str
         for key, value in context.items():
             try:
                 # Try to serialize each value individually
-                json.dumps({key: value}, default=str)
+                json.dumps({key: value}, default=str, ensure_ascii=False)
                 sanitized_context[key] = value
             except Exception:
                 # If serialization fails, convert to string representation
                 sanitized_context[key] = str(value)
 
         try:
-            return json.dumps(sanitized_context, indent=2)
+            return json.dumps(sanitized_context, indent=2, ensure_ascii=False)
         except Exception as e:
             log_error(f"Failed to convert sanitized context to JSON: {e}")
             return str(context)

--- a/libs/agno/agno/knowledge/reader/json_reader.py
+++ b/libs/agno/agno/knowledge/reader/json_reader.py
@@ -60,7 +60,7 @@ class JSONReader(Reader):
                     name=json_name,
                     id=str(uuid4()),
                     meta_data={"page": page_number},
-                    content=json.dumps(content),
+                    content=json.dumps(content, ensure_ascii=False),
                 )
                 for page_number, content in enumerate(json_contents, start=1)
             ]


### PR DESCRIPTION
Fixes #7036

When using Agno with non-ASCII languages (Chinese, Japanese, etc.) in Linux/Docker environments, json.dumps() defaults to ensure_ascii=True, which escapes characters like '赵箭' → '\u8d75\u7bad'. This can cause LLM hallucinations when the model processes unicode sequences instead of actual characters.

Fix: add ensure_ascii=False to json.dumps calls in knowledge base formatting and agent context serialization.