### PR TITLE
fix: handle IndexError in get_pull_requests when limit exceeds available PRs

### DIFF
--- a/libs/agno/agno/tools/github.py
+++ b/libs/agno/agno/tools/github.py
@@ -720,7 +720,10 @@ class GithubTools(Toolkit):
             pulls = repo.get_pulls(state=state, sort=sort, direction=direction)
 
             pr_list = []
-            for pr in pulls[:limit]:
+            count = 0
+            for pr in pulls:
+                if count >= limit:
+                    break
                 pr_info = {
                     "number": pr.number,
                     "title": pr.title,
@@ -731,6 +734,7 @@ class GithubTools(Toolkit):
                     "url": pr.html_url,
                 }
                 pr_list.append(pr_info)
+                count += 1
 
             return json.dumps(pr_list, indent=2)
         except GithubException as e:


### PR DESCRIPTION
## Summary

Fix `IndexError` in `get_pull_requests` when the requested `limit` exceeds the number of available PRs. PyGithub's `PaginatedList` does not safely support slice notation (`[:limit]`) when fewer items exist than the upper bound — this replaces that pattern with a manual counter-based iteration already used elsewhere in the codebase.

Fixes #7342

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Before fix:** `pulls[:limit]` raised `IndexError: list index out of range` when the repo had fewer PRs than `limit`.

**After fix:** Iterates using a counter and `break`, consistent with the pattern used elsewhere in `github.py` for PR statistics.