### PR TITLE
fix: address review issues in LLMsTxtReader and LLMsTxtTools

### DIFF
--- a/libs/agno/agno/knowledge/reader/llms_txt_reader.py
+++ b/libs/agno/agno/knowledge/reader/llms_txt_reader.py
@@ -14,16 +14,14 @@ from agno.knowledge.reader.base import Reader
 from agno.knowledge.types import ContentType
 from agno.utils.log import log_debug, log_error, log_warning
 
-try:
-    from bs4 import BeautifulSoup
-except ImportError:
-    raise ImportError("The `bs4` package is not installed. Please install it via `pip install beautifulsoup4`.")
-
-
 # Pattern to match markdown links: - [Title](url) or - [Title](url): description
+# Note: titles with nested brackets (e.g. [Agent [Beta]](url)) are not supported.
 _LINK_PATTERN = re.compile(r"-\s+\[([^\]]+)\]\(([^)]+)\)(?::\s*(.+))?")
 # Pattern to match H2 section headers
 _SECTION_PATTERN = re.compile(r"^##\s+(.+)$", re.MULTILINE)
+
+# Maximum number of concurrent HTTP requests when fetching linked pages
+_MAX_CONCURRENT_FETCHES = 10
 
 
 @dataclass
@@ -96,7 +94,7 @@ class LLMsTxtReader(Reader):
     def get_supported_content_types(cls) -> List[ContentType]:
         return [ContentType.URL]
 
