### PR TITLE
fix: add extend_existing=True to SQLite and MySQL _create_table

### DIFF
--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -192,7 +192,7 @@ class AsyncMySQLDb(AsyncBaseDb):
                 columns.append(Column(*column_args, **column_kwargs))  # type: ignore
 
             # Create the table object - use self.metadata to maintain FK references
-            table = Table(table_name, self.metadata, *columns, schema=self.db_schema)
+            table = Table(table_name, self.metadata, *columns, schema=self.db_schema, extend_existing=True)
 
             # Add multi-column unique constraints with table-specific names
             for constraint in schema_unique_constraints:

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -187,7 +187,7 @@ class MySQLDb(BaseDb):
                 columns.append(Column(*column_args, **column_kwargs))  # type: ignore
 
             # Create the table object
-            table = Table(table_name, self.metadata, *columns, schema=self.db_schema)
+            table = Table(table_name, self.metadata, *columns, schema=self.db_schema, extend_existing=True)
 
             # Add multi-column unique constraints with table-specific names
             for constraint in schema_unique_constraints:

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -230,7 +230,7 @@ class AsyncSqliteDb(AsyncBaseDb):
                 columns.append(Column(*column_args, **column_kwargs))  # type: ignore
 
             # Create the table object
-            table = Table(table_name, self.metadata, *columns)
+            table = Table(table_name, self.metadata, *columns, extend_existing=True)
 
             # Add multi-column unique constraints with table-specific names
             for constraint in schema_unique_constraints:

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -293,7 +293,7 @@ class SqliteDb(BaseDb):
                 columns.append(Column(*column_args, **column_kwargs))  # type: ignore
 
             # Create the table object
-            table = Table(table_name, self.metadata, *columns)
+            table = Table(table_name, self.metadata, *columns, extend_existing=True)
 
             # Composite PK
             if schema_primary_key is not None:


### PR DESCRIPTION
## Summary

Fixes #7381.

The same bug fixed in PostgreSQL (#7322, #7334) also affects SQLite and MySQL backends. When `_create_table()` fails on transient errors (locked database, connection timeout), the table name remains registered on the shared `MetaData` instance. On retry, `Table()` raises:

```
sqlalchemy.exc.InvalidRequestError: Table 'X' is already defined for this MetaData instance
```

## Changes

Add `extend_existing=True` to the `Table()` constructor in `_create_table()` across 4 files:
- `libs/agno/agno/db/sqlite/sqlite.py`
- `libs/agno/agno/db/sqlite/async_sqlite.py`
- `libs/agno/agno/db/mysql/mysql.py`
- `libs/agno/agno/db/mysql/async_mysql.py`

## Test plan

- Verify existing tests pass
- The fix is identical to the PostgreSQL fix that was already merged