### PR TITLE
fix: improve /info endpoint auth bypass and response model

### DIFF
--- a/libs/agno/agno/os/middleware/jwt.py
+++ b/libs/agno/agno/os/middleware/jwt.py
@@ -521,6 +521,7 @@ class JWTMiddleware(BaseHTTPMiddleware):
         return [
             "/",
             "/health",
+            "/info",
             "/docs",
             "/redoc",
             "/openapi.json",

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -16,6 +16,7 @@ from agno.os.schema import (
     AgentSummaryResponse,
     BadRequestResponse,
     ConfigResponse,
+    InfoResponse,
     InterfaceResponse,
     InternalServerErrorResponse,
     Model,
@@ -246,23 +247,14 @@ def get_info_router(os: "AgentOS") -> APIRouter:
         operation_id="get_info",
         summary="Get OS Info",
         description="Return lightweight, unauthenticated metadata about this AgentOS instance.",
-        responses={
-            200: {
-                "description": "OS info retrieved successfully",
-                "content": {
-                    "application/json": {
-                        "example": {"agent_count": 2, "team_count": 1, "workflow_count": 0}
-                    }
-                },
-            }
-        },
+        response_model=InfoResponse,
     )
-    async def get_info() -> dict:
-        return {
-            "agent_count": len(os.agents) if os.agents else 0,
-            "team_count": len(os.teams) if os.teams else 0,
-            "workflow_count": len(os.workflows) if os.workflows else 0,
-        }
+    async def get_info() -> InfoResponse:
+        return InfoResponse(
+            agent_count=len(os.agents or []),
+            team_count=len(os.teams or []),
+            workflow_count=len(os.workflows or []),
+        )
 
     return router
 

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -148,6 +148,14 @@ class WorkflowSummaryResponse(BaseModel):
         )
 
 
+class InfoResponse(BaseModel):
+    """Response schema for the /info endpoint returning lightweight OS metadata."""
+
+    agent_count: int = Field(0, description="Number of agents registered in the OS")
+    team_count: int = Field(0, description="Number of teams registered in the OS")
+    workflow_count: int = Field(0, description="Number of workflows registered in the OS")
+
+
 class ConfigResponse(BaseModel):
     """Response schema for the general config endpoint"""
 


### PR DESCRIPTION
## Summary

Follow-up improvements to #7190 (`/info` endpoint):

1. **Add `/info` to JWT middleware excluded routes** — The endpoint is intended to be unauthenticated (like `/health`), but was missing from `_get_default_excluded_routes()`, so it would be blocked when authorization is enabled.
2. **Use a proper Pydantic response model** — Replace raw `dict` return with `InfoResponse` model for OpenAPI schema accuracy and consistency with the rest of the API.
3. **Clean up null handling** — Replace `len(x) if x else 0` with `len(x or [])` to handle both `None` and empty lists cleanly.

## Type of change

- [x] Bug fix
- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Follow-up to #7190. The `/info` route is already re-attached during resync via `_add_built_in_routes`, so no additional changes were needed there.