### PR TITLE
fix: preserve Optional field optionality in sanitize_response_schema

### DIFF
--- a/libs/agno/agno/utils/models/openai_responses.py
+++ b/libs/agno/agno/utils/models/openai_responses.py
@@ -100,9 +100,8 @@ def sanitize_response_schema(schema: dict):
     - Sets "additionalProperties": false for all object types to disallow extra fields,
       EXCEPT when additionalProperties is already defined with a schema (Dict types).
     - Removes "default": null from optional fields.
-    - Ensures that all fields defined in "properties" are listed in "required",
-      making every property explicitly required as per OpenAI's expectations,
-      EXCEPT for Dict fields which should not be in the required array.
+    - Adds non-optional fields to "required", preserving the optionality of
+      fields with default: null (Optional fields).
     """
     if isinstance(schema, dict):
         # Enforce additionalProperties: false for object types, but preserve Dict schemas
@@ -115,15 +114,19 @@ def sanitize_response_schema(schema: dict):
                 # Convert True to False for strict mode, but preserve schema objects
                 schema["additionalProperties"] = False
 
-            # Ensure all properties are required, EXCEPT Dict fields
+            # Ensure all non-optional properties are required, EXCEPT Dict fields
             if "properties" in schema:
                 from agno.utils.models.schema_utils import is_dict_field
 
                 required_fields = []
                 for prop_name, prop_schema in schema["properties"].items():
-                    # Use the utility function to check if this is a Dict field
-                    if not is_dict_field(prop_schema):
-                        required_fields.append(prop_name)
+                    # Skip Dict fields
+                    if is_dict_field(prop_schema):
+                        continue
+                    # Skip optional fields (those with default: null)
+                    if prop_schema.get("default") is None and "default" in prop_schema:
+                        continue
+                    required_fields.append(prop_name)
 
                 schema["required"] = required_fields
 

--- a/libs/agno/tests/unit/utils/test_openai_responses.py
+++ b/libs/agno/tests/unit/utils/test_openai_responses.py
@@ -93,6 +93,40 @@ def test_sanitize_response_schema_removes_null_defaults():
     assert "default" not in optional_field or optional_field.get("default") is not None
 
 
+class OptionalWithNoneDefaultsModel(BaseModel):
+    """Model with Optional fields that have default=None, similar to issue #7066"""
+    required_field: str
+    optional_dict: dict | None = None
+    optional_list: list | None = None
+    optional_str: str | None = None
+
+
+def test_sanitize_response_schema_optional_fields_not_marked_required():
+    """Test that Optional fields (default: null) are not added to required.
+
+    Regression test for https://github.com/agno-agi/agno/issues/7066
+    Without the fix, sanitize_response_schema unconditionally adds all
+    non-Dict fields to required, even Optional fields with default: null.
+    This breaks Structured Outputs when the LLM omits optional fields.
+    """
+    original_schema = OptionalWithNoneDefaultsModel.model_json_schema()
+    schema = copy.deepcopy(original_schema)
+
+    # Before sanitization, required should be just the required field
+    assert original_schema.get("required") == ["required_field"]
+
+    sanitize_response_schema(schema)
+
+    # After sanitization, only required_field should be in required
+    # optional_dict, optional_list, optional_str have default: null
+    # and should NOT be added to required
+    assert schema.get("required") == ["required_field"]
+    # Verify the Optional fields still have default: null (before removal)
+    assert schema["properties"]["optional_dict"].get("default") is None
+    assert schema["properties"]["optional_list"].get("default") is None
+    assert schema["properties"]["optional_str"].get("default") is None
+
+
 def test_sanitize_response_schema_nested_objects():
     """Test sanitization works with nested objects"""
 


### PR DESCRIPTION
## Description

`sanitize_response_schema()` unconditionally added all non-Dict fields to the `required` array, including Optional fields with `default: null`. This caused Structured Outputs to fail when the LLM omitted optional fields.

## Root Cause

Lines 118-128 in `agno/utils/models/openai_responses.py` added every property to `required` without checking for `default: null` (the Pydantic signature of Optional fields with None defaults).

## Fix

Skip fields with `default: null` when building the `required` array, preserving the optionality of Optional fields.

## Testing

- [x] Added regression test covering Optional fields with `default: null`
- [x] Existing tests pass

Refs #7066