### PR TITLE
feat: per-request toolkit isolation for concurrent multi-user requests

### DIFF
--- a/cookbook/05_agent_os/interfaces/slack/gmail_agent.py
+++ b/cookbook/05_agent_os/interfaces/slack/gmail_agent.py
@@ -1,0 +1,101 @@
+"""
+Slack Gmail Agent (DB-backed OAuth)
+====================================
+
+Slack bot that can read/send Gmail using DB-backed OAuth tokens.
+When a user asks about email, the agent checks the DB for stored tokens.
+If none exist, it returns an OAuth URL the user clicks to authenticate.
+
+Setup:
+  1. Google Cloud: Create OAuth 2.0 Web Application credentials
+     - Authorized redirect URI: https://<your-ngrok>/google/oauth/callback
+  2. Set env vars:
+     - GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET
+     - GOOGLE_REDIRECT_URI=https://<your-ngrok>/google/oauth/callback
+     - SLACK_BOT_TOKEN, SLACK_SIGNING_SECRET
+     - OPENAI_API_KEY
+  3. Start pgvector: ./cookbook/scripts/run_pgvector.sh
+  4. Start ngrok:    ngrok http 7777
+  5. Run:            .venvs/demo/bin/python cookbook/05_agent_os/interfaces/slack/gmail_agent.py
+
+Flow:
+  User: "What are my latest emails?"
+  Bot:  Returns OAuth URL (first time) -> user clicks -> Google consent -> callback saves token
+  User: Retries -> Bot reads Gmail via stored token
+"""
+
+from agno.agent import Agent
+from agno.db.postgres.postgres import PostgresDb
+from agno.models.openai import OpenAIChat
+from agno.os.app import AgentOS
+from agno.os.interfaces.slack import Slack
+from agno.tools.google.auth import GoogleAuth
+from agno.tools.google.gmail import GmailTools
+
+# ---------------------------------------------------------------------------
+# Database (shared between agent session storage and OAuth token storage)
+# ---------------------------------------------------------------------------
+
+db = PostgresDb(
+    db_url="postgresql+psycopg://ai:ai@localhost:5532/ai",
+)
+
+# ---------------------------------------------------------------------------
+# Google Auth + Gmail
+# ---------------------------------------------------------------------------
+
+google_auth = GoogleAuth()
+
+gmail = GmailTools(
+    google_auth=google_auth,
+    get_latest_emails=True,
+    get_emails_from_user=True,
+    get_unread_emails=True,
+    search_emails=True,
+    send_email=True,
+    create_draft_email=True,
+)
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+gmail_agent = Agent(
+    name="Gmail Agent",
+    model=OpenAIChat(id="gpt-4o"),
+    tools=[google_auth, gmail],
+    db=db,
+    add_history_to_context=True,
+    num_history_runs=3,
+    add_datetime_to_context=True,
+    instructions=[
+        "You are a helpful email assistant connected to Gmail.",
+        "When authentication is needed, share the OAuth URL and ask the user to click it.",
+        "After they authenticate, retry the original request.",
+    ],
+)
+
+# ---------------------------------------------------------------------------
+# AgentOS + Slack + OAuth callback
+# ---------------------------------------------------------------------------
+
+agent_os = AgentOS(
+    agents=[gmail_agent],
+    interfaces=[
+        Slack(
+            agent=gmail_agent,
+            reply_to_mentions_only=True,
+            resolve_user_identity=True,
+        )
+    ],
+)
+
+app = agent_os.get_app()
+
+# Attach the OAuth callback endpoint to the same FastAPI app
+# Google redirects here after user consents: /google/oauth/callback?code=...&state=...
+app.include_router(google_auth.get_oauth_router())
+
+
+if __name__ == "__main__":
+    agent_os.serve(app="gmail_agent:app", reload=True)

--- a/libs/agno/agno/agent/_utils.py
+++ b/libs/agno/agno/agent/_utils.py
@@ -171,18 +171,20 @@ def deep_copy_field(agent: Agent, field_name: str, field_value: Any) -> Any:
             copied_tools = []
             for tool in field_value:  # type: ignore
                 try:
