### PR TITLE
fix: catch CancelledError and run cleanup in agent async handlers

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -1753,10 +1753,26 @@ async def _arun(
 
                 return run_response
 
-            except KeyboardInterrupt:
+            except (KeyboardInterrupt, asyncio.CancelledError):
                 run_response = cast(RunOutput, run_response)
                 run_response.status = RunStatus.cancelled
                 run_response.content = "Operation cancelled by user"
+                if agent_session is not None:
+                    _cleanup = asyncio.create_task(
+                        acleanup_and_store(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        )
+                    )
+                    _background_tasks.add(_cleanup)
+                    _cleanup.add_done_callback(_background_tasks.discard)
+                    try:
+                        await asyncio.shield(_cleanup)
+                    except (asyncio.CancelledError, Exception):
+                        pass  # task runs independently via _background_tasks
                 return run_response
             except Exception as e:
                 # Check if this is the last attempt
@@ -2375,8 +2391,24 @@ async def _arun_stream(
                 yield run_error
                 break
 
-            except KeyboardInterrupt:
+            except (KeyboardInterrupt, asyncio.CancelledError):
                 run_response = cast(RunOutput, run_response)
+                if agent_session is not None:
+                    _cleanup = asyncio.create_task(
+                        acleanup_and_store(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        )
+                    )
+                    _background_tasks.add(_cleanup)
+                    _cleanup.add_done_callback(_background_tasks.discard)
+                    try:
+                        await asyncio.shield(_cleanup)
+                    except (asyncio.CancelledError, Exception):
+                        pass  # task runs independently via _background_tasks
                 yield handle_event(  # type: ignore
                     create_run_cancelled_event(from_run_response=run_response, reason="Operation cancelled by user"),
                     run_response,
@@ -3861,10 +3893,26 @@ async def _acontinue_run(
 
                 return run_response
 
-            except KeyboardInterrupt:
+            except (KeyboardInterrupt, asyncio.CancelledError):
                 run_response = cast(RunOutput, run_response)
                 run_response.status = RunStatus.cancelled
                 run_response.content = "Operation cancelled by user"
+                if agent_session is not None:
+                    _cleanup = asyncio.create_task(
+                        acleanup_and_store(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        )
+                    )
+                    _background_tasks.add(_cleanup)
+                    _cleanup.add_done_callback(_background_tasks.discard)
+                    try:
+                        await asyncio.shield(_cleanup)
+                    except (asyncio.CancelledError, Exception):
+                        pass  # task runs independently via _background_tasks
                 return run_response
             except Exception as e:
                 run_response = cast(RunOutput, run_response)
@@ -4339,10 +4387,28 @@ async def _acontinue_run_stream(
                 # Yield the error event
                 yield run_error
                 break
-            except KeyboardInterrupt:
+            except (KeyboardInterrupt, asyncio.CancelledError):
                 if run_response is None:
                     run_response = RunOutput(run_id=run_id)
                 run_response = cast(RunOutput, run_response)
+                run_response.status = RunStatus.cancelled
+                run_response.content = "Operation cancelled by user"
+                if agent_session is not None:
+                    _cleanup = asyncio.create_task(
+                        acleanup_and_store(
+                            agent,
+                            run_response=run_response,
+                            session=agent_session,
+                            run_context=run_context,
+                            user_id=user_id,
+                        )
+                    )
+                    _background_tasks.add(_cleanup)
+                    _cleanup.add_done_callback(_background_tasks.discard)
+                    try:
+                        await asyncio.shield(_cleanup)
+                    except (asyncio.CancelledError, Exception):
+                        pass  # task runs independently via _background_tasks
                 yield handle_event(  # type: ignore
                     create_run_cancelled_event(from_run_response=run_response, reason="Operation cancelled by user"),
                     run_response,


### PR DESCRIPTION
Fixes #7318
Related: #6235

## Summary

- Add `asyncio.CancelledError` to the exception tuple in 4 agent async handlers (`_arun`, `_arun_stream`, `_acontinue_run`, `_acontinue_run_stream`)
- Run `acleanup_and_store` as a cancellation-safe detached task using the existing `_background_tasks` registry
- Agent `_run.py` previously only caught `KeyboardInterrupt` — `CancelledError` (BaseException) propagated unhandled, skipping session persistence entirely
- Team `_run.py` already catches `(KeyboardInterrupt, asyncio.CancelledError)` and runs cleanup — this brings agent parity

## Cancellation-safe cleanup pattern

```python
except (KeyboardInterrupt, asyncio.CancelledError):
    # ...
    _cleanup = asyncio.create_task(acleanup_and_store(...))
    _background_tasks.add(_cleanup)                    # strong ref
    _cleanup.add_done_callback(_background_tasks.discard)
    try:
        await asyncio.shield(_cleanup)                 # try graceful wait
    except (asyncio.CancelledError, Exception):
        pass  # task continues independently
```

Why this pattern instead of bare `await`:
- Inside a CancelledError handler, bare `await` can be re-cancelled
- `asyncio.shield()` alone is insufficient (GC can collect the local ref)
- `_background_tasks` (existing at `_run.py:112`) holds a strong reference
- Follows the same convention as `_arun_background` (line 1899-1900)

## Test plan

- [ ] Existing tests pass
- [ ] Unit: raise `asyncio.CancelledError` during model response iteration, verify `acleanup_and_store` is called
- [ ] Verify `_background_tasks` is empty after cleanup completes (done callback fired)