### PR TITLE
fix: allow memory pipeline to run for List[Message] input

### DIFF
--- a/libs/agno/agno/agent/_managers.py
+++ b/libs/agno/agno/agent/_managers.py
@@ -162,8 +162,12 @@ async def astart_memory_task(
             pass
 
     # Create new task if conditions are met
-    if (
+    has_content = (
         run_messages.user_message is not None
+        or (run_messages.extra_messages is not None and len(run_messages.extra_messages) > 0)
+    )
+    if (
+        has_content
         and agent.memory_manager is not None
         and agent.update_memory_on_run
         and not agent.enable_agentic_memory
@@ -197,8 +201,12 @@ def start_memory_future(
         existing_future.cancel()
 
     # Create new future if conditions are met
-    if (
+    has_content = (
         run_messages.user_message is not None
+        or (run_messages.extra_messages is not None and len(run_messages.extra_messages) > 0)
+    )
+    if (
+        has_content
         and agent.memory_manager is not None
         and agent.update_memory_on_run
         and not agent.enable_agentic_memory


### PR DESCRIPTION
Fixes #7469

## Problem

When `input_content` is a `List[Message]` (valid per `RunInput`), `get_run_messages` adds them as `extra_messages` and leaves `user_message` as `None`. Both `start_memory_future` and `astart_memory_task` gate on `run_messages.user_message is not None`, so the memory pipeline never starts — `make_memories` is never called even though it already has an `extra_messages` code path.

## Fix

Add a `has_content` check in both functions that also considers `extra_messages`:

```python
has_content = (
    run_messages.user_message is not None
    or (run_messages.extra_messages is not None and len(run_messages.extra_messages) > 0)
)
```

## Testing

- 254 existing unit tests pass (0 regressions)
- Verified the fix applies to both sync (`start_memory_future`) and async (`astart_memory_task`) paths