-                    # Share MCP tools (they maintain server connections)
-                    is_mcp_tool = hasattr(type(tool), "__mro__") and any(
-                        c.__name__ in ["MCPTools", "MultiMCPTools"] for c in type(tool).__mro__
-                    )
-                    if is_mcp_tool:
+                    # Share tools that maintain connections or act as coordinators
+                    mro_names = {c.__name__ for c in type(tool).__mro__} if hasattr(type(tool), "__mro__") else set()
+                    is_shared_tool = bool(mro_names & {"MCPTools", "MultiMCPTools", "GoogleAuth"})
+                    if is_shared_tool:
                         copied_tools.append(tool)
                     else:
                         try:
                             copied_tools.append(deepcopy(tool))
                         except Exception:
-                            # Tool can't be deep copied, share by reference
-                            copied_tools.append(tool)
+                            # deepcopy failed (e.g. Google httplib2 clients) — try clone()
+                            if hasattr(tool, "clone") and callable(tool.clone):
+                                copied_tools.append(tool.clone())
+                            else:
+                                copied_tools.append(tool)
                 except Exception:
                     # MCP detection failed, share tool by reference to be safe
                     copied_tools.append(tool)

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -67,6 +67,7 @@ from agno.os.utils import (
 from agno.registry import Registry
 from agno.remote.base import RemoteDb, RemoteKnowledge
 from agno.team import RemoteTeam, Team
+from agno.tools.toolkit import Toolkit
 from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.string import generate_id, generate_id_from_name
 from agno.workflow import RemoteWorkflow, Workflow
@@ -527,6 +528,17 @@ class AgentOS:
 
             agent.initialize_agent()
 
+            # Wire agent.db to toolkits that declare _db (e.g. GoogleAuth for OAuth token storage).
+            # Must happen here (init time) so the OAuth callback closure captures a wired instance.
+            # Only sync DBs that override get_auth_token — skips async and unsupported backends.
+            if agent.db is not None and isinstance(agent.tools, list):
+                from agno.db.base import BaseDb
+
+                if isinstance(agent.db, BaseDb) and type(agent.db).get_auth_token is not BaseDb.get_auth_token:
+                    for tool in agent.tools:
+                        if isinstance(tool, Toolkit) and hasattr(tool, "_db") and tool._db is None:
+                            tool._db = agent.db
+
             # Required for the built-in routes to work
             agent.store_events = True
 
@@ -556,6 +568,18 @@ class AgentOS:
                     if isinstance(member, Agent):
                         member.team_id = None
                         member.initialize_agent()
+                        # Wire DB to member agent toolkits — same guard as _initialize_agents
+                        member_db = member.db or team.db
+                        if member_db is not None and isinstance(member.tools, list):
+                            from agno.db.base import BaseDb
+
+                            if (
+                                isinstance(member_db, BaseDb)
+                                and type(member_db).get_auth_token is not BaseDb.get_auth_token
+                            ):
+                                for tool in member.tools:
+                                    if isinstance(tool, Toolkit) and hasattr(tool, "_db") and tool._db is None:
+                                        tool._db = member_db
                     elif isinstance(member, Team):
                         member.initialize_team()
 
@@ -823,7 +847,6 @@ class AgentOS:
         # This allows middleware (like JWT) to access these values
         fastapi_app.state.agent_os_id = self.id
         fastapi_app.state.cors_allowed_origins = self.cors_allowed_origins
-
         # Store internal service token for scheduler auth bypass
         if self._internal_service_token:
             fastapi_app.state.internal_service_token = self._internal_service_token

--- a/libs/agno/agno/os/interfaces/slack/router.py
+++ b/libs/agno/agno/os/interfaces/slack/router.py
@@ -191,6 +191,9 @@ def attach_routes(
             if skipped:
                 notice = "[Skipped files: " + ", ".join(skipped) + "]"
                 message_text = f"{notice}\n{message_text}"
+            # Per-request clone isolates mutable toolkit state (creds, service) between users
+            _entity = entity.deep_copy() if hasattr(entity, "deep_copy") else entity
+
             run_kwargs: Dict[str, Any] = {
                 "user_id": resolved_user_id,
                 "session_id": session_id,
@@ -207,7 +210,7 @@ def attach_routes(
                 "audio": audio or None,
             }
 
-            response = await entity.arun(message_text, **run_kwargs)  # type: ignore[union-attr]
+            response = await _entity.arun(message_text, **run_kwargs)  # type: ignore[union-attr]
 
             if response:
                 if response.status == "ERROR":
@@ -312,6 +315,8 @@ def attach_routes(
             if skipped:
                 notice = "[Skipped files: " + ", ".join(skipped) + "]"
                 message_text = f"{notice}\n{message_text}"
+            _entity = entity.deep_copy() if hasattr(entity, "deep_copy") else entity
+
             run_kwargs: Dict[str, Any] = {
                 "stream": True,
                 # Enables event-level chunks for task card and tool lifecycle rendering
@@ -331,7 +336,7 @@ def attach_routes(
                 "audio": audio or None,
             }
 
-            response_stream = entity.arun(message_text, **run_kwargs)  # type: ignore[union-attr]
+            response_stream = _entity.arun(message_text, **run_kwargs)  # type: ignore[union-attr]
 
             if response_stream is None:
                 try:

--- a/libs/agno/agno/os/interfaces/telegram/router.py
+++ b/libs/agno/agno/os/interfaces/telegram/router.py
@@ -204,6 +204,8 @@ def attach_routes(
         message_thread_id: Optional[int],
         is_private: bool = False,
     ) -> None:
+        _entity = entity.deep_copy() if hasattr(entity, "deep_copy") else entity
+
         is_workflow = entity_type == "workflow"
         stream_kwargs: dict = dict(stream=True, stream_events=True, **run_kwargs)
         if not is_workflow:
@@ -219,7 +221,7 @@ def attach_routes(
         )
 
         try:
-            async for event in entity.arun(message_text, **stream_kwargs):  # type: ignore[union-attr]
+            async for event in _entity.arun(message_text, **stream_kwargs):  # type: ignore[union-attr]
                 if isinstance(event, (RunOutput, TeamRunOutput)):
                     state.final_run_output = event
                     continue
@@ -261,7 +263,8 @@ def attach_routes(
         reply_to: Optional[int],
         message_thread_id: Optional[int],
     ) -> None:
-        response = await entity.arun(message_text, **run_kwargs)  # type: ignore[union-attr]
+        _entity = entity.deep_copy() if hasattr(entity, "deep_copy") else entity
+        response = await _entity.arun(message_text, **run_kwargs)  # type: ignore[union-attr]
         if not response or response.status == "ERROR":
             if response:
                 log_error(response.content)

--- a/libs/agno/agno/os/interfaces/whatsapp/router.py
+++ b/libs/agno/agno/os/interfaces/whatsapp/router.py
@@ -313,9 +313,10 @@ def attach_routes(
                 except asyncio.CancelledError:
                     pass
 
+            _entity = entity.deep_copy() if hasattr(entity, "deep_copy") else entity
             typing_task = asyncio.create_task(_keep_typing())
             try:
-                response = await entity.arun(parsed.text, **run_kwargs)  # type: ignore[union-attr]
+                response = await _entity.arun(parsed.text, **run_kwargs)  # type: ignore[union-attr]
             finally:
                 typing_task.cancel()
 

--- a/libs/agno/agno/team/_utils.py
+++ b/libs/agno/agno/team/_utils.py
@@ -183,18 +183,20 @@ def _deep_copy_field(team: Team, field_name: str, field_value: Any) -> Any:
             copied_tools = []
             for tool in field_value:
                 try:
-                    # Share MCP tools (they maintain server connections)
-                    is_mcp_tool = hasattr(type(tool), "__mro__") and any(
-                        c.__name__ in ["MCPTools", "MultiMCPTools"] for c in type(tool).__mro__
-                    )
-                    if is_mcp_tool:
+                    # Share tools that maintain connections or act as coordinators
+                    mro_names = {c.__name__ for c in type(tool).__mro__} if hasattr(type(tool), "__mro__") else set()
+                    is_shared_tool = bool(mro_names & {"MCPTools", "MultiMCPTools", "GoogleAuth"})
+                    if is_shared_tool:
                         copied_tools.append(tool)
                     else:
                         try:
                             copied_tools.append(deepcopy(tool))
                         except Exception:
-                            # Tool can't be deep copied, share by reference
-                            copied_tools.append(tool)
+                            # deepcopy failed (e.g. Google httplib2 clients) — try clone()
+                            if hasattr(tool, "clone") and callable(tool.clone):
+                                copied_tools.append(tool.clone())
+                            else:
+                                copied_tools.append(tool)
                 except Exception:
                     # MCP detection failed, share tool by reference to be safe
                     copied_tools.append(tool)
@@ -216,7 +218,6 @@ def _deep_copy_field(team: Team, field_name: str, field_value: Any) -> Any:
         "session_summary_manager",
         "compression_manager",
         "learning",
-        "skills",
     ):
         return field_value
 

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -234,6 +234,21 @@ class Function(BaseModel):
             approval_type=data.get("approval_type"),
         )
 
+    def clone_for(self, new_owner: Any) -> "Function":
+        """Shallow-copy this Function with its entrypoint rebound to new_owner.
+
+        Used by Toolkit.clone() so tool methods operate on the cloned toolkit's
+        state instead of the original's. Only rebinds bound methods (__self__);
+        closures and standalone functions are left as-is.
+        """
+        import types
+
+        clone = self.model_copy()
+        ep = self.entrypoint
+        if ep is not None and hasattr(ep, "__self__"):
+            clone.entrypoint = types.MethodType(ep.__func__, new_owner)  # type: ignore[attr-defined]
+        return clone
+
     def model_copy(self, *, deep: bool = False) -> "Function":
         """
         Override model_copy to handle callable fields that can't be deep copied (pickled).

--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -12,6 +12,10 @@ class Toolkit:
     # When True, the Agent will automatically call connect() before using tools and close() after
     _requires_connect: bool = False
 
+    # Subclasses override with attr names that hold per-user mutable state (creds, service, etc.).
+    # clone() resets these to None so each request rebuilds them for the current user.
+    _clone_reset_attrs: tuple = ()
+
     def __init__(
         self,
         name: str = "toolkit",
@@ -344,6 +348,30 @@ class Toolkit:
         Called automatically by the Agent when _requires_connect is True.
         """
         pass
+
+    def clone(self) -> "Toolkit":
+        """Shallow-copy this toolkit and reset per-user mutable state.
+
+        Used by deep_copy_field() as a fallback when deepcopy() fails (e.g. Google
+        API clients hold unpicklable httplib2 transports). Config attrs (scopes,
+        credentials_path, etc.) are shared; mutable attrs listed in _clone_reset_attrs
+        are set to None so the auth decorator rebuilds them for the current user.
+        """
+        import copy
+
+        clone = copy.copy(self)
+        for attr in self._clone_reset_attrs:
+            setattr(clone, attr, None)
+
+        # Rebuild function dicts so entrypoints are bound to the clone, not the original
+        clone.functions = OrderedDict()
+        clone.async_functions = OrderedDict()
+        for name, fn in self.functions.items():
+            clone.functions[name] = fn.clone_for(clone)
+        for name, fn in self.async_functions.items():
+            clone.async_functions[name] = fn.clone_for(clone)
+
+        return clone
 
     def _check_path(self, file_name: str, base_dir: Path, restrict_to_base_dir: bool = True) -> Tuple[bool, Path]:
         """Check if the file path is within the base directory.

--- a/libs/agno/tests/unit/tools/test_toolkit_isolation.py
+++ b/libs/agno/tests/unit/tools/test_toolkit_isolation.py
@@ -1,0 +1,192 @@
+import types
+from collections import OrderedDict
+from copy import deepcopy
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agno.tools.function import Function
+from agno.tools.toolkit import Toolkit
+
+
+class FakeGmailTools(Toolkit):
+    """Minimal stand-in for GmailTools — declares mutable state without Google imports."""
+
+    _clone_reset_attrs = ("creds", "service", "_label_cache")
+
+    def __init__(self):
+        self.creds = None
+        self.service = None
+        self._label_cache = None
+        self.scopes = ["https://www.googleapis.com/auth/gmail.readonly"]
+        self.credentials_path = "/fake/credentials.json"
+        super().__init__(name="gmail", tools=[self.get_latest_emails, self.send_email])
+
+    def get_latest_emails(self, count: int = 5) -> str:
+        return f"emails from {id(self)}"
+
+    def send_email(self, to: str, subject: str, body: str) -> str:
+        return f"sent by {id(self)}"
+
+
+class PlainToolkit(Toolkit):
+    """Toolkit with no _clone_reset_attrs — clone is a no-op for mutable state."""
+
+    def __init__(self):
+        super().__init__(name="plain", tools=[self.hello])
+
+    def hello(self) -> str:
+        return "hi"
+
+
+# -- clone() basics --
+
+
+class TestCloneResetsAttrs:
+    def test_mutable_state_is_none_on_clone(self):
+        tk = FakeGmailTools()
+        tk.creds = MagicMock(name="creds")
+        tk.service = MagicMock(name="service")
+        tk._label_cache = {"inbox": "INBOX"}
+
+        clone = tk.clone()
+
+        assert clone.creds is None
+        assert clone.service is None
+        assert clone._label_cache is None
+
+    def test_config_is_preserved(self):
+        tk = FakeGmailTools()
+        clone = tk.clone()
+
+        assert clone.scopes == tk.scopes
+        assert clone.credentials_path == tk.credentials_path
+        assert clone.name == tk.name
+
+    def test_clone_is_distinct_instance(self):
+        tk = FakeGmailTools()
+        clone = tk.clone()
+        assert clone is not tk
+
+    def test_plain_toolkit_clone_is_identity_like(self):
+        tk = PlainToolkit()
+        clone = tk.clone()
+        # No attrs to reset, but should still be a distinct instance with rebound fns
+        assert clone is not tk
+        assert clone.functions.keys() == tk.functions.keys()
+
+
+# -- Function rebinding --
+
+
+class TestCloneRebindsFunctions:
+    def test_entrypoints_reference_clone_not_original(self):
+        tk = FakeGmailTools()
+        clone = tk.clone()
+
+        for name, fn in clone.functions.items():
+            ep = fn.entrypoint
+            assert ep is not None
+            # Bound method's __self__ should be the clone
+            assert hasattr(ep, "__self__"), f"{name} entrypoint is not a bound method"
+            assert ep.__self__ is clone, f"{name} entrypoint bound to original, not clone"
+
+    def test_original_entrypoints_unchanged(self):
+        tk = FakeGmailTools()
+        clone = tk.clone()
+
+        for name, fn in tk.functions.items():
+            ep = fn.entrypoint
+            assert hasattr(ep, "__self__")
+            assert ep.__self__ is tk
+
+    def test_function_metadata_preserved(self):
+        tk = FakeGmailTools()
+        clone = tk.clone()
+
+        for name in tk.functions:
+            orig = tk.functions[name]
+            cloned = clone.functions[name]
+            assert cloned.name == orig.name
+            assert cloned.description == orig.description
+            assert cloned.parameters == orig.parameters
+
+
+# -- Function.clone_for --
+
+
+class TestFunctionCloneFor:
+    def test_rebinds_bound_method(self):
+        tk = FakeGmailTools()
+        fn = tk.functions["get_latest_emails"]
+        new_owner = FakeGmailTools()
+
+        cloned_fn = fn.clone_for(new_owner)
+        assert cloned_fn.entrypoint.__self__ is new_owner
+        assert cloned_fn.name == fn.name
+
+    def test_leaves_non_bound_entrypoint_alone(self):
+        def standalone(x: int) -> int:
+            return x + 1
+
+        fn = Function(name="standalone", entrypoint=standalone)
+        new_owner = object()
+
+        cloned_fn = fn.clone_for(new_owner)
+        # standalone is not a bound method — should be unchanged
+        assert cloned_fn.entrypoint is standalone
+
+
+# -- deep_copy_field fallback --
+
+
+class UndeepcopyableToolkit(Toolkit):
+    """Simulates Google toolkits that fail deepcopy due to httplib2."""
+
+    _clone_reset_attrs = ("creds", "service")
+
+    def __init__(self):
+        self.creds = None
+        self.service = None
+        self.config_val = "keep_me"
+        super().__init__(name="undeepcopyable", tools=[self.do_thing])
+
+    def do_thing(self) -> str:
+        return "done"
+
+    def __deepcopy__(self, memo):
+        raise TypeError("cannot pickle httplib2.Http")
+
+
+class TestDeepCopyFieldFallback:
+    def test_uses_clone_when_deepcopy_fails(self):
+        """deep_copy_field should call clone() when deepcopy raises."""
+        from agno.agent._utils import deep_copy_field
+
+        tk = UndeepcopyableToolkit()
+        tk.creds = MagicMock(name="user_a_creds")
+        tk.service = MagicMock(name="svc")
+
+        # deep_copy_field(agent, field_name, field_value) — agent unused for tools path
+        result = deep_copy_field(None, "tools", [tk])  # type: ignore[arg-type]
+        assert len(result) == 1
+        cloned = result[0]
+        assert cloned is not tk
+        # clone() resets mutable state
+        assert cloned.creds is None
+        assert cloned.service is None
+        # Config preserved
+        assert cloned.config_val == "keep_me"
+
+    def test_shares_by_reference_when_no_clone(self):
+        """Object without clone() falls back to share-by-reference."""
+
+        class OpaqueObj:
+            def __deepcopy__(self, memo):
+                raise TypeError("nope")
+
+        obj = OpaqueObj()
+        from agno.agent._utils import deep_copy_field
+
+        result = deep_copy_field(None, "tools", [obj])  # type: ignore[arg-type]
+        assert result[0] is obj


### PR DESCRIPTION
## Summary

Add clone-based isolation so each interface request (Slack, Telegram, WhatsApp) gets fresh toolkit state while sharing heavy resources by reference.

**Depends on:** #7376

### Problem
When multiple users message a Slack bot concurrently, they share the same agent instance. Google toolkits hold mutable state (`creds`, `service`, `_label_cache`) that can leak between users — User A's Gmail token could be used for User B's request.

### Solution
Each request clones the agent via `entity.deep_copy()` before calling `arun()`. Per-user state is reset; shared resources (DB, GoogleAuth, MCP connections) are kept by reference.

```
Slack message arrives
  │
  ▼
entity.deep_copy()
  ├─ GoogleAuth: SHARED by reference (DB coordinator, like MCP tools)
  ├─ GmailTools: CLONED via clone(), resets creds/service/_label_cache
  ├─ MCP tools: SHARED by reference (server connections)
  └─ DB, model: SHARED by reference (connection pools)
  │
  ▼
cloned_agent.arun(message, user_id=...)
  └─ Fresh creds loaded from DB for this user
```

### Init-time DB wiring
`_initialize_agents()` wires `toolkit._db = agent.db` at app startup (not runtime). This ensures the OAuth callback closure has DB access before any request arrives — no `app.state.db` needed.

### Files changed (10 files, +382 -21)

| Layer | Files |
|-------|-------|
| Clone infra | `toolkit.py` (clone + _clone_reset_attrs), `function.py` (clone_for) |
| deep_copy | `agent/_utils.py`, `team/_utils.py` (share GoogleAuth by ref) |
| Routers | `slack/router.py`, `telegram/router.py`, `whatsapp/router.py` |
| App wiring | `os/app.py` (init-time _db binding) |
| Cookbook | `slack/gmail_agent.py` |
| Tests | `test_toolkit_isolation.py` |

## Type of change

- [x] New feature

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Cookbook example included
- [x] Tests added (`test_toolkit_isolation.py`)
- [x] E2E tested: Slack → OAuth URL → Google consent → DB token → retry → emails displayed

### Duplicate and AI-Generated PR Check

- [x] No existing PR addresses this
- [x] This PR was developed with AI assistance (Claude Code)

## Additional Notes

- **E2E verified**: Full Slack OAuth flow tested with ngrok + PgVector + Gmail API
- **Pattern**: GoogleAuth follows the same shared-by-reference lifecycle as MCP tools
- **All interfaces covered**: Slack, Telegram, WhatsApp routers all call `deep_copy()`