### PR TITLE
fix: move branching id to runs level

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -5249,13 +5249,18 @@ def branch_session_dispatch(
     # Rewrite session_id on each copied run so the new session's run metadata
     # is internally consistent (runs should reference their owning session).
     # Also assign new run_ids so they are globally unique.
+    # Record branched_from on each run so the lineage is visible per-run
+    # (e.g. via the GET runs API) without needing a separate session lookup.
+    # Only set branched_from if the run doesn't already have one — this
+    # preserves the original lineage through nested branches.
     for run in branched_runs or []:
         run.run_id = str(uuid4())
         run.session_id = new_session_id
+        if not run.branched_from:
+            run.branched_from = source_session_id
 
-    # Carry over session_data and record the source session for traceability.
+    # Carry over session_data.
     new_session_data = copy.deepcopy(source_session.session_data) or {}
-    new_session_data["branched_from"] = source_session_id
 
     new_session = AgentSession(
         session_id=new_session_id,
@@ -5330,13 +5335,17 @@ async def abranch_session_dispatch(
     branched_runs = copy.deepcopy(source_session.runs)
 
     # Rewrite session_id and run_id on each copied run so run metadata is consistent.
+    # Record branched_from on each run so the lineage is visible per-run.
+    # Only set branched_from if the run doesn't already have one — this
+    # preserves the original lineage through nested branches.
     for run in branched_runs or []:
         run.run_id = str(uuid4())
         run.session_id = new_session_id
+        if not run.branched_from:
+            run.branched_from = source_session_id
 
-    # Carry over session_data and record the source session for traceability.
+    # Carry over session_data.
     new_session_data = copy.deepcopy(source_session.session_data) or {}
-    new_session_data["branched_from"] = source_session_id
 
     new_session = AgentSession(
         session_id=new_session_id,

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -411,6 +411,9 @@ class RunSchema(BaseModel):
     )
     reasoning_messages: Optional[List[dict]] = Field(None, description="Reasoning process messages")
     session_state: Optional[dict] = Field(None, description="Session state at the end of the run")
+    branched_from: Optional[str] = Field(
+        None, description="Source session ID if this run was branched from another session"
+    )
     images: Optional[List[dict]] = Field(None, description="Images included in the run")
     videos: Optional[List[dict]] = Field(None, description="Videos included in the run")
     audio: Optional[List[dict]] = Field(None, description="Audio files included in the run")
@@ -443,6 +446,7 @@ class RunSchema(BaseModel):
             citations=run_dict.get("citations", None),
             reasoning_messages=run_dict.get("reasoning_messages", []),
             session_state=run_dict.get("session_state"),
+            branched_from=run_dict.get("branched_from", ""),
             images=run_dict.get("images", []),
             videos=run_dict.get("videos", []),
             audio=run_dict.get("audio", []),
@@ -475,6 +479,7 @@ class TeamRunSchema(BaseModel):
     )
     reasoning_messages: Optional[List[dict]] = Field(None, description="Reasoning process messages")
     session_state: Optional[dict] = Field(None, description="Session state at the end of the run")
+    branched_from: Optional[str] = Field(None, description="Source session ID if this run was branched from another session")
     input_media: Optional[Dict[str, Any]] = Field(None, description="Input media attachments")
     images: Optional[List[dict]] = Field(None, description="Images included in the run")
     videos: Optional[List[dict]] = Field(None, description="Videos included in the run")
@@ -506,6 +511,7 @@ class TeamRunSchema(BaseModel):
             citations=run_dict.get("citations", None),
             reasoning_messages=run_dict.get("reasoning_messages", []),
             session_state=run_dict.get("session_state"),
+            branched_from=run_dict.get("branched_from", ""),
             images=run_dict.get("images", []),
             videos=run_dict.get("videos", []),
             audio=run_dict.get("audio", []),

--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -650,6 +650,9 @@ class RunOutput:
     metadata: Optional[Dict[str, Any]] = None
     session_state: Optional[Dict[str, Any]] = None
 
+    # Branching lineage: the source session_id this run was branched from
+    branched_from: Optional[str] = None
+
     created_at: int = field(default_factory=lambda: int(time()))
 
     events: Optional[List[RunOutputEvent]] = None

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -759,6 +759,9 @@ class TeamRunOutput:
     metadata: Optional[Dict[str, Any]] = None
     session_state: Optional[Dict[str, Any]] = None
 
+    # Branching lineage: the source session_id this run was branched from
+    branched_from: Optional[str] = None
+
     references: Optional[List[MessageReferences]] = None
     additional_input: Optional[List[Message]] = None
     reasoning_steps: Optional[List[ReasoningStep]] = None

--- a/libs/agno/tests/unit/agent/test_regenerate_fork.py
+++ b/libs/agno/tests/unit/agent/test_regenerate_fork.py
@@ -592,8 +592,72 @@ class TestBranchSessionDispatch:
         saved_session = mock_save.call_args[1].get("session") or mock_save.call_args[0][1]
         assert saved_session.session_id == new_id
         assert len(saved_session.runs) == 2
-        # branched_from should be recorded in session_data
-        assert saved_session.session_data["branched_from"] == "original"
+
+    def test_branch_records_branched_from_on_each_run(self, monkeypatch: pytest.MonkeyPatch):
+        """branched_from must be stored on each run (not session_data) so the
+        GET runs API can return it without a separate session lookup."""
+        agent = Agent(name="test")
+        run1 = _make_run(run_id="r1", messages=[Message(role="user", content="hi")])
+        run2 = _make_run(run_id="r2", messages=[Message(role="user", content="hello")])
+        session = _make_session(runs=[run1, run2], session_id="original")
+        mock_save = _patch_branch_deps(agent, monkeypatch, session)
+
+        _run.branch_session_dispatch(agent, source_session_id="original")
+
+        saved_session = mock_save.call_args[1].get("session") or mock_save.call_args[0][1]
+        for run in saved_session.runs:
+            assert run.branched_from == "original", f"Run {run.run_id} missing branched_from; lineage must be per-run"
+        # branched_from should NOT be in session_data
+        assert "branched_from" not in (saved_session.session_data or {})
+
+    def test_branch_branched_from_survives_to_dict_roundtrip(self, monkeypatch: pytest.MonkeyPatch):
+        """branched_from must appear in RunOutput.to_dict() so RunSchema.from_dict()
+        can pick it up and return it in the API response."""
+        agent = Agent(name="test")
+        run1 = _make_run(run_id="r1", messages=[Message(role="user", content="hi")])
+        session = _make_session(runs=[run1], session_id="original")
+        mock_save = _patch_branch_deps(agent, monkeypatch, session)
+
+        _run.branch_session_dispatch(agent, source_session_id="original")
+
+        saved_session = mock_save.call_args[1].get("session") or mock_save.call_args[0][1]
+        run_dict = saved_session.runs[0].to_dict()
+        assert run_dict.get("branched_from") == "original", (
+            "branched_from must be present in to_dict() output for the runs API"
+        )
+
+    def test_branch_source_runs_not_mutated(self, monkeypatch: pytest.MonkeyPatch):
+        """Branching must not set branched_from on the source session's runs."""
+        agent = Agent(name="test")
+        run1 = _make_run(run_id="r1", messages=[Message(role="user", content="hi")])
+        session = _make_session(runs=[run1], session_id="original")
+        _patch_branch_deps(agent, monkeypatch, session)
+
+        _run.branch_session_dispatch(agent, source_session_id="original")
+
+        assert run1.branched_from is None, "Source run must not be mutated"
+
+    def test_nested_branch_preserves_original_branched_from(self, monkeypatch: pytest.MonkeyPatch):
+        """When branching a session that was itself branched, runs that already
+        have branched_from set must keep their original value — only runs
+        without branched_from get the new source_session_id."""
+        agent = Agent(name="test")
+        # Simulate a run that was already branched from session "A"
+        run_from_a = _make_run(run_id="r1", messages=[Message(role="user", content="hi")])
+        run_from_a.branched_from = "session-A"
+        # A new run created natively in session "B" (no branched_from)
+        run_native = _make_run(run_id="r2", messages=[Message(role="user", content="hello")])
+
+        session_b = _make_session(runs=[run_from_a, run_native], session_id="session-B")
+        mock_save = _patch_branch_deps(agent, monkeypatch, session_b)
+
+        _run.branch_session_dispatch(agent, source_session_id="session-B")
+
+        saved_session = mock_save.call_args[1].get("session") or mock_save.call_args[0][1]
+        # run copied from A should still point to A, not overwritten to B
+        assert saved_session.runs[0].branched_from == "session-A"
+        # run native to B should now point to B
+        assert saved_session.runs[1].branched_from == "session-B"
 
     def test_branch_deep_copies_runs(self, monkeypatch: pytest.MonkeyPatch):
         agent = Agent(name="test")


### PR DESCRIPTION
- Introduced a new `branched_from` field in the RunSchema and TeamRunSchema to store the source session ID for runs that are branched from another session.
- Updated the session dispatch logic to record the `branched_from` attribute on each run, ensuring lineage visibility without requiring a separate session lookup.
- Enhanced tests to verify that `branched_from` is correctly set and preserved during session branching, including scenarios for nested branches.

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other: