### PR TITLE
fix(workflow): guard _store_executor_response when executor yields no RunOutput

### DIFF
--- a/libs/agno/agno/workflow/step.py
+++ b/libs/agno/agno/workflow/step.py
@@ -995,7 +995,7 @@ class Step:
                         if run_context is None and session_state is not None:
                             merge_dictionaries(session_state, session_state_copy)
 
-                        if store_executor_outputs and workflow_run_response is not None:
+                        if store_executor_outputs and workflow_run_response is not None and active_executor_run_response is not None:
                             self._store_executor_response(workflow_run_response, active_executor_run_response)  # type: ignore
 
                         # Check if agent/team response is paused (e.g., due to tool HITL)
@@ -1564,7 +1564,7 @@ class Step:
                         if run_context is None and session_state is not None:
                             merge_dictionaries(session_state, session_state_copy)
 
-                        if store_executor_outputs and workflow_run_response is not None:
+                        if store_executor_outputs and workflow_run_response is not None and active_executor_run_response is not None:
                             self._store_executor_response(workflow_run_response, active_executor_run_response)  # type: ignore
 
                         # Check if agent/team response is paused (e.g., due to tool HITL)


### PR DESCRIPTION
## Summary

Fixes #7185 — workflow crashes with `AttributeError: 'NoneType' object has no attribute 'parent_run_id'` when a Team executor emits a `TeamRunErrorEvent` instead of a `TeamRunOutput`.

**Root cause:** In both the sync `execute_stream` and async `aexecute_stream` streaming paths, `active_executor_run_response` is initialized to `None` and only set when the executor yields a `RunOutput` or `TeamRunOutput`:

```python
active_executor_run_response = None
async for event in response_stream:
    if isinstance(event, RunOutput) or isinstance(event, TeamRunOutput):
        active_executor_run_response = event
        break
    ...  # TeamRunErrorEvent falls through without setting the variable
```

If the executor (e.g. a Team using `gpt-5.4`) encounters an error and yields only a `TeamRunErrorEvent`, the loop exits with `active_executor_run_response` still `None`. The next line unconditionally calls `_store_executor_response(workflow_run_response, None)`, which crashes at:

```python
executor_run_response.parent_run_id = workflow_run_response.run_id  # AttributeError: NoneType
```

**Fix:** Add `active_executor_run_response is not None` to the guard condition before calling `_store_executor_response`, consistent with the adjacent `is_paused` check which already guards against `None`:

```python
# Before
if store_executor_outputs and workflow_run_response is not None:
    self._store_executor_response(workflow_run_response, active_executor_run_response)

# After
if store_executor_outputs and workflow_run_response is not None and active_executor_run_response is not None:
    self._store_executor_response(workflow_run_response, active_executor_run_response)
```

Applied to both the sync streaming path (line ~999) and the async streaming path (line ~1568).

## Test plan

- [ ] Reproduce #7185 with `gpt-5.4` team leader + workflow — verify no `AttributeError`
- [ ] Verify normal workflow execution (team yields `TeamRunOutput`) is unaffected
- [ ] Verify `max_retries` retry logic still fires on error (workflow continues after the guard)