### PR TITLE
fix(models): normalize provider identifiers for round-trip compatibility

### DIFF
--- a/libs/agno/agno/models/utils.py
+++ b/libs/agno/agno/models/utils.py
@@ -1,6 +1,35 @@
-from typing import Optional, Union
+from typing import Dict, Optional, Union
 
 from agno.models.base import Model
+
+# Mapping from runtime/display provider names to the canonical keys expected by
+# ``_get_model_class``.  Keys **must** be lowercase.  Canonical keys that are
+# already lowercase-equal to their display names (e.g. "groq" → "groq") are
+# handled automatically – only entries where the lowercased display name differs
+# from the canonical key need to appear here.
+_PROVIDER_ALIASES: Dict[str, str] = {
+    # Display name (lowered)  →  canonical key
+    "awsbedrock": "aws-bedrock",
+    "azure": "azure-openai",  # AzureOpenAI & AzureAIFoundry both expose "Azure"
+    "cerebrasopenai": "cerebras-openai",
+    "llamacpp": "llama-cpp",
+    "llamaopenai": "llama-openai",
+    "llama": "meta",
+    "openresponses": "openai-responses",
+    "vertexai": "vertexai-claude",
+    "watsonx": "ibm",
+}
+
+
+def normalize_provider(provider: str) -> str:
+    """Normalize a provider identifier to its canonical key.
+
+    Accepts any casing of the display name (e.g. ``"OpenAI"``, ``"LMStudio"``,
+    ``"Azure"``) or a canonical key (``"openai"``, ``"azure-openai"``), and
+    returns the lowercase canonical key used by ``_get_model_class``.
+    """
+    key = provider.strip().lower()
+    return _PROVIDER_ALIASES.get(key, key)
 
 
 def _get_model_class(model_id: str, model_provider: str) -> Model:
@@ -254,7 +283,7 @@ def _parse_model_string(model_string: str) -> Model:
         )
 
     model_provider, model_id = parts
-    model_provider = model_provider.strip().lower()
+    model_provider = normalize_provider(model_provider)
     model_id = model_id.strip()
 
     if not model_provider or not model_id:

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -9,6 +9,7 @@ from fastapi import (
 )
 
 from agno.exceptions import RemoteServerUnavailableError
+from agno.models.utils import normalize_provider
 from agno.os.auth import get_authentication_dependency, validate_websocket_token
 from agno.os.managers import websocket_manager
 from agno.os.routers.workflows.router import handle_workflow_subscription, handle_workflow_via_websocket
