### PR TITLE
fix(workflow): guard against None executor response in Step

### DIFF
--- a/libs/agno/agno/workflow/step.py
+++ b/libs/agno/agno/workflow/step.py
@@ -698,7 +698,7 @@ class Step:
                         if run_context is None and session_state is not None:
                             merge_dictionaries(session_state, session_state_copy)
 
-                        if store_executor_outputs and workflow_run_response is not None:
+                        if store_executor_outputs and workflow_run_response is not None and response is not None:
                             self._store_executor_response(workflow_run_response, response)  # type: ignore
 
                         # Check if agent/team response is paused (e.g., due to tool HITL)
@@ -995,7 +995,7 @@ class Step:
                         if run_context is None and session_state is not None:
                             merge_dictionaries(session_state, session_state_copy)
 
-                        if store_executor_outputs and workflow_run_response is not None:
+                        if store_executor_outputs and workflow_run_response is not None and active_executor_run_response is not None:
                             self._store_executor_response(workflow_run_response, active_executor_run_response)  # type: ignore
 
                         # Check if agent/team response is paused (e.g., due to tool HITL)
@@ -1273,7 +1273,7 @@ class Step:
                         if run_context is None and session_state is not None:
                             merge_dictionaries(session_state, session_state_copy)
 
-                        if store_executor_outputs and workflow_run_response is not None:
+                        if store_executor_outputs and workflow_run_response is not None and response is not None:
                             self._store_executor_response(workflow_run_response, response)  # type: ignore
 
                         # Check if agent/team response is paused (e.g., due to tool HITL)
@@ -1564,7 +1564,7 @@ class Step:
                         if run_context is None and session_state is not None:
                             merge_dictionaries(session_state, session_state_copy)
 
-                        if store_executor_outputs and workflow_run_response is not None:
+                        if store_executor_outputs and workflow_run_response is not None and active_executor_run_response is not None:
                             self._store_executor_response(workflow_run_response, active_executor_run_response)  # type: ignore
 
                         # Check if agent/team response is paused (e.g., due to tool HITL)


### PR DESCRIPTION
## Summary

Fixes #7185

When a Team executor's async stream ends without yielding a `RunOutput` or `TeamRunOutput` (e.g., due to an internal error, model-specific failure, or `TeamRunErrorEvent`), `active_executor_run_response` remains `None`. The subsequent call to `_store_executor_response` then crashes with:

```
AttributeError: 'NoneType' object has no attribute 'parent_run_id'
```

## Root Cause

In `workflow/step.py`, `_store_executor_response` is called at 4 sites (sync/async x streaming/non-streaming) with only a check on `workflow_run_response is not None` but no check on the executor response itself. When the executor stream terminates without yielding a final response object, the executor response variable is `None`.

## Fix

Add `and active_executor_run_response is not None` (or `and response is not None` for the non-streaming paths) to the guard condition at all 4 call sites before passing the executor response to `_store_executor_response`.

This is a minimal, targeted fix that prevents the `AttributeError` without changing any other behavior. The workflow will continue to the next step (or retry) as designed.

## Test Plan

- Verified syntax validity of the modified file
- The fix adds a null guard to an existing conditional — no new code paths introduced
- Matches the pattern already used elsewhere in the same file (e.g., the `is_paused` check on line 1004 already guards `active_executor_run_response is not None`)