### PR TITLE
fix: lazy sandbox initialization in E2BTools

### DIFF
--- a/libs/agno/agno/tools/e2b.py
+++ b/libs/agno/agno/tools/e2b.py
@@ -41,15 +41,9 @@ class E2BTools(Toolkit):
         if not self.api_key:
             raise ValueError("E2B_API_KEY not set. Please set the E2B_API_KEY environment variable.")
 
-        # Create the sandbox once and reuse it
         self.sandbox_options = sandbox_options or {}
-
-        # According to official docs, the parameter is 'timeout' (in seconds), not 'timeout_ms'
-        try:
-            self.sandbox = Sandbox.create(api_key=self.api_key, timeout=timeout, **self.sandbox_options)
-        except Exception as e:
-            logger.error(f"Warning: Could not create sandbox: {e}")
-            raise e
+        self._timeout = timeout
+        self._sandbox: Optional[Any] = None  # created lazily on first tool call
 
         # Last execution result for reference
         self.last_execution = None
@@ -84,6 +78,44 @@ class E2BTools(Toolkit):
         ]
 
         super().__init__(name="e2b_tools", tools=tools, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Lazy sandbox access
+    # ------------------------------------------------------------------
+
+    @property
+    def sandbox(self) -> Any:
+        """Return the sandbox, creating it on first access (lazy init)."""
+        if self._sandbox is None:
+            try:
+                self._sandbox = Sandbox.create(
+                    api_key=self.api_key,
+                    timeout=self._timeout,
+                    **self.sandbox_options,
+                )
+                logger.debug("E2B sandbox created: %s", self._sandbox.id)
+            except Exception as e:
+                logger.error("Could not create E2B sandbox: %s", e)
+                raise
+        return self._sandbox
+
+    def close(self) -> str:
+        """Kill the sandbox if it was ever started. Safe to call multiple times."""
+        if self._sandbox is not None:
+            try:
+                self._sandbox.kill()
+                logger.debug("E2B sandbox killed.")
+            except Exception as e:
+                return f"Error killing sandbox: {e}"
+            finally:
+                self._sandbox = None
+        return "Sandbox closed (or was never started)."
+
+    def __enter__(self) -> "E2BTools":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()
 
     # Code Execution Functions
     def run_python_code(self, code: str) -> str:

--- a/libs/agno/tests/unit/tools/test_e2b_lazy_init.py
+++ b/libs/agno/tests/unit/tools/test_e2b_lazy_init.py
@@ -1,0 +1,91 @@
+"""Unit tests for E2BTools lazy sandbox initialization (issue #7215)."""
+
+import sys
+from importlib import reload
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — no sandbox created at construction time
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_init_no_sandbox_on_import():
+    """Sandbox.create must NOT be called when E2BTools is merely instantiated."""
+    mock_sandbox = MagicMock()
+    mock_sandbox.id = "sbx-1"
+    mock_create = MagicMock(return_value=mock_sandbox)
+
+    mock_e2b_module = MagicMock()
+    mock_e2b_module.Sandbox = MagicMock(create=mock_create)
+
+    with patch.dict("sys.modules", {"e2b_code_interpreter": mock_e2b_module}):
+        import agno.tools.e2b as e2b_module
+
+        reload(e2b_module)
+
+        _tools = e2b_module.E2BTools(api_key="fake-key")
+
+    # The sandbox factory must not have been called yet
+    mock_create.assert_not_called(), "Sandbox.create was called eagerly — lazy init broken!"
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — sandbox created only when a tool method is first called
+# ---------------------------------------------------------------------------
+
+
+def test_lazy_init_sandbox_created_on_use():
+    """Sandbox.create must be called exactly once, on first tool-method access."""
+    mock_sandbox = MagicMock()
+    mock_sandbox.id = "sbx-lazy"
+    mock_sandbox.run_code.return_value = MagicMock(error=None, results=[], logs="")
+    mock_create = MagicMock(return_value=mock_sandbox)
+
+    mock_e2b_module = MagicMock()
+    mock_e2b_module.Sandbox = MagicMock(create=mock_create)
+
+    with patch.dict("sys.modules", {"e2b_code_interpreter": mock_e2b_module}):
+        import agno.tools.e2b as e2b_module
+
+        reload(e2b_module)
+
+        tools = e2b_module.E2BTools(api_key="fake-key")
+
+        # Still not created after construction
+        mock_create.assert_not_called()
+
+        # Trigger first tool call via sandbox property
+        _ = tools.sandbox
+
+    # Now it must have been created exactly once
+    mock_create.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — close() skips kill if sandbox was never started
+# ---------------------------------------------------------------------------
+
+
+def test_close_skips_kill_when_sandbox_never_started():
+    """close() must not call Sandbox.create or sandbox.kill if no tool was ever called."""
+    mock_sandbox = MagicMock()
+    mock_sandbox.id = "sbx-3"
+    mock_create = MagicMock(return_value=mock_sandbox)
+
+    mock_e2b_module = MagicMock()
+    mock_e2b_module.Sandbox = MagicMock(create=mock_create)
+
+    with patch.dict("sys.modules", {"e2b_code_interpreter": mock_e2b_module}):
+        import agno.tools.e2b as e2b_module
+
+        reload(e2b_module)
+
+        tools = e2b_module.E2BTools(api_key="fake-key")
+        result = tools.close()
+
+    # Sandbox was never created — close() should be a no-op
+    mock_create.assert_not_called()
+    assert "never started" in result or "closed" in result.lower()


### PR DESCRIPTION
Fixes #7215.

`E2BTools.__init__` was calling `Sandbox.create()` immediately, spinning up a live E2B container before any tool was ever invoked. This caused wasted sandboxes on startup, duplicate containers on process restarts, and broke AgentOS deployments where agents are constructed eagerly at boot time.

**What changed:**

- Removed `Sandbox.create()` from `__init__`; sandbox is now created lazily via a `@property` on first access (`self.sandbox`).
- Stored `timeout` as `self._timeout`; backing field is `self._sandbox = None`.
- Added `close()` method (and `__enter__`/`__exit__`) so callers can explicitly kill the sandbox and avoid leaks. `close()` is safe to call even if no tool was ever used.
- Zero changes to any tool method signatures — all existing `self.sandbox.*` calls work transparently through the property.

**Testing:** Added `libs/agno/tests/unit/tools/test_e2b_lazy_init.py` with 3 unit tests (mock `Sandbox.create`):
- `test_lazy_init_no_sandbox_on_import` — no sandbox created at construction time
- `test_lazy_init_sandbox_created_on_use` — sandbox created exactly once on first tool access
- `test_close_skips_kill_when_sandbox_never_started` — close() is a no-op if sandbox was never used