### PR TITLE
[fix] add extend_existing=True to SQLite and MySQL Table() constructors

### DIFF
--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -192,7 +192,7 @@ class AsyncMySQLDb(AsyncBaseDb):
                 columns.append(Column(*column_args, **column_kwargs))  # type: ignore
 
             # Create the table object - use self.metadata to maintain FK references
-            table = Table(table_name, self.metadata, *columns, schema=self.db_schema)
+            table = Table(table_name, self.metadata, *columns, schema=self.db_schema, extend_existing=True)
 
             # Add multi-column unique constraints with table-specific names
             for constraint in schema_unique_constraints:
@@ -393,7 +393,7 @@ class AsyncMySQLDb(AsyncBaseDb):
             async with self.db_engine.connect() as conn:
 
                 def create_table(connection):
-                    return Table(table_name, self.metadata, schema=self.db_schema, autoload_with=connection)
+                    return Table(table_name, self.metadata, schema=self.db_schema, autoload_with=connection, extend_existing=True)
 
                 table = await conn.run_sync(create_table)
                 return table

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -187,7 +187,7 @@ class MySQLDb(BaseDb):
                 columns.append(Column(*column_args, **column_kwargs))  # type: ignore
 
             # Create the table object
-            table = Table(table_name, self.metadata, *columns, schema=self.db_schema)
+            table = Table(table_name, self.metadata, *columns, schema=self.db_schema, extend_existing=True)
 
             # Add multi-column unique constraints with table-specific names
             for constraint in schema_unique_constraints:
@@ -385,7 +385,7 @@ class MySQLDb(BaseDb):
             raise ValueError(f"Table {self.db_schema}.{table_name} has an invalid schema")
 
         try:
-            table = Table(table_name, self.metadata, schema=self.db_schema, autoload_with=self.db_engine)
+            table = Table(table_name, self.metadata, schema=self.db_schema, autoload_with=self.db_engine, extend_existing=True)
             return table
 
         except Exception as e:

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -230,7 +230,7 @@ class AsyncSqliteDb(AsyncBaseDb):
                 columns.append(Column(*column_args, **column_kwargs))  # type: ignore
 
             # Create the table object
-            table = Table(table_name, self.metadata, *columns)
+            table = Table(table_name, self.metadata, *columns, extend_existing=True)
 
             # Add multi-column unique constraints with table-specific names
             for constraint in schema_unique_constraints:
@@ -431,7 +431,7 @@ class AsyncSqliteDb(AsyncBaseDb):
             async with self.db_engine.connect() as conn:
 
                 def load_table(connection):
-                    return Table(table_name, self.metadata, autoload_with=connection)
+                    return Table(table_name, self.metadata, autoload_with=connection, extend_existing=True)
 
                 table = await conn.run_sync(load_table)
                 return table

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -293,7 +293,7 @@ class SqliteDb(BaseDb):
                 columns.append(Column(*column_args, **column_kwargs))  # type: ignore
 
             # Create the table object
-            table = Table(table_name, self.metadata, *columns)
+            table = Table(table_name, self.metadata, *columns, extend_existing=True)
 
             # Composite PK
             if schema_primary_key is not None:
@@ -605,7 +605,7 @@ class SqliteDb(BaseDb):
             raise ValueError(f"Table {table_name} has an invalid schema")
 
         try:
-            table = Table(table_name, self.metadata, autoload_with=self.db_engine)
+            table = Table(table_name, self.metadata, autoload_with=self.db_engine, extend_existing=True)
             return table
 
         except Exception as e:

