### PR TITLE
[fix] correct SurrealDB flexible field syntax

### DIFF
--- a/libs/agno/agno/vectordb/surrealdb/surrealdb.py
+++ b/libs/agno/agno/vectordb/surrealdb/surrealdb.py
@@ -27,7 +27,7 @@ class SurrealDb(VectorDb):
         DEFINE TABLE IF NOT EXISTS {collection} SCHEMAFUL;
         DEFINE FIELD IF NOT EXISTS content ON {collection} TYPE string;
         DEFINE FIELD IF NOT EXISTS embedding ON {collection} TYPE array<float>;
-        DEFINE FIELD IF NOT EXISTS meta_data ON {collection} FLEXIBLE TYPE object;
+        DEFINE FIELD IF NOT EXISTS meta_data ON {collection} TYPE object FLEXIBLE;
         DEFINE INDEX IF NOT EXISTS vector_idx ON {collection} FIELDS embedding HNSW DIMENSION {dimensions} DIST {distance};
     """
 

--- a/libs/agno/tests/unit/vectordb/test_surrealdb.py
+++ b/libs/agno/tests/unit/vectordb/test_surrealdb.py
@@ -123,6 +123,7 @@ def test_create(surrealdb_vector, mock_surrealdb_client):
         assert "DEFINE TABLE IF NOT EXISTS test_collection" in args
         assert "DEFINE INDEX IF NOT EXISTS vector_idx" in args
         assert f"DIMENSION {surrealdb_vector.dimensions}" in args
+        assert "DEFINE FIELD IF NOT EXISTS meta_data ON test_collection TYPE object FLEXIBLE;" in args
 
 
 def test_exists(surrealdb_vector, mock_surrealdb_client):


### PR DESCRIPTION
fixes #7292

## Summary
- move the `FLEXIBLE` modifier after `TYPE object` in the SurrealDB table definition for `meta_data`
- lock the expected schema string into the unit test so future refactors keep the SurrealDB-compatible clause order

## Testing
- `PYTHONPATH=. python -m pytest tests/unit/vectordb/test_surrealdb.py` (from `libs/agno` in a minimal throwaway venv)
- `ruff check agno/vectordb/surrealdb/surrealdb.py tests/unit/vectordb/test_surrealdb.py`

## Notes
- `./scripts/validate.sh` returned success in this checkout, but it also printed missing local `ruff`/`mypy` commands for repo-wide validation. I did not claim that as a real green full-validate signal.
