### PR TITLE
fix: stream reasoning summary deltas in OpenAI Responses API

### DIFF
--- a/libs/agno/agno/models/openai/responses.py
+++ b/libs/agno/agno/models/openai/responses.py
@@ -1173,6 +1173,10 @@ class OpenAIResponses(Model):
             if self.reasoning is not None and self.reasoning_summary is None:
                 model_response.reasoning_content = stream_event.delta
 
+        # 3.1 Stream reasoning summary deltas
+        elif stream_event.type == "response.reasoning_summary_text.delta":
+            model_response.reasoning_content = stream_event.delta
+
         # 4. Add tool calls information
 
         # 4.1 Add starting tool call
@@ -1208,29 +1212,14 @@ class OpenAIResponses(Model):
         elif stream_event.type == "response.completed":
             model_response = ModelResponse()
 
-            # Handle reasoning output items
-            if self.reasoning_summary is not None or self.store is False:
-                summary_text: str = ""
+            # Handle reasoning output items for ZDR mode (store=False)
+            if self.store is False:
                 for out in getattr(stream_event.response, "output", []) or []:
                     if getattr(out, "type", None) == "reasoning":
-                        # In ZDR mode (store=False), store reasoning data for next request
-                        if self.store is False and hasattr(out, "encrypted_content"):
+                        if hasattr(out, "encrypted_content"):
                             if model_response.provider_data is None:
                                 model_response.provider_data = {}
-                            # Store the complete output item
                             model_response.provider_data["reasoning_output"] = out.model_dump(exclude_none=True)
-                        if self.reasoning_summary is not None:
-                            summaries = getattr(out, "summary", None)
-                            if summaries:
-                                for s in summaries:
-                                    text_val = s.get("text") if isinstance(s, dict) else getattr(s, "text", None)
-                                    if text_val:
-                                        if summary_text:
-                                            summary_text += "\n\n"
-                                        summary_text += text_val
-
-                if summary_text:
-                    model_response.reasoning_content = summary_text
 
             # Add metrics
             if stream_event.response.usage is not None:

--- a/libs/agno/tests/integration/models/openai/chat/test_reasoning_streaming.py
+++ b/libs/agno/tests/integration/models/openai/chat/test_reasoning_streaming.py
@@ -5,8 +5,6 @@ for OpenAI o-series models when used as a reasoning_model.
 
 Note: OpenAI o-series models (o1, o3, o4) perform internal reasoning but do not
 expose the reasoning content via the API. The reasoning happens internally.
-For OpenAI Responses API with reasoning_summary, the summary is provided
-as a complete block, not streamed incrementally.
 
 These tests verify the streaming reasoning feature where reasoning content
 is delivered incrementally via RunEvent.reasoning_content_delta events.


### PR DESCRIPTION
## Summary

Reasoning summaries were being extracted from the completed response object at the end of streaming, rather than being streamed incrementally. This meant users would see the entire reasoning summary dumped at the end instead of token-by-token.

Now handles `response.reasoning_summary_text.delta` events to stream reasoning content as it arrives. The `response.completed` handler is simplified to only handle ZDR mode (store=False) encrypted reasoning data.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- The `response.reasoning_summary_text.delta` event has a `delta: str` field, confirmed against the OpenAI SDK source
- ZDR mode (store=False) encrypted content handling at `response.completed` is preserved
- Non-summary reasoning path (treating output_text as reasoning content) is unchanged