### PR TITLE
[fix] Include PAUSED runs in session history by default

### DIFF
--- a/libs/agno/agno/session/agent.py
+++ b/libs/agno/agno/session/agent.py
@@ -155,7 +155,7 @@ class AgentSession:
             return []
 
         if skip_statuses is None:
-            skip_statuses = [RunStatus.paused, RunStatus.cancelled, RunStatus.error]
+            skip_statuses = [RunStatus.cancelled, RunStatus.error]
 
         runs = self.runs
 

--- a/libs/agno/tests/unit/test_agent_session.py
+++ b/libs/agno/tests/unit/test_agent_session.py
@@ -1,0 +1,108 @@
+"""Tests for AgentSession.get_messages() skip_statuses behavior."""
+
+from agno.models.message import Message
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.session.agent import AgentSession
+
+
+def _make_run(run_id: str, status: RunStatus, messages: list[Message]) -> RunOutput:
+    """Helper to create a RunOutput with the given status and messages."""
+    run = RunOutput(run_id=run_id, agent_id="test-agent", parent_run_id=None)
+    run.status = status
+    run.messages = messages
+    return run
+
+
+def test_paused_runs_included_in_history():
+    """PAUSED runs should NOT be skipped by default in get_messages().
+
+    Regression test for https://github.com/agno-agi/agno/issues/7161:
+    When using add_history_to_context=True with external execution tools,
+    PAUSED runs contain valid conversation context that must be preserved
+    when the session is resumed.
+    """
+    paused_messages = [
+        Message(role="user", content="What is the weather?"),
+        Message(role="assistant", content="Let me check the weather for you."),
+    ]
+    completed_messages = [
+        Message(role="user", content="Thanks!"),
+        Message(role="assistant", content="You're welcome!"),
+    ]
+
+    session = AgentSession(
+        session_id="test-session",
+        runs=[
+            _make_run("run-1", RunStatus.paused, paused_messages),
+            _make_run("run-2", RunStatus.completed, completed_messages),
+        ],
+    )
+
+    messages = session.get_messages()
+
+    # All messages from both PAUSED and COMPLETED runs should be present
+    contents = [m.content for m in messages]
+    assert "What is the weather?" in contents
+    assert "Let me check the weather for you." in contents
+    assert "Thanks!" in contents
+    assert "You're welcome!" in contents
+    assert len(messages) == 4
+
+
+def test_cancelled_and_error_runs_still_skipped():
+    """CANCELLED and ERROR runs should still be skipped by default."""
+    session = AgentSession(
+        session_id="test-session",
+        runs=[
+            _make_run(
+                "run-cancelled",
+                RunStatus.cancelled,
+                [Message(role="user", content="cancelled msg")],
+            ),
+            _make_run(
+                "run-error",
+                RunStatus.error,
+                [Message(role="user", content="error msg")],
+            ),
+            _make_run(
+                "run-ok",
+                RunStatus.completed,
+                [Message(role="user", content="good msg")],
+            ),
+        ],
+    )
+
+    messages = session.get_messages()
+
+    contents = [m.content for m in messages]
+    assert "cancelled msg" not in contents
+    assert "error msg" not in contents
+    assert "good msg" in contents
+    assert len(messages) == 1
+
+
+def test_explicit_skip_paused_still_works():
+    """Callers can still explicitly skip PAUSED runs if desired."""
+    session = AgentSession(
+        session_id="test-session",
+        runs=[
+            _make_run(
+                "run-paused",
+                RunStatus.paused,
+                [Message(role="user", content="paused msg")],
+            ),
+            _make_run(
+                "run-ok",
+                RunStatus.completed,
+                [Message(role="user", content="good msg")],
+            ),
+        ],
+    )
+
+    messages = session.get_messages(skip_statuses=[RunStatus.paused, RunStatus.cancelled, RunStatus.error])
+
+    contents = [m.content for m in messages]
+    assert "paused msg" not in contents
+    assert "good msg" in contents
+    assert len(messages) == 1


### PR DESCRIPTION
## Summary

When using `add_history_to_context=True` with external execution tools, PAUSED runs are excluded from the session's conversation history. This causes the agent to lose all context when a session is resumed after an external tool call.

The root cause is in `AgentSession.get_messages()` where the default `skip_statuses` includes `RunStatus.paused`. Since PAUSED runs contain valid conversation context needed for session resumption, they should not be skipped by default.

Fixes #7161

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### Change

One-line change in `libs/agno/agno/session/agent.py`: removed `RunStatus.paused` from the default `skip_statuses` list in `AgentSession.get_messages()`.

Before:
```python
skip_statuses = [RunStatus.paused, RunStatus.cancelled, RunStatus.error]
```

After:
```python
skip_statuses = [RunStatus.cancelled, RunStatus.error]
```

Callers who explicitly pass `skip_statuses` with `RunStatus.paused` are unaffected.

### Test evidence

```
libs/agno/tests/unit/test_agent_session.py::test_paused_runs_included_in_history PASSED
libs/agno/tests/unit/test_agent_session.py::test_cancelled_and_error_runs_still_skipped PASSED
libs/agno/tests/unit/test_agent_session.py::test_explicit_skip_paused_still_works PASSED

574 passed, 2 failed (pre-existing), 2 warnings
```

The 2 pre-existing failures (`test_from_dict_with_db_postgres`, `test_from_dict_with_db_sqlite`) also fail on `main` and are unrelated to this change.

### AI disclosure

This PR was developed with AI assistance (Claude) and human-reviewed.