### PR TITLE
fix: TeamSession.from_dict() no longer mutates input mapping

### DIFF
--- a/libs/agno/agno/session/team.py
+++ b/libs/agno/agno/session/team.py
@@ -57,8 +57,9 @@ class TeamSession:
             return None
 
         summary = data.get("summary")
+        summary_obj = summary
         if summary is not None and isinstance(summary, dict):
-            data["summary"] = SessionSummary.from_dict(data["summary"])  # type: ignore
+            summary_obj = SessionSummary.from_dict(summary)
 
         runs = data.get("runs")
         serialized_runs: List[Union[TeamRunOutput, RunOutput]] = []
@@ -80,7 +81,7 @@ class TeamSession:
             created_at=data.get("created_at"),
             updated_at=data.get("updated_at"),
             runs=serialized_runs,
-            summary=data.get("summary"),
+            summary=summary_obj,
         )
 
     def get_run(self, run_id: str) -> Optional[Union[TeamRunOutput, RunOutput]]:

--- a/libs/agno/tests/integration/session/test_team_session.py
+++ b/libs/agno/tests/integration/session/test_team_session.py
@@ -3,6 +3,7 @@
 import uuid
 from datetime import datetime
 from time import time
+from types import MappingProxyType
 
 from agno.db.base import SessionType
 from agno.models.message import Message
@@ -790,6 +791,37 @@ def test_from_dict_with_summary(shared_db):
     team_session = TeamSession.from_dict(session_data)
 
     assert team_session is not None
+    assert team_session.summary is not None
+    assert team_session.summary.summary == "Test summary"
+    assert team_session.summary.topics == ["topic1"]
+
+
+def test_from_dict_with_immutable_mapping_and_summary():
+    """Test creating TeamSession from an immutable mapping with summary data"""
+    session_id = f"test_session_{uuid.uuid4()}"
+
+    session_data = MappingProxyType(
+        {
+            "session_id": session_id,
+            "team_id": "test_team",
+            "team_data": {"name": "team"},
+            "session_data": {"key": "value"},
+            "metadata": {"meta_key": "meta_value"},
+            "summary": {
+                "summary": "Test summary",
+                "topics": ["topic1"],
+                "updated_at": datetime.now().isoformat(),
+            },
+        }
+    )
+
+    team_session = TeamSession.from_dict(session_data)
+
+    assert team_session is not None
+    assert team_session.team_id == "test_team"
+    assert team_session.team_data == {"name": "team"}
+    assert team_session.session_data == {"key": "value"}
+    assert team_session.metadata == {"meta_key": "meta_value"}
     assert team_session.summary is not None
     assert team_session.summary.summary == "Test summary"
     assert team_session.summary.topics == ["topic1"]


### PR DESCRIPTION
Fixes #7460

TeamSession.from_dict() mutates the incoming Mapping, which crashes when SingleStore passes immutable RowMapping objects. This mirrors the pattern already used by AgentSession.from_dict().

*btw, this fix was developed with AI assistance and reviewed by a human.*