### PR TITLE
fix: handle filepath images in workflow step conversion

### DIFF
--- a/libs/agno/agno/workflow/step.py
+++ b/libs/agno/agno/workflow/step.py
@@ -2764,11 +2764,14 @@ class Step:
                 images.append(Image(url=img_artifact.url))
 
             elif img_artifact.filepath:
+                # Pass through filepath-based images directly
                 image_kwargs: Dict[str, Any] = {"filepath": img_artifact.filepath}
+                if img_artifact.format:
+                    image_kwargs["format"] = img_artifact.format
                 if img_artifact.mime_type:
                     if "/" in img_artifact.mime_type:
                         format_from_mime = img_artifact.mime_type.split("/")[-1]
-                        image_kwargs["format"] = format_from_mime
+                        image_kwargs.setdefault("format", format_from_mime)
                 images.append(Image(**image_kwargs))
 
             elif img_artifact.content:

--- a/libs/agno/agno/workflow/step.py
+++ b/libs/agno/agno/workflow/step.py
@@ -2763,6 +2763,14 @@ class Step:
             if img_artifact.url:
                 images.append(Image(url=img_artifact.url))
 
+            elif img_artifact.filepath:
+                image_kwargs: Dict[str, Any] = {"filepath": img_artifact.filepath}
+                if img_artifact.mime_type:
+                    if "/" in img_artifact.mime_type:
+                        format_from_mime = img_artifact.mime_type.split("/")[-1]
+                        image_kwargs["format"] = format_from_mime
+                images.append(Image(**image_kwargs))
+
             elif img_artifact.content:
                 # Handle the case where content is base64-encoded bytes from OpenAI tools
                 try:
@@ -2795,8 +2803,8 @@ class Step:
                     continue
 
             else:
-                # Skip images that have neither URL nor content
-                logger.warning(f"Skipping ImageArtifact {i} with no URL or content: {img_artifact}")
+                # Skip images that have neither URL, filepath, nor content
+                logger.warning(f"Skipping ImageArtifact {i} with no URL, filepath, or content: {img_artifact}")
                 continue
 
         return images
@@ -2817,12 +2825,15 @@ class Step:
             if video_artifact.url:
                 videos.append(Video(url=video_artifact.url))
 
+            elif video_artifact.filepath:
+                videos.append(Video(filepath=video_artifact.filepath))
+
             elif video_artifact.content:
                 videos.append(Video(content=video_artifact.content))
 
             else:
-                # Skip videos that have neither URL nor content
-                logger.warning(f"Skipping VideoArtifact {i} with no URL or content: {video_artifact}")
+                # Skip videos that have neither URL, filepath, nor content
+                logger.warning(f"Skipping VideoArtifact {i} with no URL, filepath, or content: {video_artifact}")
                 continue
 
         return videos

--- a/libs/agno/tests/unit/workflow/test_step_image_conversion.py
+++ b/libs/agno/tests/unit/workflow/test_step_image_conversion.py
@@ -69,3 +69,20 @@ class TestConvertImageArtifactsToImages:
         images = step._convert_image_artifacts_to_images([Image(content=raw_png, mime_type="image/png")])
         assert len(images) == 1
         assert images[0].content == raw_png
+
+    def test_filepath_image_passes_through(self, step, tmp_path):
+        """Filepath-based images should pass through unchanged."""
+        img_file = tmp_path / "test.jpg"
+        img_file.write_bytes(b"\xff\xd8\xff\xe0\x00\x10JFIF")
+        images = step._convert_image_artifacts_to_images([Image(filepath=str(img_file))])
+        assert len(images) == 1
+        assert str(images[0].filepath) == str(img_file)
+
+    def test_filepath_image_with_mime_type_sets_format(self, step, tmp_path):
+        """Filepath image with mime_type should have format extracted."""
+        img_file = tmp_path / "test.png"
+        img_file.write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00")
+        images = step._convert_image_artifacts_to_images([Image(filepath=str(img_file), mime_type="image/png")])
+        assert len(images) == 1
+        assert str(images[0].filepath) == str(img_file)
+        assert images[0].format == "png"


### PR DESCRIPTION
## Summary

When a workflow step returns an `Image(filepath=...)`, the image is silently dropped because `_convert_image_artifacts_to_images()` only handles `url` and `content` branches — it has no `filepath` handling. This also affects `_convert_video_artifacts_to_videos()`.

Fixes #7456

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)
