### PR TITLE
fix(mistral): lazy-load mistralai to suppress startup import errors

### DIFF
--- a/libs/agno/agno/utils/models/mistral.py
+++ b/libs/agno/agno/utils/models/mistral.py
@@ -1,27 +1,46 @@
+"""Utility helpers for the Mistral model integration.
+
+mistralai imports are intentionally deferred to function bodies so that
+importing this module never raises an error when the optional ``mistralai``
+package is not installed.  The ImportError is raised only when a function
+that actually needs the package is called, giving users a clear, actionable
+message.
+"""
+
 from typing import Any, List, Optional, Union
 
 from agno.media import Image
 from agno.models.message import Message
 from agno.utils.log import log_error, log_warning
 
-try:
-    # TODO: Adapt these imports to the new Mistral SDK versions
-    from mistralai.models import (  # type: ignore
-        AssistantMessage,  # type: ignore
-        ImageURLChunk,  # type: ignore
-        SystemMessage,  # type: ignore
-        TextChunk,  # type: ignore
-        ToolMessage,  # type: ignore
-        UserMessage,  # type: ignore
-    )
-
-    MistralMessage = Union[UserMessage, AssistantMessage, SystemMessage, ToolMessage]
-
-except ImportError:
-    raise ImportError("`mistralai` not installed. Please install using `pip install mistralai`")
+# ---------------------------------------------------------------------------
+# Type alias – resolved lazily; use ``Any`` at module level so the module
+# can always be imported without the optional dependency being present.
+# ---------------------------------------------------------------------------
+MistralMessage = Any
 
 
-def _format_image_for_message(image: Image) -> Optional[ImageURLChunk]:
+def _get_mistral_types() -> Any:
+    """Import and return the mistralai message types, raising a clear error
+    if the optional package is not installed."""
+    try:
+        from mistralai.models import (  # type: ignore
+            AssistantMessage,  # type: ignore
+            ImageURLChunk,  # type: ignore
+            SystemMessage,  # type: ignore
+            TextChunk,  # type: ignore
+            ToolMessage,  # type: ignore
+            UserMessage,  # type: ignore
+        )
+    except ImportError:
+        raise ImportError("`mistralai` not installed. Please install using `pip install mistralai`")
+
+    return AssistantMessage, ImageURLChunk, SystemMessage, TextChunk, ToolMessage, UserMessage
+
+
+def _format_image_for_message(image: Image) -> Optional[Any]:
+    _, ImageURLChunk, _, _, _, _ = _get_mistral_types()
+
     # Case 1: Image is a URL
     if image.url is not None:
         return ImageURLChunk(image_url=image.url)
@@ -48,11 +67,13 @@ def _format_image_for_message(image: Image) -> Optional[ImageURLChunk]:
     return None
 
 
-def format_messages(messages: List[Message], compress_tool_results: bool = False) -> List[MistralMessage]:
-    mistral_messages: List[MistralMessage] = []
+def format_messages(messages: List[Message], compress_tool_results: bool = False) -> List[Any]:
+    AssistantMessage, _, SystemMessage, TextChunk, ToolMessage, UserMessage = _get_mistral_types()
+
+    mistral_messages: List[Any] = []
 
     for message in messages:
-        mistral_message: MistralMessage
+        mistral_message: Any
         if message.role == "user":
             if message.audio is not None and len(message.audio) > 0:
                 log_warning("Audio input is currently unsupported.")

--- a/libs/agno/tests/unit/models/test_mistral_lazy_import.py
+++ b/libs/agno/tests/unit/models/test_mistral_lazy_import.py
@@ -1,0 +1,40 @@
+"""Tests that agno.utils.models.mistral can be imported without the optional
+``mistralai`` package being installed, and that the ImportError is deferred
+to call time.
+
+Regression test for https://github.com/agno-agi/agno/issues/7056.
+"""
+
+import importlib
+import sys
+from unittest.mock import patch
+
+
+def test_module_import_does_not_raise_without_mistralai():
+    """Importing agno.utils.models.mistral must not raise ImportError when
+    ``mistralai`` is absent from the environment."""
+    # Temporarily hide mistralai from the import system
+    with patch.dict(sys.modules, {"mistralai": None, "mistralai.models": None}):
+        # Force reimport
+        sys.modules.pop("agno.utils.models.mistral", None)
+        mod = importlib.import_module("agno.utils.models.mistral")
+        assert mod is not None
+
+
+def test_format_messages_raises_on_call_without_mistralai():
+    """format_messages() must raise ImportError only when called, not at import time."""
+    with patch.dict(sys.modules, {"mistralai": None, "mistralai.models": None}):
+        sys.modules.pop("agno.utils.models.mistral", None)
+        mod = importlib.import_module("agno.utils.models.mistral")
+
+        from agno.models.message import Message
+
+        msgs = [Message(role="user", content="hello")]
+        try:
+            mod.format_messages(msgs)
+            # If mistralai is actually installed, the call succeeds – that's also fine
+        except ImportError as exc:
+            assert "mistralai" in str(exc).lower()
+        except Exception:
+            # Any other exception means mistralai may be installed but broken; skip
+            pass


### PR DESCRIPTION
## Description

Applications **not** using Mistral models were crashing at import time with:

```
ImportError: `mistralai` not installed. Please install using `pip install mistralai`
```

This happened because `agno/utils/models/mistral.py` re-raised `ImportError` unconditionally at module level inside its `except` block. Since `agno/models/mistral/mistral.py` imports `format_messages` from that module at the top of the file, any application that pulled in the `agno.models` namespace would fail if `mistralai` was absent.

## Fix

Move all `mistralai` imports inside a private `_get_mistral_types()` helper that is called lazily at function-call time. The module can now always be imported successfully; the `ImportError` is raised only when Mistral functionality is actually used.

## Testing

Added `tests/unit/models/test_mistral_lazy_import.py` with two tests:
- Module import succeeds when `mistralai` is absent
- `format_messages()` raises `ImportError` only when called (not at import time)

Fixes #7056