### PR TITLE
Refactor readers to use ChunkingStrategyFactory for default strategies

### DIFF
--- a/libs/agno/agno/knowledge/reader/arxiv_reader.py
+++ b/libs/agno/agno/knowledge/reader/arxiv_reader.py
@@ -1,8 +1,7 @@
 import asyncio
 from typing import List, Optional
 
-from agno.knowledge.chunking.fixed import FixedSizeChunking
-from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyFactory, ChunkingStrategyType
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.types import ContentType
@@ -34,10 +33,14 @@ class ArxivReader(Reader):
 
     def __init__(
         self,
-        chunking_strategy: Optional[ChunkingStrategy] = FixedSizeChunking(),
+        chunking_strategy: Optional[ChunkingStrategy] = None,
         sort_by: arxiv.SortCriterion = arxiv.SortCriterion.Relevance,
         **kwargs,
     ) -> None:
+        if chunking_strategy is None:
+            chunking_strategy = ChunkingStrategyFactory.create_strategy(
+                ChunkingStrategyType.FIXED_SIZE_CHUNKER, **kwargs
+            )
         super().__init__(chunking_strategy=chunking_strategy, **kwargs)
 
         # ArxivReader-specific attributes

--- a/libs/agno/agno/knowledge/reader/base.py
+++ b/libs/agno/agno/knowledge/reader/base.py
@@ -2,7 +2,6 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
 
-from agno.knowledge.chunking.fixed import FixedSizeChunking
 from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyFactory, ChunkingStrategyType
 from agno.knowledge.document.base import Document
 from agno.knowledge.types import ContentType
@@ -72,13 +71,17 @@ class Reader:
 
     def chunk_document(self, document: Document) -> List[Document]:
         if self.chunking_strategy is None:
-            self.chunking_strategy = FixedSizeChunking(chunk_size=self.chunk_size)
+            self.chunking_strategy = ChunkingStrategyFactory.create_strategy(
+                ChunkingStrategyType.FIXED_SIZE_CHUNKER, chunk_size=self.chunk_size
+            )
         return self.chunking_strategy.chunk(document)
 
     async def achunk_document(self, document: Document) -> List[Document]:
         """Async version of chunk_document."""
         if self.chunking_strategy is None:
-            self.chunking_strategy = FixedSizeChunking(chunk_size=self.chunk_size)
+            self.chunking_strategy = ChunkingStrategyFactory.create_strategy(
+                ChunkingStrategyType.FIXED_SIZE_CHUNKER, chunk_size=self.chunk_size
+            )
         return await self.chunking_strategy.achunk(document)
 
     async def chunk_documents_async(self, documents: List[Document]) -> List[Document]:

--- a/libs/agno/agno/knowledge/reader/csv_reader.py
+++ b/libs/agno/agno/knowledge/reader/csv_reader.py
@@ -10,8 +10,7 @@ try:
 except ImportError:
     raise ImportError("`aiofiles` not installed. Please install it with `pip install aiofiles`")
 