-    def _parse_llms_txt(self, content: str, base_url: str) -> Tuple[str, List[LLMsTxtEntry]]:
+    def parse_llms_txt(self, content: str, base_url: str) -> Tuple[str, List[LLMsTxtEntry]]:
         """Parse an llms.txt file and extract all linked URLs.
 
         Args:
@@ -155,6 +153,11 @@ class LLMsTxtReader(Reader):
 
     def _extract_content(self, html: str) -> str:
         """Extract readable text content from HTML."""
+        try:
+            from bs4 import BeautifulSoup
+        except ImportError:
+            raise ImportError("The `bs4` package is not installed. Please install it via `pip install beautifulsoup4`.")
+
         soup = BeautifulSoup(html, "html.parser")
 
         # Remove unwanted elements
@@ -164,15 +167,15 @@ class LLMsTxtReader(Reader):
         # Try to find main content
         main = soup.find("main") or soup.find("article") or soup.find(attrs={"role": "main"})
         if main:
-            return main.get_text(strip=True, separator=" ")
+            return main.get_text(separator="\n", strip=True)
 
         body = soup.find("body")
         if body:
-            return body.get_text(strip=True, separator=" ")
+            return body.get_text(separator="\n", strip=True)
 
-        return soup.get_text(strip=True, separator=" ")
+        return soup.get_text(separator="\n", strip=True)
 
-    def _fetch_url(self, url: str) -> Optional[str]:
+    def fetch_url(self, url: str) -> Optional[str]:
         """Fetch content from a URL, returning text for text-like content or extracted text from HTML."""
         try:
             log_debug(f"Fetching: {url}")
@@ -205,7 +208,7 @@ class LLMsTxtReader(Reader):
             log_error(f"Failed to fetch {url}: {str(e)}")
             return None
 
-    async def _async_fetch_url(self, client: httpx.AsyncClient, url: str) -> Optional[str]:
+    async def async_fetch_url(self, client: httpx.AsyncClient, url: str) -> Optional[str]:
         """Asynchronously fetch content from a URL."""
         try:
             log_debug(f"Fetching asynchronously: {url}")
@@ -296,13 +299,13 @@ class LLMsTxtReader(Reader):
         log_debug(f"Reading llms.txt: {url}")
 
         # Fetch the llms.txt file
-        llms_txt_content = self._fetch_url(url)
+        llms_txt_content = self.fetch_url(url)
         if not llms_txt_content:
             log_error(f"Failed to fetch llms.txt from {url}")
             return []
 
         # Parse the llms.txt content
-        overview, entries = self._parse_llms_txt(llms_txt_content, url)
+        overview, entries = self.parse_llms_txt(llms_txt_content, url)
         log_debug(f"Found {len(entries)} linked URLs in llms.txt")
 
         # Limit the number of URLs to fetch
@@ -313,7 +316,7 @@ class LLMsTxtReader(Reader):
         # Fetch all linked pages
         fetched: Dict[str, str] = {}
         for entry in entries_to_fetch:
-            content = self._fetch_url(entry.url)
+            content = self.fetch_url(entry.url)
             if content:
                 fetched[entry.url] = content
 
@@ -335,13 +338,13 @@ class LLMsTxtReader(Reader):
         client_args = {"proxy": self.proxy} if self.proxy else {}
         async with httpx.AsyncClient(**client_args) as client:  # type: ignore
             # Fetch the llms.txt file
-            llms_txt_content = await self._async_fetch_url(client, url)
+            llms_txt_content = await self.async_fetch_url(client, url)
             if not llms_txt_content:
                 log_error(f"Failed to fetch llms.txt from {url}")
                 return []
 
             # Parse the llms.txt content
-            overview, entries = self._parse_llms_txt(llms_txt_content, url)
+            overview, entries = self.parse_llms_txt(llms_txt_content, url)
             log_debug(f"Found {len(entries)} linked URLs in llms.txt")
 
             # Limit the number of URLs to fetch
@@ -349,13 +352,16 @@ class LLMsTxtReader(Reader):
             if len(entries) > self.max_urls:
                 log_warning(f"Limiting to {self.max_urls} URLs (found {len(entries)})")
 
-            # Fetch all linked pages concurrently
+            # Fetch all linked pages concurrently with a semaphore to limit parallelism
+            semaphore = asyncio.Semaphore(_MAX_CONCURRENT_FETCHES)
+
             async def _fetch_entry(entry: LLMsTxtEntry) -> Tuple[str, Optional[str]]:
-                content = await self._async_fetch_url(client, entry.url)
-                return entry.url, content
+                async with semaphore:
+                    content = await self.async_fetch_url(client, entry.url)
+                    return entry.url, content
 
             results = await asyncio.gather(*[_fetch_entry(e) for e in entries_to_fetch])
-            fetched: Dict[str, str] = {url: content for url, content in results if content}
+            fetched: Dict[str, str] = {entry_url: content for entry_url, content in results if content}
 
             log_debug(f"Successfully fetched {len(fetched)}/{len(entries_to_fetch)} linked pages")
             return self._build_documents(overview, entries_to_fetch, fetched, url, name)

--- a/libs/agno/agno/tools/llms_txt.py
+++ b/libs/agno/agno/tools/llms_txt.py
@@ -49,19 +49,30 @@ class LLMsTxtTools(Toolkit):
         skip_optional: bool = False,
         **kwargs,
     ):
+        from agno.knowledge.reader.llms_txt_reader import LLMsTxtReader
+
         self.knowledge: Optional[Knowledge] = knowledge
         self.max_urls = max_urls
         self.timeout = timeout
         self.skip_optional = skip_optional
+        self.reader = LLMsTxtReader(
+            max_urls=max_urls,
+            timeout=timeout,
+            skip_optional=skip_optional,
+        )
 
         tools: List[Any] = []
+        async_tools_list: List[tuple] = []
         if self.knowledge is not None:
             tools.append(self.read_llms_txt_and_load_knowledge)
+            async_tools_list.append((self.aread_llms_txt_and_load_knowledge, "read_llms_txt_and_load_knowledge"))
         else:
             tools.append(self.get_llms_txt_index)
             tools.append(self.read_llms_txt_url)
+            async_tools_list.append((self.aget_llms_txt_index, "get_llms_txt_index"))
+            async_tools_list.append((self.aread_llms_txt_url, "read_llms_txt_url"))
 
-        super().__init__(name="llms_txt_tools", tools=tools, **kwargs)
+        super().__init__(name="llms_txt_tools", tools=tools, async_tools=async_tools_list, **kwargs)
 
     def get_llms_txt_index(self, url: str) -> str:
         """Reads an llms.txt file and returns the index of all available documentation pages.
