### PR TITLE
chore: add weekly scheduled run to main validation workflow

### DIFF
--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -2,16 +2,11 @@ name: Main Validation
 
 on:
   schedule:
-    - cron: "30 21 * * 6"
+    - cron: "30 21 * * 6"  # Every Saturday 9:30 pm UTC
   push:
     branches:
       - "*release*" # Run on release-* format
       - "release/*" # Run on release/1.2.3 branch format
-      - "v2.5-phase1"
-      - "fix/ci-test-failures"
-      - "fix/team-hitl-streaming"
-      - "v2.5-phase2"
-      - "scheduled-runs"
   workflow_dispatch: # Allows manual triggering
     inputs:
       branch:

--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -1,6 +1,8 @@
 name: Main Validation
 
 on:
+  schedule:
+    - cron: "30 21 * * 6"
   push:
     branches:
       - "*release*" # Run on release-* format

--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -11,7 +11,7 @@ on:
       - "fix/ci-test-failures"
       - "fix/team-hitl-streaming"
       - "v2.5-phase2"
-      - "gh-7432"
+      - "scheduled-runs"
   workflow_dispatch: # Allows manual triggering
     inputs:
       branch:

--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -11,6 +11,7 @@ on:
       - "fix/ci-test-failures"
       - "fix/team-hitl-streaming"
       - "v2.5-phase2"
+      - "gh-7432"
   workflow_dispatch: # Allows manual triggering
     inputs:
       branch:


### PR DESCRIPTION
## Summary

Adds a weekly scheduled run to the `Main Validation` workflow so integration tests run automatically every Saturday 9:30 PM UTC, in addition to the existing release branch and manual triggers.

## Motivation 

Our integration tests currently only run when we push to a release branch. This means if any external dependency breaks or we have some missing system requirements, etc. we don't find out until release time, which is the worst moment to be debugging CI failures especially for the release owners. 

This to much extent gives us an early warning system and a continuous health check for external breakages on regular basis without manual triggers though this still means PRs might be merged with some associated failing integration tests, and we would know only when the scheduled run happens but its still better than discovering on the release branch (Potential follow up for this https://github.com/agno-agi/agno/pull/6898).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Testing

<img width="1461" height="757" alt="image" src="https://github.com/user-attachments/assets/fbaa7a9f-5152-4fc9-8d11-a4f73dd18893" />

Pipeline run: https://github.com/agno-agi/agno/actions/runs/24235632464
