### PR TITLE
fix(tools): exclude FunctionCall (fc) parameter from tool schema

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -293,6 +293,8 @@ class Function(BaseModel):
                 del type_hints["team"]
             if "run_context" in sig.parameters and "run_context" in type_hints:
                 del type_hints["run_context"]
+            if "fc" in sig.parameters and "fc" in type_hints:
+                del type_hints["fc"]
 
             # Remove media parameters from type hints as they are injected automatically
             if "images" in sig.parameters and "images" in type_hints:
@@ -428,6 +430,8 @@ class Function(BaseModel):
                 del type_hints["team"]
             if "run_context" in sig.parameters and "run_context" in type_hints:
                 del type_hints["run_context"]
+            if "fc" in sig.parameters and "fc" in type_hints:
+                del type_hints["fc"]
             if "images" in sig.parameters and "images" in type_hints:
                 del type_hints["images"]
             if "videos" in sig.parameters and "videos" in type_hints:
@@ -443,6 +447,7 @@ class Function(BaseModel):
                 "agent",
                 "team",
                 "run_context",
+                "fc",
                 "self",
                 "images",
                 "videos",
@@ -648,6 +653,7 @@ class Function(BaseModel):
                 "agent",
                 "team",
                 "run_context",
+                "fc",
                 "images",
                 "videos",
                 "audios",

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -1017,3 +1017,37 @@ def test_tool_hook_receives_messages_via_run_context():
     # Verify it's a copy (not the same reference), so hook mutations don't affect the run
     assert captured_messages is not run_context.messages
     assert captured_messages == run_context.messages
+
+
+def test_fc_excluded_from_schema():
+    """Test that FunctionCall parameter is excluded from tool schema sent to the LLM.
+
+    Regression test for: fc (FunctionCall) parameter was not excluded from the JSON schema,
+    causing the LLM to attempt passing it as an argument.
+    """
+
+    def my_tool(query: str, fc: FunctionCall) -> str:
+        return query
+
+    func = Function(entrypoint=my_tool)
+    func.process_entrypoint()
+
+    params = func.parameters.get("properties", {})
+    assert "fc" not in params, "fc should be excluded from schema sent to LLM"
+    assert "query" in params, "query should be present in schema"
+    assert "fc" not in func.parameters.get("required", []), "fc should not be in required list"
+
+
+def test_run_context_and_fc_both_excluded_from_schema():
+    """Test that both run_context and fc are excluded from the tool schema."""
+
+    def my_tool(query: str, run_context: RunContext, fc: FunctionCall) -> str:
+        return query
+
+    func = Function(entrypoint=my_tool)
+    func.process_entrypoint()
+
+    params = func.parameters.get("properties", {})
+    assert "fc" not in params, "fc should be excluded from schema"
+    assert "run_context" not in params, "run_context should be excluded from schema"
+    assert "query" in params, "query should be present in schema"


### PR DESCRIPTION
## Summary

Fixes #7134

## Problem

When a tool function accepts an `fc: FunctionCall` parameter, it was not being excluded from the JSON schema sent to the LLM. This caused the LLM to attempt passing `fc` as an argument, leading to unexpected behavior.

```python
@tool
async def my_tool(
    query: str,
    run_context: RunContext,  # Already excluded
    fc: FunctionCall,         # Was NOT excluded — now fixed
) -> dict:
    ...
```

## Fix

- Added `fc` to the `excluded_params` list in `process_entrypoint()`
- Added `del type_hints["fc"]` in both schema-generation paths
- Consistent with how `run_context` is already handled

## Testing

Added unit tests in `tests/unit/tools/test_functions.py` that verify:
- `fc` is excluded from the tool schema sent to LLM
- `fc` is not in the required parameters list
- Both `run_context` and `fc` are excluded when used together

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)