### PR TITLE
fix: emit reasoning events in AGUI interface

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -10,6 +10,11 @@ from ag_ui.core import (
     BaseEvent,
     CustomEvent,
     EventType,
+    ReasoningEndEvent,
+    ReasoningMessageContentEvent,
+    ReasoningMessageEndEvent,
+    ReasoningMessageStartEvent,
+    ReasoningStartEvent,
     RunFinishedEvent,
     StepFinishedEvent,
     StepStartedEvent,
@@ -197,7 +202,8 @@ def _create_events_from_chunk(
     message_id: str,
     message_started: bool,
     event_buffer: EventBuffer,
-) -> Tuple[List[BaseEvent], bool, str]:
+    reasoning_message_id: Optional[str] = None,
+) -> Tuple[List[BaseEvent], bool, str, Optional[str]]:
     """
     Process a single chunk and return events to emit + updated message_started state.
 
@@ -206,9 +212,10 @@ def _create_events_from_chunk(
         message_id: Current message identifier
         message_started: Whether a message is currently active
         event_buffer: Event buffer for tracking tool call state
+        reasoning_message_id: Current reasoning message identifier (if active)
 
     Returns:
-        Tuple of (events_to_emit, new_message_started_state, message_id)
+        Tuple of (events_to_emit, new_message_started_state, message_id, reasoning_message_id)
     """
     events_to_emit: List[BaseEvent] = []
 
