### PR TITLE
docs: add SECURITY.md security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+Thank you for helping keep Agno and its community safe.
+
+## Supported Versions
+
+As an open source project, security fixes are generally applied to the latest maintained release on the `main` branch. We encourage users to upgrade to the newest version before reporting or validating a fix.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest on `main` | :white_check_mark: |
+| Older releases | :x: |
+
+## Reporting a Vulnerability
+
+Please do **not** report security vulnerabilities through public GitHub issues, discussions, or pull requests.
+
+Instead, please report suspected vulnerabilities privately by emailing **security@agno.com** with the following information when possible:
+
+- A description of the issue and its potential impact
+- Steps to reproduce or a proof of concept
+- The affected version, commit, or deployment details
+- Any suggested mitigations or fixes
+
+We will acknowledge receipt of your report as soon as reasonably possible, review the issue, and work on a fix. We may ask for additional details to help us investigate.
+
+## Disclosure Process
+
+If your report is accepted as a security issue, we will aim to:
+
+1. Validate and assess the impact
+2. Develop and test a fix
+3. Coordinate disclosure and release timing
+4. Credit the reporter when appropriate and desired
+
+We ask that you keep vulnerability details private until a fix has been released and the maintainers have confirmed that public disclosure is safe.
+
+## Scope
+
+This policy applies to vulnerabilities in the Agno open source repository and code distributed from it. Third-party services, dependencies, and integrations may have their own security policies and disclosure processes.


### PR DESCRIPTION
## Summary
- add a repository root `SECURITY.md`
- document supported versions for security fixes
- provide a private vulnerability reporting process for the open source project

## Testing
- not applicable; documentation-only change