### PR TITLE
fix: handle msg_too_long in Slack streaming path

### DIFF
--- a/libs/agno/agno/os/interfaces/slack/router.py
+++ b/libs/agno/agno/os/interfaces/slack/router.py
@@ -41,6 +41,9 @@ _IGNORED_SUBTYPES = frozenset(
 # User-facing error message for failed requests
 _ERROR_MESSAGE = "Sorry, there was an error processing your message."
 
+# Slack caps streamed messages at ~40K chars; rotate before hitting the limit
+_STREAM_CHAR_LIMIT = 39000
+
 
 class SlackEventResponse(BaseModel):
     status: str = Field(default="ok")
@@ -333,6 +336,39 @@ def attach_routes(
                 buffer_size=buffer_size,
             )
 
+            async def _rotate_stream(pending_text: str = ""):
+                """Close current stream and open a new one, carrying over in-progress cards."""
+                nonlocal stream
+                assert stream is not None  # Caller only invokes after stream is opened
+                in_progress = [(k, v.title) for k, v in state.task_cards.items() if v.status == "in_progress"]
+                rotate_stop: Dict[str, Any] = {}
+                if state.task_cards:
+                    rotate_stop["chunks"] = state.resolve_all_pending("complete")
+                await stream.stop(**rotate_stop)
+                new_stream = await async_client.chat_stream(
+                    channel=ctx["channel_id"],
+                    thread_ts=ctx["thread_id"],
+                    recipient_team_id=team_id,
+                    recipient_user_id=user_id,
+                    task_display_mode=task_display_mode,
+                    buffer_size=buffer_size,
+                )
+                # Only mutate state after both async ops succeed
+                state.task_cards.clear()
+                state.stream_chars_sent = 0
+                stream = new_stream
+                # Re-open in-progress cards so the user sees continuity
+                for key, card_title in in_progress:
+                    state.track_task(key, card_title)
+                    await stream.append(
+                        markdown_text="",
+                        chunks=[{"type": "task_update", "id": key, "title": card_title, "status": "in_progress"}],
+                    )
+                if pending_text:
+                    continued = "_(continued)_\n" + pending_text
+                    await stream.append(markdown_text=continued)
+                    state.stream_chars_sent = len(continued)
+
             async for chunk in response_stream:
                 state.collect_media(chunk)
 
@@ -352,7 +388,13 @@ def attach_routes(
                         except Exception:
                             pass
 
-                    await stream.append(markdown_text=state.flush())
+                    content = state.flush()
+                    content_len = len(content)
+                    if state.stream_chars_sent + content_len <= _STREAM_CHAR_LIMIT:
+                        await stream.append(markdown_text=content)
+                        state.stream_chars_sent += content_len
+                    else:
+                        await _rotate_stream(content)
 
             # Default to complete when no terminal error/cancel event arrived
             final_status: Literal["in_progress", "complete", "error"] = state.terminal_status or "complete"
@@ -367,9 +409,17 @@ def attach_routes(
             await upload_response_media_async(async_client, state, ctx["channel_id"], ctx["thread_id"])
 
         except Exception as e:
-            log_error(
-                f"Error streaming slack response: {e} [channel={ctx['channel_id']}, thread={ctx['thread_id']}, user={user_id}]"
-            )
+            # Check structured response first (cheap); fall back to str(e) only if needed
+            slack_resp = getattr(e, "response", None)
+            slack_body = slack_resp.data if slack_resp else None
+            slack_error = slack_body.get("error", "") if isinstance(slack_body, dict) else ""
+            is_msg_too_long = "msg_too_long" in slack_error or "msg_blocks_too_long" in slack_error
+            if not is_msg_too_long:
+                is_msg_too_long = "msg_too_long" in str(e)
+            if not is_msg_too_long:
+                log_error(
+                    f"Error streaming slack response: {e} [channel={ctx['channel_id']}, thread={ctx['thread_id']}, user={user_id}]"
+                )
             try:
                 await async_client.assistant_threads_setStatus(
                     channel_id=ctx["channel_id"], thread_ts=ctx["thread_id"], status=""
@@ -381,16 +431,19 @@ def attach_routes(
                 try:
                     stop_kwargs_err: Dict[str, Any] = {}
                     if state.task_cards:
-                        stop_kwargs_err["chunks"] = state.resolve_all_pending("error")
+                        stop_kwargs_err["chunks"] = state.resolve_all_pending(
+                            "complete" if is_msg_too_long else "error"
+                        )
                     await stream.stop(**stop_kwargs_err)
                 except Exception:
                     pass
-            await send_slack_message_async(
-                async_client,
-                channel=ctx["channel_id"],
-                message=_ERROR_MESSAGE,
-                thread_ts=ctx["thread_id"],
-            )
+            if not is_msg_too_long:
+                await send_slack_message_async(
+                    async_client,
+                    channel=ctx["channel_id"],
+                    message=_ERROR_MESSAGE,
+                    thread_ts=ctx["thread_id"],
+                )
 
     async def _handle_thread_started(event: dict):
         from slack_sdk.web.async_client import AsyncWebClient

--- a/libs/agno/agno/os/interfaces/slack/state.py
+++ b/libs/agno/agno/os/interfaces/slack/state.py
@@ -56,6 +56,9 @@ class StreamState:
     # Set by handlers on terminal events; router reads this for the final flush
     terminal_status: Optional[TaskStatus] = None
 
+    # Total chars sent to the current Slack stream; reset on rotation
+    stream_chars_sent: int = 0
+
     def track_task(self, key: str, title: str) -> None:
         self.task_cards[key] = TaskCard(title=title)
 


### PR DESCRIPTION
## Summary
- Track cumulative text chars sent per Slack stream (`stream_chars_sent` on `StreamState`)
- When text approaches Slack's ~40K message limit (39K threshold), rotate to a new stream message
- `_rotate_stream()` closes the current stream cleanly, re-opens in-progress task cards in the new message, and prefixes with `_(continued)_`
- Detect `msg_too_long` / `msg_blocks_too_long` in the error handler to avoid showing a spurious error message when the stream already has visible content
- Mark task cards as "complete" (not "error") on `msg_too_long` since they ran successfully

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Formatted and validated (`format.sh` + `validate.sh`)
- [x] Tested E2E on Slack with queries that reproduce `msg_too_long` on main
- [x] Verified no content or task cards are dropped
- [x] Minimal diff: 2 files, ~65 lines added

## Test results

| Query | On main (no fix) | With fix |
|-------|-------------------|----------|
| "Trace full flow from Agent.run() to tool execution, every file path and line number" | `msg_too_long` crash, "Sorry, there was an error" | Completed successfully, 13 steps with all file paths |
| "Compare every model provider implementation" (11+ providers) | `msg_too_long` crash | Completed successfully, full comparison with class hierarchies |

## Context
PR #7208 fixed the primary cause of `msg_too_long` (duplicate member content in team streaming). This PR adds a safety net for the remaining case: single responses that naturally exceed ~40K chars (detailed code traces, exhaustive comparisons).