### PR TITLE
fix: catch CancelledError in agent router streaming functions

### DIFF
--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from typing import TYPE_CHECKING, Any, AsyncGenerator, List, Optional, Union, cast
 from uuid import uuid4
@@ -103,6 +104,9 @@ async def agent_response_streamer(
             additional_data=e.additional_data,
         )
         yield format_sse_event(error_response)
+    except asyncio.CancelledError:
+        # Client disconnected — clean termination, no error event (client is gone)
+        return
     except Exception as e:
         import traceback
 
@@ -149,6 +153,9 @@ async def agent_continue_response_streamer(
         )
         yield format_sse_event(error_response)
 
+    except asyncio.CancelledError:
+        # Client disconnected — clean termination, no error event (client is gone)
+        return
     except Exception as e:
         import traceback
 


### PR DESCRIPTION
Fixes #7320

## Summary

- Add `except asyncio.CancelledError: return` before `except Exception` in both `agent_response_streamer` and `agent_continue_response_streamer`
- `CancelledError` (BaseException subclass) was propagating unhandled through agent router generators when Starlette cancels a disconnected client's SSE stream
- Handled separately from `Exception`: clean `return` for disconnections (client is gone, no error event needed) vs error event for real failures
- More correct than the team router's broad `except BaseException` which also swallows `SystemExit`/`KeyboardInterrupt`

## Test plan

- [ ] Existing tests pass
- [ ] Manual: disconnect a client mid-stream — no unhandled exception in logs