### PR TITLE
fix: exclude interface routes from JWT middleware

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -874,6 +874,28 @@ class AgentOS:
         )
         fastapi_app.state.jwt_validator = jwt_validator
 
+        # Collect interface route prefixes to exclude from JWT auth.
+        # Interfaces use their own authentication mechanisms
+        # (e.g. Slack HMAC-SHA256 signing, Telegram webhook verification).
+        excluded_route_paths: Optional[List[str]] = None
+        if self.interfaces:
+            interface_prefixes = [
+                f"{interface.prefix}/*"
+                for interface in self.interfaces
+                if hasattr(interface, "prefix") and interface.prefix
+            ]
+            if interface_prefixes:
+                # Passing excluded_route_paths replaces the middleware defaults,
+                # so include the default excluded routes as well.
+                excluded_route_paths = [
+                    "/",
+                    "/health",
+                    "/docs",
+                    "/redoc",
+                    "/openapi.json",
+                    "/docs/oauth2-redirect",
+                ] + interface_prefixes
+
         # Add middleware to stack
         fastapi_app.add_middleware(
             JWTMiddleware,
@@ -882,6 +904,7 @@ class AgentOS:
             algorithm=algorithm,
             authorization=self.authorization,
             verify_audience=verify_audience,
+            excluded_route_paths=excluded_route_paths,
         )
 
     def get_routes(self) -> List[Any]:


### PR DESCRIPTION
## Summary

When `AgentOS(authorization=True)` is set, the JWT middleware rejects all webhook deliveries from interfaces like Slack with 401. Slack uses HMAC-SHA256 signing (`X-Slack-Signature`), not JWT Bearer tokens — there is no way to make Slack send a JWT.

This fix collects route prefixes from registered interfaces (e.g. `/slack/*`, `/telegram/*`, `/whatsapp/*`, `/a2a/*`) and passes them as `excluded_route_paths` to `JWTMiddleware`, so the middleware skips JWT validation for those routes and lets each interface's own auth mechanism handle verification.

**Root cause:** `_add_jwt_middleware()` in `agno/os/app.py` did not pass `excluded_route_paths` to `JWTMiddleware`. The default excluded routes only covered `/`, `/health`, `/docs`, `/redoc`, `/openapi.json`, and `/docs/oauth2-redirect` — no interface routes.

**How it works:**
- Iterates `self.interfaces`, building fnmatch glob patterns like `/slack/*` from each interface's `prefix` attribute
- Only includes interfaces with a non-empty `prefix` (AGUI with empty prefix continues using JWT)
- Since passing `excluded_route_paths` replaces middleware defaults, the default exclusions are included in the list
- If no interfaces are registered, `excluded_route_paths` stays `None` — zero behavior change

No changes to `JWTMiddleware` itself — it already supports `excluded_route_paths` with fnmatch patterns.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Affects any AgentOS deployment using both `authorization=True` and an interface (Slack, Telegram, WhatsApp, A2A). Without this fix, no workaround exists short of patching AgentOS or manually constructing the middleware.