### PR TITLE
fix: harden team continue run

### DIFF
--- a/cookbook/05_agent_os/approvals/team_approval_user_input.py
+++ b/cookbook/05_agent_os/approvals/team_approval_user_input.py
@@ -1,0 +1,91 @@
+"""
+Team Approval with User Input (AgentOS)
+========================================
+
+Approval + user input HITL on a team: member agent has @approval + @tool(requires_user_input=True).
+Run with: python libs/agno/agno/test.py
+"""
+
+import os
+from typing import Optional
+
+from agno.agent import Agent
+from agno.approval import approval
+from agno.db.sqlite import SqliteDb
+from agno.models.openai import OpenAIResponses
+from agno.os import AgentOS
+from agno.team.team import Team
+from agno.tools import tool
+
+DB_FILE = "tmp/team_approvals_test.db"
+
+
+@approval(type="required")
+@tool(requires_user_input=True, user_input_fields=["service", "environment", "version"])
+def collect_deployment_specs(
+    service: Optional[str] = None,
+    environment: Optional[str] = None,
+    version: Optional[str] = None,
+) -> str:
+    """Collect deployment specifications from the user.
+
+    Args:
+        service (str): Name of the service to deploy.
+        environment (str): Target environment (staging, production).
+        version (str): Version to deploy.
+    """
+    return f"Deployment specs collected: service={service}, environment={environment}, version={version}"
+
+
+@approval(type="required")
+@tool(requires_confirmation=True)
+def approve_deployment(service: str, environment: str, version: str) -> str:
+    """Approve and execute a deployment.
+
+    Args:
+        service (str): Name of the service.
+        environment (str): Target environment.
+        version (str): Version to deploy.
+    """
+    return f"Deployment approved: {service} v{version} to {environment}"
+
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+db = SqliteDb(db_file=DB_FILE, session_table="team_sessions", approvals_table="approvals")
+
+spec_collector = Agent(
+    name="Deployment Spec Collector",
+    model=OpenAIResponses(id="gpt-5-mini"),
+    tools=[collect_deployment_specs],
+    instructions=["Call collect_deployment_specs immediately when asked about deployments."],
+)
+
+deploy_team = Team(
+    id="deploy-approval-team",
+    name="Deployment Approval Team",
+    model=OpenAIResponses(id="gpt-5-mini"),
+    members=[spec_collector],
+    tools=[approve_deployment],
+    instructions=[
+        "Delegate to the Deployment Spec Collector to gather deployment details.",
+        "Once specs are collected, call approve_deployment with those specs.",
+    ],
+    db=db,
+)
+
+agent_os = AgentOS(
+    description="Team approval example: member collects specs (user input) + team approves (confirmation)",
+    teams=[deploy_team],
+    db=db,
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    # Clean up from previous runs
+    if os.path.exists(DB_FILE):
+        os.remove(DB_FILE)
+    os.makedirs("tmp", exist_ok=True)
+
+    agent_os.serve(app="team_approval_user_input:app", port=7777, reload=True)

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -19,7 +19,12 @@ from agno.db.base import BaseDb
 from agno.exceptions import InputCheckError, OutputCheckError
 from agno.media import Audio, Image, Video
 from agno.media import File as FileMedia
-from agno.os.auth import get_auth_token_from_request, get_authentication_dependency, require_resource_access
+from agno.os.auth import (
+    get_auth_token_from_request,
+    get_authentication_dependency,
+    require_approval_resolved,
+    require_resource_access,
+)
 from agno.os.routers.teams.schema import TeamResponse
 from agno.os.schema import (
     BadRequestResponse,
@@ -449,9 +454,11 @@ def get_team_router(
             "Continue a paused or incomplete team run with updated requirements.\n\n"
             "**Use Cases:**\n"
             "- Resume execution after tool approval/rejection\n"
-            "- Provide manual tool execution results\n\n"
+            "- Provide manual tool execution results\n"
+            "- Resume after admin approval (requirements can be empty; resolution fetched from DB)\n\n"
             "**Requirements Parameter:**\n"
-            "JSON string containing array of requirement objects with tool execution results."
+            "JSON string containing array of requirement objects with tool execution results.\n"
+            "Can be empty when an admin-required approval has been resolved."
         ),
         responses={
             200: {
@@ -466,19 +473,23 @@ def get_team_router(
                 "description": "Invalid JSON in requirements field or invalid requirement structure",
                 "model": BadRequestResponse,
             },
+            403: {"description": "Run has a pending admin approval and cannot be continued by the user yet."},
             404: {"description": "Team not found", "model": NotFoundResponse},
             409: {
                 "description": "Run is not paused (e.g. run is already running, continued, or errored). Only PAUSED runs can be continued.",
             },
         },
-        dependencies=[Depends(require_resource_access("teams", "run", "team_id"))],
+        dependencies=[
+            Depends(require_resource_access("teams", "run", "team_id")),
+            Depends(require_approval_resolved(os.db)),
+        ],
     )
     async def continue_team_run(
         team_id: str,
         run_id: str,
         request: Request,
         background_tasks: BackgroundTasks,
-        requirements: str = Form(...),  # JSON string of requirements
+        requirements: str = Form(""),  # optional when admin approval resolved
         session_id: Optional[str] = Form(None),
         user_id: Optional[str] = Form(None),
         stream: bool = Form(True),
@@ -531,7 +542,7 @@ def get_team_router(
                     )
 
         # Convert requirements dict to RunRequirement objects if provided
-        updated_requirements = []
+        updated_requirements = None
         if requirements_data:
             try:
                 from agno.run.requirement import RunRequirement
@@ -548,7 +559,7 @@ def get_team_router(
                 team_continue_response_streamer(
                     team,
                     run_id=run_id,
-                    requirements=updated_requirements,
+                    requirements=updated_requirements or [],
                     session_id=session_id,
                     user_id=user_id,
                     background_tasks=background_tasks,
@@ -574,7 +585,7 @@ def get_team_router(
                 )
                 return run_response_obj.to_dict()
 
-            except InputCheckError as e:
+            except (InputCheckError, ValueError) as e:
                 raise HTTPException(status_code=400, detail=str(e))
 
     @router.get(

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -33,7 +33,7 @@ from agno.models.base import Model
 from agno.models.fallback import acall_model_with_fallback, call_model_with_fallback
 from agno.models.message import Message
 from agno.models.metrics import RunMetrics, merge_background_metrics
-from agno.models.response import ModelResponse
+from agno.models.response import ModelResponse, ToolExecution
 from agno.run import RunContext, RunStatus
 from agno.run.agent import RunOutput, RunOutputEvent
 from agno.run.cancel import (
@@ -4997,6 +4997,11 @@ def _build_continuation_message(member_results: List[str]) -> str:
     return "\n".join(parts)
 
 
+def _tool_result_requires_human_input(tool: ToolExecution) -> bool:
+    result = tool.result or ""
+    return isinstance(result, str) and "requires human input" in result.lower()
+
+
 def _prepare_member_hitl_continuation(
     run_response: TeamRunOutput,
     run_messages: RunMessages,
@@ -5004,8 +5009,9 @@ def _prepare_member_hitl_continuation(
 ) -> None:
     """Prepare run_response and run_messages for member HITL continuation.
 
-    Updates the delegate_task_to_member tool result in both run_response.tools
-    and the corresponding message in run_messages. Also resets run state for continuation.
+    Updates the delegate_task_to_member/delegate_task_to_members tool result in both
+    run_response.tools and the corresponding message in run_messages. Also resets run
+    state for continuation.
 
     This is called after the member agent's HITL has been resolved and we need to
     continue the team run with the member's results.
@@ -5013,21 +5019,28 @@ def _prepare_member_hitl_continuation(
 
     continuation_message = _build_continuation_message(member_results)
 
-    # Find the tool_call_id for the delegate_task_to_member tool that needs updating
-    target_tool_call_id: Optional[str] = None
+    target_tool_call_ids: set[str] = set()
     for tool in run_response.tools or []:
-        if tool.tool_name == "delegate_task_to_member" and tool.result is not None:
-            if "requires human input" in (tool.result or ""):
-                tool.result = continuation_message
-                target_tool_call_id = tool.tool_call_id
-                break
+        if tool.tool_name in {
+            "delegate_task_to_member",
+            "delegate_task_to_members",
+        } and _tool_result_requires_human_input(tool):
+            tool.result = continuation_message
+            if tool.tool_call_id is not None:
+                target_tool_call_ids.add(tool.tool_call_id)
 
-    # Update the existing tool result message in run_messages
-    if target_tool_call_id:
+    if not target_tool_call_ids:
+        for tool in run_response.tools or []:
+            if _tool_result_requires_human_input(tool):
+                tool.result = continuation_message
+                if tool.tool_call_id is not None:
+                    target_tool_call_ids.add(tool.tool_call_id)
+
+    # Update the existing tool result messages in run_messages
+    if target_tool_call_ids:
         for msg in run_messages.messages:
-            if msg.role == "tool" and msg.tool_call_id == target_tool_call_id:
+            if msg.role == "tool" and msg.tool_call_id in target_tool_call_ids:
                 msg.content = continuation_message
-                break
 
     # Reset run state for continuation
     run_response.status = RunStatus.running
@@ -5215,6 +5228,18 @@ def continue_run_dispatch(
             run_response.tools = [updated_tools_map.get(tool.tool_call_id, tool) for tool in run_response.tools]
         elif updated_tools:
             run_response.tools = updated_tools
+    elif run_response.tools:
+        from agno.run.approval import check_and_apply_approval_resolution
+
+        try:
+            check_and_apply_approval_resolution(team.db, run_id_resolved, run_response)
+        except RuntimeError:
+            raise ValueError(
+                "To continue a run from a given run_id, the requirements parameter must be provided "
+                "(or resolve an admin approval first)."
+            )
+    else:
+        raise ValueError("To continue a run from a given run_id, the requirements parameter must be provided.")
 
     # Determine what kind of pause we're continuing from
     has_member = _has_member_requirements(run_response.requirements or [])
@@ -6226,6 +6251,22 @@ async def _acontinue_run(
                         ]
                     elif updated_tools:
                         run_response.tools = updated_tools
+                elif run_response.tools:
+                    from agno.run.approval import acheck_and_apply_approval_resolution
+
+                    try:
+                        await acheck_and_apply_approval_resolution(
+                            team.db, run_response.run_id or run_id or "", run_response
+                        )
+                    except RuntimeError:
+                        raise ValueError(
+                            "To continue a run from a given run_id, the requirements parameter must be provided "
+                            "(or resolve an admin approval first)."
+                        )
+                else:
+                    raise ValueError(
+                        "To continue a run from a given run_id, the requirements parameter must be provided."
+                    )
 
                 await aregister_run(run_response.run_id)  # type: ignore
 
@@ -6533,6 +6574,22 @@ async def _acontinue_run_stream(
                         ]
                     elif updated_tools:
                         run_response.tools = updated_tools
+                elif run_response.tools:
+                    from agno.run.approval import acheck_and_apply_approval_resolution
+
+                    try:
+                        await acheck_and_apply_approval_resolution(
+                            team.db, run_response.run_id or run_id or "", run_response
+                        )
+                    except RuntimeError:
+                        raise ValueError(
+                            "To continue a run from a given run_id, the requirements parameter must be provided "
+                            "(or resolve an admin approval first)."
+                        )
+                else:
+                    raise ValueError(
+                        "To continue a run from a given run_id, the requirements parameter must be provided."
+                    )
 
                 await aregister_run(run_response.run_id)  # type: ignore
 

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -1276,7 +1276,7 @@ def _run(
                     else:
                         delay = team.delay_between_retries
 
-                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed: {str(e)}. Retrying in {delay}s...")
+                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed. Retrying in {delay}s...: {str(e)}")
                     time.sleep(delay)
                     continue
 
@@ -1726,7 +1726,7 @@ def _run_stream(
                     else:
                         delay = team.delay_between_retries
 
-                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed: {str(e)}. Retrying in {delay}s...")
+                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed. Retrying in {delay}s...: {str(e)}")
                     time.sleep(delay)
                     continue
 
@@ -3134,7 +3134,7 @@ async def _arun(
                     else:
                         delay = team.delay_between_retries
 
-                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed: {str(e)}. Retrying in {delay}s...")
+                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed. Retrying in {delay}s...: {str(e)}")
                     await asyncio.sleep(delay)
                     continue
 
@@ -3238,15 +3238,15 @@ async def _arun_background(
                 background_tasks=background_tasks,
                 **kwargs,
             )
-        except Exception:
-            log_error(f"Background run {run_response.run_id} failed", exc_info=True)
+        except Exception as e:
+            log_error(f"Background run {run_response.run_id} failed: {str(e)}")
             # Persist ERROR status
             try:
                 run_response.status = RunStatus.error
                 team_session.upsert_run(run_response=run_response)
                 await asave_session(team, session=team_session)
-            except Exception:
-                log_error(f"Failed to persist error state for background run {run_response.run_id}", exc_info=True)
+            except Exception as e:
+                log_error(f"Failed to persist error state for background run {run_response.run_id}: {str(e)}")
             # Note: acleanup_run is already called by _arun's finally block
 
     task = asyncio.create_task(_background_task())
@@ -3704,7 +3704,7 @@ async def _arun_stream(
                     else:
                         delay = team.delay_between_retries
 
-                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed: {str(e)}. Retrying in {delay}s...")
+                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed. Retrying in {delay}s...: {str(e)}")
                     await asyncio.sleep(delay)
                     continue
 
@@ -4156,7 +4156,7 @@ def _resolve_run_dependencies(team: "Team", run_context: RunContext) -> None:
 
             run_context.dependencies[key] = resolved_value
         except Exception as e:
-            log_warning(f"Failed to resolve dependencies for {key}: {e}")
+            log_warning(f"Failed to resolve dependencies for {key}: {str(e)}")
 
 
 async def _aresolve_run_dependencies(team: "Team", run_context: RunContext) -> None:
@@ -4191,7 +4191,7 @@ async def _aresolve_run_dependencies(team: "Team", run_context: RunContext) -> N
 
             run_context.dependencies[key] = resolved_value
         except Exception as e:
-            log_warning(f"Failed to resolve context for '{key}': {e}")
+            log_warning(f"Failed to resolve context for '{key}': {str(e)}")
 
 
 # ---------------------------------------------------------------------------
@@ -4290,6 +4290,7 @@ def _handle_team_tool_call_updates(
     etc.) that ``Team`` also provides, so passing a ``Team`` is safe at runtime.
     """
     from agno.agent._tools import (
+        handle_ask_user_tool_update,
         handle_external_execution_update,
         handle_get_user_input_tool_update,
         handle_user_input_update,
@@ -4304,7 +4305,7 @@ def _handle_team_tool_call_updates(
         # Case 1: Handle confirmed tools and execute them
         if _t.requires_confirmation is not None and _t.requires_confirmation is True and _functions:
             if _t.confirmed is not None and _t.confirmed is True and _t.result is None:
-                deque(run_tool(team, run_response, run_messages, _t, functions=_functions), maxlen=0)  # type: ignore
+                deque(run_tool(team, run_response, run_messages, _t, functions=_functions, team_mode=True), maxlen=0)  # type: ignore
             else:
                 reject_tool_call(team, run_messages, _t, functions=_functions)  # type: ignore
                 _t.confirmed = False
@@ -4316,9 +4317,15 @@ def _handle_team_tool_call_updates(
         elif _t.external_execution_required is not None and _t.external_execution_required is True:
             handle_external_execution_update(team, run_messages=run_messages, tool=_t)  # type: ignore
 
-        # Case 3: Agentic user input required
+        # Case 3a: Agentic user input required
         elif _t.tool_name == "get_user_input" and _t.requires_user_input is not None and _t.requires_user_input is True:
             handle_get_user_input_tool_update(team, run_messages=run_messages, tool=_t)  # type: ignore
+            _t.requires_user_input = False
+            _t.answered = True
+
+        # Case 3b: User feedback (ask_user) required
+        elif _t.tool_name == "ask_user" and _t.requires_user_input is not None and _t.requires_user_input is True:
+            handle_ask_user_tool_update(team, run_messages=run_messages, tool=_t)  # type: ignore
             _t.requires_user_input = False
             _t.answered = True
 
@@ -4327,7 +4334,7 @@ def _handle_team_tool_call_updates(
             handle_user_input_update(team, tool=_t)  # type: ignore
             _t.requires_user_input = False
             _t.answered = True
-            deque(run_tool(team, run_response, run_messages, _t, functions=_functions), maxlen=0)  # type: ignore
+            deque(run_tool(team, run_response, run_messages, _t, functions=_functions, team_mode=True), maxlen=0)  # type: ignore
 
 
 def _handle_team_tool_call_updates_stream(
@@ -4343,6 +4350,7 @@ def _handle_team_tool_call_updates_stream(
     Yields events during tool execution for streaming responses.
     """
     from agno.agent._tools import (
+        handle_ask_user_tool_update,
         handle_external_execution_update,
         handle_get_user_input_tool_update,
         handle_user_input_update,
@@ -4364,6 +4372,7 @@ def _handle_team_tool_call_updates_stream(
                     _t,
                     functions=_functions,
                     stream_events=stream_events,  # type: ignore
+                    team_mode=True,
                 )
             else:
                 reject_tool_call(team, run_messages, _t, functions=_functions)  # type: ignore
@@ -4376,9 +4385,15 @@ def _handle_team_tool_call_updates_stream(
         elif _t.external_execution_required is not None and _t.external_execution_required is True:
             handle_external_execution_update(team, run_messages=run_messages, tool=_t)  # type: ignore
 
-        # Case 3: Agentic user input required
+        # Case 3a: Agentic user input required
         elif _t.tool_name == "get_user_input" and _t.requires_user_input is not None and _t.requires_user_input is True:
             handle_get_user_input_tool_update(team, run_messages=run_messages, tool=_t)  # type: ignore
+            _t.requires_user_input = False
+            _t.answered = True
+
+        # Case 3b: User feedback (ask_user) required
+        elif _t.tool_name == "ask_user" and _t.requires_user_input is not None and _t.requires_user_input is True:
+            handle_ask_user_tool_update(team, run_messages=run_messages, tool=_t)  # type: ignore
             _t.requires_user_input = False
             _t.answered = True
 
@@ -4392,6 +4407,7 @@ def _handle_team_tool_call_updates_stream(
                 _t,
                 functions=_functions,
                 stream_events=stream_events,  # type: ignore
+                team_mode=True,
             )
             _t.requires_user_input = False
             _t.answered = True
@@ -4409,6 +4425,7 @@ async def _ahandle_team_tool_call_updates(
     """
     from agno.agent._tools import (
         arun_tool,
+        handle_ask_user_tool_update,
         handle_external_execution_update,
         handle_get_user_input_tool_update,
         handle_user_input_update,
@@ -4421,7 +4438,7 @@ async def _ahandle_team_tool_call_updates(
     for _t in run_response.tools or []:
         if _t.requires_confirmation is not None and _t.requires_confirmation is True and _functions:
             if _t.confirmed is not None and _t.confirmed is True and _t.result is None:
-                async for _ in arun_tool(team, run_response, run_messages, _t, functions=_functions):  # type: ignore
+                async for _ in arun_tool(team, run_response, run_messages, _t, functions=_functions, team_mode=True):  # type: ignore
                     pass
             else:
                 reject_tool_call(team, run_messages, _t, functions=_functions)  # type: ignore
@@ -4433,8 +4450,15 @@ async def _ahandle_team_tool_call_updates(
         elif _t.external_execution_required is not None and _t.external_execution_required is True:
             handle_external_execution_update(team, run_messages=run_messages, tool=_t)  # type: ignore
 
+        # Case 3a: Agentic user input required
         elif _t.tool_name == "get_user_input" and _t.requires_user_input is not None and _t.requires_user_input is True:
             handle_get_user_input_tool_update(team, run_messages=run_messages, tool=_t)  # type: ignore
+            _t.requires_user_input = False
+            _t.answered = True
+
+        # Case 3b: User feedback (ask_user) required
+        elif _t.tool_name == "ask_user" and _t.requires_user_input is not None and _t.requires_user_input is True:
+            handle_ask_user_tool_update(team, run_messages=run_messages, tool=_t)  # type: ignore
             _t.requires_user_input = False
             _t.answered = True
 
@@ -4442,7 +4466,7 @@ async def _ahandle_team_tool_call_updates(
             handle_user_input_update(team, tool=_t)  # type: ignore
             _t.requires_user_input = False
             _t.answered = True
-            async for _ in arun_tool(team, run_response, run_messages, _t, functions=_functions):  # type: ignore
+            async for _ in arun_tool(team, run_response, run_messages, _t, functions=_functions, team_mode=True):  # type: ignore
                 pass
 
 
@@ -4460,6 +4484,7 @@ async def _ahandle_team_tool_call_updates_stream(
     """
     from agno.agent._tools import (
         arun_tool,
+        handle_ask_user_tool_update,
         handle_external_execution_update,
         handle_get_user_input_tool_update,
         handle_user_input_update,
@@ -4480,6 +4505,7 @@ async def _ahandle_team_tool_call_updates_stream(
                     _t,
                     functions=_functions,
                     stream_events=stream_events,  # type: ignore
+                    team_mode=True,
                 ):
                     yield event  # type: ignore
             else:
@@ -4493,9 +4519,15 @@ async def _ahandle_team_tool_call_updates_stream(
         elif _t.external_execution_required is not None and _t.external_execution_required is True:
             handle_external_execution_update(team, run_messages=run_messages, tool=_t)  # type: ignore
 
-        # Case 3: Agentic user input required
+        # Case 3a: Agentic user input required
         elif _t.tool_name == "get_user_input" and _t.requires_user_input is not None and _t.requires_user_input is True:
             handle_get_user_input_tool_update(team, run_messages=run_messages, tool=_t)  # type: ignore
+            _t.requires_user_input = False
+            _t.answered = True
+
+        # Case 3b: User feedback (ask_user) required
+        elif _t.tool_name == "ask_user" and _t.requires_user_input is not None and _t.requires_user_input is True:
+            handle_ask_user_tool_update(team, run_messages=run_messages, tool=_t)  # type: ignore
             _t.requires_user_input = False
             _t.answered = True
 
@@ -4509,6 +4541,7 @@ async def _ahandle_team_tool_call_updates_stream(
                 _t,
                 functions=_functions,
                 stream_events=stream_events,  # type: ignore
+                team_mode=True,
             ):
                 yield event  # type: ignore
             _t.requires_user_input = False
@@ -4720,7 +4753,7 @@ def _route_requirements_to_members_stream(
             event.parent_run_id = getattr(event, "parent_run_id", None) or run_response.run_id
 
             # Store event and yield (same as _handle_model_response_chunk for member events)
-            if team.stream_member_events:
+            if stream_events or team.stream_member_events:
                 yield handle_event(
                     event,
                     run_response,
@@ -4930,7 +4963,7 @@ async def _aroute_requirements_to_members_stream(
             event.parent_run_id = getattr(event, "parent_run_id", None) or run_response.run_id
 
             # Store event and yield (same as _handle_model_response_chunk for member events)
-            if team.stream_member_events:
+            if stream_events or team.stream_member_events:
                 yield handle_event(
                     event,
                     run_response,
@@ -4976,8 +5009,9 @@ def _prepare_member_hitl_continuation(
 ) -> None:
     """Prepare run_response and run_messages for member HITL continuation.
 
-    Updates the delegate_task_to_member tool result in both run_response.tools
-    and the corresponding message in run_messages. Also resets run state for continuation.
+    Updates the delegate_task_to_member/delegate_task_to_members tool result in both
+    run_response.tools and the corresponding message in run_messages. Also resets run
+    state for continuation.
 
     This is called after the member agent's HITL has been resolved and we need to
     continue the team run with the member's results.
@@ -5634,7 +5668,7 @@ def _continue_run(
     handle_event(
         create_team_run_continued_event(run_response),
         run_response,
-        # events_to_skip=team.events_to_skip,
+        events_to_skip=team.events_to_skip,
         store_events=team.store_events,
     )
 
@@ -5759,7 +5793,7 @@ def _continue_run(
                         delay = team.delay_between_retries * (2**attempt)
                     else:
                         delay = team.delay_between_retries
-                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed: {str(e)}. Retrying in {delay}s...")
+                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed. Retrying in {delay}s...: {str(e)}")
                     _time.sleep(delay)
                     continue
 
@@ -6023,7 +6057,7 @@ def _continue_run_stream(
                         delay = team.delay_between_retries * (2**attempt)
                     else:
                         delay = team.delay_between_retries
-                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed: {str(e)}. Retrying in {delay}s...")
+                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed. Retrying in {delay}s...: {str(e)}")
                     _time.sleep(delay)
                     continue
 
@@ -6215,7 +6249,9 @@ async def _acontinue_run(
                     from agno.run.approval import acheck_and_apply_approval_resolution
 
                     try:
-                        await acheck_and_apply_approval_resolution(team.db, run_response.run_id, run_response)
+                        await acheck_and_apply_approval_resolution(
+                            team.db, run_response.run_id or run_id or "", run_response
+                        )
                     except RuntimeError:
                         raise ValueError(
                             "To continue a run from a given run_id, the requirements parameter must be provided "
@@ -6443,7 +6479,7 @@ async def _acontinue_run(
                         delay = team.delay_between_retries * (2**attempt)
                     else:
                         delay = team.delay_between_retries
-                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed: {str(e)}. Retrying in {delay}s...")
+                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed. Retrying in {delay}s...: {str(e)}")
                     await asyncio.sleep(delay)
                     continue
 
@@ -6534,7 +6570,9 @@ async def _acontinue_run_stream(
                     from agno.run.approval import acheck_and_apply_approval_resolution
 
                     try:
-                        await acheck_and_apply_approval_resolution(team.db, run_response.run_id, run_response)
+                        await acheck_and_apply_approval_resolution(
+                            team.db, run_response.run_id or run_id or "", run_response
+                        )
                     except RuntimeError:
                         raise ValueError(
                             "To continue a run from a given run_id, the requirements parameter must be provided "
@@ -6974,7 +7012,7 @@ async def _acontinue_run_stream(
                         delay = team.delay_between_retries * (2**attempt)
                     else:
                         delay = team.delay_between_retries
-                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed: {str(e)}. Retrying in {delay}s...")
+                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed. Retrying in {delay}s...: {str(e)}")
                     await asyncio.sleep(delay)
                     continue
 

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -1276,7 +1276,7 @@ def _run(
                     else:
                         delay = team.delay_between_retries
 
-                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed. Retrying in {delay}s...: {str(e)}")
+                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed: {str(e)}. Retrying in {delay}s...")
                     time.sleep(delay)
                     continue
 
@@ -1726,7 +1726,7 @@ def _run_stream(
                     else:
                         delay = team.delay_between_retries
 
-                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed. Retrying in {delay}s...: {str(e)}")
+                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed: {str(e)}. Retrying in {delay}s...")
                     time.sleep(delay)
                     continue
 
@@ -3134,7 +3134,7 @@ async def _arun(
                     else:
                         delay = team.delay_between_retries
 
-                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed. Retrying in {delay}s...: {str(e)}")
+                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed: {str(e)}. Retrying in {delay}s...")
                     await asyncio.sleep(delay)
                     continue
 
@@ -3238,15 +3238,15 @@ async def _arun_background(
                 background_tasks=background_tasks,
                 **kwargs,
             )
-        except Exception as e:
-            log_error(f"Background run {run_response.run_id} failed: {str(e)}")
+        except Exception:
+            log_error(f"Background run {run_response.run_id} failed", exc_info=True)
             # Persist ERROR status
             try:
                 run_response.status = RunStatus.error
                 team_session.upsert_run(run_response=run_response)
                 await asave_session(team, session=team_session)
-            except Exception as e:
-                log_error(f"Failed to persist error state for background run {run_response.run_id}: {str(e)}")
+            except Exception:
+                log_error(f"Failed to persist error state for background run {run_response.run_id}", exc_info=True)
             # Note: acleanup_run is already called by _arun's finally block
 
     task = asyncio.create_task(_background_task())
@@ -3704,7 +3704,7 @@ async def _arun_stream(
                     else:
                         delay = team.delay_between_retries
 
-                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed. Retrying in {delay}s...: {str(e)}")
+                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed: {str(e)}. Retrying in {delay}s...")
                     await asyncio.sleep(delay)
                     continue
 
@@ -4156,7 +4156,7 @@ def _resolve_run_dependencies(team: "Team", run_context: RunContext) -> None:
 
             run_context.dependencies[key] = resolved_value
         except Exception as e:
-            log_warning(f"Failed to resolve dependencies for {key}: {str(e)}")
+            log_warning(f"Failed to resolve dependencies for {key}: {e}")
 
 
 async def _aresolve_run_dependencies(team: "Team", run_context: RunContext) -> None:
@@ -4191,7 +4191,7 @@ async def _aresolve_run_dependencies(team: "Team", run_context: RunContext) -> N
 
             run_context.dependencies[key] = resolved_value
         except Exception as e:
-            log_warning(f"Failed to resolve context for '{key}': {str(e)}")
+            log_warning(f"Failed to resolve context for '{key}': {e}")
 
 
 # ---------------------------------------------------------------------------
@@ -4290,7 +4290,6 @@ def _handle_team_tool_call_updates(
     etc.) that ``Team`` also provides, so passing a ``Team`` is safe at runtime.
     """
     from agno.agent._tools import (
-        handle_ask_user_tool_update,
         handle_external_execution_update,
         handle_get_user_input_tool_update,
         handle_user_input_update,
@@ -4305,7 +4304,7 @@ def _handle_team_tool_call_updates(
         # Case 1: Handle confirmed tools and execute them
         if _t.requires_confirmation is not None and _t.requires_confirmation is True and _functions:
             if _t.confirmed is not None and _t.confirmed is True and _t.result is None:
-                deque(run_tool(team, run_response, run_messages, _t, functions=_functions, team_mode=True), maxlen=0)  # type: ignore
+                deque(run_tool(team, run_response, run_messages, _t, functions=_functions), maxlen=0)  # type: ignore
             else:
                 reject_tool_call(team, run_messages, _t, functions=_functions)  # type: ignore
                 _t.confirmed = False
@@ -4317,15 +4316,9 @@ def _handle_team_tool_call_updates(
         elif _t.external_execution_required is not None and _t.external_execution_required is True:
             handle_external_execution_update(team, run_messages=run_messages, tool=_t)  # type: ignore
 
-        # Case 3a: Agentic user input required
+        # Case 3: Agentic user input required
         elif _t.tool_name == "get_user_input" and _t.requires_user_input is not None and _t.requires_user_input is True:
             handle_get_user_input_tool_update(team, run_messages=run_messages, tool=_t)  # type: ignore
-            _t.requires_user_input = False
-            _t.answered = True
-
-        # Case 3b: User feedback (ask_user) required
-        elif _t.tool_name == "ask_user" and _t.requires_user_input is not None and _t.requires_user_input is True:
-            handle_ask_user_tool_update(team, run_messages=run_messages, tool=_t)  # type: ignore
             _t.requires_user_input = False
             _t.answered = True
 
@@ -4334,7 +4327,7 @@ def _handle_team_tool_call_updates(
             handle_user_input_update(team, tool=_t)  # type: ignore
             _t.requires_user_input = False
             _t.answered = True
-            deque(run_tool(team, run_response, run_messages, _t, functions=_functions, team_mode=True), maxlen=0)  # type: ignore
+            deque(run_tool(team, run_response, run_messages, _t, functions=_functions), maxlen=0)  # type: ignore
 
 
 def _handle_team_tool_call_updates_stream(
@@ -4350,7 +4343,6 @@ def _handle_team_tool_call_updates_stream(
     Yields events during tool execution for streaming responses.
     """
     from agno.agent._tools import (
-        handle_ask_user_tool_update,
         handle_external_execution_update,
         handle_get_user_input_tool_update,
         handle_user_input_update,
@@ -4372,7 +4364,6 @@ def _handle_team_tool_call_updates_stream(
                     _t,
                     functions=_functions,
                     stream_events=stream_events,  # type: ignore
-                    team_mode=True,
                 )
             else:
                 reject_tool_call(team, run_messages, _t, functions=_functions)  # type: ignore
@@ -4385,15 +4376,9 @@ def _handle_team_tool_call_updates_stream(
         elif _t.external_execution_required is not None and _t.external_execution_required is True:
             handle_external_execution_update(team, run_messages=run_messages, tool=_t)  # type: ignore
 
-        # Case 3a: Agentic user input required
+        # Case 3: Agentic user input required
         elif _t.tool_name == "get_user_input" and _t.requires_user_input is not None and _t.requires_user_input is True:
             handle_get_user_input_tool_update(team, run_messages=run_messages, tool=_t)  # type: ignore
-            _t.requires_user_input = False
-            _t.answered = True
-
-        # Case 3b: User feedback (ask_user) required
-        elif _t.tool_name == "ask_user" and _t.requires_user_input is not None and _t.requires_user_input is True:
-            handle_ask_user_tool_update(team, run_messages=run_messages, tool=_t)  # type: ignore
             _t.requires_user_input = False
             _t.answered = True
 
@@ -4407,7 +4392,6 @@ def _handle_team_tool_call_updates_stream(
                 _t,
                 functions=_functions,
                 stream_events=stream_events,  # type: ignore
-                team_mode=True,
             )
             _t.requires_user_input = False
             _t.answered = True
@@ -4425,7 +4409,6 @@ async def _ahandle_team_tool_call_updates(
     """
     from agno.agent._tools import (
         arun_tool,
-        handle_ask_user_tool_update,
         handle_external_execution_update,
         handle_get_user_input_tool_update,
         handle_user_input_update,
@@ -4438,7 +4421,7 @@ async def _ahandle_team_tool_call_updates(
     for _t in run_response.tools or []:
         if _t.requires_confirmation is not None and _t.requires_confirmation is True and _functions:
             if _t.confirmed is not None and _t.confirmed is True and _t.result is None:
-                async for _ in arun_tool(team, run_response, run_messages, _t, functions=_functions, team_mode=True):  # type: ignore
+                async for _ in arun_tool(team, run_response, run_messages, _t, functions=_functions):  # type: ignore
                     pass
             else:
                 reject_tool_call(team, run_messages, _t, functions=_functions)  # type: ignore
@@ -4450,15 +4433,8 @@ async def _ahandle_team_tool_call_updates(
         elif _t.external_execution_required is not None and _t.external_execution_required is True:
             handle_external_execution_update(team, run_messages=run_messages, tool=_t)  # type: ignore
 
-        # Case 3a: Agentic user input required
         elif _t.tool_name == "get_user_input" and _t.requires_user_input is not None and _t.requires_user_input is True:
             handle_get_user_input_tool_update(team, run_messages=run_messages, tool=_t)  # type: ignore
-            _t.requires_user_input = False
-            _t.answered = True
-
-        # Case 3b: User feedback (ask_user) required
-        elif _t.tool_name == "ask_user" and _t.requires_user_input is not None and _t.requires_user_input is True:
-            handle_ask_user_tool_update(team, run_messages=run_messages, tool=_t)  # type: ignore
             _t.requires_user_input = False
             _t.answered = True
 
@@ -4466,7 +4442,7 @@ async def _ahandle_team_tool_call_updates(
             handle_user_input_update(team, tool=_t)  # type: ignore
             _t.requires_user_input = False
             _t.answered = True
-            async for _ in arun_tool(team, run_response, run_messages, _t, functions=_functions, team_mode=True):  # type: ignore
+            async for _ in arun_tool(team, run_response, run_messages, _t, functions=_functions):  # type: ignore
                 pass
 
 
@@ -4484,7 +4460,6 @@ async def _ahandle_team_tool_call_updates_stream(
     """
     from agno.agent._tools import (
         arun_tool,
-        handle_ask_user_tool_update,
         handle_external_execution_update,
         handle_get_user_input_tool_update,
         handle_user_input_update,
@@ -4505,7 +4480,6 @@ async def _ahandle_team_tool_call_updates_stream(
                     _t,
                     functions=_functions,
                     stream_events=stream_events,  # type: ignore
-                    team_mode=True,
                 ):
                     yield event  # type: ignore
             else:
@@ -4519,15 +4493,9 @@ async def _ahandle_team_tool_call_updates_stream(
         elif _t.external_execution_required is not None and _t.external_execution_required is True:
             handle_external_execution_update(team, run_messages=run_messages, tool=_t)  # type: ignore
 
-        # Case 3a: Agentic user input required
+        # Case 3: Agentic user input required
         elif _t.tool_name == "get_user_input" and _t.requires_user_input is not None and _t.requires_user_input is True:
             handle_get_user_input_tool_update(team, run_messages=run_messages, tool=_t)  # type: ignore
-            _t.requires_user_input = False
-            _t.answered = True
-
-        # Case 3b: User feedback (ask_user) required
-        elif _t.tool_name == "ask_user" and _t.requires_user_input is not None and _t.requires_user_input is True:
-            handle_ask_user_tool_update(team, run_messages=run_messages, tool=_t)  # type: ignore
             _t.requires_user_input = False
             _t.answered = True
 
@@ -4541,7 +4509,6 @@ async def _ahandle_team_tool_call_updates_stream(
                 _t,
                 functions=_functions,
                 stream_events=stream_events,  # type: ignore
-                team_mode=True,
             ):
                 yield event  # type: ignore
             _t.requires_user_input = False
@@ -4753,7 +4720,7 @@ def _route_requirements_to_members_stream(
             event.parent_run_id = getattr(event, "parent_run_id", None) or run_response.run_id
 
             # Store event and yield (same as _handle_model_response_chunk for member events)
-            if stream_events or team.stream_member_events:
+            if team.stream_member_events:
                 yield handle_event(
                     event,
                     run_response,
@@ -4963,7 +4930,7 @@ async def _aroute_requirements_to_members_stream(
             event.parent_run_id = getattr(event, "parent_run_id", None) or run_response.run_id
 
             # Store event and yield (same as _handle_model_response_chunk for member events)
-            if stream_events or team.stream_member_events:
+            if team.stream_member_events:
                 yield handle_event(
                     event,
                     run_response,
@@ -5009,9 +4976,8 @@ def _prepare_member_hitl_continuation(
 ) -> None:
     """Prepare run_response and run_messages for member HITL continuation.
 
-    Updates the delegate_task_to_member/delegate_task_to_members tool result in both
-    run_response.tools and the corresponding message in run_messages. Also resets run
-    state for continuation.
+    Updates the delegate_task_to_member tool result in both run_response.tools
+    and the corresponding message in run_messages. Also resets run state for continuation.
 
     This is called after the member agent's HITL has been resolved and we need to
     continue the team run with the member's results.
@@ -5207,9 +5173,6 @@ def continue_run_dispatch(
 
     # Resolve run_response from run_id if needed
     if run_response is None and run_id is not None:
-        if requirements is None:
-            raise ValueError("To continue a run from a given run_id, the requirements parameter must be provided.")
-
         runs = team_session.runs or []
         run_response = next((r for r in runs if r.run_id == run_id), None)  # type: ignore
         if run_response is None:
@@ -5671,7 +5634,7 @@ def _continue_run(
     handle_event(
         create_team_run_continued_event(run_response),
         run_response,
-        events_to_skip=team.events_to_skip,
+        # events_to_skip=team.events_to_skip,
         store_events=team.store_events,
     )
 
@@ -5796,7 +5759,7 @@ def _continue_run(
                         delay = team.delay_between_retries * (2**attempt)
                     else:
                         delay = team.delay_between_retries
-                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed. Retrying in {delay}s...: {str(e)}")
+                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed: {str(e)}. Retrying in {delay}s...")
                     _time.sleep(delay)
                     continue
 
@@ -6060,7 +6023,7 @@ def _continue_run_stream(
                         delay = team.delay_between_retries * (2**attempt)
                     else:
                         delay = team.delay_between_retries
-                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed. Retrying in {delay}s...: {str(e)}")
+                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed: {str(e)}. Retrying in {delay}s...")
                     _time.sleep(delay)
                     continue
 
@@ -6229,9 +6192,6 @@ async def _acontinue_run(
 
                 # Resolve run_response from run_id if needed
                 if run_response is None and run_id is not None:
-                    if requirements is None:
-                        raise ValueError("Requirements are required to continue a run from a run_id.")
-
                     runs = team_session.runs or []
                     run_response = next((r for r in runs if r.run_id == run_id), None)  # type: ignore
                     if run_response is None:
@@ -6255,9 +6215,7 @@ async def _acontinue_run(
                     from agno.run.approval import acheck_and_apply_approval_resolution
 
                     try:
-                        await acheck_and_apply_approval_resolution(
-                            team.db, run_response.run_id or run_id or "", run_response
-                        )
+                        await acheck_and_apply_approval_resolution(team.db, run_response.run_id, run_response)
                     except RuntimeError:
                         raise ValueError(
                             "To continue a run from a given run_id, the requirements parameter must be provided "
@@ -6485,7 +6443,7 @@ async def _acontinue_run(
                         delay = team.delay_between_retries * (2**attempt)
                     else:
                         delay = team.delay_between_retries
-                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed. Retrying in {delay}s...: {str(e)}")
+                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed: {str(e)}. Retrying in {delay}s...")
                     await asyncio.sleep(delay)
                     continue
 
@@ -6553,8 +6511,6 @@ async def _acontinue_run_stream(
 
                 # Resolve run_response from run_id if needed
                 if run_response is None and run_id is not None:
-                    if requirements is None:
-                        raise ValueError("Requirements are required to continue a run from a run_id.")
                     runs = team_session.runs or []
                     run_response = next((r for r in runs if r.run_id == run_id), None)  # type: ignore
                     if run_response is None:
@@ -6578,9 +6534,7 @@ async def _acontinue_run_stream(
                     from agno.run.approval import acheck_and_apply_approval_resolution
 
                     try:
-                        await acheck_and_apply_approval_resolution(
-                            team.db, run_response.run_id or run_id or "", run_response
-                        )
+                        await acheck_and_apply_approval_resolution(team.db, run_response.run_id, run_response)
                     except RuntimeError:
                         raise ValueError(
                             "To continue a run from a given run_id, the requirements parameter must be provided "
@@ -7020,7 +6974,7 @@ async def _acontinue_run_stream(
                         delay = team.delay_between_retries * (2**attempt)
                     else:
                         delay = team.delay_between_retries
-                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed. Retrying in {delay}s...: {str(e)}")
+                    log_warning(f"Attempt {attempt + 1}/{num_attempts} failed: {str(e)}. Retrying in {delay}s...")
                     await asyncio.sleep(delay)
                     continue
 

--- a/libs/agno/tests/integration/os/test_team_runs.py
+++ b/libs/agno/tests/integration/os/test_team_runs.py
@@ -146,3 +146,53 @@ def test_create_team_run_with_kwargs(test_os_client, test_team: Team):
         call_args = mock_arun.call_args
         assert call_args.kwargs["extra_field"] == "foo"
         assert call_args.kwargs["extra_field_two"] == "bar"
+
+
+def test_continue_team_run_route_requires_approval_resolution_dependency(test_os_client):
+    route = next(
+        route
+        for route in test_os_client.app.routes
+        if getattr(route, "path", None) == "/teams/{team_id}/runs/{run_id}/continue"
+    )
+
+    dependency_qualnames = [getattr(dep.call, "__qualname__", "") for dep in route.dependant.dependencies]
+    assert any("require_approval_resolved" in qualname for qualname in dependency_qualnames)
+
+
+def test_continue_team_run_requires_session_id_for_local_teams(test_os_client, test_team: Team):
+    response = test_os_client.post(
+        f"/teams/{test_team.id}/runs/run-123/continue",
+        data={"requirements": "[]", "stream": "false"},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "session_id is required to continue a team run"
+
+
+def test_continue_team_run_allows_empty_requirements_payload(test_os_client, test_team: Team):
+    class MockRunOutput:
+        def to_dict(self):
+            return {"run_id": "run-123"}
+
+    with (
+        patch.object(test_team, "deep_copy", return_value=test_team),
+        patch.object(test_team, "aget_run_output", new_callable=AsyncMock) as mock_get_run_output,
+        patch.object(test_team, "acontinue_run", new_callable=AsyncMock) as mock_continue_run,
+    ):
+        mock_get_run_output.return_value = None
+        mock_continue_run.return_value = MockRunOutput()
+
+        response = test_os_client.post(
+            f"/teams/{test_team.id}/runs/run-123/continue",
+            data={
+                "requirements": "",
+                "session_id": "session-123",
+                "stream": "false",
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["run_id"] == "run-123"
+    assert mock_continue_run.call_args.kwargs["requirements"] is None

--- a/libs/agno/tests/integration/os/test_team_runs.py
+++ b/libs/agno/tests/integration/os/test_team_runs.py
@@ -167,7 +167,7 @@ def test_continue_team_run_requires_session_id_for_local_teams(test_os_client, t
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"] == "session_id is required to continue a team run"
+    assert response.json()["detail"] == "session_id is required to continue a run"
 
 
 def test_continue_team_run_allows_empty_requirements_payload(test_os_client, test_team: Team):

--- a/libs/agno/tests/unit/team/test_continue_run_requirements.py
+++ b/libs/agno/tests/unit/team/test_continue_run_requirements.py
@@ -666,31 +666,162 @@ class TestAsyncGatherErrorHandling:
         assert len(member_results) == 0
 
 
+# ===========================================================================
+# 12. _tool_result_requires_human_input
+# ===========================================================================
+
+
+class TestToolResultRequiresHumanInput:
+    def test_matching_string(self):
+        from agno.team._run import _tool_result_requires_human_input
+
+        tool = _make_tool_execution(result="Tool requires human input to proceed")
+        assert _tool_result_requires_human_input(tool) is True
+
+    def test_case_insensitive(self):
+        from agno.team._run import _tool_result_requires_human_input
+
+        tool = _make_tool_execution(result="REQUIRES HUMAN INPUT")
+        assert _tool_result_requires_human_input(tool) is True
+
+    def test_no_match(self):
+        from agno.team._run import _tool_result_requires_human_input
+
+        tool = _make_tool_execution(result="Success: operation completed")
+        assert _tool_result_requires_human_input(tool) is False
+
+    def test_none_result(self):
+        from agno.team._run import _tool_result_requires_human_input
+
+        tool = _make_tool_execution(result=None)
+        assert _tool_result_requires_human_input(tool) is False
+
+    def test_non_string_result(self):
+        from agno.team._run import _tool_result_requires_human_input
+
+        tool = _make_tool_execution(result={"key": "requires human input"})
+        assert _tool_result_requires_human_input(tool) is False
+
+
+# ===========================================================================
+# 13. _prepare_member_hitl_continuation improvements
+# ===========================================================================
+
+
 class TestPrepareMemberHitlContinuation:
-    def test_updates_delegate_task_to_members_placeholder_case_insensitively(self):
-        from agno.models.message import Message
+    """Tests for the improved _prepare_member_hitl_continuation that handles
+    delegate_task_to_members (plural) and case-insensitive matching."""
+
+    def _make_run_response_with_tools(self, tools):
+        run_response = MagicMock()
+        run_response.tools = tools
+        run_response.requirements = None
+        return run_response
+
+    def _make_run_messages(self, tool_call_ids):
+        msgs = []
+        for tc_id in tool_call_ids:
+            msg = MagicMock()
+            msg.role = "tool"
+            msg.tool_call_id = tc_id
+            msg.content = "requires human input"
+            msgs.append(msg)
+        run_messages = MagicMock()
+        run_messages.messages = msgs
+        return run_messages
+
+    def test_updates_delegate_task_to_member(self):
+        from agno.team._run import _prepare_member_hitl_continuation
+
+        tool = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            tool_call_id="tc-1",
+            result="Tool requires human input",
+        )
+        run_response = self._make_run_response_with_tools([tool])
+        run_messages = self._make_run_messages(["tc-1"])
+
+        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
+
+        assert "requires human input" not in tool.result
+        assert "Done" in tool.result
+
+    def test_updates_delegate_task_to_members_plural(self):
         from agno.team._run import _prepare_member_hitl_continuation
 
         tool = _make_tool_execution(
             tool_name="delegate_task_to_members",
-            tool_call_id="tool-1",
-            result="Agent Analyst: Requires human input before continuing.",
+            tool_call_id="tc-1",
+            result="Tool requires human input",
         )
-        run_response = MagicMock()
-        run_response.tools = [tool]
+        run_response = self._make_run_response_with_tools([tool])
+        run_messages = self._make_run_messages(["tc-1"])
+
+        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
+
+        assert "Done" in tool.result
+
+    def test_updates_multiple_matching_tools(self):
+        from agno.team._run import _prepare_member_hitl_continuation
+
+        tool1 = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            tool_call_id="tc-1",
+            result="requires human input",
+        )
+        tool2 = _make_tool_execution(
+            tool_name="delegate_task_to_members",
+            tool_call_id="tc-2",
+            result="requires human input",
+        )
+        run_response = self._make_run_response_with_tools([tool1, tool2])
+        run_messages = self._make_run_messages(["tc-1", "tc-2"])
+
+        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
+
+        assert "Done" in tool1.result
+        assert "Done" in tool2.result
+        assert run_messages.messages[0].content == run_messages.messages[1].content
+
+    def test_falls_back_to_any_tool_with_human_input(self):
+        """If no delegate tool matches, falls back to any tool with human input result."""
+        from agno.team._run import _prepare_member_hitl_continuation
+
+        tool = _make_tool_execution(
+            tool_name="some_other_tool",
+            tool_call_id="tc-1",
+            result="requires human input",
+        )
+        run_response = self._make_run_response_with_tools([tool])
+        run_messages = self._make_run_messages(["tc-1"])
+
+        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
+
+        assert "Done" in tool.result
+
+    def test_resets_run_state(self):
+        from agno.run import RunStatus
+        from agno.team._run import _prepare_member_hitl_continuation
+
+        tool = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            tool_call_id="tc-1",
+            result="requires human input",
+        )
+        run_response = self._make_run_response_with_tools([tool])
         run_response.status = RunStatus.paused
-        run_response.content = "paused"
+        run_response.content = "old content"
+        run_messages = self._make_run_messages(["tc-1"])
 
-        run_messages = MagicMock()
-        run_messages.messages = [Message(role="tool", content=tool.result, tool_call_id="tool-1")]
+        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
 
-        _prepare_member_hitl_continuation(run_response, run_messages, ["[Analyst]: Approved"])
-
-        expected = "Member results after human-in-the-loop resolution:\n[Analyst]: Approved"
-        assert tool.result == expected
-        assert run_messages.messages[0].content == expected
         assert run_response.status == RunStatus.running
         assert run_response.content is None
+
+
+# ===========================================================================
+# 14. Approval resolution fallback in continue_run_dispatch
+# ===========================================================================
 
 
 class TestContinueRunApprovalResolution:

--- a/libs/agno/tests/unit/team/test_continue_run_requirements.py
+++ b/libs/agno/tests/unit/team/test_continue_run_requirements.py
@@ -1,7 +1,11 @@
 """Tests for Team continue_run helpers (propagation, routing, normalization)."""
 
-from unittest.mock import MagicMock, patch
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from agno.run import RunStatus
+from agno.run.team import TeamRunOutput
 from agno.models.response import ToolExecution
 from agno.run.requirement import RunRequirement
 
@@ -662,226 +666,212 @@ class TestAsyncGatherErrorHandling:
         assert len(member_results) == 0
 
 
-# ===========================================================================
-# 12. _tool_result_requires_human_input
-# ===========================================================================
-
-
-class TestToolResultRequiresHumanInput:
-    def test_matching_string(self):
-        from agno.team._run import _tool_result_requires_human_input
-
-        tool = _make_tool_execution(result="Tool requires human input to proceed")
-        assert _tool_result_requires_human_input(tool) is True
-
-    def test_case_insensitive(self):
-        from agno.team._run import _tool_result_requires_human_input
-
-        tool = _make_tool_execution(result="REQUIRES HUMAN INPUT")
-        assert _tool_result_requires_human_input(tool) is True
-
-    def test_no_match(self):
-        from agno.team._run import _tool_result_requires_human_input
-
-        tool = _make_tool_execution(result="Success: operation completed")
-        assert _tool_result_requires_human_input(tool) is False
-
-    def test_none_result(self):
-        from agno.team._run import _tool_result_requires_human_input
-
-        tool = _make_tool_execution(result=None)
-        assert _tool_result_requires_human_input(tool) is False
-
-    def test_non_string_result(self):
-        from agno.team._run import _tool_result_requires_human_input
-
-        tool = _make_tool_execution(result={"key": "requires human input"})
-        assert _tool_result_requires_human_input(tool) is False
-
-
-# ===========================================================================
-# 13. _prepare_member_hitl_continuation improvements
-# ===========================================================================
-
-
 class TestPrepareMemberHitlContinuation:
-    """Tests for the improved _prepare_member_hitl_continuation that handles
-    delegate_task_to_members (plural) and case-insensitive matching."""
+    def test_updates_delegate_task_to_members_placeholder_case_insensitively(self):
+        from agno.models.message import Message
+        from agno.team._run import _prepare_member_hitl_continuation
 
-    def _make_run_response_with_tools(self, tools):
+        tool = _make_tool_execution(
+            tool_name="delegate_task_to_members",
+            tool_call_id="tool-1",
+            result="Agent Analyst: Requires human input before continuing.",
+        )
         run_response = MagicMock()
-        run_response.tools = tools
-        run_response.requirements = None
-        return run_response
-
-    def _make_run_messages(self, tool_call_ids):
-        msgs = []
-        for tc_id in tool_call_ids:
-            msg = MagicMock()
-            msg.role = "tool"
-            msg.tool_call_id = tc_id
-            msg.content = "requires human input"
-            msgs.append(msg)
-        run_messages = MagicMock()
-        run_messages.messages = msgs
-        return run_messages
-
-    def test_updates_delegate_task_to_member(self):
-        from agno.team._run import _prepare_member_hitl_continuation
-
-        tool = _make_tool_execution(
-            tool_name="delegate_task_to_member",
-            tool_call_id="tc-1",
-            result="Tool requires human input",
-        )
-        run_response = self._make_run_response_with_tools([tool])
-        run_messages = self._make_run_messages(["tc-1"])
-
-        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
-
-        assert "requires human input" not in tool.result
-        assert "Done" in tool.result
-
-    def test_updates_delegate_task_to_members_plural(self):
-        from agno.team._run import _prepare_member_hitl_continuation
-
-        tool = _make_tool_execution(
-            tool_name="delegate_task_to_members",
-            tool_call_id="tc-1",
-            result="Tool requires human input",
-        )
-        run_response = self._make_run_response_with_tools([tool])
-        run_messages = self._make_run_messages(["tc-1"])
-
-        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
-
-        assert "Done" in tool.result
-
-    def test_updates_multiple_matching_tools(self):
-        from agno.team._run import _prepare_member_hitl_continuation
-
-        tool1 = _make_tool_execution(
-            tool_name="delegate_task_to_member",
-            tool_call_id="tc-1",
-            result="requires human input",
-        )
-        tool2 = _make_tool_execution(
-            tool_name="delegate_task_to_members",
-            tool_call_id="tc-2",
-            result="requires human input",
-        )
-        run_response = self._make_run_response_with_tools([tool1, tool2])
-        run_messages = self._make_run_messages(["tc-1", "tc-2"])
-
-        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
-
-        assert "Done" in tool1.result
-        assert "Done" in tool2.result
-        assert run_messages.messages[0].content == run_messages.messages[1].content
-
-    def test_falls_back_to_any_tool_with_human_input(self):
-        """If no delegate tool matches, falls back to any tool with human input result."""
-        from agno.team._run import _prepare_member_hitl_continuation
-
-        tool = _make_tool_execution(
-            tool_name="some_other_tool",
-            tool_call_id="tc-1",
-            result="requires human input",
-        )
-        run_response = self._make_run_response_with_tools([tool])
-        run_messages = self._make_run_messages(["tc-1"])
-
-        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
-
-        assert "Done" in tool.result
-
-    def test_resets_run_state(self):
-        from agno.run import RunStatus
-        from agno.team._run import _prepare_member_hitl_continuation
-
-        tool = _make_tool_execution(
-            tool_name="delegate_task_to_member",
-            tool_call_id="tc-1",
-            result="requires human input",
-        )
-        run_response = self._make_run_response_with_tools([tool])
+        run_response.tools = [tool]
         run_response.status = RunStatus.paused
-        run_response.content = "old content"
-        run_messages = self._make_run_messages(["tc-1"])
+        run_response.content = "paused"
 
-        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
+        run_messages = MagicMock()
+        run_messages.messages = [Message(role="tool", content=tool.result, tool_call_id="tool-1")]
 
+        _prepare_member_hitl_continuation(run_response, run_messages, ["[Analyst]: Approved"])
+
+        expected = "Member results after human-in-the-loop resolution:\n[Analyst]: Approved"
+        assert tool.result == expected
+        assert run_messages.messages[0].content == expected
         assert run_response.status == RunStatus.running
         assert run_response.content is None
 
 
-# ===========================================================================
-# 14. Approval resolution fallback in continue_run_dispatch
-# ===========================================================================
-
-
 class TestContinueRunApprovalResolution:
-    """Tests for the approval resolution fallback logic.
+    def test_continue_run_dispatch_uses_resolved_admin_approval_without_requirements(self):
+        from agno.team._run import continue_run_dispatch
 
-    The approval resolution fallback is applied when requirements=None and
-    run_response.tools is non-empty. We test the branching logic directly
-    since continue_run_dispatch has complex setup dependencies.
-    """
+        team = MagicMock()
+        team.session_id = None
+        team.add_history_to_context = False
+        team.parser_model = None
+        team.initialize_team = MagicMock()
+        team.db = MagicMock()
 
-    def test_no_tools_no_requirements_raises_value_error(self):
-        """When run_response has no tools and no requirements, should raise ValueError."""
-        import pytest
+        tool = _make_tool_execution(
+            tool_call_id="tool-1",
+            approval_type="required",
+            requires_confirmation=True,
+        )
+        requirement = RunRequirement(tool)
+        run_response = TeamRunOutput(
+            run_id="run-1",
+            session_id="session-1",
+            requirements=[requirement],
+            tools=[tool],
+        )
 
-        # Simulate the branching logic from continue_run_dispatch
-        requirements = None
-        tools = []  # empty list is falsy
+        opts = SimpleNamespace(
+            stream=False,
+            stream_events=False,
+            yield_run_output=False,
+            dependencies=None,
+            knowledge_filters=None,
+            metadata=None,
+        )
+        team_session = MagicMock()
+        team_session.runs = [run_response]
+        sentinel = object()
 
-        if requirements is not None:
-            pass
-        elif tools:
-            pass  # would try approval
-        else:
-            with pytest.raises(ValueError):
-                raise ValueError("To continue a run from a given run_id, the requirements parameter must be provided.")
+        def _resolve_approval(db, run_id, paused_run_response):
+            paused_run_response.requirements[0].confirm()
 
-    def test_calls_approval_when_tools_present_no_requirements(self):
-        """When run_response has tools but no requirements, should try approval resolution."""
-        import agno.run.approval as approval_mod
-
-        requirements = None
-        tools = [_make_tool_execution(requires_confirmation=True)]
-        run_response = MagicMock()
-        run_response.tools = tools
-
-        with patch.object(approval_mod, "check_and_apply_approval_resolution") as mock_approval:
-            # Simulate the branching logic
-            if requirements is not None:
-                pass
-            elif run_response.tools:
-                approval_mod.check_and_apply_approval_resolution(MagicMock(), "run-123", run_response)
-            else:
-                raise ValueError("unreachable")
-
-            mock_approval.assert_called_once()
-
-    def test_approval_runtime_error_becomes_value_error(self):
-        """When approval resolution raises RuntimeError, should wrap as ValueError."""
-        import pytest
-
-        run_response = MagicMock()
-        run_response.tools = [_make_tool_execution(requires_confirmation=True)]
-
-        with patch(
-            "agno.run.approval.check_and_apply_approval_resolution",
-            side_effect=RuntimeError("no approval found"),
+        with (
+            patch("agno.team._init._has_async_db", return_value=False),
+            patch("agno.team._init._initialize_session", return_value=("session-1", None)),
+            patch("agno.team._storage._read_or_create_session", return_value=team_session),
+            patch("agno.team._storage._update_metadata"),
+            patch("agno.team._storage._load_session_state", return_value={}),
+            patch("agno.team._run_options.resolve_run_options", return_value=opts),
+            patch("agno.team._response.get_response_format", return_value=None),
+            patch("agno.team._tools._determine_tools_for_model", return_value=[]),
+            patch("agno.team._run._get_continue_run_messages", return_value=MagicMock(messages=[])),
+            patch("agno.team._run._handle_team_tool_call_updates"),
+            patch("agno.team._run._continue_run", return_value=sentinel) as mock_continue,
+            patch("agno.run.approval.check_and_apply_approval_resolution", side_effect=_resolve_approval) as mock_apply,
         ):
-            from agno.run.approval import check_and_apply_approval_resolution
+            result = continue_run_dispatch(
+                team,
+                run_id="run-1",
+                session_id="session-1",
+                stream=False,
+            )
 
-            with pytest.raises(ValueError, match="resolve an admin approval first"):
-                try:
-                    check_and_apply_approval_resolution(MagicMock(), "run-123", run_response)
-                except RuntimeError:
-                    raise ValueError(
-                        "To continue a run from a given run_id, the requirements parameter must be provided "
-                        "(or resolve an admin approval first)."
-                    )
+        assert result is sentinel
+        mock_apply.assert_called_once_with(team.db, "run-1", run_response)
+        mock_continue.assert_called_once()
+
+    def test_acontinue_run_uses_resolved_admin_approval_without_requirements(self):
+        from agno.team._run import _acontinue_run
+
+        team = MagicMock()
+        team.retries = 0
+        team.add_history_to_context = False
+        team.events_to_skip = []
+        team.store_events = False
+        team.db = MagicMock()
+        team.model = MagicMock()
+
+        tool = _make_tool_execution(
+            tool_call_id="tool-1",
+            approval_type="required",
+            requires_confirmation=True,
+        )
+        requirement = RunRequirement(tool)
+        run_response = TeamRunOutput(
+            run_id="run-1",
+            session_id="session-1",
+            requirements=[requirement],
+            tools=[tool],
+        )
+
+        team_session = MagicMock()
+        team_session.runs = [run_response]
+        run_context = MagicMock()
+        sentinel = object()
+
+        async def _resolve_approval(db, run_id, paused_run_response):
+            paused_run_response.requirements[0].confirm()
+
+        async def _exercise():
+            with (
+                patch("agno.team._run._asetup_session", new=AsyncMock(return_value=team_session)),
+                patch("agno.team._run.aregister_run", new=AsyncMock()),
+                patch("agno.team._run.acleanup_run", new=AsyncMock()),
+                patch("agno.team._init._disconnect_connectable_tools"),
+                patch("agno.team._init._disconnect_mcp_tools", new=AsyncMock()),
+                patch("agno.team._tools._check_and_refresh_mcp_tools", new=AsyncMock()),
+                patch("agno.team._tools._determine_tools_for_model", return_value=[]),
+                patch("agno.team._run._get_continue_run_messages", return_value=MagicMock(messages=[])),
+                patch("agno.team._run._ahandle_team_tool_call_updates", new=AsyncMock()),
+                patch("agno.team._run._ahandle_model_response_for_continue", new=AsyncMock(return_value=sentinel)),
+                patch(
+                    "agno.run.approval.acheck_and_apply_approval_resolution",
+                    side_effect=_resolve_approval,
+                ) as mock_apply,
+            ):
+                result = await _acontinue_run(
+                    team,
+                    session_id="session-1",
+                    run_context=run_context,
+                    run_id="run-1",
+                    requirements=None,
+                )
+
+            assert result is sentinel
+            mock_apply.assert_called_once_with(team.db, "run-1", run_response)
+
+        asyncio.run(_exercise())
+
+    def test_acontinue_run_stream_uses_run_id_for_empty_requirements(self):
+        from agno.team._run import _acontinue_run_stream
+
+        team = MagicMock()
+        team.retries = 0
+        team.events_to_skip = []
+        team.store_events = False
+        team.db = MagicMock()
+
+        tool = _make_tool_execution(
+            tool_call_id="tool-1",
+            approval_type="required",
+            requires_confirmation=True,
+        )
+        requirement = RunRequirement(tool)
+        run_response = TeamRunOutput(
+            run_id="run-1",
+            session_id="session-1",
+            requirements=[requirement],
+            tools=[tool],
+        )
+
+        team_session = MagicMock()
+        team_session.runs = [run_response]
+        run_context = MagicMock()
+
+        async def _pause_stream(*args, **kwargs):
+            yield "paused-event"
+
+        async def _exercise():
+            with (
+                patch("agno.team._run._asetup_session", new=AsyncMock(return_value=team_session)),
+                patch("agno.team._run.aregister_run", new=AsyncMock()),
+                patch("agno.team._run.acleanup_run", new=AsyncMock()),
+                patch("agno.team._init._disconnect_connectable_tools"),
+                patch("agno.team._init._disconnect_mcp_tools", new=AsyncMock()),
+                patch(
+                    "agno.run.approval.acheck_and_apply_approval_resolution",
+                    new=AsyncMock(),
+                ) as mock_apply,
+                patch("agno.team._hooks.ahandle_team_run_paused_stream", side_effect=_pause_stream),
+            ):
+                events = []
+                async for event in _acontinue_run_stream(
+                    team,
+                    session_id="session-1",
+                    run_context=run_context,
+                    run_id="run-1",
+                    requirements=None,
+                ):
+                    events.append(event)
+
+            assert events == ["paused-event"]
+            mock_apply.assert_called_once_with(team.db, "run-1", run_response)
+
+        asyncio.run(_exercise())

--- a/libs/agno/tests/unit/team/test_continue_run_requirements.py
+++ b/libs/agno/tests/unit/team/test_continue_run_requirements.py
@@ -800,7 +800,6 @@ class TestPrepareMemberHitlContinuation:
         assert "Done" in tool.result
 
     def test_resets_run_state(self):
-        from agno.run import RunStatus
         from agno.team._run import _prepare_member_hitl_continuation
 
         tool = _make_tool_execution(

--- a/libs/agno/tests/unit/team/test_continue_run_requirements.py
+++ b/libs/agno/tests/unit/team/test_continue_run_requirements.py
@@ -660,3 +660,228 @@ class TestAsyncGatherErrorHandling:
                 member_results.append(r)
 
         assert len(member_results) == 0
+
+
+# ===========================================================================
+# 12. _tool_result_requires_human_input
+# ===========================================================================
+
+
+class TestToolResultRequiresHumanInput:
+    def test_matching_string(self):
+        from agno.team._run import _tool_result_requires_human_input
+
+        tool = _make_tool_execution(result="Tool requires human input to proceed")
+        assert _tool_result_requires_human_input(tool) is True
+
+    def test_case_insensitive(self):
+        from agno.team._run import _tool_result_requires_human_input
+
+        tool = _make_tool_execution(result="REQUIRES HUMAN INPUT")
+        assert _tool_result_requires_human_input(tool) is True
+
+    def test_no_match(self):
+        from agno.team._run import _tool_result_requires_human_input
+
+        tool = _make_tool_execution(result="Success: operation completed")
+        assert _tool_result_requires_human_input(tool) is False
+
+    def test_none_result(self):
+        from agno.team._run import _tool_result_requires_human_input
+
+        tool = _make_tool_execution(result=None)
+        assert _tool_result_requires_human_input(tool) is False
+
+    def test_non_string_result(self):
+        from agno.team._run import _tool_result_requires_human_input
+
+        tool = _make_tool_execution(result={"key": "requires human input"})
+        assert _tool_result_requires_human_input(tool) is False
+
+
+# ===========================================================================
+# 13. _prepare_member_hitl_continuation improvements
+# ===========================================================================
+
+
+class TestPrepareMemberHitlContinuation:
+    """Tests for the improved _prepare_member_hitl_continuation that handles
+    delegate_task_to_members (plural) and case-insensitive matching."""
+
+    def _make_run_response_with_tools(self, tools):
+        run_response = MagicMock()
+        run_response.tools = tools
+        run_response.requirements = None
+        return run_response
+
+    def _make_run_messages(self, tool_call_ids):
+        msgs = []
+        for tc_id in tool_call_ids:
+            msg = MagicMock()
+            msg.role = "tool"
+            msg.tool_call_id = tc_id
+            msg.content = "requires human input"
+            msgs.append(msg)
+        run_messages = MagicMock()
+        run_messages.messages = msgs
+        return run_messages
+
+    def test_updates_delegate_task_to_member(self):
+        from agno.team._run import _prepare_member_hitl_continuation
+
+        tool = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            tool_call_id="tc-1",
+            result="Tool requires human input",
+        )
+        run_response = self._make_run_response_with_tools([tool])
+        run_messages = self._make_run_messages(["tc-1"])
+
+        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
+
+        assert "requires human input" not in tool.result
+        assert "Done" in tool.result
+
+    def test_updates_delegate_task_to_members_plural(self):
+        from agno.team._run import _prepare_member_hitl_continuation
+
+        tool = _make_tool_execution(
+            tool_name="delegate_task_to_members",
+            tool_call_id="tc-1",
+            result="Tool requires human input",
+        )
+        run_response = self._make_run_response_with_tools([tool])
+        run_messages = self._make_run_messages(["tc-1"])
+
+        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
+
+        assert "Done" in tool.result
+
+    def test_updates_multiple_matching_tools(self):
+        from agno.team._run import _prepare_member_hitl_continuation
+
+        tool1 = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            tool_call_id="tc-1",
+            result="requires human input",
+        )
+        tool2 = _make_tool_execution(
+            tool_name="delegate_task_to_members",
+            tool_call_id="tc-2",
+            result="requires human input",
+        )
+        run_response = self._make_run_response_with_tools([tool1, tool2])
+        run_messages = self._make_run_messages(["tc-1", "tc-2"])
+
+        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
+
+        assert "Done" in tool1.result
+        assert "Done" in tool2.result
+        assert run_messages.messages[0].content == run_messages.messages[1].content
+
+    def test_falls_back_to_any_tool_with_human_input(self):
+        """If no delegate tool matches, falls back to any tool with human input result."""
+        from agno.team._run import _prepare_member_hitl_continuation
+
+        tool = _make_tool_execution(
+            tool_name="some_other_tool",
+            tool_call_id="tc-1",
+            result="requires human input",
+        )
+        run_response = self._make_run_response_with_tools([tool])
+        run_messages = self._make_run_messages(["tc-1"])
+
+        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
+
+        assert "Done" in tool.result
+
+    def test_resets_run_state(self):
+        from agno.run import RunStatus
+        from agno.team._run import _prepare_member_hitl_continuation
+
+        tool = _make_tool_execution(
+            tool_name="delegate_task_to_member",
+            tool_call_id="tc-1",
+            result="requires human input",
+        )
+        run_response = self._make_run_response_with_tools([tool])
+        run_response.status = RunStatus.paused
+        run_response.content = "old content"
+        run_messages = self._make_run_messages(["tc-1"])
+
+        _prepare_member_hitl_continuation(run_response, run_messages, ["[Agent]: Done"])
+
+        assert run_response.status == RunStatus.running
+        assert run_response.content is None
+
+
+# ===========================================================================
+# 14. Approval resolution fallback in continue_run_dispatch
+# ===========================================================================
+
+
+class TestContinueRunApprovalResolution:
+    """Tests for the approval resolution fallback logic.
+
+    The approval resolution fallback is applied when requirements=None and
+    run_response.tools is non-empty. We test the branching logic directly
+    since continue_run_dispatch has complex setup dependencies.
+    """
+
+    def test_no_tools_no_requirements_raises_value_error(self):
+        """When run_response has no tools and no requirements, should raise ValueError."""
+        import pytest
+
+        # Simulate the branching logic from continue_run_dispatch
+        requirements = None
+        tools = []  # empty list is falsy
+
+        if requirements is not None:
+            pass
+        elif tools:
+            pass  # would try approval
+        else:
+            with pytest.raises(ValueError):
+                raise ValueError("To continue a run from a given run_id, the requirements parameter must be provided.")
+
+    def test_calls_approval_when_tools_present_no_requirements(self):
+        """When run_response has tools but no requirements, should try approval resolution."""
+        import agno.run.approval as approval_mod
+
+        requirements = None
+        tools = [_make_tool_execution(requires_confirmation=True)]
+        run_response = MagicMock()
+        run_response.tools = tools
+
+        with patch.object(approval_mod, "check_and_apply_approval_resolution") as mock_approval:
+            # Simulate the branching logic
+            if requirements is not None:
+                pass
+            elif run_response.tools:
+                approval_mod.check_and_apply_approval_resolution(MagicMock(), "run-123", run_response)
+            else:
+                raise ValueError("unreachable")
+
+            mock_approval.assert_called_once()
+
+    def test_approval_runtime_error_becomes_value_error(self):
+        """When approval resolution raises RuntimeError, should wrap as ValueError."""
+        import pytest
+
+        run_response = MagicMock()
+        run_response.tools = [_make_tool_execution(requires_confirmation=True)]
+
+        with patch(
+            "agno.run.approval.check_and_apply_approval_resolution",
+            side_effect=RuntimeError("no approval found"),
+        ):
+            from agno.run.approval import check_and_apply_approval_resolution
+
+            with pytest.raises(ValueError, match="resolve an admin approval first"):
+                try:
+                    check_and_apply_approval_resolution(MagicMock(), "run-123", run_response)
+                except RuntimeError:
+                    raise ValueError(
+                        "To continue a run from a given run_id, the requirements parameter must be provided "
+                        "(or resolve an admin approval first)."
+                    )


### PR DESCRIPTION
## Summary

Fixes three blockers in the team HITL `/continue` flow on top of #6725:

- add the missing admin approval gate to the team `/continue` route
- allow empty `requirements` payloads when an admin approval has already been resolved
- return a 400 when `session_id` is omitted for local team continuations instead of falling through to a server error
- resume member-only HITL continuations correctly for both `delegate_task_to_member` and `delegate_task_to_members`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

This is a follow-up to #6725 rather than a duplicate: it only addresses the continuation blockers found during review and leaves the original feature scope unchanged.

---

## Additional Notes

Targeted verification run:

- `python3 -m pytest libs/agno/tests/unit/team/test_continue_run_requirements.py libs/agno/tests/integration/os/test_team_runs.py libs/agno/tests/unit/os/test_require_approval_resolved.py`
- `python3 -m ruff check libs/agno/agno/os/routers/teams/router.py libs/agno/agno/team/_run.py libs/agno/tests/unit/team/test_continue_run_requirements.py libs/agno/tests/integration/os/test_team_runs.py`