@@ -327,12 +334,40 @@ def _create_events_from_chunk(
                     events_to_emit.append(result_event)
 
     # Handle reasoning
-    elif chunk.event == RunEvent.reasoning_started:
-        step_started_event = StepStartedEvent(type=EventType.STEP_STARTED, step_name="reasoning")
-        events_to_emit.append(step_started_event)
-    elif chunk.event == RunEvent.reasoning_completed:
-        step_finished_event = StepFinishedEvent(type=EventType.STEP_FINISHED, step_name="reasoning")
-        events_to_emit.append(step_finished_event)
+    elif chunk.event == RunEvent.reasoning_started or chunk.event == TeamRunEvent.reasoning_started:
+        reasoning_message_id = str(uuid.uuid4())
+        events_to_emit.append(StepStartedEvent(type=EventType.STEP_STARTED, step_name="reasoning"))
+        events_to_emit.append(ReasoningStartEvent(type=EventType.REASONING_START, message_id=reasoning_message_id))
+        events_to_emit.append(
+            ReasoningMessageStartEvent(
+                type=EventType.REASONING_MESSAGE_START, message_id=reasoning_message_id, role="reasoning"
+            )
+        )
+    elif chunk.event in (
+        RunEvent.reasoning_step,
+        TeamRunEvent.reasoning_step,
+        RunEvent.reasoning_content_delta,
+        TeamRunEvent.reasoning_content_delta,
+    ):
+        # Both reasoning_step (accumulated) and reasoning_content_delta (streaming)
+        # carry reasoning text — map both to REASONING_MESSAGE_CONTENT
+        if reasoning_message_id is None:
+            reasoning_message_id = str(uuid.uuid4())
+        reasoning_content = chunk.reasoning_content  # type: ignore[union-attr]
+        if reasoning_content:
+            events_to_emit.append(
+                ReasoningMessageContentEvent(
+                    type=EventType.REASONING_MESSAGE_CONTENT, message_id=reasoning_message_id, delta=reasoning_content
+                )
+            )
+    elif chunk.event == RunEvent.reasoning_completed or chunk.event == TeamRunEvent.reasoning_completed:
+        if reasoning_message_id is not None:
+            events_to_emit.append(
+                ReasoningMessageEndEvent(type=EventType.REASONING_MESSAGE_END, message_id=reasoning_message_id)
+            )
+            events_to_emit.append(ReasoningEndEvent(type=EventType.REASONING_END, message_id=reasoning_message_id))
+            reasoning_message_id = None
+            events_to_emit.append(StepFinishedEvent(type=EventType.STEP_FINISHED, step_name="reasoning"))
 
     # Handle custom events
     elif chunk.event == RunEvent.custom_event:
@@ -351,7 +386,7 @@ def _create_events_from_chunk(
         custom_event = CustomEvent(name=custom_event_name, value=custom_event_value)
         events_to_emit.append(custom_event)
 
-    return events_to_emit, message_started, message_id
+    return events_to_emit, message_started, message_id, reasoning_message_id
 
 
 def _create_completion_events(
@@ -361,9 +396,18 @@ def _create_completion_events(
     message_id: str,
     thread_id: str,
     run_id: str,
+    reasoning_message_id: Optional[str] = None,
 ) -> List[BaseEvent]:
     """Create events for run completion."""
     events_to_emit: List[BaseEvent] = []
+
+    # Close orphaned reasoning session if stream ended mid-reasoning
+    if reasoning_message_id is not None:
+        events_to_emit.append(
+            ReasoningMessageEndEvent(type=EventType.REASONING_MESSAGE_END, message_id=reasoning_message_id)
+        )
+        events_to_emit.append(ReasoningEndEvent(type=EventType.REASONING_END, message_id=reasoning_message_id))
+        events_to_emit.append(StepFinishedEvent(type=EventType.STEP_FINISHED, step_name="reasoning"))
 
     # End remaining active tool calls if needed
     for tool_call_id in list(event_buffer.active_tool_call_ids):
@@ -465,6 +509,7 @@ def stream_agno_response_as_agui_events(
     message_started = False
     event_buffer = EventBuffer()
     stream_completed = False
+    reasoning_message_id: Optional[str] = None
 
     completion_chunk = None
 
@@ -480,8 +525,8 @@ def stream_agno_response_as_agui_events(
             stream_completed = True
         else:
             # Process regular chunk immediately
-            events_from_chunk, message_started, message_id = _create_events_from_chunk(
-                chunk, message_id, message_started, event_buffer
+            events_from_chunk, message_started, message_id, reasoning_message_id = _create_events_from_chunk(
+                chunk, message_id, message_started, event_buffer, reasoning_message_id
             )
 
             for event in events_from_chunk:
@@ -492,7 +537,7 @@ def stream_agno_response_as_agui_events(
     # Process ONLY completion cleanup events, not content from completion chunk
     if completion_chunk:
         completion_events = _create_completion_events(
-            completion_chunk, event_buffer, message_started, message_id, thread_id, run_id
+            completion_chunk, event_buffer, message_started, message_id, thread_id, run_id, reasoning_message_id
         )
         for event in completion_events:
             events_to_emit = _emit_event_logic(event_buffer=event_buffer, event=event)
@@ -525,6 +570,7 @@ async def async_stream_agno_response_as_agui_events(
     message_started = False
     event_buffer = EventBuffer()
     stream_completed = False
+    reasoning_message_id: Optional[str] = None
 
     completion_chunk = None
 
@@ -540,8 +586,8 @@ async def async_stream_agno_response_as_agui_events(
             stream_completed = True
         else:
             # Process regular chunk immediately
-            events_from_chunk, message_started, message_id = _create_events_from_chunk(
-                chunk, message_id, message_started, event_buffer
+            events_from_chunk, message_started, message_id, reasoning_message_id = _create_events_from_chunk(
+                chunk, message_id, message_started, event_buffer, reasoning_message_id
             )
 
             for event in events_from_chunk:
@@ -552,7 +598,7 @@ async def async_stream_agno_response_as_agui_events(
     # Process ONLY completion cleanup events, not content from completion chunk
     if completion_chunk:
         completion_events = _create_completion_events(
-            completion_chunk, event_buffer, message_started, message_id, thread_id, run_id
+            completion_chunk, event_buffer, message_started, message_id, thread_id, run_id, reasoning_message_id
         )
         for event in completion_events:
             events_to_emit = _emit_event_logic(event_buffer=event_buffer, event=event)

--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -16,8 +16,6 @@ from ag_ui.core import (
     ReasoningMessageStartEvent,
     ReasoningStartEvent,
     RunFinishedEvent,
-    StepFinishedEvent,
-    StepStartedEvent,
     TextMessageContentEvent,
     TextMessageEndEvent,
     TextMessageStartEvent,
@@ -30,7 +28,16 @@ from ag_ui.core.types import Message as AGUIMessage
 from pydantic import BaseModel
 
 from agno.models.message import Message
+from agno.reasoning.step import ReasoningStep
+from agno.run.agent import ReasoningCompletedEvent as AgentReasoningCompletedEvent
+from agno.run.agent import ReasoningContentDeltaEvent as AgentReasoningContentDeltaEvent
+from agno.run.agent import ReasoningStartedEvent as AgentReasoningStartedEvent
+from agno.run.agent import ReasoningStepEvent as AgentReasoningStepEvent
 from agno.run.agent import RunContentEvent, RunEvent, RunOutputEvent, RunPausedEvent
+from agno.run.team import ReasoningCompletedEvent as TeamReasoningCompletedEvent
+from agno.run.team import ReasoningContentDeltaEvent as TeamReasoningContentDeltaEvent
+from agno.run.team import ReasoningStartedEvent as TeamReasoningStartedEvent
+from agno.run.team import ReasoningStepEvent as TeamReasoningStepEvent
 from agno.run.team import RunContentEvent as TeamRunContentEvent
 from agno.run.team import TeamRunEvent, TeamRunOutputEvent
 from agno.utils.log import log_debug, log_warning
@@ -78,6 +85,8 @@ class EventBuffer:
     current_text_message_id: str = ""  # ID of the current text message context (for tool call parenting)
     next_text_message_id: str = ""  # Pre-generated ID for the next text message
     pending_tool_calls_parent_id: str = ""  # Parent message ID for pending tool calls
+    reasoning_message_id: Optional[str] = None  # Active reasoning session ID, set by reasoning_started
+    reasoning_step_count: int = 0  # Step counter for ReasoningTools (reset each session)
 
     def __init__(self):
         self.active_tool_call_ids = set()
@@ -85,6 +94,8 @@ class EventBuffer:
         self.current_text_message_id = ""
         self.next_text_message_id = str(uuid.uuid4())
         self.pending_tool_calls_parent_id = ""
+        self.reasoning_message_id = None
+        self.reasoning_step_count = 0
 
     def start_tool_call(self, tool_call_id: str) -> None:
         """Start a new tool call."""
@@ -117,6 +128,30 @@ class EventBuffer:
     def clear_pending_tool_calls_parent_id(self) -> None:
         """Clear the pending parent ID when a new text message starts."""
         self.pending_tool_calls_parent_id = ""
+
+    def start_reasoning(self) -> str:
+        """Start a new reasoning session and return its message ID."""
+        self.reasoning_message_id = str(uuid.uuid4())
+        self.reasoning_step_count = 0
+        return self.reasoning_message_id
+
+    def next_reasoning_step(self) -> int:
+        """Increment and return the current reasoning step number."""
+        self.reasoning_step_count += 1
+        return self.reasoning_step_count
+
+    def ensure_reasoning_started(self) -> Tuple[str, bool]:
+        """Return the active reasoning session ID, starting one if needed.
+        Returns (reasoning_id, is_new) where is_new is True if a new session was created.
+        """
+        if self.reasoning_message_id is not None:
+            return self.reasoning_message_id, False
+        return self.start_reasoning(), True
+
+    def end_reasoning(self) -> None:
+        """End the active reasoning session."""
+        self.reasoning_message_id = None
+        self.reasoning_step_count = 0
 
 
 def convert_agui_messages_to_agno_messages(messages: List[AGUIMessage]) -> List[Message]:
@@ -197,13 +232,38 @@ def extract_response_chunk_content(response: RunContentEvent) -> str:
     return get_text_from_message(response.content) if response.content is not None else ""
 
 
+def _format_reasoning_step_delta(step: Optional[ReasoningStep], step_number: int = 0) -> str:
+    """Format a single ReasoningStep as a text delta for REASONING_MESSAGE_CONTENT.
+
+    ReasoningStepEvent.content holds a ReasoningStep object (title, reasoning,
+    action, result, confidence). We format just this one step — NOT the
+    accumulated reasoning_content field, which duplicates prior steps.
+    """
+    if step is None:
+        return ""
+    parts: List[str] = []
+    title = step.title or "Thinking"
+    if step_number > 0:
+        parts.append(f"## Step {step_number}: {title}")
+    else:
+        parts.append(f"## {title}")
+    if step.reasoning:
+        parts.append(step.reasoning)
+    if step.action:
+        parts.append(f"Action: {step.action}")
+    if step.result:
+        parts.append(f"Result: {step.result}")
+    if step.confidence is not None:
+        parts.append(f"Confidence: {step.confidence}")
+    return "\n".join(parts) + "\n\n" if parts else ""
+
+
 def _create_events_from_chunk(
     chunk: Union[RunOutputEvent, TeamRunOutputEvent],
     message_id: str,
     message_started: bool,
     event_buffer: EventBuffer,
-    reasoning_message_id: Optional[str] = None,
-) -> Tuple[List[BaseEvent], bool, str, Optional[str]]:
+) -> Tuple[List[BaseEvent], bool, str]:
     """
     Process a single chunk and return events to emit + updated message_started state.
 
@@ -211,11 +271,10 @@ def _create_events_from_chunk(
         chunk: The event chunk to process
         message_id: Current message identifier
         message_started: Whether a message is currently active
-        event_buffer: Event buffer for tracking tool call state
-        reasoning_message_id: Current reasoning message identifier (if active)
+        event_buffer: Event buffer for tracking tool call state (includes reasoning session state)
 
     Returns:
-        Tuple of (events_to_emit, new_message_started_state, message_id, reasoning_message_id)
+        Tuple of (events_to_emit, new_message_started_state, message_id)
     """
     events_to_emit: List[BaseEvent] = []
 
@@ -333,41 +392,64 @@ def _create_events_from_chunk(
                     )
                     events_to_emit.append(result_event)
 
-    # Handle reasoning
-    elif chunk.event == RunEvent.reasoning_started or chunk.event == TeamRunEvent.reasoning_started:
-        reasoning_message_id = str(uuid.uuid4())
-        events_to_emit.append(StepStartedEvent(type=EventType.STEP_STARTED, step_name="reasoning"))
-        events_to_emit.append(ReasoningStartEvent(type=EventType.REASONING_START, message_id=reasoning_message_id))
+    # Handle reasoning — isinstance() dispatch for Agent and Team event types.
+    # Two producers: native model reasoning (o4-mini, Claude extended thinking)
+    # emits ReasoningContentDeltaEvent with true streaming deltas, while
+    # ReasoningTools (think/analyze) emits ReasoningStepEvent with a ReasoningStep object.
+    elif isinstance(chunk, (AgentReasoningStartedEvent, TeamReasoningStartedEvent)):
+        reasoning_id = event_buffer.start_reasoning()
+        events_to_emit.append(ReasoningStartEvent(type=EventType.REASONING_START, message_id=reasoning_id))
         events_to_emit.append(
             ReasoningMessageStartEvent(
-                type=EventType.REASONING_MESSAGE_START, message_id=reasoning_message_id, role="reasoning"
+                type=EventType.REASONING_MESSAGE_START, message_id=reasoning_id, role="reasoning"
             )
         )
-    elif chunk.event in (
-        RunEvent.reasoning_step,
-        TeamRunEvent.reasoning_step,
-        RunEvent.reasoning_content_delta,
-        TeamRunEvent.reasoning_content_delta,
-    ):
-        # Both reasoning_step (accumulated) and reasoning_content_delta (streaming)
-        # carry reasoning text — map both to REASONING_MESSAGE_CONTENT
-        if reasoning_message_id is None:
-            reasoning_message_id = str(uuid.uuid4())
-        reasoning_content = chunk.reasoning_content  # type: ignore[union-attr]
-        if reasoning_content:
+
+    elif isinstance(chunk, (AgentReasoningContentDeltaEvent, TeamReasoningContentDeltaEvent)):
+        # Native model reasoning — chunk.reasoning_content is a true streaming delta
+        reasoning_id, is_new = event_buffer.ensure_reasoning_started()
+        if is_new:
+            events_to_emit.append(ReasoningStartEvent(type=EventType.REASONING_START, message_id=reasoning_id))
             events_to_emit.append(
-                ReasoningMessageContentEvent(
-                    type=EventType.REASONING_MESSAGE_CONTENT, message_id=reasoning_message_id, delta=reasoning_content
+                ReasoningMessageStartEvent(
+                    type=EventType.REASONING_MESSAGE_START, message_id=reasoning_id, role="reasoning"
                 )
             )
-    elif chunk.event == RunEvent.reasoning_completed or chunk.event == TeamRunEvent.reasoning_completed:
-        if reasoning_message_id is not None:
+        if chunk.reasoning_content:
             events_to_emit.append(
-                ReasoningMessageEndEvent(type=EventType.REASONING_MESSAGE_END, message_id=reasoning_message_id)
+                ReasoningMessageContentEvent(
+                    type=EventType.REASONING_MESSAGE_CONTENT, message_id=reasoning_id, delta=chunk.reasoning_content
+                )
             )
-            events_to_emit.append(ReasoningEndEvent(type=EventType.REASONING_END, message_id=reasoning_message_id))
-            reasoning_message_id = None
-            events_to_emit.append(StepFinishedEvent(type=EventType.STEP_FINISHED, step_name="reasoning"))
+
+    elif isinstance(chunk, (AgentReasoningStepEvent, TeamReasoningStepEvent)):
+        # ReasoningTools — chunk.reasoning_content is accumulated (all steps so far),
+        # so we format chunk.content (the single ReasoningStep) as the delta instead
+        reasoning_id, is_new = event_buffer.ensure_reasoning_started()
+        if is_new:
+            events_to_emit.append(ReasoningStartEvent(type=EventType.REASONING_START, message_id=reasoning_id))
+            events_to_emit.append(
+                ReasoningMessageStartEvent(
+                    type=EventType.REASONING_MESSAGE_START, message_id=reasoning_id, role="reasoning"
+                )
+            )
+        step_num = event_buffer.next_reasoning_step()
+        delta = _format_reasoning_step_delta(chunk.content, step_num)
+        if delta:
+            events_to_emit.append(
+                ReasoningMessageContentEvent(
+                    type=EventType.REASONING_MESSAGE_CONTENT, message_id=reasoning_id, delta=delta
+                )
+            )
+
+    elif isinstance(chunk, (AgentReasoningCompletedEvent, TeamReasoningCompletedEvent)):
+        if event_buffer.reasoning_message_id is not None:
+            reasoning_id = event_buffer.reasoning_message_id
+            events_to_emit.append(
+                ReasoningMessageEndEvent(type=EventType.REASONING_MESSAGE_END, message_id=reasoning_id)
+            )
+            events_to_emit.append(ReasoningEndEvent(type=EventType.REASONING_END, message_id=reasoning_id))
+            event_buffer.end_reasoning()
 
     # Handle custom events
     elif chunk.event == RunEvent.custom_event:
@@ -386,7 +468,7 @@ def _create_events_from_chunk(
         custom_event = CustomEvent(name=custom_event_name, value=custom_event_value)
         events_to_emit.append(custom_event)
 
-    return events_to_emit, message_started, message_id, reasoning_message_id
+    return events_to_emit, message_started, message_id
 
 
 def _create_completion_events(
@@ -396,18 +478,19 @@ def _create_completion_events(
     message_id: str,
     thread_id: str,
     run_id: str,
-    reasoning_message_id: Optional[str] = None,
 ) -> List[BaseEvent]:
     """Create events for run completion."""
     events_to_emit: List[BaseEvent] = []
 
     # Close orphaned reasoning session if stream ended mid-reasoning
-    if reasoning_message_id is not None:
+    if event_buffer.reasoning_message_id is not None:
         events_to_emit.append(
-            ReasoningMessageEndEvent(type=EventType.REASONING_MESSAGE_END, message_id=reasoning_message_id)
+            ReasoningMessageEndEvent(type=EventType.REASONING_MESSAGE_END, message_id=event_buffer.reasoning_message_id)
         )
-        events_to_emit.append(ReasoningEndEvent(type=EventType.REASONING_END, message_id=reasoning_message_id))
-        events_to_emit.append(StepFinishedEvent(type=EventType.STEP_FINISHED, step_name="reasoning"))
+        events_to_emit.append(
+            ReasoningEndEvent(type=EventType.REASONING_END, message_id=event_buffer.reasoning_message_id)
+        )
+        event_buffer.end_reasoning()
 
     # End remaining active tool calls if needed
     for tool_call_id in list(event_buffer.active_tool_call_ids):
@@ -509,8 +592,6 @@ def stream_agno_response_as_agui_events(
     message_started = False
     event_buffer = EventBuffer()
     stream_completed = False
-    reasoning_message_id: Optional[str] = None
-
     completion_chunk = None
 
     for chunk in response_stream:
@@ -525,8 +606,8 @@ def stream_agno_response_as_agui_events(
             stream_completed = True
         else:
             # Process regular chunk immediately
-            events_from_chunk, message_started, message_id, reasoning_message_id = _create_events_from_chunk(
-                chunk, message_id, message_started, event_buffer, reasoning_message_id
+            events_from_chunk, message_started, message_id = _create_events_from_chunk(
+                chunk, message_id, message_started, event_buffer
             )
 
             for event in events_from_chunk:
@@ -537,7 +618,7 @@ def stream_agno_response_as_agui_events(
     # Process ONLY completion cleanup events, not content from completion chunk
     if completion_chunk:
         completion_events = _create_completion_events(
-            completion_chunk, event_buffer, message_started, message_id, thread_id, run_id, reasoning_message_id
+            completion_chunk, event_buffer, message_started, message_id, thread_id, run_id
         )
         for event in completion_events:
             events_to_emit = _emit_event_logic(event_buffer=event_buffer, event=event)
@@ -570,8 +651,6 @@ async def async_stream_agno_response_as_agui_events(
     message_started = False
     event_buffer = EventBuffer()
     stream_completed = False
-    reasoning_message_id: Optional[str] = None
-
     completion_chunk = None
 
     async for chunk in response_stream:
@@ -586,8 +665,8 @@ async def async_stream_agno_response_as_agui_events(
             stream_completed = True
         else:
             # Process regular chunk immediately
-            events_from_chunk, message_started, message_id, reasoning_message_id = _create_events_from_chunk(
-                chunk, message_id, message_started, event_buffer, reasoning_message_id
+            events_from_chunk, message_started, message_id = _create_events_from_chunk(
+                chunk, message_id, message_started, event_buffer
             )
 
             for event in events_from_chunk:
@@ -598,7 +677,7 @@ async def async_stream_agno_response_as_agui_events(
     # Process ONLY completion cleanup events, not content from completion chunk
     if completion_chunk:
         completion_events = _create_completion_events(
-            completion_chunk, event_buffer, message_started, message_id, thread_id, run_id, reasoning_message_id
+            completion_chunk, event_buffer, message_started, message_id, thread_id, run_id
         )
         for event in completion_events:
             events_to_emit = _emit_event_logic(event_buffer=event_buffer, event=event)

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -186,7 +186,7 @@ markdown = ["unstructured<0.18.31", "markdown", "aiofiles"]
 chonkie = ["chonkie[semantic]", "chonkie[code]", "chonkie"]
 
 # Dependencies for AG-UI integration
-agui = ["ag-ui-protocol>=0.1.15"]
+agui = ["ag-ui-protocol"]
 
 # Dependencies for A2A integration
 a2a = ["a2a-sdk"]

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -186,7 +186,7 @@ markdown = ["unstructured<0.18.31", "markdown", "aiofiles"]
 chonkie = ["chonkie[semantic]", "chonkie[code]", "chonkie"]
 
 # Dependencies for AG-UI integration
-agui = ["ag-ui-protocol"]
+agui = ["ag-ui-protocol>=0.1.15"]
 
 # Dependencies for A2A integration
 a2a = ["a2a-sdk"]

--- a/libs/agno/tests/unit/app/test_agui_app.py
+++ b/libs/agno/tests/unit/app/test_agui_app.py
@@ -564,33 +564,29 @@ async def test_stream_ends_without_completion_event():
 
 @pytest.mark.asyncio
 async def test_reasoning_events_handling():
-    """Test that reasoning events are properly converted to step events"""
-    from agno.run.agent import RunEvent
+    """Test that reasoning events emit proper REASONING_* AG-UI events"""
+    from agno.run.agent import (
+        ReasoningCompletedEvent,
+        ReasoningContentDeltaEvent,
+        ReasoningStartedEvent,
+        RunCompletedEvent,
+    )
 
     async def mock_stream_with_reasoning():
-        # Start reasoning
-        reasoning_start = RunContentEvent()
-        reasoning_start.event = RunEvent.reasoning_started
-        reasoning_start.content = ""
-        yield reasoning_start
+        yield ReasoningStartedEvent()
 
-        # Some reasoning content
-        reasoning_content = RunContentEvent()
-        reasoning_content.event = RunEvent.run_content
-        reasoning_content.content = "Thinking about this problem..."
-        yield reasoning_content
+        delta = ReasoningContentDeltaEvent()
+        delta.reasoning_content = "Thinking about this problem..."
+        yield delta
 
-        # End reasoning
-        reasoning_end = RunContentEvent()
-        reasoning_end.event = RunEvent.reasoning_completed
-        reasoning_end.content = ""
-        yield reasoning_end
+        yield ReasoningCompletedEvent()
 
-        # Complete run
-        completed_response = RunContentEvent()
-        completed_response.event = RunEvent.run_completed
-        completed_response.content = ""
-        yield completed_response
+        # Text response after reasoning
+        text = RunContentEvent()
+        text.content = "The answer is 42."
+        yield text
+
+        yield RunCompletedEvent()
 
     events = []
     async for event in async_stream_agno_response_as_agui_events(mock_stream_with_reasoning(), "thread_1", "run_1"):
@@ -598,11 +594,22 @@ async def test_reasoning_events_handling():
 
     event_types = [event.type for event in events]
 
-    # Should have step events for reasoning
-    assert EventType.STEP_STARTED in event_types, "Should have STEP_STARTED for reasoning"
-    assert EventType.STEP_FINISHED in event_types, "Should have STEP_FINISHED for reasoning"
+    # Should have REASONING_* events (not generic STEP events)
+    assert EventType.REASONING_START in event_types, "Should have REASONING_START"
+    assert EventType.REASONING_MESSAGE_START in event_types, "Should have REASONING_MESSAGE_START"
+    assert EventType.REASONING_MESSAGE_CONTENT in event_types, "Should have REASONING_MESSAGE_CONTENT"
+    assert EventType.REASONING_MESSAGE_END in event_types, "Should have REASONING_MESSAGE_END"
+    assert EventType.REASONING_END in event_types, "Should have REASONING_END"
 
-    # Should have text content during reasoning
+    # Verify correct ordering: START before CONTENT before END
+    r_start = event_types.index(EventType.REASONING_START)
+    r_msg_start = event_types.index(EventType.REASONING_MESSAGE_START)
+    r_content = event_types.index(EventType.REASONING_MESSAGE_CONTENT)
+    r_msg_end = event_types.index(EventType.REASONING_MESSAGE_END)
+    r_end = event_types.index(EventType.REASONING_END)
+    assert r_start < r_msg_start < r_content < r_msg_end < r_end
+
+    # Should have text content after reasoning
     assert EventType.TEXT_MESSAGE_CONTENT in event_types
     assert EventType.RUN_FINISHED in event_types
 

--- a/libs/agno/tests/unit/app/test_agui_app.py
+++ b/libs/agno/tests/unit/app/test_agui_app.py
@@ -615,6 +615,87 @@ async def test_reasoning_events_handling():
 
 
 @pytest.mark.asyncio
+async def test_reasoning_step_events_no_duplication():
+    """Test that ReasoningStepEvent formatting avoids accumulated content duplication"""
+    from agno.reasoning.step import ReasoningStep
+    from agno.run.agent import (
+        ReasoningCompletedEvent,
+        ReasoningStartedEvent,
+        ReasoningStepEvent,
+        RunCompletedEvent,
+    )
+
+    async def mock_stream_with_steps():
+        yield ReasoningStartedEvent()
+
+        # Step 1: reasoning_content is just this step
+        step1 = ReasoningStepEvent()
+        step1.content = ReasoningStep(title="Calculate", reasoning="15 * 37 = 555")
+        step1.reasoning_content = "## Calculate\n15 * 37 = 555\n\n"
+        yield step1
+
+        # Step 2: reasoning_content is accumulated (step1 + step2)
+        step2 = ReasoningStepEvent()
+        step2.content = ReasoningStep(title="Verify", reasoning="555 / 15 = 37, correct")
+        step2.reasoning_content = "## Calculate\n15 * 37 = 555\n\n## Verify\n555 / 15 = 37, correct\n\n"
+        yield step2
+
+        yield ReasoningCompletedEvent()
+        yield RunCompletedEvent()
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream_with_steps(), "thread_1", "run_1"):
+        events.append(event)
+
+    # Extract reasoning content deltas
+    content_events = [e for e in events if e.type == EventType.REASONING_MESSAGE_CONTENT]
+    assert len(content_events) == 2, f"Expected 2 content events, got {len(content_events)}"
+
+    # Each delta should contain only its own step, not accumulated
+    assert "Calculate" in content_events[0].delta
+    assert "Verify" in content_events[1].delta
+
+    # "Calculate" should NOT appear in the second delta (no duplication)
+    assert "Calculate" not in content_events[1].delta
+
+    # Step numbers should be present
+    assert "Step 1" in content_events[0].delta
+    assert "Step 2" in content_events[1].delta
+
+
+@pytest.mark.asyncio
+async def test_orphaned_reasoning_cleanup():
+    """Test that reasoning sessions are closed when stream ends without ReasoningCompletedEvent"""
+    from agno.run.agent import (
+        ReasoningContentDeltaEvent,
+        ReasoningStartedEvent,
+    )
+
+    async def mock_stream_orphaned():
+        yield ReasoningStartedEvent()
+
+        delta = ReasoningContentDeltaEvent()
+        delta.reasoning_content = "Thinking..."
+        yield delta
+
+        # Stream ends without ReasoningCompletedEvent or RunCompletedEvent
+
+    events = []
+    async for event in async_stream_agno_response_as_agui_events(mock_stream_orphaned(), "thread_1", "run_1"):
+        events.append(event)
+
+    event_types = [e.type for e in events]
+
+    # Reasoning session should be properly opened AND closed
+    assert EventType.REASONING_START in event_types
+    assert EventType.REASONING_MESSAGE_START in event_types
+    assert EventType.REASONING_MESSAGE_CONTENT in event_types
+    assert EventType.REASONING_MESSAGE_END in event_types, "Orphaned session should be closed"
+    assert EventType.REASONING_END in event_types, "Orphaned session should be closed"
+    assert EventType.RUN_FINISHED in event_types, "Should still emit RUN_FINISHED"
+
+
+@pytest.mark.asyncio
 async def test_tool_call_without_result():
     """Test tool calls that complete without results (edge case)"""
     from agno.models.response import ToolExecution


### PR DESCRIPTION
## Summary

- Map Agno reasoning events to AG-UI protocol reasoning event types (`REASONING_START`, `REASONING_MESSAGE_CONTENT`, etc.) using `isinstance()` dispatch for type-safe Agent and Team event handling
- Handle two distinct reasoning producers:
  - **Native model reasoning** (o4-mini, Claude extended thinking) → `ReasoningContentDeltaEvent` with true streaming deltas
  - **ReasoningTools** (think/analyze tool calls) → `ReasoningStepEvent` with structured `ReasoningStep` content, formatted as text delta per step (avoids accumulated content duplication)
- Emit fallback `REASONING_START`/`REASONING_MESSAGE_START` when content arrives without a preceding `reasoning_started` event
- Close orphaned reasoning sessions on stream completion/abort (including synthetic completion path)
- Remove redundant `STEP_STARTED`/`STEP_FINISHED` wrapping — replaced by dedicated `REASONING_*` events (ag-ui-protocol ≥0.1.15)
- Bump `ag-ui-protocol` dependency to `>=0.1.15` for reasoning event types

## Why Two Reasoning Paths?

Agno has two distinct reasoning producers that emit different event types:

| Producer | Event Type | `reasoning_content` field | Correct mapping |
|----------|-----------|--------------------------|-----------------|
| **Native model** (o4-mini, Claude extended thinking) | `ReasoningContentDeltaEvent` | True streaming delta (new tokens only) | Use directly as `REASONING_MESSAGE_CONTENT.delta` |
| **ReasoningTools** (think/analyze tool calls) | `ReasoningStepEvent` | Accumulated (all previous steps + new step) | Format `chunk.content` (single `ReasoningStep`) as delta text |

The AG-UI SDK concatenates deltas: `targetMessage.content += delta` ([source](https://github.com/ag-ui-protocol/ag-ui/blob/main/sdks/typescript/packages/client/src/apply/default.ts#L946)). Sending accumulated content as delta duplicates text.

## Bugs Fixed

1. **Accumulated content duplication** — `ReasoningStepEvent.reasoning_content` is accumulated (all steps so far), but AG-UI SDK concatenates deltas. Sending accumulated content as delta caused step 1 to appear multiple times. Fixed by formatting `chunk.content` (the single `ReasoningStep` object) directly via `_format_reasoning_step_delta()`.
2. **Orphaned reasoning sessions** — Synthetic completion path (stream ends without `run_completed`) didn't pass `reasoning_message_id`, leaving `REASONING_START` unclosed. Fixed by threading `reasoning_message_id` through both sync and async completion paths.
3. **Protocol violation** — `REASONING_MESSAGE_CONTENT` emitted without preceding `REASONING_START`/`REASONING_MESSAGE_START` when `reasoning_content_delta` arrived before `reasoning_started`. Fixed by emitting START events in fallback path.
4. **Redundant STEP wrapping** — `STEP_STARTED`/`STEP_FINISHED` emitted alongside `REASONING_*` events. Removed since dedicated reasoning events replace the generic step markers.

## Test Matrix

All scenarios tested on both AG-UI Dojo and os.agno.com:

| # | Scenario | Platform | Query | Result |
|---|----------|----------|-------|--------|
| 1 | o4-mini native reasoning | AG-UI Dojo | "What is 15*37?" | PASS — "Thought for 5 seconds", step-by-step response |
| 2 | ReasoningTools simple | AG-UI Dojo | "What is 15*37?" | PASS — "Thought for 2 seconds", single step, no duplication |
| 3 | ReasoningTools complex | AG-UI Dojo | Fox/chicken/grain puzzle | PASS — "Thought for 4 seconds", 3 reasoning steps, no duplication |
| 4 | o4-mini native reasoning | os.agno.com | "What is 15*37?" | PASS — "REASONING > 555", "Worked for 5 s" |
| 5 | ReasoningTools simple | os.agno.com | "What is 15*37?" | PASS — "3 TOOLS CALLED", "REASONING", "Worked for 9 s" |
| 6 | ReasoningTools complex | os.agno.com | Fox/chicken/grain puzzle | PASS — "3 TOOLS CALLED", "REASONING", "Worked for 11 s", multi-step solution |

### Raw SSE Event Sequence (ReasoningTools, complex query)

```
REASONING_START → REASONING_MESSAGE_START
  → REASONING_MESSAGE_CONTENT(delta="## Solving the river crossing problem\n...")
  → REASONING_MESSAGE_CONTENT(delta="## Developing step-by-step solution\n1. Take the chicken...")
  → REASONING_MESSAGE_CONTENT(delta="## Analysis of the proposed crossing steps\n...")
→ REASONING_MESSAGE_END → REASONING_END
→ TEXT_MESSAGE_START → TEXT_MESSAGE_CONTENT... → TEXT_MESSAGE_END
→ RUN_FINISHED
```

Each step appears exactly once — no accumulated duplication.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Formatted using `./scripts/format.sh`
- [x] Validated using `./scripts/validate.sh`
- [x] 33/33 existing AGUI unit tests pass
- [x] All 4 bugs reproduced with targeted scripts, then verified fixed (5/5 pass)
- [x] Verified via curl: full `REASONING_*` event sequence for both native reasoning and ReasoningTools
- [x] Verified via AG-UI Dojo: "Thought for N seconds" rendered correctly for both reasoning paths
- [x] Verified on os.agno.com: Feature parity with AgentOS native streaming for both reasoning paths
- [x] Complex multi-step query (fox/chicken/grain puzzle) — 3 reasoning steps, no duplication
- [x] AG-UI SDK source confirmed: `targetMessage.content += delta` (concatenation), validating delta approach
- [x] Codex review: confirmed isinstance dispatch, fallback START emission, and completion cleanup are correct

## Test plan

- [x] Run `pytest libs/agno/tests/unit/app/test_agui_app.py` — 33 pass
- [x] Start reasoning agent (o4-mini + ReasoningTools), curl `/agui` endpoint, verify `REASONING_*` events in SSE stream
- [x] Run AG-UI Dojo locally, select Agno > Agentic Chat + Backend Tool Rendering, confirm "Thought for N seconds" renders with expandable reasoning content
- [x] Test on os.agno.com with both Thinking Agent and Reasoning Tools Agent — feature parity confirmed

Fixes #7216