### PR TITLE
fix(workflow): guard _store_executor_response against None active_executor_run_response

### DIFF
--- a/libs/agno/agno/workflow/step.py
+++ b/libs/agno/agno/workflow/step.py
@@ -995,7 +995,7 @@ class Step:
                         if run_context is None and session_state is not None:
                             merge_dictionaries(session_state, session_state_copy)
 
-                        if store_executor_outputs and workflow_run_response is not None:
+                        if store_executor_outputs and workflow_run_response is not None and active_executor_run_response is not None:
                             self._store_executor_response(workflow_run_response, active_executor_run_response)  # type: ignore
 
                         # Check if agent/team response is paused (e.g., due to tool HITL)
@@ -1564,7 +1564,7 @@ class Step:
                         if run_context is None and session_state is not None:
                             merge_dictionaries(session_state, session_state_copy)
 
-                        if store_executor_outputs and workflow_run_response is not None:
+                        if store_executor_outputs and workflow_run_response is not None and active_executor_run_response is not None:
                             self._store_executor_response(workflow_run_response, active_executor_run_response)  # type: ignore
 
                         # Check if agent/team response is paused (e.g., due to tool HITL)


### PR DESCRIPTION
## Problem

When a `Workflow` step wraps a `Team` and the Team's async stream ends without yielding a `RunOutput` or `TeamRunOutput` (e.g. the Team emits a `TeamRunErrorEvent` instead), `active_executor_run_response` stays `None`.

The subsequent `_store_executor_response` call is not guarded against `None`:

```python
# execute_stream / aexecute_stream — current code
if store_executor_outputs and workflow_run_response is not None:
    self._store_executor_response(workflow_run_response, active_executor_run_response)
#                                                        ^^^^ can be None → AttributeError
```

This crashes with `AttributeError: 'NoneType' object has no attribute 'parent_run_id'` and also **masks the original Team error** entirely — the user never sees why the Team failed.

Reproducible with `gpt-5.4` as the Team leader model; does not occur with `gpt-4o`.

## Fix

Add `and active_executor_run_response is not None` to the guard in `execute_stream` and `aexecute_stream` (the two streaming code paths that accumulate `active_executor_run_response` from the stream, rather than receiving it as a direct return value):

```python
if store_executor_outputs and workflow_run_response is not None and active_executor_run_response is not None:
    self._store_executor_response(workflow_run_response, active_executor_run_response)
```

The non-streaming `execute` / `aexecute` paths at lines 701 and 1276 use the local `response` loop variable (set by the executor's direct return) which is not `None` in the same way, so those are left unchanged.

Note: The surrounding `is_paused` check already correctly guards `active_executor_run_response is not None` (line 1004) — this PR brings the `_store_executor_response` call just above it to the same standard.

Fixes #7185

## Test plan

- [ ] Reproduce #7185: `Workflow` with a `Team` step where the Team yields a `TeamRunErrorEvent` instead of `TeamRunOutput` — should no longer raise `AttributeError` and should propagate cleanly
- [ ] Existing workflow/step tests should be unaffected