### PR TITLE
feat: add background mode support for OpenAI Responses API

### DIFF
--- a/cookbook/90_models/openai/responses/background.py
+++ b/cookbook/90_models/openai/responses/background.py
@@ -1,0 +1,32 @@
+"""
+Background Mode
+===============
+
+Background mode enables long-running tasks on reasoning models like GPT-5.4
+without worrying about timeouts or connectivity issues. The API returns
+immediately and Agno polls for the result automatically.
+
+Requires: openai>=2.0.0
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIResponses
+
+# ---------------------------------------------------------------------------
+# Create Agent with background mode enabled
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    model=OpenAIResponses(
+        id="gpt-5.4",
+        background=True,
+        background_poll_interval=2.0,  # seconds between polls (default)
+    ),
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response("Explain the history of quantum computing in detail")

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -203,6 +203,7 @@ class OpenAIResponses(Model):
         deadline = time.monotonic() + self.background_max_wait
         while True:
             response = client.responses.retrieve(response_id)
+            log_debug(f"Background response {response_id} status: {response.status}")
             if response.status in ("completed", "failed", "incomplete", "cancelled"):
                 return response
             if time.monotonic() >= deadline:
@@ -229,6 +230,7 @@ class OpenAIResponses(Model):
         deadline = time.monotonic() + self.background_max_wait
         while True:
             response = await client.responses.retrieve(response_id)
+            log_debug(f"Background response {response_id} status: {response.status}")
             if response.status in ("completed", "failed", "incomplete", "cancelled"):
                 return response
             if time.monotonic() >= deadline:
@@ -1251,11 +1253,6 @@ class OpenAIResponses(Model):
             ModelResponse: Parsed response delta
         """
         model_response = ModelResponse()
-
-        print("--------------------------------")
-        print(stream_event.type)
-        print(stream_event)
-        print("--------------------------------")
 
         # 1. Add response ID
         if stream_event.type == "response.created":

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -303,7 +303,7 @@ class OpenAIResponses(Model):
 
         # Handle reasoning tools for o3 and o4-mini models
         if self._using_reasoning_model() and messages is not None:
-            if self.store is False:
+            if store is False:
                 request_params["store"] = False
 
                 # Add encrypted reasoning content to include if not already present

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -766,12 +766,15 @@ class OpenAIResponses(Model):
                 **request_params,
             )
 
+            # Stop the timer before polling so wall-clock polling wait is not counted as inference time.
+            # For background mode, the initial create() measures submission latency; the polling loop
+            # is then allowed to run without inflating time_to_first_token / total time metrics.
+            assistant_message.metrics.stop_timer()
+
             # Poll for completion if background mode is enabled
             if self.background and provider_response.status in ("queued", "in_progress"):
                 log_debug(f"Background response submitted: {provider_response.id}, polling for completion...")
                 provider_response = self._poll_background_response(provider_response.id)
-
-            assistant_message.metrics.stop_timer()
 
             if provider_response.status == "failed":
                 error_msg = provider_response.error.message if provider_response.error else "Background response failed"
@@ -868,12 +871,15 @@ class OpenAIResponses(Model):
                 **request_params,
             )
 
+            # Stop the timer before polling so wall-clock polling wait is not counted as inference time.
+            # For background mode, the initial create() measures submission latency; the polling loop
+            # is then allowed to run without inflating time_to_first_token / total time metrics.
+            assistant_message.metrics.stop_timer()
+
             # Poll for completion if background mode is enabled
             if self.background and provider_response.status in ("queued", "in_progress"):
                 log_debug(f"Background response submitted: {provider_response.id}, polling for completion...")
                 provider_response = await self._apoll_background_response(provider_response.id)
