### PR TITLE
[fix] Guard against None executor_run_response in Step._store_executor_response

### DIFF
--- a/libs/agno/agno/workflow/step.py
+++ b/libs/agno/agno/workflow/step.py
@@ -995,7 +995,11 @@ class Step:
                         if run_context is None and session_state is not None:
                             merge_dictionaries(session_state, session_state_copy)
 
-                        if store_executor_outputs and workflow_run_response is not None and active_executor_run_response is not None:
+                        if (
+                            store_executor_outputs
+                            and workflow_run_response is not None
+                            and active_executor_run_response is not None
+                        ):
                             self._store_executor_response(workflow_run_response, active_executor_run_response)  # type: ignore
 
                         # Check if agent/team response is paused (e.g., due to tool HITL)
@@ -1564,7 +1568,11 @@ class Step:
                         if run_context is None and session_state is not None:
                             merge_dictionaries(session_state, session_state_copy)
 
-                        if store_executor_outputs and workflow_run_response is not None and active_executor_run_response is not None:
+                        if (
+                            store_executor_outputs
+                            and workflow_run_response is not None
+                            and active_executor_run_response is not None
+                        ):
                             self._store_executor_response(workflow_run_response, active_executor_run_response)  # type: ignore
 
                         # Check if agent/team response is paused (e.g., due to tool HITL)

--- a/libs/agno/tests/unit/workflow/test_step_none_executor_response.py
+++ b/libs/agno/tests/unit/workflow/test_step_none_executor_response.py
@@ -17,7 +17,6 @@ import pytest
 from agno.workflow.step import Step
 from agno.workflow.types import StepInput, StepOutput
 
-
 # =============================================================================
 # Helpers
 # =============================================================================
@@ -95,11 +94,7 @@ class TestStoreExecutorResponseNoneGuard:
             mock_executor_response = MagicMock()
             store_executor_outputs = True
 
-            if (
-                store_executor_outputs
-                and mock_workflow_response is not None
-                and mock_executor_response is not None
-            ):
+            if store_executor_outputs and mock_workflow_response is not None and mock_executor_response is not None:
                 step._store_executor_response(mock_workflow_response, mock_executor_response)
 
             mock_store.assert_called_once_with(mock_workflow_response, mock_executor_response)
@@ -113,11 +108,7 @@ class TestStoreExecutorResponseNoneGuard:
             mock_executor_response = MagicMock()
             store_executor_outputs = False
 
-            if (
-                store_executor_outputs
-                and mock_workflow_response is not None
-                and mock_executor_response is not None
-            ):
+            if store_executor_outputs and mock_workflow_response is not None and mock_executor_response is not None:
                 step._store_executor_response(mock_workflow_response, mock_executor_response)
 
             mock_store.assert_not_called()
@@ -131,11 +122,7 @@ class TestStoreExecutorResponseNoneGuard:
             mock_executor_response = MagicMock()
             store_executor_outputs = True
 
-            if (
-                store_executor_outputs
-                and mock_workflow_response is not None
-                and mock_executor_response is not None
-            ):
+            if store_executor_outputs and mock_workflow_response is not None and mock_executor_response is not None:
                 step._store_executor_response(mock_workflow_response, mock_executor_response)
 
             mock_store.assert_not_called()


### PR DESCRIPTION
## Summary

When the executor stream ends without yielding a `RunOutput`/`TeamRunOutput` (e.g., API timeout, silent Team error yielding `TeamRunErrorEvent` instead of `TeamRunOutput`), `active_executor_run_response` remains `None`. Passing it to `_store_executor_response` causes:

```
AttributeError: 'NoneType' object has no attribute 'parent_run_id'
```

This PR adds a `None` check on the executor response in all 4 call sites (`execute`, `execute_stream`, `aexecute`, `aexecute_stream`) before calling `_store_executor_response`.

Fixes #7185
Related: #5451, #5379

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**AI Disclosure:** This PR was created with assistance from Claude Code. The changes have been reviewed, tested (`ruff format`, `ruff check`, `mypy`, `pytest` — all passing), and the author understands the fix.

**Context:** We hit this bug in production with Anthropic API timeouts (agno 2.5.11). We've been running a [monkey-patch workaround](https://github.com/BossaBox-Labs/factor-os-agno/pull/18) successfully. This PR is the proper upstream fix.

**Regarding issue assignment:** I commented on #7185 before opening this PR. The previous PR (#7281) was auto-closed by the triage bot because the issue was assigned. I'm resubmitting with tests, formatting, and proper PR template as requested by CONTRIBUTING.md.

**Changes:**
- `libs/agno/agno/workflow/step.py` — Added `and response is not None` / `and active_executor_run_response is not None` to all 4 call sites (lines 701, 998, 1276, 1568)
- `libs/agno/tests/unit/workflow/test_step_none_executor_response.py` — 5 unit tests covering the guard condition