### PR TITLE
[feat] Add asqav observability integration cookbook example

### DIFF
--- a/cookbook/92_integrations/observability/README.md
+++ b/cookbook/92_integrations/observability/README.md
@@ -6,6 +6,7 @@ Observability examples for tracing and monitoring Agno agents, teams, and workfl
 
 - `agent_ops.py`
 - `arize_phoenix_moving_traces_to_different_projects.py`
+- `asqav_via_openinference.py`
 - `arize_phoenix_via_openinference.py`
 - `arize_phoenix_via_openinference_local.py`
 - `atla_op.py`

--- a/cookbook/92_integrations/observability/asqav_via_openinference.py
+++ b/cookbook/92_integrations/observability/asqav_via_openinference.py
@@ -1,0 +1,84 @@
+"""
+Asqav Via OpenInference
+=======================
+
+Demonstrates instrumenting an Agno agent with asqav for governance
+audit trails, cryptographic signing, and compliance reporting.
+
+asqav signs every agent action with ML-DSA post-quantum signatures,
+producing a verifiable audit trail alongside Agno's OpenTelemetry traces.
+
+Requirements:
+    pip install asqav opentelemetry-api opentelemetry-sdk openinference-instrumentation-agno
+
+More info: https://github.com/jagmarques/asqav-sdk
+"""
+
+import os
+
+import asqav
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools.yfinance import YFinanceTools
+from openinference.instrumentation.agno import AgnoInstrumentor
+from opentelemetry import trace as trace_api
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+
+# ---------------------------------------------------------------------------
+# Setup - asqav governance layer
+# ---------------------------------------------------------------------------
+# Initialize asqav with your API key (get one at https://asqav.com)
+asqav.init(api_key=os.getenv("ASQAV_API_KEY", "sk_..."))
+
+# Create an asqav agent identity for cryptographic action signing
+asqav_agent = asqav.Agent.create("agno-stock-analyst")
+
+# Configure asqav to export its governance spans via OpenTelemetry
+asqav.configure_otel(os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
+
+# ---------------------------------------------------------------------------
+# Setup - Agno OpenTelemetry tracing
+# ---------------------------------------------------------------------------
+# Use any OTel-compatible exporter (OTLP, console, etc.)
+# asqav governance events are captured separately via asqav.configure_otel()
+tracer_provider = TracerProvider()
+tracer_provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+trace_api.set_tracer_provider(tracer_provider)
+
+# Enable automatic OpenInference instrumentation for Agno
+AgnoInstrumentor().instrument()
+
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+agent = Agent(
+    name="Stock Price Agent",
+    model=OpenAIChat(id="gpt-4o"),
+    tools=[YFinanceTools()],
+    instructions="You are a stock price analyst. Answer with concise, sourced updates.",
+    debug_mode=True,
+    trace_attributes={
+        "session.id": "demo-session-001",
+        "environment": "development",
+    },
+)
+
+
+# ---------------------------------------------------------------------------
+# Run Example
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # Sign the agent run as a governance event in asqav's audit trail.
+    # This creates a cryptographic record that this agent was authorized to run.
+    asqav_agent.sign("agent:run", {"task": "stock-analysis", "framework": "agno"})
+
+    # Run the agent - OpenInference captures the full trace (agent, model, tool spans)
+    # while asqav records the governance signature for compliance.
+    agent.print_response(
+        "What is the current price of Apple and how did it move today?"
+    )
+
+    # Flush asqav governance spans
+    asqav.flush_spans()

--- a/libs/agno/tests/unit/integrations/test_asqav_cookbook.py
+++ b/libs/agno/tests/unit/integrations/test_asqav_cookbook.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for the asqav observability cookbook example.
+
+Validates that the integration pattern in
+cookbook/92_integrations/observability/asqav_via_openinference.py
+uses the correct Agno APIs for OpenTelemetry-based observability.
+"""
+
+import ast
+import os
+
+import pytest
+
+
+COOKBOOK_PATH = os.path.realpath(
+    os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        "..",
+        "..",
+        "..",
+        "..",
+        "..",
+        "cookbook",
+        "92_integrations",
+        "observability",
+        "asqav_via_openinference.py",
+    )
+)
+
+
+def test_cookbook_file_exists():
+    """The asqav cookbook example file must exist."""
+    assert os.path.isfile(COOKBOOK_PATH), f"Missing cookbook file: {COOKBOOK_PATH}"
+
+
+def test_cookbook_file_parses():
+    """The cookbook example must be valid Python."""
+    with open(COOKBOOK_PATH) as f:
+        source = f.read()
+    # ast.parse raises SyntaxError on invalid Python
+    tree = ast.parse(source)
+    assert tree is not None
+
+
+def test_cookbook_imports_agno_agent():
+    """The cookbook example must import agno.agent.Agent."""
+    with open(COOKBOOK_PATH) as f:
+        source = f.read()
+    tree = ast.parse(source)
+
+    agno_imports = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module and "agno" in node.module:
+            for alias in node.names:
+                agno_imports.append(f"{node.module}.{alias.name}")
+
+    assert any("agno.agent" in imp for imp in agno_imports), (
+        f"Expected agno.agent import, found: {agno_imports}"
+    )
+
+
+def test_cookbook_imports_openinference():
+    """The cookbook example must import AgnoInstrumentor."""
+    with open(COOKBOOK_PATH) as f:
+        source = f.read()
+    tree = ast.parse(source)
+
+    oi_imports = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module and "openinference" in node.module:
+            for alias in node.names:
+                oi_imports.append(alias.name)
+
+    assert "AgnoInstrumentor" in oi_imports, (
+        f"Expected AgnoInstrumentor import, found: {oi_imports}"
+    )
+
+
+def test_cookbook_imports_asqav():
+    """The cookbook example must import asqav."""
+    with open(COOKBOOK_PATH) as f:
+        source = f.read()
+    tree = ast.parse(source)
+
+    has_asqav = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "asqav":
+                    has_asqav = True
+        elif isinstance(node, ast.ImportFrom) and node.module and "asqav" in node.module:
+            has_asqav = True
+
+    assert has_asqav, "Expected asqav import in cookbook example"
+
+
+def test_cookbook_has_main_guard():
+    """The cookbook example must have an if __name__ == '__main__' guard."""
+    with open(COOKBOOK_PATH) as f:
+        source = f.read()
+    assert '__name__' in source and '__main__' in source, (
+        "Cookbook example should have a __main__ guard"
+    )


### PR DESCRIPTION
Fixes #7425

## Summary

- Adds a cookbook example (`cookbook/92_integrations/observability/asqav_via_openinference.py`) showing how to instrument Agno agents with [asqav](https://github.com/jagmarques/asqav-sdk) for governance audit trails and cryptographic action signing
- asqav provides ML-DSA post-quantum signatures for every agent action, producing a verifiable audit trail alongside Agno's OpenTelemetry traces
- Follows the same pattern as existing observability integrations (Langfuse, Opik, etc.)
- Updates the observability README to list the new example
- Includes unit tests validating the cookbook example structure and imports

## How it works

asqav adds a governance layer on top of Agno's OpenInference instrumentation:
1. Initialize asqav and create an agent identity
2. Configure Agno's OpenTelemetry tracing as usual
3. Sign agent actions as governance events with `agent.sign()`
4. Each signed action gets a cryptographic record for compliance

Install: `pip install asqav`

## AI disclosure

This PR was authored with Claude Code. All changes have been reviewed and tested by the author.

## Test plan

- [x] Unit tests pass (`pytest libs/agno/tests/unit/integrations/test_asqav_cookbook.py` - 6/6 passing)
- [x] Cookbook file is valid Python (verified via ast.parse)
- [x] Cookbook imports match expected Agno and OpenInference APIs
- [ ] Cookbook example runs end-to-end with valid API keys (requires asqav and OpenAI keys)