-
-            assistant_message.metrics.stop_timer()
 
             if provider_response.status == "failed":
                 error_msg = provider_response.error.message if provider_response.error else "Background response failed"

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Tuple, Type, Union
@@ -56,6 +57,12 @@ class OpenAIResponses(Model):
     user: Optional[str] = None
     service_tier: Optional[Literal["auto", "default", "flex", "priority"]] = None
     strict_output: bool = True  # When True, guarantees schema adherence for structured outputs. When False, attempts to follow schema as a guide but may occasionally deviate
+    background: Optional[bool] = (
+        None  # When True, enables background mode for long-running tasks. The API returns immediately and the response is polled until completion.
+    )
+    background_poll_interval: float = (
+        2.0  # Interval in seconds between polling attempts when background mode is enabled.
+    )
     extra_headers: Optional[Any] = None
     extra_query: Optional[Any] = None
     extra_body: Optional[Any] = None
@@ -186,6 +193,24 @@ class OpenAIResponses(Model):
         self.async_client = AsyncOpenAI(**client_params)
         return self.async_client
 
+    def _poll_background_response(self, response_id: str) -> "Response":
+        """Poll for a background response until it reaches a terminal state."""
+        client = self.get_client()
+        while True:
+            response = client.responses.retrieve(response_id)
+            if response.status in ("completed", "failed", "incomplete"):
+                return response
+            time.sleep(self.background_poll_interval)
+
+    async def _apoll_background_response(self, response_id: str) -> "Response":
+        """Async poll for a background response until it reaches a terminal state."""
+        client = self.get_async_client()
+        while True:
+            response = await client.responses.retrieve(response_id)
+            if response.status in ("completed", "failed", "incomplete"):
+                return response
+            await asyncio.sleep(self.background_poll_interval)
+
     def get_request_params(
         self,
         messages: Optional[List[Message]] = None,
@@ -199,14 +224,20 @@ class OpenAIResponses(Model):
         Returns:
             Dict[str, Any]: A dictionary of keyword arguments for API requests.
         """
+        # Background mode requires store=True
+        store = self.store
+        if self.background:
+            store = True
+
         # Define base request parameters
         base_params: Dict[str, Any] = {
+            "background": self.background,
             "include": self.include,
             "max_output_tokens": self.max_output_tokens,
             "max_tool_calls": self.max_tool_calls,
             "metadata": self.metadata,
             "parallel_tool_calls": self.parallel_tool_calls,
-            "store": self.store,
+            "store": store,
             "temperature": self.temperature,
             "top_p": self.top_p,
             "truncation": self.truncation,
@@ -700,7 +731,21 @@ class OpenAIResponses(Model):
                 **request_params,
             )
 
+            # Poll for completion if background mode is enabled
+            if self.background and provider_response.status in ("queued", "in_progress"):
+                log_debug(f"Background response submitted: {provider_response.id}, polling for completion...")
+                provider_response = self._poll_background_response(provider_response.id)
+
             assistant_message.metrics.stop_timer()
+
+            if provider_response.status == "failed":
+                error_msg = provider_response.error.message if provider_response.error else "Background response failed"
+                raise ModelProviderError(message=error_msg, model_name=self.name, model_id=self.id)
+            if provider_response.status == "incomplete":
+                log_warning(
+                    f"Background response {provider_response.id} completed with status 'incomplete': "
+                    f"{provider_response.incomplete_details}"
+                )
 
             model_response = self._parse_provider_response(provider_response, response_format=response_format)
 
@@ -782,7 +827,21 @@ class OpenAIResponses(Model):
                 **request_params,
             )
 
+            # Poll for completion if background mode is enabled
+            if self.background and provider_response.status in ("queued", "in_progress"):
+                log_debug(f"Background response submitted: {provider_response.id}, polling for completion...")
+                provider_response = await self._apoll_background_response(provider_response.id)
+
             assistant_message.metrics.stop_timer()
+
+            if provider_response.status == "failed":
+                error_msg = provider_response.error.message if provider_response.error else "Background response failed"
+                raise ModelProviderError(message=error_msg, model_name=self.name, model_id=self.id)
+            if provider_response.status == "incomplete":
+                log_warning(
+                    f"Background response {provider_response.id} completed with status 'incomplete': "
+                    f"{provider_response.incomplete_details}"
+                )
 
             model_response = self._parse_provider_response(provider_response, response_format=response_format)
 

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -198,6 +198,7 @@ class OpenAIResponses(Model):
         client = self.get_client()
         while True:
             response = client.responses.retrieve(response_id)
+            log_debug(f"Background response {response_id} status: {response.status}")
             if response.status in ("completed", "failed", "incomplete"):
                 return response
             time.sleep(self.background_poll_interval)
@@ -207,6 +208,7 @@ class OpenAIResponses(Model):
         client = self.get_async_client()
         while True:
             response = await client.responses.retrieve(response_id)
+            log_debug(f"Background response {response_id} status: {response.status}")
             if response.status in ("completed", "failed", "incomplete"):
                 return response
             await asyncio.sleep(self.background_poll_interval)
@@ -1192,6 +1194,11 @@ class OpenAIResponses(Model):
             ModelResponse: Parsed response delta
         """
         model_response = ModelResponse()
+
+        print("--------------------------------")
+        print(stream_event.type)
+        print(stream_event)
+        print("--------------------------------")
 
         # 1. Add response ID
         if stream_event.type == "response.created":

--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -58,11 +58,12 @@ class OpenAIResponses(Model):
     service_tier: Optional[Literal["auto", "default", "flex", "priority"]] = None
     strict_output: bool = True  # When True, guarantees schema adherence for structured outputs. When False, attempts to follow schema as a guide but may occasionally deviate
     background: Optional[bool] = (
-        None  # When True, enables background mode for long-running tasks. The API returns immediately and the response is polled until completion.
+        None  # When True, enables background mode for long-running tasks. The API returns immediately and the response is polled until completion. Not supported for streaming.
     )
     background_poll_interval: float = (
         2.0  # Interval in seconds between polling attempts when background mode is enabled.
     )
+    background_max_wait: float = 600.0  # Maximum time in seconds to wait for a background response before cancelling it and raising an error. Defaults to 10 minutes, matching OpenAI's storage window.
     extra_headers: Optional[Any] = None
     extra_query: Optional[Any] = None
     extra_body: Optional[Any] = None
@@ -194,23 +195,55 @@ class OpenAIResponses(Model):
         return self.async_client
 
     def _poll_background_response(self, response_id: str) -> "Response":
-        """Poll for a background response until it reaches a terminal state."""
+        """Poll for a background response until it reaches a terminal state.
+
+        If background_max_wait is exceeded, cancels the response and raises ModelProviderError.
+        """
         client = self.get_client()
+        deadline = time.monotonic() + self.background_max_wait
         while True:
             response = client.responses.retrieve(response_id)
-            log_debug(f"Background response {response_id} status: {response.status}")
-            if response.status in ("completed", "failed", "incomplete"):
+            if response.status in ("completed", "failed", "incomplete", "cancelled"):
                 return response
+            if time.monotonic() >= deadline:
+                log_warning(
+                    f"Background response {response_id} exceeded max wait of {self.background_max_wait}s, cancelling."
+                )
+                try:
+                    client.responses.cancel(response_id)
+                except Exception as cancel_exc:
+                    log_warning(f"Failed to cancel background response {response_id}: {cancel_exc}")
+                raise ModelProviderError(
+                    message=f"Background response {response_id} exceeded max wait of {self.background_max_wait}s",
+                    model_name=self.name,
+                    model_id=self.id,
+                )
             time.sleep(self.background_poll_interval)
 
     async def _apoll_background_response(self, response_id: str) -> "Response":
-        """Async poll for a background response until it reaches a terminal state."""
+        """Async poll for a background response until it reaches a terminal state.
+
+        If background_max_wait is exceeded, cancels the response and raises ModelProviderError.
+        """
         client = self.get_async_client()
+        deadline = time.monotonic() + self.background_max_wait
         while True:
             response = await client.responses.retrieve(response_id)
-            log_debug(f"Background response {response_id} status: {response.status}")
-            if response.status in ("completed", "failed", "incomplete"):
+            if response.status in ("completed", "failed", "incomplete", "cancelled"):
                 return response
+            if time.monotonic() >= deadline:
+                log_warning(
+                    f"Background response {response_id} exceeded max wait of {self.background_max_wait}s, cancelling."
+                )
+                try:
+                    await client.responses.cancel(response_id)
+                except Exception as cancel_exc:
+                    log_warning(f"Failed to cancel background response {response_id}: {cancel_exc}")
+                raise ModelProviderError(
+                    message=f"Background response {response_id} exceeded max wait of {self.background_max_wait}s",
+                    model_name=self.name,
+                    model_id=self.id,
+                )
             await asyncio.sleep(self.background_poll_interval)
 
     def get_request_params(
@@ -743,6 +776,12 @@ class OpenAIResponses(Model):
             if provider_response.status == "failed":
                 error_msg = provider_response.error.message if provider_response.error else "Background response failed"
                 raise ModelProviderError(message=error_msg, model_name=self.name, model_id=self.id)
+            if provider_response.status == "cancelled":
+                raise ModelProviderError(
+                    message=f"Background response {provider_response.id} was cancelled",
+                    model_name=self.name,
+                    model_id=self.id,
+                )
             if provider_response.status == "incomplete":
                 log_warning(
                     f"Background response {provider_response.id} completed with status 'incomplete': "
@@ -839,6 +878,12 @@ class OpenAIResponses(Model):
             if provider_response.status == "failed":
                 error_msg = provider_response.error.message if provider_response.error else "Background response failed"
                 raise ModelProviderError(message=error_msg, model_name=self.name, model_id=self.id)
+            if provider_response.status == "cancelled":
+                raise ModelProviderError(
+                    message=f"Background response {provider_response.id} was cancelled",
+                    model_name=self.name,
+                    model_id=self.id,
+                )
             if provider_response.status == "incomplete":
                 log_warning(
                     f"Background response {provider_response.id} completed with status 'incomplete': "
@@ -916,6 +961,9 @@ class OpenAIResponses(Model):
             request_params = self.get_request_params(
                 messages=messages, response_format=response_format, tools=tools, tool_choice=tool_choice
             )
+            # Background mode is not supported for streaming. Strip the flag and warn.
+            if request_params.pop("background", None):
+                log_warning("Background mode is not supported for streaming requests. Ignoring `background=True`.")
             tool_use: Dict[str, Any] = {}
 
             assistant_message.metrics.start_timer()
@@ -1002,6 +1050,9 @@ class OpenAIResponses(Model):
             request_params = self.get_request_params(
                 messages=messages, response_format=response_format, tools=tools, tool_choice=tool_choice
             )
+            # Background mode is not supported for streaming. Strip the flag and warn.
+            if request_params.pop("background", None):
+                log_warning("Background mode is not supported for streaming requests. Ignoring `background=True`.")
             tool_use: Dict[str, Any] = {}
 
             assistant_message.metrics.start_timer()

--- a/libs/agno/tests/unit/models/openai/test_openai_responses_background.py
+++ b/libs/agno/tests/unit/models/openai/test_openai_responses_background.py
@@ -1,0 +1,321 @@
+"""Tests for OpenAI Responses background mode support."""
+
+from typing import Any, List, Optional
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agno.exceptions import ModelProviderError
+from agno.models.message import Message
+from agno.models.openai.responses import OpenAIResponses
+
+
+class _FakeError:
+    def __init__(self, message: str):
+        self.message = message
+
+
+class _FakeResponse:
+    """Minimal stand-in for openai.types.responses.Response."""
+
+    def __init__(
+        self,
+        *,
+        _id: str = "resp_test",
+        status: str = "completed",
+        output: Optional[List[Any]] = None,
+        output_text: str = "hello",
+        usage: Any = None,
+        error: Optional[_FakeError] = None,
+        incomplete_details: Any = None,
+    ):
+        self.id = _id
+        self.status = status
+        self.output = output or []
+        self.output_text = output_text
+        self.usage = usage
+        self.error = error
+        self.incomplete_details = incomplete_details
+
+
+def _make_assistant_message() -> Message:
+    msg = Message(role="assistant")
+    # Ensure metrics timer methods don't crash
+    return msg
+
+
+def _make_fake_client() -> MagicMock:
+    """Build a MagicMock client whose is_closed() returns False so get_client() reuses it."""
+    client = MagicMock()
+    client.is_closed.return_value = False
+    return client
+
+
+# ---------------------------------------------------------------------------
+# get_request_params
+# ---------------------------------------------------------------------------
+
+
+def test_background_true_forces_store_true():
+    """When background=True, store should be forced to True even if self.store=False."""
+    model = OpenAIResponses(id="gpt-4.1-mini", background=True, store=False)
+    params = model.get_request_params(messages=[Message(role="user", content="hi")])
+    assert params.get("background") is True
+    assert params.get("store") is True
+
+
+def test_background_true_forces_store_for_reasoning_model():
+    """Reasoning-model branch must not overwrite background-forced store=True back to False."""
+    model = OpenAIResponses(id="gpt-5.4", background=True, store=False)
+    params = model.get_request_params(messages=[Message(role="user", content="hi")])
+    assert params.get("background") is True
+    assert params.get("store") is True
+
+
+def test_background_none_does_not_add_param():
+    """When background is not set, the param should not appear in request params."""
+    model = OpenAIResponses(id="gpt-4.1-mini")
+    params = model.get_request_params(messages=[Message(role="user", content="hi")])
+    assert "background" not in params
+
+
+# ---------------------------------------------------------------------------
+# _poll_background_response (sync)
+# ---------------------------------------------------------------------------
+
+
+def test_poll_returns_on_completed_status():
+    model = OpenAIResponses(id="gpt-4.1-mini", background=True, background_poll_interval=0.01)
+
+    fake_client = _make_fake_client()
+    fake_client.responses.retrieve.side_effect = [
+        _FakeResponse(status="queued"),
+        _FakeResponse(status="in_progress"),
+        _FakeResponse(status="completed"),
+    ]
+    model.client = fake_client
+
+    result = model._poll_background_response("resp_test")
+    assert result.status == "completed"
+    assert fake_client.responses.retrieve.call_count == 3
+
+
+def test_poll_returns_on_cancelled_status():
+    """Cancelled should be treated as a terminal state."""
+    model = OpenAIResponses(id="gpt-4.1-mini", background=True, background_poll_interval=0.01)
+
+    fake_client = _make_fake_client()
+    fake_client.responses.retrieve.return_value = _FakeResponse(status="cancelled")
+    model.client = fake_client
+
+    result = model._poll_background_response("resp_test")
+    assert result.status == "cancelled"
+
+
+def test_poll_returns_on_failed_status():
+    model = OpenAIResponses(id="gpt-4.1-mini", background=True, background_poll_interval=0.01)
+
+    fake_client = _make_fake_client()
+    fake_client.responses.retrieve.return_value = _FakeResponse(status="failed")
+    model.client = fake_client
+
+    result = model._poll_background_response("resp_test")
+    assert result.status == "failed"
+
+
+def test_poll_timeout_cancels_and_raises():
+    """When max wait is exceeded, should call cancel() and raise ModelProviderError."""
+    model = OpenAIResponses(
+        id="gpt-4.1-mini",
+        background=True,
+        background_poll_interval=0.01,
+        background_max_wait=0.0,  # immediate timeout
+    )
+
+    fake_client = _make_fake_client()
+    fake_client.responses.retrieve.return_value = _FakeResponse(status="in_progress")
+    model.client = fake_client
+
+    with pytest.raises(ModelProviderError, match="exceeded max wait"):
+        model._poll_background_response("resp_test")
+
+    fake_client.responses.cancel.assert_called_once_with("resp_test")
+
+
+def test_poll_timeout_swallows_cancel_failure():
+    """If cancel() fails after timeout, still raise the timeout error, not the cancel error."""
+    model = OpenAIResponses(
+        id="gpt-4.1-mini",
+        background=True,
+        background_poll_interval=0.01,
+        background_max_wait=0.0,
+    )
+
+    fake_client = _make_fake_client()
+    fake_client.responses.retrieve.return_value = _FakeResponse(status="in_progress")
+    fake_client.responses.cancel.side_effect = RuntimeError("cancel failed")
+    model.client = fake_client
+
+    with pytest.raises(ModelProviderError, match="exceeded max wait"):
+        model._poll_background_response("resp_test")
+
+
+# ---------------------------------------------------------------------------
+# _apoll_background_response (async)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apoll_returns_on_completed_status():
+    model = OpenAIResponses(id="gpt-4.1-mini", background=True, background_poll_interval=0.01)
+
+    fake_client = _make_fake_client()
+    fake_client.responses.retrieve = AsyncMock(
+        side_effect=[
+            _FakeResponse(status="in_progress"),
+            _FakeResponse(status="completed"),
+        ]
+    )
+    model.async_client = fake_client
+
+    result = await model._apoll_background_response("resp_test")
+    assert result.status == "completed"
+    assert fake_client.responses.retrieve.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_apoll_timeout_cancels_and_raises():
+    model = OpenAIResponses(
+        id="gpt-4.1-mini",
+        background=True,
+        background_poll_interval=0.01,
+        background_max_wait=0.0,
+    )
+
+    fake_client = _make_fake_client()
+    fake_client.responses.retrieve = AsyncMock(return_value=_FakeResponse(status="in_progress"))
+    fake_client.responses.cancel = AsyncMock()
+    model.async_client = fake_client
+
+    with pytest.raises(ModelProviderError, match="exceeded max wait"):
+        await model._apoll_background_response("resp_test")
+
+    fake_client.responses.cancel.assert_awaited_once_with("resp_test")
+
+
+# ---------------------------------------------------------------------------
+# invoke / ainvoke integration with polling
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_polls_when_background_response_not_terminal():
+    model = OpenAIResponses(id="gpt-4.1-mini", background=True, background_poll_interval=0.01)
+
+    fake_client = _make_fake_client()
+    fake_client.responses.create.return_value = _FakeResponse(_id="resp_1", status="queued")
+    fake_client.responses.retrieve.side_effect = [
+        _FakeResponse(_id="resp_1", status="in_progress"),
+        _FakeResponse(_id="resp_1", status="completed", output_text="done"),
+    ]
+    model.client = fake_client
+
+    assistant = _make_assistant_message()
+    with patch.object(model, "_format_messages", return_value=[]):
+        result = model.invoke(
+            messages=[Message(role="user", content="hi")],
+            assistant_message=assistant,
+        )
+
+    assert fake_client.responses.retrieve.call_count == 2
+    # Parsed response should come from the final polled response
+    assert result is not None
+
+
+def test_invoke_raises_on_cancelled_status():
+    model = OpenAIResponses(id="gpt-4.1-mini", background=True, background_poll_interval=0.01)
+
+    fake_client = _make_fake_client()
+    fake_client.responses.create.return_value = _FakeResponse(_id="resp_1", status="cancelled")
+    model.client = fake_client
+
+    assistant = _make_assistant_message()
+    with patch.object(model, "_format_messages", return_value=[]):
+        with pytest.raises(ModelProviderError, match="was cancelled"):
+            model.invoke(
+                messages=[Message(role="user", content="hi")],
+                assistant_message=assistant,
+            )
+
+
+def test_invoke_raises_on_failed_status():
+    model = OpenAIResponses(id="gpt-4.1-mini", background=True, background_poll_interval=0.01)
+
+    fake_client = _make_fake_client()
+    fake_client.responses.create.return_value = _FakeResponse(
+        _id="resp_1",
+        status="failed",
+        error=_FakeError("model crashed"),
+    )
+    model.client = fake_client
+
+    assistant = _make_assistant_message()
+    with patch.object(model, "_format_messages", return_value=[]):
+        with pytest.raises(ModelProviderError, match="model crashed"):
+            model.invoke(
+                messages=[Message(role="user", content="hi")],
+                assistant_message=assistant,
+            )
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_polls_when_background_response_not_terminal():
+    model = OpenAIResponses(id="gpt-4.1-mini", background=True, background_poll_interval=0.01)
+
+    fake_client = _make_fake_client()
+    fake_client.responses.create = AsyncMock(return_value=_FakeResponse(_id="resp_1", status="queued"))
+    fake_client.responses.retrieve = AsyncMock(
+        side_effect=[
+            _FakeResponse(_id="resp_1", status="in_progress"),
+            _FakeResponse(_id="resp_1", status="completed", output_text="done"),
+        ]
+    )
+    model.async_client = fake_client
+
+    assistant = _make_assistant_message()
+    with patch.object(model, "_format_messages", return_value=[]):
+        result = await model.ainvoke(
+            messages=[Message(role="user", content="hi")],
+            assistant_message=assistant,
+        )
+
+    assert fake_client.responses.retrieve.call_count == 2
+    assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Streaming: background should be stripped
+# ---------------------------------------------------------------------------
+
+
+def test_invoke_stream_strips_background_flag():
+    """invoke_stream should pop `background` from request params before calling the API."""
+    model = OpenAIResponses(id="gpt-4.1-mini", background=True)
+
+    fake_client = _make_fake_client()
+    fake_client.responses.create.return_value = iter([])
+    model.client = fake_client
+
+    assistant = _make_assistant_message()
+    with patch.object(model, "_format_messages", return_value=[]):
+        list(
+            model.invoke_stream(
+                messages=[Message(role="user", content="hi")],
+                assistant_message=assistant,
+            )
+        )
+
+    # Verify background was NOT passed to responses.create
+    assert fake_client.responses.create.called
+    _, kwargs = fake_client.responses.create.call_args
+    assert "background" not in kwargs
+    assert kwargs.get("stream") is True


### PR DESCRIPTION
## Summary

Adds support for OpenAI's [Background Mode API](https://developers.openai.com/api/docs/guides/background) in the `OpenAIResponses` model. Background mode enables long-running tasks on reasoning models like GPT-5.4 without worrying about timeouts or connectivity issues.

Two new parameters on `OpenAIResponses`:
- `background: Optional[bool]` - when `True`, submits the request in background mode and polls for completion
- `background_poll_interval: float` - seconds between polling attempts (default: 2.0)

When background mode is enabled, `store` is automatically set to `True` (required by the API). The polling is handled transparently inside `invoke()`/`ainvoke()` so the Agent layer requires no changes.

### Usage

```python
from agno.agent import Agent
from agno.models.openai import OpenAIResponses

agent = Agent(
    model=OpenAIResponses(id="gpt-5.4", background=True),
)
agent.print_response("Complex long-running task...")
```

## Type of change

- [x] New feature

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- Tested with `gpt-5.4` and confirmed the background polling flow works end-to-end
- Also removed a stray `print(stream_event)` debug line in `_parse_provider_response_delta`
- Compatible with both older (`openai>=1.75`) and newer (`openai>=2.0`) SDK versions since `responses.retrieve()` exists in both