### PR TITLE
fix: use array::first() for SurrealDB trace session stats

### DIFF
--- a/libs/agno/agno/db/surrealdb/surrealdb.py
+++ b/libs/agno/agno/db/surrealdb/surrealdb.py
@@ -1764,10 +1764,10 @@ class SurrealDb(BaseDb):
             query = dedent(f"""
                 SELECT
                     session_id,
-                    math::max(user_id) AS user_id,
-                    math::max(agent_id) AS agent_id,
-                    math::max(team_id) AS team_id,
-                    math::max(workflow_id) AS workflow_id,
+                    array::first(user_id) AS user_id,
+                    array::first(agent_id) AS agent_id,
+                    array::first(team_id) AS team_id,
+                    array::first(workflow_id) AS workflow_id,
                     count() AS total_traces,
                     time::min(created_at) AS first_trace_at,
                     time::max(created_at) AS last_trace_at


### PR DESCRIPTION
## Summary

Fixes the SurrealDB adapter for `get_trace_stats` to correctly group by `session_id` only, matching the fix in #7243.

`math::max()` is numeric-only in SurrealDB and silently returns `None` for string fields (`user_id`, `agent_id`, `team_id`, `workflow_id`). This uses `array::first()` instead — when SurrealDB groups rows, non-aggregated fields become arrays, and `array::first()` picks the first element. This mirrors MongoDB's `$first` behavior.

Related: #7243

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

PR #7243 changed all DB adapters to `GROUP BY session_id` only, using `MAX()` for the string fields. This works for SQL databases but breaks SurrealDB where `math::max()` is numeric-only. This PR provides the correct SurrealDB-native fix using `array::first()`.