--- a/libs/agno/tests/unit/db/test_extend_existing.py
+++ b/libs/agno/tests/unit/db/test_extend_existing.py
@@ -1,0 +1,113 @@
+"""Test that Table() calls use extend_existing=True to prevent InvalidRequestError on retry.
+
+Regression test for #7381 (SQLite / MySQL) and related to #7319 (PostgreSQL).
+When _create_table() fails after registering the table on MetaData, the next
+retry must not raise InvalidRequestError.  Setting extend_existing=True ensures
+that re-registering the same table name is safe.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import MetaData, Table, Column, String, Integer
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_metadata_with_existing_table(table_name: str) -> MetaData:
+    """Return a MetaData that already has *table_name* registered."""
+    metadata = MetaData()
+    Table(table_name, metadata, Column("id", String, primary_key=True))
+    assert table_name in metadata.tables
+    return metadata
+
+
+# ---------------------------------------------------------------------------
+# Tests: Table() with extend_existing=True tolerates duplicate registration
+# ---------------------------------------------------------------------------
+
+class TestExtendExistingGuard:
+    """Verify that creating a Table with the same name on the same MetaData
+    succeeds when extend_existing=True and fails without it."""
+
+    def test_duplicate_table_without_extend_existing_raises(self):
+        metadata = _make_metadata_with_existing_table("test_table")
+        with pytest.raises(Exception):  # InvalidRequestError
+            Table("test_table", metadata, Column("id", String, primary_key=True))
+
+    def test_duplicate_table_with_extend_existing_succeeds(self):
+        metadata = _make_metadata_with_existing_table("test_table")
+        # This must NOT raise
+        table = Table(
+            "test_table",
+            metadata,
+            Column("id", String, primary_key=True),
+            extend_existing=True,
+        )
+        assert table is not None
+        assert table.name == "test_table"
+
+
+# ---------------------------------------------------------------------------
+# Tests: SQLite backends pass extend_existing=True
+# ---------------------------------------------------------------------------
+
+class TestSQLiteExtendExisting:
+    """Check that SQLite Table() calls include extend_existing=True."""
+
+    def test_sqlite_create_table_uses_extend_existing(self):
+        """Verify sqlite.py _create_table passes extend_existing=True."""
+        import importlib
+        import inspect
+
+        mod = importlib.import_module("agno.db.sqlite.sqlite")
+        source = inspect.getsource(mod)
+
+        # Every Table() in _create_table should have extend_existing
+        # We check the source contains extend_existing=True near Table(
+        assert "extend_existing=True" in source, (
+            "sqlite.py must pass extend_existing=True to Table() constructors"
+        )
+
+    def test_async_sqlite_create_table_uses_extend_existing(self):
+        """Verify async_sqlite.py _create_table passes extend_existing=True."""
+        import importlib
+        import inspect
+
+        mod = importlib.import_module("agno.db.sqlite.async_sqlite")
+        source = inspect.getsource(mod)
+        assert "extend_existing=True" in source, (
+            "async_sqlite.py must pass extend_existing=True to Table() constructors"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: MySQL backends pass extend_existing=True
+# ---------------------------------------------------------------------------
+
+class TestMySQLExtendExisting:
+    """Check that MySQL Table() calls include extend_existing=True."""
+
+    def test_mysql_create_table_uses_extend_existing(self):
+        """Verify mysql.py _create_table passes extend_existing=True."""
+        import importlib
+        import inspect
+
+        mod = importlib.import_module("agno.db.mysql.mysql")
+        source = inspect.getsource(mod)
+        assert "extend_existing=True" in source, (
+            "mysql.py must pass extend_existing=True to Table() constructors"
+        )
+
+    def test_async_mysql_create_table_uses_extend_existing(self):
+        """Verify async_mysql.py _create_table passes extend_existing=True."""
+        import importlib
+        import inspect
+
+        mod = importlib.import_module("agno.db.mysql.async_mysql")
+        source = inspect.getsource(mod)
+        assert "extend_existing=True" in source, (
+            "async_mysql.py must pass extend_existing=True to Table() constructors"
+        )


### PR DESCRIPTION
## Summary

Fixes #7381

The same bug reported in #7319 for PostgreSQL also affects SQLite and MySQL backends. When `_create_table()` fails after registering the table name on `MetaData`, the retry raises `sqlalchemy.exc.InvalidRequestError` because `Table()` does not allow re-registration by default.

## Changes

Add `extend_existing=True` to all `Table()` constructors in:
- `libs/agno/agno/db/sqlite/sqlite.py` (2 call sites)
- `libs/agno/agno/db/sqlite/async_sqlite.py` (2 call sites)
- `libs/agno/agno/db/mysql/mysql.py` (2 call sites)
- `libs/agno/agno/db/mysql/async_mysql.py` (2 call sites)

This is safe because `table.create(checkfirst=True)` is already used for DDL, so the actual database schema is idempotent. `extend_existing=True` only affects the Python-side MetaData registry.

## Tests

Added `libs/agno/tests/unit/db/test_extend_existing.py` with:
- Regression test verifying `Table()` with `extend_existing=True` tolerates duplicate registration
- Source-level checks that all 4 backend files include `extend_existing=True`

## Note

The existing PRs #7322 and #7334 fix only the PostgreSQL backend. This PR covers the remaining SQLite and MySQL backends.