### PR TITLE
fix(agent_os): expose available_models from YAML config at /models endpoint

### DIFF
--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -209,7 +209,12 @@ def get_base_router(
         },
     )
     async def get_models() -> List[Model]:
-        """Return the list of all models used by agents and teams in the contextual OS"""
+        """Return the list of all models used by agents and teams in the contextual OS.
+
+        Also includes any models listed in the ``available_models`` field of the
+        AgentOS YAML configuration so that models which are offered by the server
+        but not yet assigned to a specific agent are discoverable via this endpoint.
+        """
         unique_models = {}
 
         # Collect models from local agents
@@ -229,6 +234,14 @@ def get_base_router(
                     key = (model.id, model.provider)
                     if key not in unique_models:
                         unique_models[key] = Model(id=model.id, provider=model.provider)
+
+        # Include models declared in the YAML config's available_models list.
+        # These are stored as plain model-ID strings; provider is unknown at this
+        # point so we leave it as None rather than guessing.
+        if os.config is not None and os.config.available_models:
+            for model_id in os.config.available_models:
+                if model_id and model_id not in {m.id for m in unique_models.values()}:
+                    unique_models[model_id] = Model(id=model_id)
 
         return list(unique_models.values())
 

--- a/libs/agno/tests/unit/os/routers/test_models_endpoint.py
+++ b/libs/agno/tests/unit/os/routers/test_models_endpoint.py
@@ -1,0 +1,125 @@
+"""Unit tests for the /models endpoint.
+
+Verifies that models declared in the AgentOS YAML config's
+``available_models`` list are exposed through the GET /models endpoint.
+
+Regression test for https://github.com/agno-agi/agno/issues/7060.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from agno.os.config import AgentOSConfig
+from agno.os.router import get_agentOS_router
+from agno.os.settings import AgnoAPISettings
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_agent_os(
+    agents=None,
+    teams=None,
+    config=None,
+    interfaces=None,
+    storage=None,
+):
+    """Return a minimal mock AgentOS object."""
+    os_mock = MagicMock()
+    os_mock.agents = agents or []
+    os_mock.teams = teams or []
+    os_mock.config = config
+    os_mock.interfaces = interfaces or []
+    os_mock.storage = storage
+    return os_mock
+
+
+def _make_test_client(agent_os) -> TestClient:
+    app = FastAPI()
+    router = get_agentOS_router(agent_os, AgnoAPISettings())
+    app.include_router(router)
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestModelsEndpoint:
+    """Tests for GET /models."""
+
+    def test_empty_config_returns_empty_list(self):
+        """No agents, no teams, no config → empty model list."""
+        client = _make_test_client(_make_agent_os())
+        resp = client.get("/models")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    def test_available_models_from_config_included(self):
+        """Models in config.available_models appear in /models response.
+
+        This is the core regression case for issue #7060: previously the
+        endpoint ignored available_models and always returned an empty list
+        when no agents/teams were registered.
+        """
+        cfg = AgentOSConfig(available_models=["gpt-4o", "claude-3-7-sonnet"])
+        client = _make_test_client(_make_agent_os(config=cfg))
+
+        resp = client.get("/models")
+        assert resp.status_code == 200
+        ids = [m["id"] for m in resp.json()]
+        assert "gpt-4o" in ids
+        assert "claude-3-7-sonnet" in ids
+
+    def test_agent_models_still_included(self):
+        """Models from registered agents are still present alongside config models."""
+        cfg = AgentOSConfig(available_models=["extra-model"])
+
+        agent = MagicMock()
+        agent.model = MagicMock()
+        agent.model.id = "gpt-4o-mini"
+        agent.model.provider = "openai"
+
+        client = _make_test_client(_make_agent_os(agents=[agent], config=cfg))
+
+        resp = client.get("/models")
+        assert resp.status_code == 200
+        ids = [m["id"] for m in resp.json()]
+        assert "gpt-4o-mini" in ids
+        assert "extra-model" in ids
+
+    def test_no_duplicate_models(self):
+        """A model present both in an agent and in available_models is listed once."""
+        cfg = AgentOSConfig(available_models=["gpt-4o-mini"])
+
+        agent = MagicMock()
+        agent.model = MagicMock()
+        agent.model.id = "gpt-4o-mini"
+        agent.model.provider = "openai"
+
+        client = _make_test_client(_make_agent_os(agents=[agent], config=cfg))
+
+        resp = client.get("/models")
+        assert resp.status_code == 200
+        ids = [m["id"] for m in resp.json()]
+        assert ids.count("gpt-4o-mini") == 1
+
+    def test_config_none_does_not_raise(self):
+        """When config is None the endpoint returns models from agents only."""
+        agent = MagicMock()
+        agent.model = MagicMock()
+        agent.model.id = "gpt-4o"
+        agent.model.provider = "openai"
+
+        client = _make_test_client(_make_agent_os(agents=[agent], config=None))
+
+        resp = client.get("/models")
+        assert resp.status_code == 200
+        ids = [m["id"] for m in resp.json()]
+        assert "gpt-4o" in ids


### PR DESCRIPTION
## Description

When `available_models` was set in `agent_os_config.yaml`, the `/config` endpoint showed them correctly, but the `GET /models` endpoint returned an empty list because the config value was never wired into the router handler.

## Root Cause

`get_models()` in `agno/os/router.py` only iterated over `os.agents` and `os.teams` to collect models. The `os.config.available_models` list (a `List[str]` of model IDs) was ignored entirely.

## Fix

After collecting models from agents and teams, the handler now merges `os.config.available_models` into the response:

```python
if os.config is not None and os.config.available_models:
    for model_id in os.config.available_models:
        if model_id and model_id not in {m.id for m in unique_models.values()}:
            unique_models[model_id] = Model(id=model_id)
```

Config-sourced models are returned as `Model(id=<model_id>)` with `provider=None` (the config only stores IDs). De-duplication is preserved: a model present in both an agent and in `available_models` is returned only once.

## Testing

Added `tests/unit/os/routers/test_models_endpoint.py` with 5 tests:
- Empty config/agents → empty list
- `available_models` from config are included (**core regression case**)
- Agent models still included alongside config models
- No duplicates when a model appears in both places
- `config=None` does not raise

Fixes #7060