### PR TITLE
[fix] handle Wikipedia DisambiguationError and add configurable auto_suggest

### DIFF
--- a/libs/agno/agno/tools/wikipedia.py
+++ b/libs/agno/agno/tools/wikipedia.py
@@ -5,18 +5,26 @@ from agno.knowledge.document import Document
 from agno.knowledge.knowledge import Knowledge
 from agno.knowledge.reader.wikipedia_reader import WikipediaReader
 from agno.tools import Toolkit
-from agno.utils.log import log_debug, log_info
+from agno.utils.log import log_debug, log_error, log_info
+
+try:
+    import wikipedia
+    from wikipedia.exceptions import DisambiguationError
+except ImportError:
+    raise ImportError("The `wikipedia` package is not installed. Please install it via `pip install wikipedia`.")
 
 
 class WikipediaTools(Toolkit):
     def __init__(
         self,
         knowledge: Optional[Knowledge] = None,
+        auto_suggest: bool = True,
         all: bool = False,
         **kwargs,
     ):
         tools = []
 
+        self.auto_suggest = auto_suggest
         self.knowledge: Optional[Knowledge] = knowledge
         if self.knowledge is not None and isinstance(self.knowledge, Knowledge):
             tools.append(self.search_wikipedia_and_update_knowledge_base)
@@ -40,7 +48,7 @@ class WikipediaTools(Toolkit):
         log_debug(f"Adding to knowledge: {topic}")
         self.knowledge.insert(
             topics=[topic],
-            reader=WikipediaReader(),
+            reader=WikipediaReader(auto_suggest=self.auto_suggest),
         )
         log_debug(f"Searching knowledge: {topic}")
         relevant_docs: List[Document] = self.knowledge.search(query=topic)
@@ -52,12 +60,12 @@ class WikipediaTools(Toolkit):
         :param query: The query to search for.
         :return: Relevant documents from wikipedia.
         """
-        try:
-            import wikipedia  # noqa: F401
-        except ImportError:
-            raise ImportError(
-                "The `wikipedia` package is not installed. Please install it via `pip install wikipedia`."
-            )
-
         log_info(f"Searching wikipedia for: {query}")
-        return json.dumps(Document(name=query, content=wikipedia.summary(query)).to_dict())
+        try:
+            content = wikipedia.summary(query, auto_suggest=self.auto_suggest)
+            return json.dumps(Document(name=query, content=content).to_dict())
+        except DisambiguationError as e:
+            return json.dumps({"disambiguation": query, "options": e.options})
+        except Exception as e:
+            log_error(f"Error searching Wikipedia for '{query}': {e}")
+            return json.dumps({"error": str(e)})

--- a/libs/agno/tests/unit/tools/test_wikipedia.py
+++ b/libs/agno/tests/unit/tools/test_wikipedia.py
@@ -1,0 +1,75 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+wikipedia = pytest.importorskip("wikipedia")
+
+from wikipedia.exceptions import DisambiguationError, PageError  # noqa: E402
+
+from agno.tools.wikipedia import WikipediaTools  # noqa: E402
+
+
+def test_init_defaults():
+    tools = WikipediaTools()
+    assert tools.auto_suggest is True
+    assert tools.knowledge is None
+
+
+def test_init_auto_suggest_false():
+    tools = WikipediaTools(auto_suggest=False)
+    assert tools.auto_suggest is False
+
+
+def test_search_happy_path():
+    tools = WikipediaTools()
+    with patch("wikipedia.summary", return_value="Nvidia Corporation is a technology company.") as mock_summary:
+        result = tools.search_wikipedia("Nvidia")
+        data = json.loads(result)
+        assert data["name"] == "Nvidia"
+        assert "Nvidia Corporation" in data["content"]
+        mock_summary.assert_called_once_with("Nvidia", auto_suggest=True)
+
+
+def test_search_auto_suggest_false_passed_through():
+    tools = WikipediaTools(auto_suggest=False)
+    with patch("wikipedia.summary", return_value="Test content") as mock_summary:
+        tools.search_wikipedia("Test")
+        mock_summary.assert_called_once_with("Test", auto_suggest=False)
+
+
+def test_search_disambiguation_error():
+    tools = WikipediaTools()
+    error = DisambiguationError("Nvidia", ["Nvidia Corporation", "Nvidia Shield", "Nvidia Tegra"])
+    with patch("wikipedia.summary", side_effect=error):
+        result = tools.search_wikipedia("Nvidia")
+        data = json.loads(result)
+        assert data["disambiguation"] == "Nvidia"
+        assert "Nvidia Corporation" in data["options"]
+        assert len(data["options"]) == 3
+
+
+def test_search_page_error():
+    tools = WikipediaTools()
+    with patch("wikipedia.summary", side_effect=PageError(pageid="nonexistent_page_xyz")):
+        result = tools.search_wikipedia("nonexistent_page_xyz")
+        data = json.loads(result)
+        assert "error" in data
+
+
+def test_search_generic_exception():
+    tools = WikipediaTools()
+    with patch("wikipedia.summary", side_effect=ConnectionError("network down")):
+        result = tools.search_wikipedia("Test")
+        data = json.loads(result)
+        assert "network down" in data["error"]
+
+
+def test_disambiguation_returns_all_options():
+    many_options = [f"Option {i}" for i in range(30)]
+    tools = WikipediaTools()
+    error = DisambiguationError("Mercury", many_options)
+    with patch("wikipedia.summary", side_effect=error):
+        result = tools.search_wikipedia("Mercury")
+        data = json.loads(result)
+        assert len(data["options"]) == 30


### PR DESCRIPTION
## Summary

- Fix `WikipediaTools.search_wikipedia` crashing on ambiguous queries by handling `DisambiguationError` — returns structured JSON with disambiguation options so the LLM can retry with the correct article
- Add configurable `auto_suggest` parameter (default `True`, matching the `wikipedia` SDK default) so users can disable auto-suggest when it mangles proper nouns (e.g. "Nvidia" → "nida")
- Pass `auto_suggest` through to `WikipediaReader` in the knowledge-backed path for consistency
- Move `wikipedia` import to top level, matching codebase pattern (cartesia, elevenlabs, youtube, etc.)
- Add unit tests for all error paths

## Changes

### `libs/agno/agno/tools/wikipedia.py`

**Problem:** `wikipedia.summary(query)` uses `auto_suggest=True` by default. The Wikipedia suggestion API mangles proper nouns (e.g. "Nvidia" → "nida"), causing `DisambiguationError`. The method had zero error handling — any exception crashed the tool call.

**Fix:**
- Add `auto_suggest: bool = True` constructor parameter — configurable, backward-compatible default matching the SDK
- Catch `DisambiguationError` — return all disambiguation options as JSON so the LLM can pick the correct article
- Catch generic `Exception` — log via `logger.error` and return structured error JSON
- Pass `auto_suggest` to `WikipediaReader` in the knowledge path
- Move `import wikipedia` to top level (was redundantly inside the method — `WikipediaReader` already imports it at module level)

### `libs/agno/tests/unit/tools/test_wikipedia.py` (new)

8 unit tests covering: init defaults, `auto_suggest` passthrough, happy path, disambiguation error, page error, generic exception, and all-options disambiguation.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test Plan

- [x] `pytest libs/agno/tests/unit/tools/test_wikipedia.py` — 8/8 pass
- [x] `ruff format` — all files unchanged
- [x] `ruff check` — all checks passed
- [x] `mypy` — no issues