### PR TITLE
fix: reject SAS token mixed with partial SP credentials in AzureBlobConfig

### DIFF
--- a/libs/agno/agno/knowledge/loaders/azure_blob.py
+++ b/libs/agno/agno/knowledge/loaders/azure_blob.py
@@ -154,8 +154,8 @@ class AzureBlobLoader(BaseLoader):
     ):
         """Load content from Azure Blob Storage (async).
 
-        Requires the AzureBlobConfig to contain tenant_id, client_id, client_secret,
-        storage_account, and container.
+        Requires a valid AzureBlobConfig with either Service Principal credentials
+        or a SAS token, plus storage_account and container.
 
         Uses the async Azure SDK to avoid blocking the event loop.
         """
@@ -300,8 +300,8 @@ class AzureBlobLoader(BaseLoader):
     ):
         """Load content from Azure Blob Storage (sync).
 
-        Requires the AzureBlobConfig to contain tenant_id, client_id, client_secret,
-        storage_account, and container.
+        Requires a valid AzureBlobConfig with either Service Principal credentials
+        or a SAS token, plus storage_account and container.
         """
         remote_content: AzureBlobContent = cast(AzureBlobContent, content.remote_content)
         azure_config = self._validate_azure_config(content, config)

--- a/libs/agno/agno/knowledge/remote_content/azure_blob.py
+++ b/libs/agno/agno/knowledge/remote_content/azure_blob.py
@@ -71,7 +71,12 @@ class AzureBlobConfig(BaseStorageConfig):
                 "Provide either Service Principal credentials (tenant_id, client_id, client_secret) "
                 "or a sas_token, not both."
             )
-        if has_partial_sp and not has_sas:
+        if has_partial_sp:
+            if has_sas:
+                raise ValueError(
+                    "Provide either a sas_token or complete Service Principal credentials "
+                    "(tenant_id, client_id, client_secret), not a mix of both."
+                )
             raise ValueError(
                 "Incomplete Service Principal credentials: all of tenant_id, client_id, and client_secret are required."
             )

--- a/libs/agno/tests/unit/knowledge/test_remote_content_config.py
+++ b/libs/agno/tests/unit/knowledge/test_remote_content_config.py
@@ -520,6 +520,19 @@ def test_azure_blob_config_both_auth_methods_raises():
         )
 
 
+def test_azure_blob_config_sas_with_partial_sp_raises():
+    """Test that providing SAS token with partial SP credentials raises ValidationError."""
+    with pytest.raises(ValidationError, match="not a mix"):
+        AzureBlobConfig(
+            id="azure-source",
+            name="Azure",
+            sas_token="sv=2024-11-04&sr=c&sig=abc",
+            tenant_id="tenant-123",
+            storage_account="mystorageaccount",
+            container="mycontainer",
+        )
+
+
 def test_azure_blob_config_partial_sp_raises():
     """Test that providing incomplete SP credentials raises ValidationError."""
     with pytest.raises(ValidationError, match="Incomplete Service Principal"):


### PR DESCRIPTION
## Summary

- Fix validation bug where `sas_token` + partial Service Principal fields (e.g. only `tenant_id`) silently passed validation, ignoring the stray SP fields
- Update stale docstrings in `AzureBlobLoader` that still referenced only SP auth
- Add test for the mixed SAS + partial SP edge case

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)