### PR TITLE
fix: exclude `fc` parameter from tool JSON schema #7134

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -314,7 +314,7 @@ class Function(BaseModel):
                 not in [
                     "agent",
                     "team",
-                    "run_context",
+                    "run_context", "fc",
                     "self",
                     "images",
                     "videos",
@@ -353,7 +353,7 @@ class Function(BaseModel):
                     not in [
                         "agent",
                         "team",
-                        "run_context",
+                        "run_context", "fc",
                         "self",
                         "images",
                         "videos",
@@ -371,7 +371,7 @@ class Function(BaseModel):
                     not in [
                         "agent",
                         "team",
-                        "run_context",
+                        "run_context", "fc",
                         "self",
                         "images",
                         "videos",
@@ -442,7 +442,7 @@ class Function(BaseModel):
                 "return",
                 "agent",
                 "team",
-                "run_context",
+                "run_context", "fc",
                 "self",
                 "images",
                 "videos",
@@ -647,7 +647,7 @@ class Function(BaseModel):
             not in [
                 "agent",
                 "team",
-                "run_context",
+                "run_context", "fc",
                 "images",
                 "videos",
                 "audios",


### PR DESCRIPTION
This PR addresses issue #7134 by adding the `fc` (FunctionCall) parameter to the list of excluded parameters during tool schema generation.

### Changes:
- Updated `libs/agno/agno/tools/function.py` to ensure `fc` is not exposed to the LLM.
- Prevents models from attempting to provide the internal `FunctionCall` instance as an argument.

/claim #7134