### PR TITLE
fix(run): preserve CustomEvent dynamic attributes in to_dict()

### DIFF
--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -493,6 +493,15 @@ class CustomEvent(BaseAgentRunEvent):
         for key, value in kwargs.items():
             setattr(self, key, value)
 
+    def to_dict(self) -> Dict[str, Any]:
+        """Override to include dynamically-set attributes not declared as dataclass fields.
+
+        CustomEvent uses a custom __init__ that stores all kwargs directly via setattr,
+        bypassing the dataclass __init__. As a result asdict() cannot be used safely here.
+        We build the dict directly from __dict__ instead, filtering out private attributes.
+        """
+        return {k: v for k, v in self.__dict__.items() if not k.startswith("_") and v is not None}
+
 
 RunOutputEvent = Union[
     RunStartedEvent,

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -606,6 +606,15 @@ class CustomEvent(BaseTeamRunEvent):
         for key, value in kwargs.items():
             setattr(self, key, value)
 
+    def to_dict(self) -> Dict[str, Any]:
+        """Override to include dynamically-set attributes not declared as dataclass fields.
+
+        CustomEvent uses a custom __init__ that stores all kwargs directly via setattr,
+        bypassing the dataclass __init__. As a result asdict() cannot be used safely here.
+        We build the dict directly from __dict__ instead, filtering out private attributes.
+        """
+        return {k: v for k, v in self.__dict__.items() if not k.startswith("_") and v is not None}
+
 
 TeamRunOutputEvent = Union[
     RunStartedEvent,

--- a/libs/agno/agno/run/workflow.py
+++ b/libs/agno/agno/run/workflow.py
@@ -464,6 +464,15 @@ class CustomEvent(BaseWorkflowRunOutputEvent):
         for key, value in kwargs.items():
             setattr(self, key, value)
 
+    def to_dict(self) -> Dict[str, Any]:
+        """Override to include dynamically-set attributes not declared as dataclass fields.
+
+        CustomEvent uses a custom __init__ that stores all kwargs directly via setattr,
+        bypassing the dataclass __init__. As a result asdict() cannot be used safely here.
+        We build the dict directly from __dict__ instead, filtering out private attributes.
+        """
+        return {k: v for k, v in self.__dict__.items() if not k.startswith("_") and v is not None}
+
 
 # Union type for all workflow run response events
 WorkflowRunOutputEvent = Union[

--- a/libs/agno/tests/unit/run/test_run_events.py
+++ b/libs/agno/tests/unit/run/test_run_events.py
@@ -395,3 +395,52 @@ def test_requirements_in_run_paused_event():
     assert reconstructed.requirements[0].tool_execution.tool_name == "get_the_weather"
     assert reconstructed.requirements[0].tool_execution.requires_confirmation is True
     assert reconstructed.requirements[0].needs_confirmation is True
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tests for CustomEvent.to_dict() preserving dynamic attributes (issue #7075)
+# ──────────────────────────────────────────────────────────────────────────────
+
+from agno.run.agent import CustomEvent as AgentCustomEvent
+from agno.run.team import CustomEvent as TeamCustomEvent
+from agno.run.workflow import CustomEvent as WorkflowCustomEvent
+
+
+def test_agent_custom_event_to_dict_preserves_dynamic_attrs():
+    """CustomEvent dynamic attributes must survive to_dict() serialisation.
+
+    Regression test for https://github.com/agno-agi/agno/issues/7075.
+    """
+    evt = AgentCustomEvent(event="my_custom_event", user_id="u-42", step=3)
+    d = evt.to_dict()
+
+    assert d.get("event") == "my_custom_event"
+    assert d.get("user_id") == "u-42"
+    assert d.get("step") == 3
+
+
+def test_team_custom_event_to_dict_preserves_dynamic_attrs():
+    evt = TeamCustomEvent(event="team_event", payload={"key": "value"})
+    d = evt.to_dict()
+
+    assert d.get("event") == "team_event"
+    assert d.get("payload") == {"key": "value"}
+
+
+def test_workflow_custom_event_to_dict_preserves_dynamic_attrs():
+    # Note: "status" is a property on BaseWorkflowRunOutputEvent, so use a different name
+    evt = WorkflowCustomEvent(event="wf_event", wf_status="running", progress=0.5)
+    d = evt.to_dict()
+
+    assert d.get("event") == "wf_event"
+    assert d.get("wf_status") == "running"
+    assert d.get("progress") == 0.5
+
+
+def test_agent_custom_event_none_dynamic_attrs_excluded():
+    """Attributes explicitly set to None should be excluded from to_dict()."""
+    evt = AgentCustomEvent(event="evt", nullable_field=None, real_field="hello")
+    d = evt.to_dict()
+
+    assert "nullable_field" not in d
+    assert d.get("real_field") == "hello"


### PR DESCRIPTION
## Description

`CustomEvent` uses a custom `__init__` that stores all keyword arguments directly via `setattr`, bypassing the dataclass `__init__`. Because of this, `asdict()` in the parent `BaseRunOutputEvent.to_dict()` does not see the dynamically-set attributes, causing them to be silently dropped on serialisation.

## Fix

Override `to_dict()` in all three `CustomEvent` classes (`agent`, `team`, `workflow`) to build the dict directly from `self.__dict__`, filtering out private attributes and `None` values — the same exclusion policy used by the parent.

## Testing

Added four unit tests in `libs/agno/tests/unit/run/test_run_events.py` that verify:
- Agent / Team / Workflow `CustomEvent.to_dict()` preserves dynamic attrs
- Attributes set to `None` are excluded from the output dict

Fixes #7075