-from agno.knowledge.chunking.row import RowChunking
-from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyFactory, ChunkingStrategyType
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.reader.utils import stringify_cell_value
@@ -41,7 +40,9 @@ class CSVReader(Reader):
         ```
     """
 
-    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = RowChunking(), **kwargs):
+    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = None, **kwargs):
+        if chunking_strategy is None:
+            chunking_strategy = ChunkingStrategyFactory.create_strategy(ChunkingStrategyType.ROW_CHUNKER, **kwargs)
         super().__init__(chunking_strategy=chunking_strategy, **kwargs)
 
     @classmethod

--- a/libs/agno/agno/knowledge/reader/docx_reader.py
+++ b/libs/agno/agno/knowledge/reader/docx_reader.py
@@ -3,8 +3,7 @@ from pathlib import Path
 from typing import IO, Any, List, Optional, Union
 from uuid import uuid4
 
-from agno.knowledge.chunking.document import DocumentChunking
-from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyFactory, ChunkingStrategyType
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.types import ContentType
@@ -19,7 +18,9 @@ except ImportError:
 class DocxReader(Reader):
     """Reader for Doc/Docx files"""
 
-    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = DocumentChunking(), **kwargs):
+    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = None, **kwargs):
+        if chunking_strategy is None:
+            chunking_strategy = ChunkingStrategyFactory.create_strategy(ChunkingStrategyType.DOCUMENT_CHUNKER, **kwargs)
         super().__init__(chunking_strategy=chunking_strategy, **kwargs)
 
     @classmethod

--- a/libs/agno/agno/knowledge/reader/excel_reader.py
+++ b/libs/agno/agno/knowledge/reader/excel_reader.py
@@ -3,8 +3,7 @@ import io
 from pathlib import Path
 from typing import IO, Any, Iterable, List, Optional, Sequence, Tuple, Union
 
-from agno.knowledge.chunking.row import RowChunking
-from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyFactory, ChunkingStrategyType
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.reader.utils import (
@@ -23,9 +22,11 @@ class ExcelReader(Reader):
     def __init__(
         self,
         sheets: Optional[List[Union[str, int]]] = None,
-        chunking_strategy: Optional[ChunkingStrategy] = RowChunking(),
+        chunking_strategy: Optional[ChunkingStrategy] = None,
         **kwargs,
     ):
+        if chunking_strategy is None:
+            chunking_strategy = ChunkingStrategyFactory.create_strategy(ChunkingStrategyType.ROW_CHUNKER, **kwargs)
         super().__init__(chunking_strategy=chunking_strategy, **kwargs)
         self.sheets = sheets
 

--- a/libs/agno/agno/knowledge/reader/firecrawl_reader.py
+++ b/libs/agno/agno/knowledge/reader/firecrawl_reader.py
@@ -2,8 +2,7 @@ import asyncio
 from dataclasses import dataclass
 from typing import Dict, List, Literal, Optional
 
-from agno.knowledge.chunking.semantic import SemanticChunking
-from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyFactory, ChunkingStrategyType
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.types import ContentType
@@ -28,10 +27,14 @@ class FirecrawlReader(Reader):
         mode: Literal["scrape", "crawl"] = "scrape",
         chunk: bool = True,
         chunk_size: int = 5000,
-        chunking_strategy: Optional[ChunkingStrategy] = SemanticChunking(),
+        chunking_strategy: Optional[ChunkingStrategy] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
     ) -> None:
+        if chunking_strategy is None:
+            chunking_strategy = ChunkingStrategyFactory.create_strategy(
+                ChunkingStrategyType.SEMANTIC_CHUNKER, chunk_size=chunk_size
+            )
         # Initialise base Reader (handles chunk_size / strategy)
         super().__init__(
             chunk=chunk, chunk_size=chunk_size, chunking_strategy=chunking_strategy, name=name, description=description

--- a/libs/agno/agno/knowledge/reader/json_reader.py
+++ b/libs/agno/agno/knowledge/reader/json_reader.py
@@ -4,8 +4,7 @@ from pathlib import Path
 from typing import IO, Any, List, Optional, Union
 from uuid import uuid4
 
-from agno.knowledge.chunking.fixed import FixedSizeChunking
-from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyFactory, ChunkingStrategyType
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.types import ContentType
@@ -17,7 +16,11 @@ class JSONReader(Reader):
 
     chunk: bool = False
 
-    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = FixedSizeChunking(), **kwargs):
+    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = None, **kwargs):
+        if chunking_strategy is None:
+            chunking_strategy = ChunkingStrategyFactory.create_strategy(
+                ChunkingStrategyType.FIXED_SIZE_CHUNKER, **kwargs
+            )
         super().__init__(chunking_strategy=chunking_strategy, **kwargs)
 
     @classmethod

--- a/libs/agno/agno/knowledge/reader/markdown_reader.py
+++ b/libs/agno/agno/knowledge/reader/markdown_reader.py
@@ -3,24 +3,18 @@ import uuid
 from pathlib import Path
 from typing import IO, Any, List, Optional, Union
 
-from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyFactory, ChunkingStrategyType
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.types import ContentType
 from agno.utils.log import log_debug, log_error, log_warning
 
-DEFAULT_CHUNKER_STRATEGY: ChunkingStrategy
-
-# Try to import MarkdownChunking, fallback to FixedSizeChunking if not available
+# Check MarkdownChunking availability at import time (for get_supported_chunking_strategies)
 try:
-    from agno.knowledge.chunking.markdown import MarkdownChunking
+    from agno.knowledge.chunking.markdown import MarkdownChunking as _MarkdownChunking  # noqa: F401
 
-    DEFAULT_CHUNKER_STRATEGY = MarkdownChunking()
     MARKDOWN_CHUNKER_AVAILABLE = True
 except ImportError:
-    from agno.knowledge.chunking.fixed import FixedSizeChunking
-
-    DEFAULT_CHUNKER_STRATEGY = FixedSizeChunking()
     MARKDOWN_CHUNKER_AVAILABLE = False
 
 
@@ -54,12 +48,19 @@ class MarkdownReader(Reader):
         chunking_strategy: Optional[ChunkingStrategy] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
+        **kwargs,
     ) -> None:
-        # Use the default chunking strategy if none provided
         if chunking_strategy is None:
-            chunking_strategy = DEFAULT_CHUNKER_STRATEGY
+            try:
+                chunking_strategy = ChunkingStrategyFactory.create_strategy(
+                    ChunkingStrategyType.MARKDOWN_CHUNKER, **kwargs
+                )
+            except ImportError:
+                chunking_strategy = ChunkingStrategyFactory.create_strategy(
+                    ChunkingStrategyType.FIXED_SIZE_CHUNKER, **kwargs
+                )
 
-        super().__init__(chunking_strategy=chunking_strategy, name=name, description=description)
+        super().__init__(chunking_strategy=chunking_strategy, name=name, description=description, **kwargs)
 
     def read(self, file: Union[Path, IO[Any]], name: Optional[str] = None) -> List[Document]:
         try:

--- a/libs/agno/agno/knowledge/reader/pdf_reader.py
+++ b/libs/agno/agno/knowledge/reader/pdf_reader.py
@@ -4,8 +4,7 @@ from pathlib import Path
 from typing import IO, Any, List, Optional, Tuple, Union
 from uuid import uuid4
 
-from agno.knowledge.chunking.document import DocumentChunking
-from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyFactory, ChunkingStrategyType
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.types import ContentType
@@ -206,13 +205,16 @@ class BasePDFReader(Reader):
         page_end_numbering_format: Optional[str] = None,
         password: Optional[str] = None,
         sanitize_content: bool = True,
-        chunking_strategy: Optional[ChunkingStrategy] = DocumentChunking(chunk_size=5000),
+        chunking_strategy: Optional[ChunkingStrategy] = None,
         **kwargs,
     ):
         if page_start_numbering_format is None:
             page_start_numbering_format = PAGE_START_NUMBERING_FORMAT_DEFAULT
         if page_end_numbering_format is None:
             page_end_numbering_format = PAGE_END_NUMBERING_FORMAT_DEFAULT
+
+        if chunking_strategy is None:
+            chunking_strategy = ChunkingStrategyFactory.create_strategy(ChunkingStrategyType.DOCUMENT_CHUNKER, **kwargs)
 
         self.split_on_pages = split_on_pages
         self.page_start_numbering_format = page_start_numbering_format

--- a/libs/agno/agno/knowledge/reader/pptx_reader.py
+++ b/libs/agno/agno/knowledge/reader/pptx_reader.py
@@ -3,8 +3,7 @@ from pathlib import Path
 from typing import IO, Any, List, Optional, Union
 from uuid import uuid4
 
-from agno.knowledge.chunking.document import DocumentChunking
-from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyFactory, ChunkingStrategyType
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.types import ContentType
@@ -19,7 +18,9 @@ except ImportError:
 class PPTXReader(Reader):
     """Reader for PPTX files"""
 
-    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = DocumentChunking(), **kwargs):
+    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = None, **kwargs):
+        if chunking_strategy is None:
+            chunking_strategy = ChunkingStrategyFactory.create_strategy(ChunkingStrategyType.DOCUMENT_CHUNKER, **kwargs)
         super().__init__(chunking_strategy=chunking_strategy, **kwargs)
 
     @classmethod

--- a/libs/agno/agno/knowledge/reader/s3_reader.py
+++ b/libs/agno/agno/knowledge/reader/s3_reader.py
@@ -3,8 +3,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import List, Optional
 
-from agno.knowledge.chunking.fixed import FixedSizeChunking
-from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyFactory, ChunkingStrategyType
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.reader.pdf_reader import PDFReader
@@ -31,7 +30,11 @@ except ImportError:
 class S3Reader(Reader):
     """Reader for S3 files"""
 
-    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = FixedSizeChunking(), **kwargs):
+    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = None, **kwargs):
+        if chunking_strategy is None:
+            chunking_strategy = ChunkingStrategyFactory.create_strategy(
+                ChunkingStrategyType.FIXED_SIZE_CHUNKER, **kwargs
+            )
         super().__init__(chunking_strategy=chunking_strategy, **kwargs)
 
     @classmethod

--- a/libs/agno/agno/knowledge/reader/tavily_reader.py
+++ b/libs/agno/agno/knowledge/reader/tavily_reader.py
@@ -2,8 +2,7 @@ import asyncio
 from dataclasses import dataclass
 from typing import Dict, List, Literal, Optional
 
-from agno.knowledge.chunking.semantic import SemanticChunking
-from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyFactory, ChunkingStrategyType
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.types import ContentType
@@ -32,7 +31,7 @@ class TavilyReader(Reader):
         extract_depth: Literal["basic", "advanced"] = "basic",
         chunk: bool = True,
         chunk_size: int = 5000,
-        chunking_strategy: Optional[ChunkingStrategy] = SemanticChunking(),
+        chunking_strategy: Optional[ChunkingStrategy] = None,
         name: Optional[str] = None,
         description: Optional[str] = None,
     ) -> None:
@@ -50,6 +49,10 @@ class TavilyReader(Reader):
             name: Name of the reader
             description: Description of the reader
         """
+        if chunking_strategy is None:
+            chunking_strategy = ChunkingStrategyFactory.create_strategy(
+                ChunkingStrategyType.SEMANTIC_CHUNKER, chunk_size=chunk_size
+            )
         # Initialize base Reader (handles chunk_size / strategy)
         super().__init__(
             chunk=chunk, chunk_size=chunk_size, chunking_strategy=chunking_strategy, name=name, description=description

--- a/libs/agno/agno/knowledge/reader/text_reader.py
+++ b/libs/agno/agno/knowledge/reader/text_reader.py
@@ -3,8 +3,7 @@ import uuid
 from pathlib import Path
 from typing import IO, Any, List, Optional, Union
 
-from agno.knowledge.chunking.fixed import FixedSizeChunking
-from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyFactory, ChunkingStrategyType
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.types import ContentType
@@ -14,7 +13,11 @@ from agno.utils.log import log_debug, log_error, log_warning
 class TextReader(Reader):
     """Reader for Text files"""
 
-    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = FixedSizeChunking(), **kwargs):
+    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = None, **kwargs):
+        if chunking_strategy is None:
+            chunking_strategy = ChunkingStrategyFactory.create_strategy(
+                ChunkingStrategyType.FIXED_SIZE_CHUNKER, **kwargs
+            )
         super().__init__(chunking_strategy=chunking_strategy, **kwargs)
 
     @classmethod

--- a/libs/agno/agno/knowledge/reader/web_search_reader.py
+++ b/libs/agno/agno/knowledge/reader/web_search_reader.py
@@ -7,8 +7,7 @@ from urllib.parse import urlparse
 
 import httpx
 
-from agno.knowledge.chunking.semantic import SemanticChunking
-from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyFactory, ChunkingStrategyType
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.types import ContentType
@@ -50,7 +49,13 @@ class WebSearchReader(Reader):
     _last_search_time: float = field(default=0.0, init=False)
 
     # Override default chunking strategy
-    chunking_strategy: Optional[ChunkingStrategy] = SemanticChunking()
+    chunking_strategy: Optional[ChunkingStrategy] = None
+
+    def __post_init__(self) -> None:
+        if self.chunking_strategy is None:
+            self.chunking_strategy = ChunkingStrategyFactory.create_strategy(
+                ChunkingStrategyType.SEMANTIC_CHUNKER, chunk_size=self.chunk_size
+            )
 
     @classmethod
     def get_supported_chunking_strategies(cls) -> List[ChunkingStrategyType]:

--- a/libs/agno/agno/knowledge/reader/website_reader.py
+++ b/libs/agno/agno/knowledge/reader/website_reader.py
@@ -7,8 +7,7 @@ from urllib.parse import urljoin, urlparse
 
 import httpx
 
-from agno.knowledge.chunking.fixed import FixedSizeChunking
-from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyFactory, ChunkingStrategyType
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.types import ContentType
@@ -32,13 +31,17 @@ class WebsiteReader(Reader):
 
     def __init__(
         self,
-        chunking_strategy: Optional[ChunkingStrategy] = FixedSizeChunking(),
+        chunking_strategy: Optional[ChunkingStrategy] = None,
         max_depth: int = 3,
         max_links: int = 10,
         timeout: int = 10,
         proxy: Optional[str] = None,
         **kwargs,
     ):
+        if chunking_strategy is None:
+            chunking_strategy = ChunkingStrategyFactory.create_strategy(
+                ChunkingStrategyType.FIXED_SIZE_CHUNKER, **kwargs
+            )
         super().__init__(chunking_strategy=chunking_strategy, **kwargs)
         self.max_depth = max_depth
         self.max_links = max_links

--- a/libs/agno/agno/knowledge/reader/wikipedia_reader.py
+++ b/libs/agno/agno/knowledge/reader/wikipedia_reader.py
@@ -1,8 +1,7 @@
 import asyncio
 from typing import List, Optional
 
-from agno.knowledge.chunking.fixed import FixedSizeChunking
-from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyFactory, ChunkingStrategyType
 from agno.knowledge.document import Document
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.types import ContentType
@@ -17,9 +16,11 @@ except ImportError:
 class WikipediaReader(Reader):
     auto_suggest: bool = True
 
-    def __init__(
-        self, chunking_strategy: Optional[ChunkingStrategy] = FixedSizeChunking(), auto_suggest: bool = True, **kwargs
-    ):
+    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = None, auto_suggest: bool = True, **kwargs):
+        if chunking_strategy is None:
+            chunking_strategy = ChunkingStrategyFactory.create_strategy(
+                ChunkingStrategyType.FIXED_SIZE_CHUNKER, **kwargs
+            )
         super().__init__(chunking_strategy=chunking_strategy, **kwargs)
         self.auto_suggest = auto_suggest
 

--- a/libs/agno/agno/knowledge/reader/youtube_reader.py
+++ b/libs/agno/agno/knowledge/reader/youtube_reader.py
@@ -1,8 +1,7 @@
 import asyncio
 from typing import List, Optional
 
-from agno.knowledge.chunking.recursive import RecursiveChunking
-from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
+from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyFactory, ChunkingStrategyType
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.base import Reader
 from agno.knowledge.types import ContentType
@@ -19,7 +18,11 @@ except ImportError:
 class YouTubeReader(Reader):
     """Reader for YouTube video transcripts"""
 
-    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = RecursiveChunking(), **kwargs):
+    def __init__(self, chunking_strategy: Optional[ChunkingStrategy] = None, **kwargs):
+        if chunking_strategy is None:
+            chunking_strategy = ChunkingStrategyFactory.create_strategy(
+                ChunkingStrategyType.RECURSIVE_CHUNKER, **kwargs
+            )
         super().__init__(chunking_strategy=chunking_strategy, **kwargs)
 
     @classmethod


### PR DESCRIPTION
  Fixes  #7120 

- Replace mutable default arguments (e.g. FixedSizeChunking()) with None in all reader __init__ methods
- Use ChunkingStrategyFactory.create_strategy() to lazily create the default strategy, forwarding **kwargs so chunk_size, overlap, and any strategy-specific params are correctly passed through
- Add __post_init__ to WebSearchReader (dataclass) for the same fix
- Fix markdown_reader to use factory with ImportError fallback instead of module-level global
- Also update base.py fallback in chunk_document/achunk_document to use factory

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [x ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses  #this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
