### PR TITLE
fix(telegram): respect 429 retry_after during streaming edits

### DIFF
--- a/libs/agno/agno/os/interfaces/telegram/events.py
+++ b/libs/agno/agno/os/interfaces/telegram/events.py
@@ -1,3 +1,4 @@
+import re
 import time
 from typing import TYPE_CHECKING, Awaitable, Callable, Dict
 
@@ -8,6 +9,9 @@ from agno.utils.log import log_error, log_warning
 
 if TYPE_CHECKING:
     from agno.run.base import BaseRunOutputEvent
+
+# Matches Telegram 429 "retry after N" in error messages
+_RETRY_AFTER_RE = re.compile(r"retry after (\d+)", re.IGNORECASE)
 
 # Suppress inner-agent events in workflow mode — only workflow-level
 # lifecycle events (step/loop/parallel/etc.) are shown
@@ -118,7 +122,15 @@ async def _on_run_content(chunk: "BaseRunOutputEvent", state: StreamState) -> bo
             try:
                 await state.send_or_edit(state.build_display_html())
             except Exception as e:
-                log_warning(f"Stream edit failed (will retry on next chunk): {str(e)}")
+                err_str = str(e)
+                if "429" in err_str or "Too Many Requests" in err_str:
+                    m = _RETRY_AFTER_RE.search(err_str)
+                    if m:
+                        wait = int(m.group(1))
+                        state._rate_limited_until = time.monotonic() + wait
+                        log_warning(f"Telegram rate limited during stream, pausing edits for {wait}s")
+                else:
+                    log_warning(f"Stream edit failed (will retry on next chunk): {err_str}")
     return False
 
 

--- a/libs/agno/agno/os/interfaces/telegram/state.py
+++ b/libs/agno/agno/os/interfaces/telegram/state.py
@@ -28,6 +28,9 @@ import re as _re
 # Matches any HTML tag (opening, closing, self-closing)
 _TAG_RE = _re.compile(r"<[^>]+>")
 
+# Matches Telegram 429 "retry after N" in error messages
+_RETRY_AFTER_RE = _re.compile(r"retry after (\d+)", _re.IGNORECASE)
+
 TG_STREAM_EDIT_INTERVAL = 1.0
 
 EntityType = Literal["agent", "team", "workflow"]
@@ -161,6 +164,7 @@ class StreamState:
         self.accumulated_content: str = ""
         self.status_lines: list[str] = []
         self.last_edit_time: float = 0.0
+        self._rate_limited_until: float = 0.0  # monotonic timestamp; skip edits until this time
         # Set by router after stream ends; used for error/media handling
         self.final_run_output: Optional[Union["RunOutput", "TeamRunOutput"]] = None
         # Set by step_output handler; fallback if workflow omits final content
@@ -221,11 +225,24 @@ class StreamState:
         )
 
     async def _edit(self, html: str) -> None:
+        # Skip edit while rate-limited
+        if time.monotonic() < self._rate_limited_until:
+            return
         try:
             await self.bot.edit_message_text(html, self.chat_id, self.sent_message_id, parse_mode="HTML")
         except Exception as e:
-            if "message is not modified" not in str(e):
-                log_warning(f"Failed to edit message: {str(e)}")
+            err_str = str(e)
+            if "message is not modified" not in err_str:
+                if "429" in err_str or "Too Many Requests" in err_str:
+                    m = _RETRY_AFTER_RE.search(err_str)
+                    if m:
+                        wait = int(m.group(1))
+                        self._rate_limited_until = time.monotonic() + wait
+                        log_warning(f"Telegram rate limited, pausing edits for {wait}s")
+                    else:
+                        log_warning(f"Failed to edit message: {err_str}")
+                else:
+                    log_warning(f"Failed to edit message: {err_str}")
 
     async def _send_chunks(self, content: str) -> None:
         await send_message(
@@ -251,6 +268,9 @@ class StreamState:
 
     async def send_or_edit(self, html: str) -> None:
         if not html or not html.strip():
+            return
+        # Skip edit while rate-limited (but allow new message sends)
+        if self.sent_message_id is not None and time.monotonic() < self._rate_limited_until:
             return
         display = self._truncate_html(html)
         if self.sent_message_id is None:


### PR DESCRIPTION
Fixes #7360

## Problem

When Telegram Bot API returns 429 Too Many Requests during streaming message edits, Agno ignored the `retry_after` value and immediately retried on every subsequent streaming chunk (~1/sec). This caused a flood of repeated 429 errors:

```
WARNING  Failed to edit message: ... 429 ... retry after 33
WARNING  Failed to edit message: ... 429 ... retry after 32
WARNING  Failed to edit message: ... 429 ... retry after 32
```

## Root Cause

Two locations caught exceptions from `edit_message_text` but did not handle 429 specifically:
1. `state.py` → `StreamState._edit()` — caught all exceptions, logged warning, no rate-limit awareness
2. `events.py` → `_on_run_content()` — caught exceptions from `send_or_edit()`, logged warning, continued retrying

## Fix

- Add `_rate_limited_until` monotonic timestamp to `StreamState`
- Parse `retry_after` from 429 error messages via regex (`/retry after (\d+)/i`)
- Skip edit attempts in `_edit()` and `send_or_edit()` while the hold is active
- Set hold in both `_edit()` and `_on_run_content()` when 429 is detected

## Testing

- 192 existing Telegram tests pass (0 regressions)
- Tested with a fast model (Gemini Flash) streaming long responses in a Telegram supergroup

## Files changed

- `agno/os/interfaces/telegram/state.py` — `_rate_limited_until` field + 429 handling in `_edit()` + skip in `send_or_edit()`
- `agno/os/interfaces/telegram/events.py` — 429 handling in `_on_run_content()`