### PR TITLE
fix: add thread-aware messaging instructions to SlackTools

### DIFF
--- a/libs/agno/agno/tools/slack.py
+++ b/libs/agno/agno/tools/slack.py
@@ -72,6 +72,21 @@ class SlackTools(Toolkit):
                 text += "\nWhen to use: only when search_workspace is unavailable."
             sections.append(text)
 
+        # Messaging guidance — critical for thread-aware responses
+        if "send_message" in enabled and "send_message_thread" in enabled:
+            sections.append(
+                "**send_message** vs **send_message_thread** — choosing correctly:\n"
+                "- If you have a `Slack thread_ts` in your context/dependencies, "
+                "ALWAYS use send_message_thread with that thread_ts. "
+                "Never use send_message when replying inside a thread.\n"
+                "- Only use send_message for new top-level channel messages."
+            )
+        elif "send_message_thread" in enabled:
+            sections.append(
+                "**send_message_thread** — reply inside a thread.\n"
+                "When you have a `Slack thread_ts` in your context/dependencies, use it."
+            )
+
         # Only inject guidance when there are multiple tools to choose between
         if len(sections) < 2:
             return ""
@@ -88,6 +103,9 @@ class SlackTools(Toolkit):
             routing.append("- Always expand threads with high reply_count before summarizing")
         if "search_messages" in enabled and "search_workspace" in enabled:
             routing.append("- Fallback (user-token only) → search_messages")
+        if "send_message" in enabled and "send_message_thread" in enabled:
+            routing.append("- Replying in a thread → send_message_thread (use Slack thread_ts from context)")
+            routing.append("- New top-level channel message → send_message")
 
         if routing:
             result += "\n\n## When to use which\n" + "\n".join(routing)


### PR DESCRIPTION
## Summary

`SlackTools._build_instructions()` had no guidance for `send_message` vs `send_message_thread`. When the LLM needed to post messages autonomously (e.g., answering questions individually via tool calls), it picked `send_message` (channel-level) because it has fewer parameters and its docstring doesn't mention threads. This caused bot responses to post directly to the channel instead of replying in-thread.

Added routing instructions to `_build_instructions()` telling the LLM to use `send_message_thread` when `Slack thread_ts` is available in context, and only use `send_message` for new top-level channel messages.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Tested in clean environment

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Files changed (1):**
- `libs/agno/agno/tools/slack.py` — `_build_instructions()` now includes messaging tool guidance when both `send_message` and `send_message_thread` are enabled

**E2E tested** on a live Slack workspace with a multi-agent team — verified bot responds in-thread when @mentioned.