### PR TITLE
fix: handle non-serializable types in cache key generation

### DIFF
--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -463,7 +463,14 @@ class Model(ABC):
             "stream": stream,
         }
 
-        cache_str = json.dumps(cache_data, sort_keys=True)
+        def _cache_default(obj: Any) -> Any:
+            if isinstance(obj, type):
+                return obj.__name__
+            if hasattr(obj, "model_dump"):
+                return obj.model_dump()
+            raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+        cache_str = json.dumps(cache_data, sort_keys=True, default=_cache_default)
         return md5(cache_str.encode()).hexdigest()
 
     def _get_model_cache_file_path(self, cache_key: str) -> Path:

--- a/libs/agno/tests/unit/models/test_cache_key_serialization.py
+++ b/libs/agno/tests/unit/models/test_cache_key_serialization.py
@@ -1,0 +1,57 @@
+"""Tests for model cache key generation with non-serializable objects.
+
+Verifies that _get_model_cache_key handles Pydantic model classes (ModelMetaclass)
+and Pydantic model instances without raising TypeError.
+
+Regression test for: https://github.com/agno-agi/agno/issues/7126
+"""
+
+import os
+
+from pydantic import BaseModel
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key-for-testing")
+
+from agno.models.message import Message
+from agno.models.openai.chat import OpenAIChat
+
+
+class DummyResponseFormat(BaseModel):
+    answer: str
+    confidence: float
+
+
+class TestCacheKeySerialization:
+    def setup_method(self):
+        self.model = OpenAIChat(id="gpt-4o")
+        self.messages = [
+            Message(role="system", content="You are a helpful assistant."),
+            Message(role="user", content="Hello"),
+        ]
+
+    def test_cache_key_with_class_type_response_format(self):
+        """Passing a Pydantic class (ModelMetaclass) as response_format should not raise."""
+        key = self.model._get_model_cache_key(self.messages, stream=False, response_format=DummyResponseFormat)
+        assert isinstance(key, str)
+        assert len(key) == 32  # md5 hex digest
+
+    def test_cache_key_with_pydantic_instance_response_format(self):
+        """Passing a Pydantic model instance as response_format should not raise."""
+        instance = DummyResponseFormat(answer="test", confidence=0.9)
+        key = self.model._get_model_cache_key(self.messages, stream=False, response_format=instance)
+        assert isinstance(key, str)
+        assert len(key) == 32
+
+    def test_cache_key_deterministic(self):
+        """Same inputs should produce the same cache key."""
+        key1 = self.model._get_model_cache_key(self.messages, stream=False, response_format=DummyResponseFormat)
+        key2 = self.model._get_model_cache_key(self.messages, stream=False, response_format=DummyResponseFormat)
+        assert key1 == key2
+
+    def test_cache_key_differs_for_different_response_formats(self):
+        """Different response_format values should produce different keys."""
+        key_with_class = self.model._get_model_cache_key(
+            self.messages, stream=False, response_format=DummyResponseFormat
+        )
+        key_without = self.model._get_model_cache_key(self.messages, stream=False, response_format=None)
+        assert key_with_class != key_without


### PR DESCRIPTION
## Summary

Fixes JSON serialization error when using `cache_response=True` with models that set `response_format` to a Pydantic class (e.g. `Followups`). The `_get_model_cache_key` method passes `cache_data` to `json.dumps`, which fails on `ModelMetaclass` objects.

The fix uses `json.dumps`'s `default` parameter to handle non-serializable types at any nesting depth:
- **Class types** (ModelMetaclass) → serialized as the class name
- **Pydantic instances** → serialized via `model_dump()`

Resolves #7126

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Only changes `_get_model_cache_key` in `models/base.py` — no changes to team delegation or other areas. The `default` handler approach is more robust than pre-normalizing top-level values because it handles objects at any depth in the serialization tree.