### PR TITLE
fix: propagate Reader chunk_size to default chunking_strategy

### DIFF
--- a/libs/agno/agno/knowledge/reader/base.py
+++ b/libs/agno/agno/knowledge/reader/base.py
@@ -39,6 +39,9 @@ class Reader:
             separators if separators is not None else ["\n", "\n\n", "\r", "\r\n", "\n\r", "\t", " ", "  "]
         )
         self.chunking_strategy = chunking_strategy
+        # Propagate chunk_size to the chunking_strategy if it supports it
+        if self.chunking_strategy is not None and hasattr(self.chunking_strategy, "chunk_size"):
+            self.chunking_strategy.chunk_size = self.chunk_size
         self.name = name
         self.description = description
         self.max_results = max_results

--- a/libs/agno/tests/unit/knowledge/test_reader_chunk_size_propagation.py
+++ b/libs/agno/tests/unit/knowledge/test_reader_chunk_size_propagation.py
@@ -1,0 +1,59 @@
+"""Tests that Reader propagates chunk_size to its chunking_strategy."""
+
+import pytest
+
+from agno.knowledge.chunking.document import DocumentChunking
+from agno.knowledge.chunking.fixed import FixedSizeChunking
+from agno.knowledge.chunking.recursive import RecursiveChunking
+from agno.knowledge.document.base import Document
+from agno.knowledge.reader.base import Reader
+from agno.knowledge.reader.text_reader import TextReader
+
+
+class DummyReader(Reader):
+    """Minimal Reader subclass for testing."""
+
+    def read(self, obj, name=None, password=None):
+        return [Document(content=str(obj))]
+
+
+class TestReaderChunkSizePropagation:
+    """Verify that chunk_size is propagated to the chunking_strategy."""
+
+    def test_chunk_size_propagated_to_fixed_size_chunking(self):
+        reader = DummyReader(chunk_size=200, chunking_strategy=FixedSizeChunking())
+        assert reader.chunking_strategy.chunk_size == 200
+        assert reader.chunk_size == 200
+
+    def test_chunk_size_propagated_to_document_chunking(self):
+        reader = DummyReader(chunk_size=300, chunking_strategy=DocumentChunking())
+        assert reader.chunking_strategy.chunk_size == 300
+
+    def test_chunk_size_propagated_to_recursive_chunking(self):
+        reader = DummyReader(chunk_size=400, chunking_strategy=RecursiveChunking())
+        assert reader.chunking_strategy.chunk_size == 400
+
+    def test_none_chunking_strategy_no_error(self):
+        reader = DummyReader(chunk_size=100, chunking_strategy=None)
+        assert reader.chunking_strategy is None
+
+    def test_default_chunk_size_unchanged(self):
+        reader = DummyReader(chunking_strategy=FixedSizeChunking())
+        assert reader.chunking_strategy.chunk_size == 5000
+        assert reader.chunk_size == 5000
+
+    def test_custom_chunk_size_used_in_chunking(self):
+        """Verify the propagated chunk_size actually affects chunking behavior."""
+        chunk_size = 50
+        reader = DummyReader(chunk_size=chunk_size, chunking_strategy=FixedSizeChunking())
+        long_text = "a" * 200
+        documents = reader.read(long_text)
+        chunked = reader.chunk_document(documents[0])
+        for doc in chunked:
+            assert len(doc.content) <= chunk_size
+
+    def test_text_reader_with_custom_chunk_size(self):
+        """Test a real Reader subclass with custom chunk_size."""
+        reader = TextReader(chunk_size=100)
+        # TextReader defaults to FixedSizeChunking() - chunk_size should be propagated
+        assert reader.chunking_strategy.chunk_size == 100


### PR DESCRIPTION
Fixes #7120

## Problem

When a Reader subclass (e.g., `FirecrawlReader`, `TextReader`, `ArxivReader`) provides a default `chunking_strategy` instance in its `__init__` signature, the strategy's internal `chunk_size` is not updated to match the user-provided `chunk_size` parameter.

For example:
```python
reader = TextReader(chunk_size=100)
# reader.chunk_size == 100, but reader.chunking_strategy.chunk_size == 5000 (default)
```

This is because Python evaluates default argument values at function definition time, so `FixedSizeChunking()` always gets its own default `chunk_size=5000`.

## Fix

In the base `Reader.__init__`, after setting `self.chunking_strategy`, propagate `chunk_size` to the strategy if it has a `chunk_size` attribute:

```python
if self.chunking_strategy is not None and hasattr(self.chunking_strategy, "chunk_size"):
    self.chunking_strategy.chunk_size = self.chunk_size
```

This is a single 3-line change in the base class that fixes the issue for all Reader subclasses without modifying any of them individually.

## Tests

Added `test_reader_chunk_size_propagation.py` with 7 tests covering:
- Propagation to `FixedSizeChunking`, `DocumentChunking`, `RecursiveChunking`
- `None` strategy doesn't cause errors
- Default `chunk_size` is unchanged when not overridden
- Propagated `chunk_size` actually affects chunking behavior
- Real subclass (`TextReader`) with custom `chunk_size`
