### PR TITLE
fix: propagate OutputCheckError to caller instead of silently returning

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -639,7 +639,8 @@ def _run(
 
                 return run_response
             except (InputCheckError, OutputCheckError) as e:
-                # Handle exceptions during streaming
+                # Handle validation exceptions — propagate to caller so
+                # try/except OutputCheckError works as documented.
                 run_response.status = RunStatus.error
                 # If the content is None, set it to the error message
                 if run_response.content is None:
@@ -656,7 +657,7 @@ def _run(
                         user_id=user_id,
                     )
 
-                return run_response
+                raise
             except KeyboardInterrupt:
                 run_response = cast(RunOutput, run_response)
                 run_response.status = RunStatus.cancelled
@@ -1734,7 +1735,8 @@ async def _arun(
 
                 return run_response
             except (InputCheckError, OutputCheckError) as e:
-                # Handle exceptions during streaming
+                # Handle validation exceptions — propagate to caller so
+                # try/except OutputCheckError works as documented.
                 run_response.status = RunStatus.error
                 # If the content is None, set it to the error message
                 if run_response.content is None:
@@ -1751,7 +1753,7 @@ async def _arun(
                         user_id=user_id,
                     )
 
-                return run_response
+                raise
 
             except KeyboardInterrupt:
                 run_response = cast(RunOutput, run_response)
@@ -3049,7 +3051,8 @@ def _continue_run(
                 return run_response
             except (InputCheckError, OutputCheckError) as e:
                 run_response = cast(RunOutput, run_response)
-                # Handle exceptions during streaming
+                # Handle validation exceptions — propagate to caller so
+                # try/except OutputCheckError works as documented.
                 run_response.status = RunStatus.error
                 # If the content is None, set it to the error message
                 if run_response.content is None:
@@ -3061,7 +3064,7 @@ def _continue_run(
                     agent, run_response=run_response, session=session, run_context=run_context, user_id=user_id
                 )
 
-                return run_response
+                raise
             except KeyboardInterrupt:
                 run_response = cast(RunOutput, run_response)
                 run_response.status = RunStatus.cancelled
@@ -3842,7 +3845,8 @@ async def _acontinue_run(
                 return run_response
             except (InputCheckError, OutputCheckError) as e:
                 run_response = cast(RunOutput, run_response)
-                # Handle exceptions during streaming
+                # Handle validation exceptions — propagate to caller so
+                # try/except OutputCheckError works as documented.
                 run_response.status = RunStatus.error
                 # If the content is None, set it to the error message
                 if run_response.content is None:
@@ -3859,7 +3863,7 @@ async def _acontinue_run(
                         user_id=user_id,
                     )
 
-                return run_response
+                raise
 
             except KeyboardInterrupt:
                 run_response = cast(RunOutput, run_response)


### PR DESCRIPTION
## Summary

Fixes #7414

`OutputCheckError` raised inside `output_validation_post_hook` is caught internally by the run methods and returned as a normal `RunResponse` with `status=error`. This means the documented `try/except OutputCheckError` pattern never works:

```python
# This except block is NEVER reached (before this fix)
try:
    result = await agent.arun(input="...")
except OutputCheckError as e:
    print(f"Validation failed: {e}")  # Dead code
```

## Changes

Changed `return run_response` → `raise` in the `except (InputCheckError, OutputCheckError)` handler of all four non-streaming run methods:

| Method | Type |
|--------|------|
| `_run` | sync |
| `_arun` | async |
| `_continue_run` | sync continuation |
| `_acontinue_run` | async continuation |

Session cleanup and error logging are preserved before the re-raise. The exception object (with `run_output`, `check_trigger`, etc.) is propagated intact.

Streaming methods (`_run_stream`, `_arun_stream`, etc.) still return the error response since exceptions can't meaningfully propagate mid-stream iteration.