@@ -217,18 +218,20 @@ def get_base_router(
             for agent in os.agents:
                 model = cast(Model, agent.model)
                 if model and model.id is not None and model.provider is not None:
-                    key = (model.id, model.provider)
+                    normalized = normalize_provider(model.provider)
+                    key = (model.id, normalized)
                     if key not in unique_models:
-                        unique_models[key] = Model(id=model.id, provider=model.provider)
+                        unique_models[key] = Model(id=model.id, provider=normalized)
 
         # Collect models from local teams
         if os.teams:
             for team in os.teams:
                 model = cast(Model, team.model)
                 if model and model.id is not None and model.provider is not None:
-                    key = (model.id, model.provider)
+                    normalized = normalize_provider(model.provider)
+                    key = (model.id, normalized)
                     if key not in unique_models:
-                        unique_models[key] = Model(id=model.id, provider=model.provider)
+                        unique_models[key] = Model(id=model.id, provider=normalized)
 
         return list(unique_models.values())
 

--- a/libs/agno/agno/os/routers/evals/evals.py
+++ b/libs/agno/agno/os/routers/evals/evals.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from agno.agent import Agent, RemoteAgent
 from agno.db.base import AsyncBaseDb, BaseDb
 from agno.db.schemas.evals import EvalFilterType, EvalType
-from agno.models.utils import get_model
+from agno.models.utils import get_model, normalize_provider
 from agno.os.auth import get_auth_token_from_request, get_authentication_dependency
 from agno.os.routers.evals.schemas import (
     DeleteEvalRunsRequest,
@@ -429,7 +429,7 @@ def attach_routes(
             ):
                 default_model = deepcopy(agent.model)
                 if eval_run_input.model_id != agent.model.id or eval_run_input.model_provider != agent.model.provider:
-                    model_provider = eval_run_input.model_provider.lower()
+                    model_provider = normalize_provider(eval_run_input.model_provider)
                     model_id = eval_run_input.model_id.lower()
                     model_string = f"{model_provider}:{model_id}"
                     model = get_model(model_string)
@@ -455,7 +455,7 @@ def attach_routes(
             ):
                 default_model = deepcopy(team.model)  # Save original
                 if eval_run_input.model_id != team.model.id or eval_run_input.model_provider != team.model.provider:
-                    model_provider = eval_run_input.model_provider.lower()
+                    model_provider = normalize_provider(eval_run_input.model_provider)
                     model_id = eval_run_input.model_id.lower()
                     model_string = f"{model_provider}:{model_id}"
                     model = get_model(model_string)

--- a/libs/agno/tests/unit/utils/test_normalize_provider.py
+++ b/libs/agno/tests/unit/utils/test_normalize_provider.py
@@ -1,0 +1,82 @@
+"""Tests for provider identifier normalization.
+
+Ensures that display names exposed at runtime (e.g. ``"OpenAI"``, ``"Azure"``,
+``"LMStudio"``) are correctly normalized to the canonical keys expected by
+``_get_model_class`` and ``get_model``.
+
+See: https://github.com/agno-agi/agno/issues/7093
+"""
+
+import pytest
+
+from agno.models.utils import normalize_provider
+
+
+# ---------------------------------------------------------------------------
+# normalize_provider — unit tests
+# ---------------------------------------------------------------------------
+
+class TestNormalizeProvider:
+    """Test the normalize_provider helper directly."""
+
+    @pytest.mark.parametrize(
+        "input_val,expected",
+        [
+            # Canonical keys pass through unchanged
+            ("openai", "openai"),
+            ("anthropic", "anthropic"),
+            ("azure-openai", "azure-openai"),
+            ("aws-bedrock", "aws-bedrock"),
+            ("openai-responses", "openai-responses"),
+            ("lmstudio", "lmstudio"),
+            ("siliconflow", "siliconflow"),
+            ("vertexai-claude", "vertexai-claude"),
+            ("cerebras-openai", "cerebras-openai"),
+            ("llama-cpp", "llama-cpp"),
+            ("llama-openai", "llama-openai"),
+            ("meta", "meta"),
+            ("ibm", "ibm"),
+            # Display names → canonical keys
+            ("OpenAI", "openai"),
+            ("Anthropic", "anthropic"),
+            ("Azure", "azure-openai"),
+            ("AwsBedrock", "aws-bedrock"),
+            ("LMStudio", "lmstudio"),
+            ("Siliconflow", "siliconflow"),
+            ("CerebrasOpenAI", "cerebras-openai"),
+            ("LlamaCpp", "llama-cpp"),
+            ("LlamaOpenAI", "llama-openai"),
+            ("Llama", "meta"),
+            ("OpenResponses", "openai-responses"),
+            ("VertexAI", "vertexai-claude"),
+            ("IBM", "ibm"),
+            ("WatsonX", "ibm"),
+            # Case insensitivity
+            ("OPENAI", "openai"),
+            ("azure", "azure-openai"),
+            ("AZURE", "azure-openai"),
+            ("awsbedrock", "aws-bedrock"),
+            ("AWSBEDROCK", "aws-bedrock"),
+            # Whitespace stripping
+            ("  openai  ", "openai"),
+            ("  Azure  ", "azure-openai"),
+        ],
+    )
+    def test_normalizes_correctly(self, input_val: str, expected: str) -> None:
+        assert normalize_provider(input_val) == expected
+
+    def test_unknown_provider_passes_through(self) -> None:
+        """Unknown providers are lowercased and returned as-is."""
+        assert normalize_provider("SomeNewProvider") == "somenewprovider"
+
+    def test_already_canonical_is_idempotent(self) -> None:
+        """Applying normalize_provider twice yields the same result."""
+        for key in [
+            "openai",
+            "azure-openai",
+            "aws-bedrock",
+            "lmstudio",
+            "cerebras-openai",
+            "vertexai-claude",
+        ]:
+            assert normalize_provider(normalize_provider(key)) == key


### PR DESCRIPTION
## Summary

Fixes #7093 — Provider identifiers are inconsistent between runtime model classes, `get_model()`, and AgentOS output.

## Problem

Model classes expose display names like `"OpenAI"`, `"Azure"`, `"LMStudio"`, `"AwsBedrock"` in their `provider` field, while `_get_model_class()` and `get_model()` expect canonical keys like `"openai"`, `"azure-openai"`, `"lmstudio"`, `"aws-bedrock"`.

The current `_parse_model_string()` only lowercases the provider string, which is insufficient for cases where the lowercased display name differs from the canonical key (e.g. `"Azure"` → `"azure"` ≠ `"azure-openai"`).

This breaks round-tripping: model metadata returned by AgentOS `/models` or evals cannot be fed back into `get_model()`.

## Solution

Add a `normalize_provider()` helper with an alias mapping from display names to canonical keys, and apply it at three boundaries:

1. **`_parse_model_string()`** — model string parsing
2. **AgentOS `/models` endpoint** — serialized model metadata output
3. **Evals router** — model override construction

The alias table only contains entries where the lowercased display name differs from the canonical key — providers whose names are already canonical after lowercasing (e.g. `"Groq"` → `"groq"`) work automatically.

## Changes

- `libs/agno/agno/models/utils.py` — Add `_PROVIDER_ALIASES` dict and `normalize_provider()` function; use it in `_parse_model_string()`
- `libs/agno/agno/os/router.py` — Normalize provider names in `/models` endpoint
- `libs/agno/agno/os/routers/evals/evals.py` — Use `normalize_provider()` instead of `.lower()` for model override construction
- `libs/agno/tests/unit/utils/test_normalize_provider.py` — 36 test cases covering canonical keys, display names, case insensitivity, whitespace, and idempotency

## Notes

- `"Azure"` is used by both `AzureOpenAI` and `AzureAIFoundry` — this maps to `"azure-openai"` by default. A follow-up could differentiate these by giving `AzureAIFoundry` a distinct display name.
- Backward compatible: all existing canonical keys pass through unchanged.
- Unknown providers are lowercased and returned as-is (no breakage for new providers).