### PR TITLE
[fix] Include extra_messages in memory pipeline gate check

### DIFF
--- a/libs/agno/agno/agent/_managers.py
+++ b/libs/agno/agno/agent/_managers.py
@@ -162,8 +162,11 @@ async def astart_memory_task(
             pass
 
     # Create new task if conditions are met
+    has_content = run_messages.user_message is not None or (
+        run_messages.extra_messages is not None and len(run_messages.extra_messages) > 0
+    )
     if (
-        run_messages.user_message is not None
+        has_content
         and agent.memory_manager is not None
         and agent.update_memory_on_run
         and not agent.enable_agentic_memory
@@ -197,8 +200,11 @@ def start_memory_future(
         existing_future.cancel()
 
     # Create new future if conditions are met
+    has_content = run_messages.user_message is not None or (
+        run_messages.extra_messages is not None and len(run_messages.extra_messages) > 0
+    )
     if (
-        run_messages.user_message is not None
+        has_content
         and agent.memory_manager is not None
         and agent.update_memory_on_run
         and not agent.enable_agentic_memory

--- a/libs/agno/tests/unit/agent/test_memory_extra_messages.py
+++ b/libs/agno/tests/unit/agent/test_memory_extra_messages.py
@@ -1,0 +1,87 @@
+"""Test that memory pipeline processes extra_messages when user_message is None.
+
+Regression test for https://github.com/agno-agi/agno/issues/7469
+When input_content is a List[Message], Agno sets extra_messages instead of
+user_message. The memory pipeline should still run in this case.
+"""
+
+from concurrent.futures import Future
+from unittest.mock import MagicMock
+
+from agno.agent._managers import start_memory_future
+from agno.models.message import Message
+from agno.run.messages import RunMessages
+
+
+def _make_agent(*, update_memory: bool = True, agentic: bool = False) -> MagicMock:
+    agent = MagicMock()
+    agent.memory_manager = MagicMock()
+    agent.update_memory_on_run = update_memory
+    agent.enable_agentic_memory = agentic
+    agent.background_executor.submit.return_value = MagicMock(spec=Future)
+    return agent
+
+
+class TestStartMemoryFuture:
+    def test_starts_when_user_message_present(self) -> None:
+        agent = _make_agent()
+        run_messages = RunMessages()
+        run_messages.user_message = Message(role="user", content="Hello")
+
+        result = start_memory_future(agent, run_messages, user_id="user-1")
+
+        assert result is not None
+        agent.background_executor.submit.assert_called_once()
+
+    def test_starts_when_only_extra_messages_present(self) -> None:
+        """Regression: extra_messages alone should trigger memory creation."""
+        agent = _make_agent()
+        run_messages = RunMessages()
+        run_messages.user_message = None
+        run_messages.extra_messages = [Message(role="user", content="Hello from list")]
+
+        result = start_memory_future(agent, run_messages, user_id="user-1")
+
+        assert result is not None
+        agent.background_executor.submit.assert_called_once()
+
+    def test_skips_when_no_messages_at_all(self) -> None:
+        agent = _make_agent()
+        run_messages = RunMessages()
+        run_messages.user_message = None
+        run_messages.extra_messages = None
+
+        result = start_memory_future(agent, run_messages, user_id="user-1")
+
+        assert result is None
+        agent.background_executor.submit.assert_not_called()
+
+    def test_skips_when_empty_extra_messages(self) -> None:
+        agent = _make_agent()
+        run_messages = RunMessages()
+        run_messages.user_message = None
+        run_messages.extra_messages = []
+
+        result = start_memory_future(agent, run_messages, user_id="user-1")
+
+        assert result is None
+        agent.background_executor.submit.assert_not_called()
+
+    def test_skips_when_memory_manager_is_none(self) -> None:
+        agent = _make_agent()
+        agent.memory_manager = None
+        run_messages = RunMessages()
+        run_messages.extra_messages = [Message(role="user", content="Hello")]
+
+        result = start_memory_future(agent, run_messages, user_id="user-1")
+
+        assert result is None
+
+    def test_skips_when_update_memory_disabled(self) -> None:
+        agent = _make_agent(update_memory=False)
+        run_messages = RunMessages()
+        run_messages.extra_messages = [Message(role="user", content="Hello")]
+
+        result = start_memory_future(agent, run_messages, user_id="user-1")
+
+        assert result is None

--- a/libs/agno/tests/unit/agent/test_memory_extra_messages.py
+++ b/libs/agno/tests/unit/agent/test_memory_extra_messages.py
@@ -1,6 +1,5 @@
 """Test that memory pipeline processes extra_messages when user_message is None.
 
-Regression test for https://github.com/agno-agi/agno/issues/7469
 When input_content is a List[Message], Agno sets extra_messages instead of
 user_message. The memory pipeline should still run in this case.
 """


### PR DESCRIPTION
## Summary

When `input_content` is a `List[Message]`, the memory pipeline is silently skipped because `start_memory_future` and `astart_memory_task` only gate on `run_messages.user_message is not None`. Since `get_run_messages` puts `List[Message]` inputs into `extra_messages` (not `user_message`), the memory future/task is never started — even though `make_memories()` already handles `extra_messages`.

This fix expands the gate condition to also check for non-empty `extra_messages`.

Fixes #7469

## Changes

- `libs/agno/agno/agent/_managers.py`: Updated gate condition in both `start_memory_future` and `astart_memory_task` to check for `extra_messages` when `user_message` is None.
- `libs/agno/tests/unit/agent/test_memory_extra_messages.py`: Added 6 unit tests covering all gate condition branches.

## Test plan

- [x] All 6 new tests pass (`pytest libs/agno/tests/unit/agent/test_memory_extra_messages.py`)
- [x] `scripts/format.sh` passes
- [ ] CI passes