### PR TITLE
fix(models): use safe JSON serializer in _get_model_cache_key

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -463,7 +463,22 @@ class Model(ABC):
             "stream": stream,
         }
 
-        cache_str = json.dumps(cache_data, sort_keys=True)
+        def _safe_json_default(obj: Any) -> Any:
+            """Fallback serializer for types json cannot handle natively.
+
+            Pydantic ModelMetaclass and similar non-serialisable types (e.g. those
+            passed via response_format) trigger TypeError with the default encoder.
+            Convert them to a stable string representation so cache-key generation
+            never fails due to unexpected types in the message payload.
+            """
+            if isinstance(obj, type):
+                return obj.__name__
+            try:
+                return str(obj)
+            except Exception:
+                return repr(obj)
+
+        cache_str = json.dumps(cache_data, sort_keys=True, default=_safe_json_default)
         return md5(cache_str.encode()).hexdigest()
 
     def _get_model_cache_file_path(self, cache_key: str) -> Path:

--- a/libs/agno/tests/unit/models/test_model_helpers.py
+++ b/libs/agno/tests/unit/models/test_model_helpers.py
@@ -435,3 +435,30 @@ class TestHandleAgentException:
         assert len(additional) == 2
         assert additional[0].role == "user"
         assert additional[1].role == "assistant"
+
+    def test_cache_key_with_non_serialisable_response_format(self, model):
+        """_get_model_cache_key must not raise TypeError when response_format
+        is a class (ModelMetaclass) rather than a JSON-serialisable value.
+
+        Regression test for https://github.com/agno-agi/agno/issues/7126.
+        """
+        from pydantic import BaseModel
+
+        class MyOutputModel(BaseModel):
+            answer: str
+
+        msgs = [Message(role="user", content="hello")]
+        # Should not raise TypeError: Object of type ModelMetaclass is not JSON serializable
+        key = model._get_model_cache_key(msgs, stream=False, response_format=MyOutputModel)
+        assert isinstance(key, str) and len(key) == 32  # MD5 hex digest
+
+    def test_cache_key_with_arbitrary_non_serialisable_type(self, model):
+        """Other non-serialisable types in kwargs are also handled gracefully."""
+
+        class _Opaque:
+            def __str__(self):
+                return "opaque-object"
+
+        msgs = [Message(role="user", content="test")]
+        key = model._get_model_cache_key(msgs, stream=False, response_format=_Opaque())
+        assert isinstance(key, str) and len(key) == 32


### PR DESCRIPTION
## Description

When `cache_response=True`, `_get_model_cache_key` calls `json.dumps` on `cache_data` which can contain Pydantic `ModelMetaclass` types (e.g. when `response_format=MyPydanticModel` is passed). These are not JSON-serialisable by default, raising:

```
TypeError: Object of type ModelMetaclass is not JSON serializable
```

## Fix

Added a `_safe_json_default` fallback serialiser as a local helper inside `_get_model_cache_key`. It converts non-serialisable types to their string representation, ensuring cache-key generation never fails due to unexpected types in the payload.

```python
def _safe_json_default(obj):
    if isinstance(obj, type):
        return obj.__name__
    try:
        return str(obj)
    except Exception:
        return repr(obj)
```

## Testing

Added two unit tests to `TestModelCaching` in `tests/unit/models/test_model_helpers.py`:
- Pydantic `BaseModel` subclass passed as `response_format`
- Arbitrary non-serialisable object passed as `response_format`

Fixes #7126