@@ -74,19 +85,44 @@ class LLMsTxtTools(Toolkit):
         :param url: The URL of the llms.txt file (e.g. https://docs.example.com/llms.txt).
         :return: JSON with the overview and list of available documentation pages.
         """
-        from agno.knowledge.reader.llms_txt_reader import LLMsTxtReader
-
-        reader = LLMsTxtReader(
-            timeout=self.timeout,
-            skip_optional=self.skip_optional,
-        )
-
         log_info(f"Reading llms.txt index from {url}")
-        llms_txt_content = reader._fetch_url(url)
+        llms_txt_content = self.reader.fetch_url(url)
         if not llms_txt_content:
             return f"Failed to fetch llms.txt from {url}"
 
-        overview, entries = reader._parse_llms_txt(llms_txt_content, url)
+        overview, entries = self.reader.parse_llms_txt(llms_txt_content, url)
+
+        index = {
+            "overview": overview,
+            "pages": [
+                {
+                    "title": entry.title,
+                    "url": entry.url,
+                    "description": entry.description,
+                    "section": entry.section,
+                }
+                for entry in entries
+            ],
+            "total_pages": len(entries),
+        }
+        return json.dumps(index)
+
+    async def aget_llms_txt_index(self, url: str) -> str:
+        """Async variant of get_llms_txt_index.
+
+        :param url: The URL of the llms.txt file (e.g. https://docs.example.com/llms.txt).
+        :return: JSON with the overview and list of available documentation pages.
+        """
+        import httpx
+
+        log_info(f"Reading llms.txt index from {url}")
+        async with httpx.AsyncClient() as client:
+            llms_txt_content = await self.reader.async_fetch_url(client, url)
+
+        if not llms_txt_content:
+            return f"Failed to fetch llms.txt from {url}"
+
+        overview, entries = self.reader.parse_llms_txt(llms_txt_content, url)
 
         index = {
             "overview": overview,
@@ -112,12 +148,25 @@ class LLMsTxtTools(Toolkit):
         :param url: The URL of the documentation page to read.
         :return: The text content of the page.
         """
-        from agno.knowledge.reader.llms_txt_reader import LLMsTxtReader
+        log_debug(f"Fetching URL: {url}")
+        content = self.reader.fetch_url(url)
+        if not content:
+            return f"Failed to fetch content from {url}"
 
-        reader = LLMsTxtReader(timeout=self.timeout)
+        return content
+
+    async def aread_llms_txt_url(self, url: str) -> str:
+        """Async variant of read_llms_txt_url.
+
+        :param url: The URL of the documentation page to read.
+        :return: The text content of the page.
+        """
+        import httpx
 
         log_debug(f"Fetching URL: {url}")
-        content = reader._fetch_url(url)
+        async with httpx.AsyncClient() as client:
+            content = await self.reader.async_fetch_url(client, url)
+
         if not content:
             return f"Failed to fetch content from {url}"
 
@@ -136,16 +185,8 @@ class LLMsTxtTools(Toolkit):
         if self.knowledge is None:
             return "Knowledge base not provided"
 
-        from agno.knowledge.reader.llms_txt_reader import LLMsTxtReader
-
-        reader = LLMsTxtReader(
-            max_urls=self.max_urls,
-            timeout=self.timeout,
-            skip_optional=self.skip_optional,
-        )
-
         log_info(f"Reading llms.txt from {url}")
-        documents: List[Document] = reader.read(url=url)
+        documents: List[Document] = self.reader.read(url=url)
 
         if not documents:
             return f"No documents found in llms.txt at {url}"
@@ -153,6 +194,31 @@ class LLMsTxtTools(Toolkit):
         log_debug(f"Loading {len(documents)} documents into knowledge base")
         for doc in documents:
             self.knowledge.insert(
+                text_content=doc.content,
+                name=doc.name,
+                metadata=doc.meta_data,
+            )
+
+        return f"Successfully loaded {len(documents)} documents from llms.txt into the knowledge base"
+
+    async def aread_llms_txt_and_load_knowledge(self, url: str) -> str:
+        """Async variant of read_llms_txt_and_load_knowledge.
+
+        :param url: The URL of the llms.txt file (e.g. https://docs.example.com/llms.txt).
+        :return: Summary of what was loaded into the knowledge base.
+        """
+        if self.knowledge is None:
+            return "Knowledge base not provided"
+
+        log_info(f"Reading llms.txt from {url}")
+        documents: List[Document] = await self.reader.async_read(url=url)
+
+        if not documents:
+            return f"No documents found in llms.txt at {url}"
+
+        log_debug(f"Loading {len(documents)} documents into knowledge base")
+        for doc in documents:
+            await self.knowledge.ainsert(
                 text_content=doc.content,
                 name=doc.name,
                 metadata=doc.meta_data,

--- a/libs/agno/tests/unit/tools/test_llms_txt.py
+++ b/libs/agno/tests/unit/tools/test_llms_txt.py
@@ -73,7 +73,7 @@ class TestLLMsTxtReaderInit:
 class TestParseLLMsTxt:
     def test_parses_entries(self):
         reader = LLMsTxtReader()
-        overview, entries = reader._parse_llms_txt(SAMPLE_LLMS_TXT, "https://docs.acme.com/llms.txt")
+        overview, entries = reader.parse_llms_txt(SAMPLE_LLMS_TXT, "https://docs.acme.com/llms.txt")
 
         assert len(entries) == 7
         assert entries[0].title == "Introduction"
@@ -83,35 +83,35 @@ class TestParseLLMsTxt:
 
     def test_parses_overview(self):
         reader = LLMsTxtReader()
-        overview, entries = reader._parse_llms_txt(SAMPLE_LLMS_TXT, "https://docs.acme.com/llms.txt")
+        overview, entries = reader.parse_llms_txt(SAMPLE_LLMS_TXT, "https://docs.acme.com/llms.txt")
 
         assert "# Acme Project" in overview
         assert "Acme makes it easy" in overview
 
     def test_sections_assigned(self):
         reader = LLMsTxtReader()
-        _, entries = reader._parse_llms_txt(SAMPLE_LLMS_TXT, "https://docs.acme.com/llms.txt")
+        _, entries = reader.parse_llms_txt(SAMPLE_LLMS_TXT, "https://docs.acme.com/llms.txt")
 
         sections = {e.section for e in entries}
         assert sections == {"Getting Started", "API Reference", "Optional"}
 
     def test_skip_optional(self):
         reader = LLMsTxtReader(skip_optional=True)
-        _, entries = reader._parse_llms_txt(SAMPLE_LLMS_TXT, "https://docs.acme.com/llms.txt")
+        _, entries = reader.parse_llms_txt(SAMPLE_LLMS_TXT, "https://docs.acme.com/llms.txt")
 
         assert len(entries) == 5
         assert all(e.section != "Optional" for e in entries)
 
     def test_relative_urls_resolved(self):
         reader = LLMsTxtReader()
-        _, entries = reader._parse_llms_txt(SAMPLE_LLMS_TXT_RELATIVE, "https://example.com/llms.txt")
+        _, entries = reader.parse_llms_txt(SAMPLE_LLMS_TXT_RELATIVE, "https://example.com/llms.txt")
 
         assert entries[0].url == "https://example.com/docs/guide"
         assert entries[1].url == "https://example.com/api/reference"
 
     def test_empty_content(self):
         reader = LLMsTxtReader()
-        overview, entries = reader._parse_llms_txt("", "https://example.com/llms.txt")
+        overview, entries = reader.parse_llms_txt("", "https://example.com/llms.txt")
 
         assert overview == ""
         assert entries == []
@@ -119,7 +119,7 @@ class TestParseLLMsTxt:
     def test_no_links(self):
         content = "# Title\n\nSome overview text.\n\n## Section\n\nNo links here."
         reader = LLMsTxtReader()
-        overview, entries = reader._parse_llms_txt(content, "https://example.com/llms.txt")
+        overview, entries = reader.parse_llms_txt(content, "https://example.com/llms.txt")
 
         assert "# Title" in overview
         assert entries == []
@@ -146,6 +146,14 @@ class TestExtractContent:
         assert "var x" not in result
         assert "Text" in result
 
+    def test_preserves_structure_with_newlines(self):
+        reader = LLMsTxtReader()
+        html = "<html><body><main><p>First paragraph</p><p>Second paragraph</p></main></body></html>"
+        result = reader._extract_content(html)
+        assert "First paragraph" in result
+        assert "Second paragraph" in result
+        assert "\n" in result
+
 
 class TestFetchUrl:
     def test_returns_text_for_plain_content(self):
@@ -156,7 +164,7 @@ class TestFetchUrl:
         mock_response.raise_for_status = MagicMock()
 
         with patch("httpx.get", return_value=mock_response):
-            result = reader._fetch_url("https://example.com/file.txt")
+            result = reader.fetch_url("https://example.com/file.txt")
 
         assert result == "Plain text content"
 
@@ -168,7 +176,7 @@ class TestFetchUrl:
         mock_response.raise_for_status = MagicMock()
 
         with patch("httpx.get", return_value=mock_response):
-            result = reader._fetch_url("https://example.com/page")
+            result = reader.fetch_url("https://example.com/page")
 
         assert "Extracted" in result
 
@@ -179,7 +187,7 @@ class TestFetchUrl:
             "httpx.get",
             side_effect=httpx.HTTPStatusError("error", request=MagicMock(), response=MagicMock(status_code=404)),
         ):
-            result = reader._fetch_url("https://example.com/missing")
+            result = reader.fetch_url("https://example.com/missing")
 
         assert result is None
 
@@ -187,7 +195,7 @@ class TestFetchUrl:
         reader = LLMsTxtReader()
 
         with patch("httpx.get", side_effect=httpx.RequestError("connection failed")):
-            result = reader._fetch_url("https://example.com/down")
+            result = reader.fetch_url("https://example.com/down")
 
         assert result is None
 
@@ -243,7 +251,7 @@ class TestRead:
                 return SAMPLE_LLMS_TXT
             return f"Content of {url}"
 
-        with patch.object(reader, "_fetch_url", side_effect=mock_fetch):
+        with patch.object(reader, "fetch_url", side_effect=mock_fetch):
             docs = reader.read("https://example.com/llms.txt")
 
         # 1 overview + 5 linked docs (max_urls=5)
@@ -253,7 +261,7 @@ class TestRead:
     def test_read_returns_empty_on_fetch_failure(self):
         reader = LLMsTxtReader()
 
-        with patch.object(reader, "_fetch_url", return_value=None):
+        with patch.object(reader, "fetch_url", return_value=None):
             docs = reader.read("https://example.com/llms.txt")
 
         assert docs == []
@@ -266,7 +274,7 @@ class TestRead:
                 return SAMPLE_LLMS_TXT
             return f"Content of {url}"
 
-        with patch.object(reader, "_fetch_url", side_effect=mock_fetch):
+        with patch.object(reader, "fetch_url", side_effect=mock_fetch):
             docs = reader.read("https://example.com/llms.txt")
 
         # 1 overview + 2 linked docs (max_urls=2)
@@ -286,6 +294,12 @@ class TestLLMsTxtToolsInit:
         assert "read_llms_txt_url" in func_names
         assert "read_llms_txt_and_load_knowledge" not in func_names
 
+    def test_without_knowledge_registers_async_tools(self):
+        tools = LLMsTxtTools()
+        async_func_names = [func.name for func in tools.async_functions.values()]
+        assert "get_llms_txt_index" in async_func_names
+        assert "read_llms_txt_url" in async_func_names
+
     def test_with_knowledge_registers_load(self):
         mock_knowledge = MagicMock()
         tools = LLMsTxtTools(knowledge=mock_knowledge)
@@ -293,11 +307,23 @@ class TestLLMsTxtToolsInit:
         assert "read_llms_txt_and_load_knowledge" in func_names
         assert "get_llms_txt_index" not in func_names
 
+    def test_with_knowledge_registers_async_load(self):
+        mock_knowledge = MagicMock()
+        tools = LLMsTxtTools(knowledge=mock_knowledge)
+        async_func_names = [func.name for func in tools.async_functions.values()]
+        assert "read_llms_txt_and_load_knowledge" in async_func_names
+
     def test_custom_params(self):
         tools = LLMsTxtTools(max_urls=50, timeout=10, skip_optional=True)
         assert tools.max_urls == 50
         assert tools.timeout == 10
         assert tools.skip_optional is True
+
+    def test_reader_is_reused(self):
+        tools = LLMsTxtTools()
+        assert tools.reader is not None
+        assert tools.reader.timeout == tools.timeout
+        assert tools.reader.max_urls == tools.max_urls
 
 
 class TestGetLLMsTxtIndex:


### PR DESCRIPTION
## Summary

Addresses code review feedback on #7458. Fixes several issues in the LLMsTxtReader and LLMsTxtTools implementation.

**Changes:**
- **Lazy BeautifulSoup import** - Deferred to `_extract_content()` instead of hard-failing at module import time
- **Variable shadowing fix** - Renamed `url` to `entry_url` in `async_read()` dict comprehension to avoid shadowing the method parameter
- **Concurrency limiting** - Added `asyncio.Semaphore(10)` to prevent overwhelming target servers when fetching 100+ URLs concurrently
- **Better text extraction** - Changed `_extract_content()` separator from `" "` to `"\n"` to preserve document structure
- **Public API methods** - Renamed `_fetch_url` / `_parse_llms_txt` to `fetch_url` / `parse_llms_txt` since they are called by the toolkit
- **Reader reuse** - LLMsTxtTools now creates a single `LLMsTxtReader` instance in `__init__` instead of per tool call
- **Async tool variants** - Added `aget_llms_txt_index`, `aread_llms_txt_url`, `aread_llms_txt_and_load_knowledge` registered via `async_tools` following the codebase convention (e.g. BrandfetchTools)
- **New tests** - Added tests for async tool registration, reader reuse, and newline preservation in HTML extraction

## Type of change

- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

All 36 tests pass (up from 32 - added 4 new tests for async registration, reader reuse, and HTML newline preservation).