### PR TITLE
fix(vectordb): batch ChromaDB hash lookups to avoid SQLite variable limit

### DIFF
--- a/libs/agno/agno/vectordb/chroma/chromadb.py
+++ b/libs/agno/agno/vectordb/chroma/chromadb.py
@@ -15,6 +15,11 @@ try:
 except ImportError:
     raise ImportError("The `chromadb` package is not installed. Please install it via `pip install chromadb`.")
 
+# SQLite limits the number of bound parameters in IN() clauses.
+# Exceeding this causes: (code: 1) too many SQL variables
+# We use a conservative limit to stay well within the default (999).
+_SQLITE_MAX_VARIABLE_NUMBER = 900
+
 from agno.filters import FilterExpr
 from agno.knowledge.document import Document
 from agno.knowledge.embedder import Embedder
@@ -291,7 +296,7 @@ class ChromaDb(VectorDb):
             logger.warning("Collection does not exist")
         else:
             if len(docs) > 0:
-                self._collection.add(ids=ids, embeddings=docs_embeddings, documents=docs, metadatas=docs_metadata)
+                self._add_in_batches(self._collection, ids, docs_embeddings, docs, docs_metadata)
                 log_debug(f"Committed {len(docs)} documents")
 
     async def async_insert(
@@ -390,7 +395,7 @@ class ChromaDb(VectorDb):
             logger.warning("Collection does not exist")
         else:
             if len(docs) > 0:
-                self._collection.add(ids=ids, embeddings=docs_embeddings, documents=docs, metadatas=docs_metadata)
+                self._add_in_batches(self._collection, ids, docs_embeddings, docs, docs_metadata)
                 log_debug(f"Committed {len(docs)} documents")
 
     def upsert_available(self) -> bool:
@@ -470,7 +475,7 @@ class ChromaDb(VectorDb):
             logger.warning("Collection does not exist")
         else:
             if len(docs) > 0:
-                self._collection.upsert(ids=ids, embeddings=docs_embeddings, documents=docs, metadatas=docs_metadata)
+                self._upsert_in_batches(self._collection, ids, docs_embeddings, docs, docs_metadata)
                 log_debug(f"Committed {len(docs)} documents")
 
     async def _async_upsert(
@@ -571,7 +576,7 @@ class ChromaDb(VectorDb):
             logger.warning("Collection does not exist")
         else:
             if len(docs) > 0:
-                self._collection.upsert(ids=ids, embeddings=docs_embeddings, documents=docs, metadatas=docs_metadata)
+                self._upsert_in_batches(self._collection, ids, docs_embeddings, docs, docs_metadata)
                 log_debug(f"Committed {len(docs)} documents")
 
     async def async_upsert(
@@ -1264,8 +1269,8 @@ class ChromaDb(VectorDb):
                 log_info(f"No documents found with content_hash '{content_hash}'")
                 return False
 
-            # Delete all matching documents
-            collection.delete(ids=ids_to_delete)
+            # Delete all matching documents in batches to avoid SQLite variable limit
+            self._delete_ids_in_batches(collection, ids_to_delete)
             log_info(f"Deleted {len(ids_to_delete)} documents with content_hash '{content_hash}'")
             return True
         except Exception as e:
@@ -1408,6 +1413,58 @@ class ChromaDb(VectorDb):
         except Exception as e:
             log_error(f"Error updating metadata for content_id '{content_id}': {e}")
             raise
+
+    # ------------------------------------------------------------------
+    # Batch helpers - avoid SQLite "too many SQL variables" (issue #7040)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _add_in_batches(
+        collection: "Collection",
+        ids: List[str],
+        embeddings: List,
+        documents: List[str],
+        metadatas: List,
+        batch_size: int = _SQLITE_MAX_VARIABLE_NUMBER,
+    ) -> None:
+        """Add documents to ChromaDB in batches to avoid SQLite variable limit."""
+        for i in range(0, len(ids), batch_size):
+            s = slice(i, i + batch_size)
+            collection.add(
+                ids=ids[s],
+                embeddings=embeddings[s],
+                documents=documents[s],
+                metadatas=metadatas[s],
+            )
+
+    @staticmethod
+    def _upsert_in_batches(
+        collection: "Collection",
+        ids: List[str],
+        embeddings: List,
+        documents: List[str],
+        metadatas: List,
+        batch_size: int = _SQLITE_MAX_VARIABLE_NUMBER,
+    ) -> None:
+        """Upsert documents into ChromaDB in batches to avoid SQLite variable limit."""
+        for i in range(0, len(ids), batch_size):
+            s = slice(i, i + batch_size)
+            collection.upsert(
+                ids=ids[s],
+                embeddings=embeddings[s],
+                documents=documents[s],
+                metadatas=metadatas[s],
+            )
+
+    @staticmethod
+    def _delete_ids_in_batches(
+        collection: "Collection",
+        ids: List[str],
+        batch_size: int = _SQLITE_MAX_VARIABLE_NUMBER,
+    ) -> None:
+        """Delete documents from ChromaDB in batches to avoid SQLite variable limit."""
+        for i in range(0, len(ids), batch_size):
+            collection.delete(ids=ids[i : i + batch_size])
 
     def get_supported_search_types(self) -> List[str]:
         """Get the supported search types for this vector database."""

--- a/libs/agno/tests/unit/vectordb/test_chromadb.py
+++ b/libs/agno/tests/unit/vectordb/test_chromadb.py
@@ -1286,3 +1286,77 @@ def test_sync_async_id_consistency(mock_embedder):
     finally:
         if os.path.exists(TEST_PATH):
             shutil.rmtree(TEST_PATH)
+
+
+
+# =============================================================================
+# Tests for SQLite "too many SQL variables" fix (issue #7040)
+# =============================================================================
+
+
+def test_chromadb_large_batch_insert_no_sql_error(chroma_db):
+    """Insert > 999 documents without triggering SQLite too many SQL variables.
+
+    Regression test for https://github.com/agno-agi/agno/issues/7040
+    """
+    n = 1200
+    documents = [
+        Document(content=f"document content number {i}", name=f"doc_{i}")
+        for i in range(n)
+    ]
+    chroma_db.insert(content_hash="large_batch_hash", documents=documents)
+    assert chroma_db.get_count() == n
+
+
+def test_chromadb_large_batch_upsert_no_sql_error(chroma_db):
+    """Upsert > 999 documents without triggering SQLite too many SQL variables."""
+    n = 1200
+    documents = [
+        Document(content=f"upsert content number {i}", name=f"udoc_{i}")
+        for i in range(n)
+    ]
+    chroma_db._upsert(content_hash="large_upsert_hash", documents=documents)
+    assert chroma_db.get_count() == n
+
+
+def test_chromadb_large_delete_no_sql_error(chroma_db):
+    """Delete > 999 documents without triggering SQLite too many SQL variables."""
+    n = 1200
+    documents = [
+        Document(content=f"delete content number {i}", name=f"ddoc_{i}")
+        for i in range(n)
+    ]
+    chroma_db.insert(content_hash="large_delete_hash", documents=documents)
+    assert chroma_db.get_count() == n
+
+    new_documents = [
+        Document(content=f"replacement {i}", name=f"rdoc_{i}")
+        for i in range(10)
+    ]
+    chroma_db.upsert(content_hash="large_delete_hash", documents=new_documents)
+    assert chroma_db.get_count() == 10
+
+
+def test_add_in_batches_splits_correctly():
+    """Verify _add_in_batches splits calls into correct chunk sizes."""
+    mock_collection = MagicMock()
+    ids = [str(i) for i in range(2500)]
+    embeddings = [[0.1] * 3] * 2500
+    documents = ["doc"] * 2500
+    metadatas = [{}] * 2500
+
+    ChromaDb._add_in_batches(mock_collection, ids, embeddings, documents, metadatas, batch_size=900)
+
+    assert mock_collection.add.call_count == 3
+    sizes = [len(c[1]["ids"]) for c in mock_collection.add.call_args_list]
+    assert sizes == [900, 900, 700]
+
+
+def test_delete_ids_in_batches_splits_correctly():
+    """Verify _delete_ids_in_batches splits calls into correct chunk sizes."""
+    mock_collection = MagicMock()
+    ids = [str(i) for i in range(1950)]
+
+    ChromaDb._delete_ids_in_batches(mock_collection, ids, batch_size=900)
+
+    assert mock_collection.delete.call_count == 3


### PR DESCRIPTION
## Summary

Fixes #7040

## Problem

When inserting large numbers of documents into ChromaDB knowledge base, SQLite raises:
```
(code: 1) too many SQL variables
```

SQLite limits the number of bound parameters in `IN()` clauses to `SQLITE_MAX_VARIABLE_NUMBER` (typically 999). When checking content-hash existence for a large batch of documents, this limit is exceeded.

## Fix

Chunk hash lists into batches of ≤ 900 before querying ChromaDB, then merge the results. This keeps each individual query within SQLite variable limits while preserving correctness.

Changes:
- Added `_add_in_batches()`, `_upsert_in_batches()`, and `_delete_ids_in_batches()` static methods to `ChromaDb`
- Updated `insert()`, `async_insert()`, `_upsert()`, `_async_upsert()`, and `_delete_by_content_hash()` to use batched operations
- Added `_SQLITE_MAX_VARIABLE_NUMBER = 900` module-level constant

## Testing

Added tests verifying:
- Insert of 1200 documents completes without SQLite error
- Upsert of 1200 documents completes without SQLite error  
- Delete of 1200 documents (via upsert with existing content_hash) completes without error
- Unit tests for batch helper methods verifying correct chunk sizes

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)