### PR TITLE
fix: unblock CI tests broken by litellm PyPI quarantine

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -222,7 +222,7 @@ models = [
   "agno[google]",
   "agno[groq]",
   "agno[ibm]",
-  "agno[litellm]",
+  # "agno[litellm]",  # TODO: re-enable when litellm is unquarantined on PyPI
   "agno[meta]",
   "agno[mistral]",
   "agno[ollama]",

--- a/scripts/test_setup.sh
+++ b/scripts/test_setup.sh
@@ -8,6 +8,8 @@
 # Usage: ./scripts/dev_setup.sh
 ############################################################################
 
+set -e
+
 CURR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "${CURR_DIR}")"
 AGNO_DIR="${REPO_ROOT}/libs/agno"


### PR DESCRIPTION
## Summary

CI unit tests on main have been failing because `litellm` was quarantined by PyPI admins, making it uninstallable. Since `litellm` is part of the `models` extra which is pulled in by the `tests` extra, `uv pip install -e ".[tests]"` fails during dependency resolution. Because `test_setup.sh` lacked `set -e`, this failure was silently swallowed — meaning `pytest-cov` and all other test dependencies were never installed, causing the `--cov` unrecognized argument error.

**Changes:**
- Comment out `agno[litellm]` from the `models` extra with a TODO to re-enable once the PyPI quarantine is lifted
- Add `set -e` to `scripts/test_setup.sh` so future install failures are caught immediately instead of silently ignored

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Self-review completed
- [x] Tested in clean environment

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)