### PR TITLE
[fix] Prevent concurrent session runs from being silently dropped

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import time
 import warnings
 from collections import deque
@@ -4498,10 +4499,8 @@ def cleanup_and_store(
         user_id=user_id,
     )
 
-    # Add scrubbed RunOutput to Agent Session
+    # Calculate session metrics (needs run in session temporarily)
     session.upsert_run(run=storage_copy)
-
-    # Calculate session metrics
     update_session_metrics(agent, session=session, run_response=run_response)
 
     # Update session state before saving the session
@@ -4511,8 +4510,25 @@ def cleanup_and_store(
         else:
             session.session_data = {"session_state": run_context.session_state}
 
-    # Save session to memory
-    _session.save_session(agent, session=session)
+    # Persist the run atomically via upsert_run (uses SELECT FOR UPDATE in Postgres
+    # to prevent concurrent writes from silently dropping runs), then save session
+    # metadata separately without overwriting the runs column.
+    if agent.db is not None and hasattr(agent.db, "upsert_run"):
+        from agno.db.base import SessionType
+
+        run_dict = storage_copy.to_dict()
+        agent.db.upsert_run(
+            session_id=session.session_id,
+            session_type=SessionType.AGENT,
+            run_data=run_dict,
+            user_id=user_id,
+        )
+        # Save session metadata without clobbering atomically-persisted runs
+        meta_session = copy.copy(session)
+        meta_session.runs = None
+        _session.save_session(agent, session=meta_session)
+    else:
+        _session.save_session(agent, session=session)
 
     # Update approval run_status if this run has an associated approval.
     # This is a no-op if no approval exists for this run_id.
@@ -4555,10 +4571,8 @@ async def acleanup_and_store(
         user_id=user_id,
     )
 
-    # Add scrubbed RunOutput to Agent Session
+    # Calculate session metrics (needs run in session temporarily)
     session.upsert_run(run=storage_copy)
-
-    # Calculate session metrics
     update_session_metrics(agent, session=session, run_response=run_response)
 
     # Update session state before saving the session
@@ -4568,8 +4582,28 @@ async def acleanup_and_store(
         else:
             session.session_data = {"session_state": run_context.session_state}
 
-    # Save session to memory
-    await _session.asave_session(agent, session=session)
+    # Persist the run atomically via upsert_run (uses SELECT FOR UPDATE in Postgres
+    # to prevent concurrent writes from silently dropping runs), then save session
+    # metadata separately without overwriting the runs column.
+    if agent.db is not None and hasattr(agent.db, "upsert_run"):
+        from agno.db.base import SessionType
+
+        run_dict = storage_copy.to_dict()
+        result = agent.db.upsert_run(  # type: ignore[union-attr]
+            session_id=session.session_id,
+            session_type=SessionType.AGENT,
+            run_data=run_dict,
+            user_id=user_id,
+        )
+        # If the backend is async, the call returns a coroutine — await it.
+        if inspect.isawaitable(result):
+            await result
+        # Save session metadata without clobbering atomically-persisted runs
+        meta_session = copy.copy(session)
+        meta_session.runs = None
+        await _session.asave_session(agent, session=meta_session)
+    else:
+        await _session.asave_session(agent, session=session)
 
     # Update approval run_status if this run has an associated approval.
     # This is a no-op if no approval exists for this run_id.

--- a/libs/agno/agno/db/base.py
+++ b/libs/agno/agno/db/base.py
@@ -209,6 +209,36 @@ class BaseDb(ABC):
         """Bulk upsert multiple sessions for improved performance on large datasets."""
         raise NotImplementedError
 
+    def upsert_run(
+        self,
+        session_id: str,
+        session_type: SessionType,
+        run_data: Dict[str, Any],
+        user_id: Optional[str] = None,
+    ) -> None:
+        """Atomically persist a single run into a session's runs array.
+
+        The default implementation falls back to a non-atomic read-merge-write cycle.
+        Backends that support row-level locking (e.g. PostgreSQL) should override this
+        with an atomic implementation to prevent concurrent writes from losing runs.
+        """
+        session = self.get_session(session_id, session_type, user_id)
+        if session is None:
+            return
+        existing_runs: list = session.runs or []  # type: ignore[union-attr]
+        run_id = run_data.get("run_id")
+        merged = False
+        for i, existing in enumerate(existing_runs):
+            existing_id = existing.run_id if hasattr(existing, "run_id") else existing.get("run_id")
+            if existing_id == run_id:
+                existing_runs[i] = run_data  # type: ignore[assignment]
+                merged = True
+                break
+        if not merged:
+            existing_runs.append(run_data)  # type: ignore[arg-type]
+        session.runs = existing_runs  # type: ignore[union-attr]
+        self.upsert_session(session)  # type: ignore[arg-type]
+
     # --- Memory ---
     @abstractmethod
     def clear_memories(self) -> None:
@@ -1221,6 +1251,36 @@ class AsyncBaseDb(ABC):
         self, session: Session, deserialize: Optional[bool] = True
     ) -> Optional[Union[Session, Dict[str, Any]]]:
         raise NotImplementedError
+
+    async def upsert_run(
+        self,
+        session_id: str,
+        session_type: SessionType,
+        run_data: Dict[str, Any],
+        user_id: Optional[str] = None,
+    ) -> None:
+        """Atomically persist a single run into a session's runs array.
+
+        The default implementation falls back to a non-atomic read-merge-write cycle.
+        Backends that support row-level locking (e.g. PostgreSQL) should override this
+        with an atomic implementation to prevent concurrent writes from losing runs.
+        """
+        session = await self.get_session(session_id, session_type, user_id)
+        if session is None:
+            return
+        existing_runs: list = session.runs or []  # type: ignore[union-attr]
+        run_id = run_data.get("run_id")
+        merged = False
+        for i, existing in enumerate(existing_runs):
+            existing_id = existing.run_id if hasattr(existing, "run_id") else existing.get("run_id")
+            if existing_id == run_id:
+                existing_runs[i] = run_data  # type: ignore[assignment]
+                merged = True
+                break
+        if not merged:
+            existing_runs.append(run_data)  # type: ignore[arg-type]
+        session.runs = existing_runs  # type: ignore[union-attr]
+        await self.upsert_session(session)  # type: ignore[arg-type]
 
     # --- Memory ---
     @abstractmethod

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -858,18 +858,22 @@ class AsyncPostgresDb(AsyncBaseDb):
                         created_at=session_dict.get("created_at"),
                         updated_at=session_dict.get("created_at"),
                     )
+                    update_fields: Dict[str, Any] = dict(
+                        agent_id=session_dict.get("agent_id"),
+                        user_id=session_dict.get("user_id"),
+                        agent_data=session_dict.get("agent_data"),
+                        session_data=session_dict.get("session_data"),
+                        summary=session_dict.get("summary"),
+                        metadata=session_dict.get("metadata"),
+                        updated_at=int(time.time()),
+                    )
+                    # Only overwrite runs if explicitly provided — allows upsert_run()
+                    # to persist runs atomically without upsert_session clobbering them.
+                    if session_dict.get("runs") is not None:
+                        update_fields["runs"] = session_dict["runs"]
                     stmt = stmt.on_conflict_do_update(  # type: ignore
                         index_elements=["session_id"],
-                        set_=dict(
-                            agent_id=session_dict.get("agent_id"),
-                            user_id=session_dict.get("user_id"),
-                            agent_data=session_dict.get("agent_data"),
-                            session_data=session_dict.get("session_data"),
-                            summary=session_dict.get("summary"),
-                            metadata=session_dict.get("metadata"),
-                            runs=session_dict.get("runs"),
-                            updated_at=int(time.time()),
-                        ),
+                        set_=update_fields,
                         where=(table.c.user_id == session_dict.get("user_id")) | (table.c.user_id.is_(None)),
                     ).returning(table)
                     result = await sess.execute(stmt)
@@ -899,18 +903,20 @@ class AsyncPostgresDb(AsyncBaseDb):
                         created_at=session_dict.get("created_at"),
                         updated_at=session_dict.get("created_at"),
                     )
+                    update_fields = dict(
+                        team_id=session_dict.get("team_id"),
+                        user_id=session_dict.get("user_id"),
+                        team_data=session_dict.get("team_data"),
+                        session_data=session_dict.get("session_data"),
+                        summary=session_dict.get("summary"),
+                        metadata=session_dict.get("metadata"),
+                        updated_at=int(time.time()),
+                    )
+                    if session_dict.get("runs") is not None:
+                        update_fields["runs"] = session_dict["runs"]
                     stmt = stmt.on_conflict_do_update(  # type: ignore
                         index_elements=["session_id"],
-                        set_=dict(
-                            team_id=session_dict.get("team_id"),
-                            user_id=session_dict.get("user_id"),
-                            team_data=session_dict.get("team_data"),
-                            session_data=session_dict.get("session_data"),
-                            summary=session_dict.get("summary"),
-                            metadata=session_dict.get("metadata"),
-                            runs=session_dict.get("runs"),
-                            updated_at=int(time.time()),
-                        ),
+                        set_=update_fields,
                         where=(table.c.user_id == session_dict.get("user_id")) | (table.c.user_id.is_(None)),
                     ).returning(table)
                     result = await sess.execute(stmt)
@@ -940,18 +946,20 @@ class AsyncPostgresDb(AsyncBaseDb):
                         created_at=session_dict.get("created_at"),
                         updated_at=session_dict.get("created_at"),
                     )
+                    update_fields = dict(
+                        workflow_id=session_dict.get("workflow_id"),
+                        user_id=session_dict.get("user_id"),
+                        workflow_data=session_dict.get("workflow_data"),
+                        session_data=session_dict.get("session_data"),
+                        summary=session_dict.get("summary"),
+                        metadata=session_dict.get("metadata"),
+                        updated_at=int(time.time()),
+                    )
+                    if session_dict.get("runs") is not None:
+                        update_fields["runs"] = session_dict["runs"]
                     stmt = stmt.on_conflict_do_update(  # type: ignore
                         index_elements=["session_id"],
-                        set_=dict(
-                            workflow_id=session_dict.get("workflow_id"),
-                            user_id=session_dict.get("user_id"),
-                            workflow_data=session_dict.get("workflow_data"),
-                            session_data=session_dict.get("session_data"),
-                            summary=session_dict.get("summary"),
-                            metadata=session_dict.get("metadata"),
-                            runs=session_dict.get("runs"),
-                            updated_at=int(time.time()),
-                        ),
+                        set_=update_fields,
                         where=(table.c.user_id == session_dict.get("user_id")) | (table.c.user_id.is_(None)),
                     ).returning(table)
                     result = await sess.execute(stmt)
@@ -972,6 +980,62 @@ class AsyncPostgresDb(AsyncBaseDb):
         except Exception as e:
             log_error(f"Exception upserting into sessions table: {str(e)}")
             return None
+
+    async def upsert_run(
+        self,
+        session_id: str,
+        session_type: SessionType,
+        run_data: Dict[str, Any],
+        user_id: Optional[str] = None,
+    ) -> None:
+        """Atomically persist a single run into a session's runs array.
+
+        Uses SELECT FOR UPDATE to prevent concurrent writes from losing runs.
+        The row lock is scoped to the specific session_id, so different sessions
+        remain fully concurrent.
+        """
+        try:
+            table = await self._get_table(table_type="sessions")
+            if table is None:
+                return
+
+            run_data = cast(Dict[str, Any], sanitize_postgres_strings(run_data))
+
+            async with self.async_session_factory() as sess, sess.begin():
+                # Lock the session row to prevent concurrent overwrites
+                row = (
+                    await sess.execute(select(table.c.runs).where(table.c.session_id == session_id).with_for_update())
+                ).fetchone()
+
+                if row is None:
+                    log_warning(f"Session {session_id} not found, cannot upsert run")
+                    return
+
+                existing_runs: list = row.runs or []
+                run_id = run_data.get("run_id")
+
+                # Merge: update existing run or append new one
+                merged = False
+                for i, existing in enumerate(existing_runs):
+                    existing_id = (
+                        existing.get("run_id") if isinstance(existing, dict) else getattr(existing, "run_id", None)
+                    )
+                    if existing_id == run_id:
+                        existing_runs[i] = run_data
+                        merged = True
+                        break
+                if not merged:
+                    existing_runs.append(run_data)
+
+                await sess.execute(
+                    update(table)
+                    .where(table.c.session_id == session_id)
+                    .values(runs=existing_runs, updated_at=int(time.time()))
+                )
+
+        except Exception as e:
+            log_error(f"Exception upserting run into session {session_id}: {e}")
+            raise e
 
     # -- Memory methods --
     async def delete_user_memory(self, memory_id: str, user_id: Optional[str] = None):

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -1013,18 +1013,22 @@ class PostgresDb(BaseDb):
                         created_at=session_dict.get("created_at"),
                         updated_at=session_dict.get("created_at"),
                     )
+                    update_fields: Dict[str, Any] = dict(
+                        agent_id=session_dict.get("agent_id"),
+                        user_id=session_dict.get("user_id"),
+                        agent_data=session_dict.get("agent_data"),
+                        session_data=session_dict.get("session_data"),
+                        summary=session_dict.get("summary"),
+                        metadata=session_dict.get("metadata"),
+                        updated_at=int(time.time()),
+                    )
+                    # Only overwrite runs if explicitly provided — allows upsert_run()
+                    # to persist runs atomically without upsert_session clobbering them.
+                    if session_dict.get("runs") is not None:
+                        update_fields["runs"] = session_dict["runs"]
                     stmt = stmt.on_conflict_do_update(  # type: ignore
                         index_elements=["session_id"],
-                        set_=dict(
-                            agent_id=session_dict.get("agent_id"),
-                            user_id=session_dict.get("user_id"),
-                            agent_data=session_dict.get("agent_data"),
-                            session_data=session_dict.get("session_data"),
-                            summary=session_dict.get("summary"),
-                            metadata=session_dict.get("metadata"),
-                            runs=session_dict.get("runs"),
-                            updated_at=int(time.time()),
-                        ),
+                        set_=update_fields,
                         where=(table.c.user_id == session_dict.get("user_id")) | (table.c.user_id.is_(None)),
                     ).returning(table)
                     result = sess.execute(stmt)
@@ -1052,18 +1056,20 @@ class PostgresDb(BaseDb):
                         created_at=session_dict.get("created_at"),
                         updated_at=session_dict.get("created_at"),
                     )
+                    update_fields = dict(
+                        team_id=session_dict.get("team_id"),
+                        user_id=session_dict.get("user_id"),
+                        team_data=session_dict.get("team_data"),
+                        session_data=session_dict.get("session_data"),
+                        summary=session_dict.get("summary"),
+                        metadata=session_dict.get("metadata"),
+                        updated_at=int(time.time()),
+                    )
+                    if session_dict.get("runs") is not None:
+                        update_fields["runs"] = session_dict["runs"]
                     stmt = stmt.on_conflict_do_update(  # type: ignore
                         index_elements=["session_id"],
-                        set_=dict(
-                            team_id=session_dict.get("team_id"),
-                            user_id=session_dict.get("user_id"),
-                            team_data=session_dict.get("team_data"),
-                            session_data=session_dict.get("session_data"),
-                            summary=session_dict.get("summary"),
-                            metadata=session_dict.get("metadata"),
-                            runs=session_dict.get("runs"),
-                            updated_at=int(time.time()),
-                        ),
+                        set_=update_fields,
                         where=(table.c.user_id == session_dict.get("user_id")) | (table.c.user_id.is_(None)),
                     ).returning(table)
                     result = sess.execute(stmt)
@@ -1091,18 +1097,20 @@ class PostgresDb(BaseDb):
                         created_at=session_dict.get("created_at"),
                         updated_at=session_dict.get("created_at"),
                     )
+                    update_fields = dict(
+                        workflow_id=session_dict.get("workflow_id"),
+                        user_id=session_dict.get("user_id"),
+                        workflow_data=session_dict.get("workflow_data"),
+                        session_data=session_dict.get("session_data"),
+                        summary=session_dict.get("summary"),
+                        metadata=session_dict.get("metadata"),
+                        updated_at=int(time.time()),
+                    )
+                    if session_dict.get("runs") is not None:
+                        update_fields["runs"] = session_dict["runs"]
                     stmt = stmt.on_conflict_do_update(  # type: ignore
                         index_elements=["session_id"],
-                        set_=dict(
-                            workflow_id=session_dict.get("workflow_id"),
-                            user_id=session_dict.get("user_id"),
-                            workflow_data=session_dict.get("workflow_data"),
-                            session_data=session_dict.get("session_data"),
-                            summary=session_dict.get("summary"),
-                            metadata=session_dict.get("metadata"),
-                            runs=session_dict.get("runs"),
-                            updated_at=int(time.time()),
-                        ),
+                        set_=update_fields,
                         where=(table.c.user_id == session_dict.get("user_id")) | (table.c.user_id.is_(None)),
                     ).returning(table)
                     result = sess.execute(stmt)
@@ -1336,6 +1344,62 @@ class PostgresDb(BaseDb):
         except Exception as e:
             log_error(f"Exception bulk upserting sessions: {str(e)}")
             return []
+
+    def upsert_run(
+        self,
+        session_id: str,
+        session_type: SessionType,
+        run_data: Dict[str, Any],
+        user_id: Optional[str] = None,
+    ) -> None:
+        """Atomically persist a single run into a session's runs array.
+
+        Uses SELECT FOR UPDATE to prevent concurrent writes from losing runs.
+        The row lock is scoped to the specific session_id, so different sessions
+        remain fully concurrent.
+        """
+        try:
+            table = self._get_table(table_type="sessions")
+            if table is None:
+                return
+
+            run_data = cast(Dict[str, Any], sanitize_postgres_strings(run_data))
+
+            with self.Session() as sess, sess.begin():
+                # Lock the session row to prevent concurrent overwrites
+                row = sess.execute(
+                    select(table.c.runs).where(table.c.session_id == session_id).with_for_update()
+                ).fetchone()
+
+                if row is None:
+                    log_warning(f"Session {session_id} not found, cannot upsert run")
+                    return
+
+                existing_runs: list = row.runs or []
+                run_id = run_data.get("run_id")
+
+                # Merge: update existing run or append new one
+                merged = False
+                for i, existing in enumerate(existing_runs):
+                    existing_id = (
+                        existing.get("run_id") if isinstance(existing, dict) else getattr(existing, "run_id", None)
+                    )
+                    if existing_id == run_id:
+                        existing_runs[i] = run_data
+                        merged = True
+                        break
+                if not merged:
+                    existing_runs.append(run_data)
+
+                sess.execute(
+                    update(table)
+                    .where(table.c.session_id == session_id)
+                    .values(runs=existing_runs, updated_at=int(time.time()))
+                )
+
+        except Exception as e:
+            log_error(f"Exception upserting run into session {session_id}: {e}")
+            raise e
 
     # -- Memory methods --
     def delete_user_memory(self, memory_id: str, user_id: Optional[str] = None):

--- a/libs/agno/tests/integration/db/async_postgres/test_session.py
+++ b/libs/agno/tests/integration/db/async_postgres/test_session.py
@@ -1,5 +1,7 @@
 """Integration tests for the Session related methods of the AsyncPostgresDb class"""
 
+import asyncio
+import copy
 import time
 
 import pytest
@@ -279,3 +281,173 @@ async def test_rename_session(async_postgres_db_real: AsyncPostgresDb, sample_ag
         session_id="test_agent_session_1", session_type=SessionType.AGENT
     )
     assert retrieved.session_data["session_name"] == "New Session Name"
+
+
+# ---------------------------------------------------------------------------
+# upsert_run — atomic per-run persistence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_upsert_run_appends_new_run(async_postgres_db_real: AsyncPostgresDb, sample_agent_session: AgentSession):
+    """upsert_run appends a new run to an existing session."""
+    await async_postgres_db_real.upsert_session(sample_agent_session)
+
+    new_run = RunOutput(
+        run_id="test_agent_run_2",
+        agent_id="test_agent_1",
+        user_id="test_user_1",
+        status=RunStatus.completed,
+        messages=[],
+    )
+    await async_postgres_db_real.upsert_run(
+        session_id="test_agent_session_1",
+        session_type=SessionType.AGENT,
+        run_data=new_run.to_dict(),
+    )
+
+    result = await async_postgres_db_real.get_session(session_id="test_agent_session_1", session_type=SessionType.AGENT)
+    assert result is not None
+    assert len(result.runs) == 2
+    run_ids = {r.run_id for r in result.runs}
+    assert run_ids == {"test_agent_run_1", "test_agent_run_2"}
+
+
+@pytest.mark.asyncio
+async def test_upsert_run_updates_existing_run(
+    async_postgres_db_real: AsyncPostgresDb, sample_agent_session: AgentSession
+):
+    """upsert_run with the same run_id updates the existing entry instead of duplicating."""
+    await async_postgres_db_real.upsert_session(sample_agent_session)
+
+    updated_run = RunOutput(
+        run_id="test_agent_run_1",  # same as original
+        agent_id="test_agent_1",
+        user_id="test_user_1",
+        status=RunStatus.error,  # changed
+        messages=[],
+    )
+    await async_postgres_db_real.upsert_run(
+        session_id="test_agent_session_1",
+        session_type=SessionType.AGENT,
+        run_data=updated_run.to_dict(),
+    )
+
+    result = await async_postgres_db_real.get_session(session_id="test_agent_session_1", session_type=SessionType.AGENT)
+    assert result is not None
+    assert len(result.runs) == 1
+    assert result.runs[0].run_id == "test_agent_run_1"
+    assert result.runs[0].status == RunStatus.error
+
+
+@pytest.mark.asyncio
+async def test_upsert_run_concurrent_same_session(
+    async_postgres_db_real: AsyncPostgresDb, sample_agent_session: AgentSession
+):
+    """Two concurrent upsert_run calls for the same session must both survive.
+
+    This is the core race condition test — before the fix, the last writer would
+    silently overwrite the first writer's run.
+    """
+    await async_postgres_db_real.upsert_session(sample_agent_session)
+
+    run_a = RunOutput(
+        run_id="concurrent_run_a",
+        agent_id="test_agent_1",
+        user_id="test_user_1",
+        status=RunStatus.completed,
+        messages=[],
+    )
+    run_b = RunOutput(
+        run_id="concurrent_run_b",
+        agent_id="test_agent_1",
+        user_id="test_user_1",
+        status=RunStatus.completed,
+        messages=[],
+    )
+
+    await asyncio.gather(
+        async_postgres_db_real.upsert_run(
+            session_id="test_agent_session_1",
+            session_type=SessionType.AGENT,
+            run_data=run_a.to_dict(),
+        ),
+        async_postgres_db_real.upsert_run(
+            session_id="test_agent_session_1",
+            session_type=SessionType.AGENT,
+            run_data=run_b.to_dict(),
+        ),
+    )
+
+    result = await async_postgres_db_real.get_session(session_id="test_agent_session_1", session_type=SessionType.AGENT)
+    assert result is not None
+    # Original run + two concurrent runs = 3
+    assert len(result.runs) == 3, f"Expected 3 runs, got {len(result.runs)} — concurrent write lost a run"
+    run_ids = {r.run_id for r in result.runs}
+    assert {"test_agent_run_1", "concurrent_run_a", "concurrent_run_b"} == run_ids
+
+
+@pytest.mark.asyncio
+async def test_upsert_run_cross_session_no_contention(
+    async_postgres_db_real: AsyncPostgresDb,
+):
+    """Concurrent upsert_run to different sessions must not block each other."""
+    session_a = AgentSession(
+        session_id="cross_session_a",
+        agent_id="test_agent_1",
+        user_id="test_user_1",
+        runs=[],
+        created_at=int(time.time()),
+    )
+    session_b = AgentSession(
+        session_id="cross_session_b",
+        agent_id="test_agent_1",
+        user_id="test_user_2",
+        runs=[],
+        created_at=int(time.time()),
+    )
+    await async_postgres_db_real.upsert_session(session_a)
+    await async_postgres_db_real.upsert_session(session_b)
+
+    run_a = RunOutput(run_id="run_a", agent_id="test_agent_1", status=RunStatus.completed, messages=[])
+    run_b = RunOutput(run_id="run_b", agent_id="test_agent_1", status=RunStatus.completed, messages=[])
+
+    await asyncio.gather(
+        async_postgres_db_real.upsert_run(
+            session_id="cross_session_a", session_type=SessionType.AGENT, run_data=run_a.to_dict()
+        ),
+        async_postgres_db_real.upsert_run(
+            session_id="cross_session_b", session_type=SessionType.AGENT, run_data=run_b.to_dict()
+        ),
+    )
+
+    result_a = await async_postgres_db_real.get_session(session_id="cross_session_a", session_type=SessionType.AGENT)
+    result_b = await async_postgres_db_real.get_session(session_id="cross_session_b", session_type=SessionType.AGENT)
+    assert result_a is not None and len(result_a.runs) == 1
+    assert result_b is not None and len(result_b.runs) == 1
+
+
+@pytest.mark.asyncio
+async def test_upsert_session_with_none_runs_preserves_existing(
+    async_postgres_db_real: AsyncPostgresDb, sample_agent_session: AgentSession
+):
+    """upsert_session with runs=None must not overwrite existing runs.
+
+    This supports the split save path where upsert_run() persists the run
+    atomically, then upsert_session() saves metadata without touching runs.
+    """
+    await async_postgres_db_real.upsert_session(sample_agent_session)
+
+    # Save metadata-only update with runs=None
+    meta_session = copy.copy(sample_agent_session)
+    meta_session.runs = None
+    meta_session.session_data = {"session_name": "Updated Metadata"}
+    await async_postgres_db_real.upsert_session(meta_session)
+
+    result = await async_postgres_db_real.get_session(session_id="test_agent_session_1", session_type=SessionType.AGENT)
+    assert result is not None
+    # Metadata was updated
+    assert result.session_data["session_name"] == "Updated Metadata"
+    # Runs were NOT clobbered
+    assert len(result.runs) == 1
+    assert result.runs[0].run_id == "test_agent_run_1"

--- a/libs/agno/tests/integration/db/postgres/test_session.py
+++ b/libs/agno/tests/integration/db/postgres/test_session.py
@@ -1,5 +1,6 @@
 """Integration tests for the Session related methods of the PostgresDb class"""
 
+import copy
 import time
 from datetime import datetime
 
@@ -949,3 +950,74 @@ def test_upsert_sessions_performance(postgres_db_real: PostgresDb):
     assert bulk_time < individual_time / 2, (
         f"Bulk upsert is not fast enough: {bulk_time:.3f}s vs {individual_time:.3f}s"
     )
+
+
+# ---------------------------------------------------------------------------
+# upsert_run — atomic per-run persistence (sync)
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_run_appends_new_run(postgres_db_real: PostgresDb, sample_agent_session: AgentSession):
+    """upsert_run appends a new run to an existing session."""
+    postgres_db_real.upsert_session(sample_agent_session)
+
+    new_run = RunOutput(
+        run_id="test_agent_run_2",
+        agent_id="test_agent_1",
+        user_id="test_user_1",
+        status=RunStatus.completed,
+        messages=[],
+    )
+    postgres_db_real.upsert_run(
+        session_id="test_agent_session_1",
+        session_type=SessionType.AGENT,
+        run_data=new_run.to_dict(),
+    )
+
+    result = postgres_db_real.get_session(session_id="test_agent_session_1", session_type=SessionType.AGENT)
+    assert result is not None
+    assert len(result.runs) == 2
+    run_ids = {r.run_id for r in result.runs}
+    assert run_ids == {"test_agent_run_1", "test_agent_run_2"}
+
+
+def test_upsert_run_updates_existing_run(postgres_db_real: PostgresDb, sample_agent_session: AgentSession):
+    """upsert_run with the same run_id updates the existing entry instead of duplicating."""
+    postgres_db_real.upsert_session(sample_agent_session)
+
+    updated_run = RunOutput(
+        run_id="test_agent_run_1",
+        agent_id="test_agent_1",
+        user_id="test_user_1",
+        status=RunStatus.error,
+        messages=[],
+    )
+    postgres_db_real.upsert_run(
+        session_id="test_agent_session_1",
+        session_type=SessionType.AGENT,
+        run_data=updated_run.to_dict(),
+    )
+
+    result = postgres_db_real.get_session(session_id="test_agent_session_1", session_type=SessionType.AGENT)
+    assert result is not None
+    assert len(result.runs) == 1
+    assert result.runs[0].run_id == "test_agent_run_1"
+    assert result.runs[0].status == RunStatus.error
+
+
+def test_upsert_session_with_none_runs_preserves_existing(
+    postgres_db_real: PostgresDb, sample_agent_session: AgentSession
+):
+    """upsert_session with runs=None must not overwrite existing runs."""
+    postgres_db_real.upsert_session(sample_agent_session)
+
+    meta_session = copy.copy(sample_agent_session)
+    meta_session.runs = None
+    meta_session.session_data = {"session_name": "Updated Metadata"}
+    postgres_db_real.upsert_session(meta_session)
+
+    result = postgres_db_real.get_session(session_id="test_agent_session_1", session_type=SessionType.AGENT)
+    assert result is not None
+    assert result.session_data["session_name"] == "Updated Metadata"
+    assert len(result.runs) == 1
+    assert result.runs[0].run_id == "test_agent_run_1"


### PR DESCRIPTION
## Summary

Fixes #7479

`upsert_session` overwrites the entire `runs` JSONB column on every save. When two concurrent `arun()` calls share the same `session_id`, the second writer silently drops the first's run — data loss with no error.

This is **not** the same bug as:
- **#4663** / **#3120** — in-memory shared state on the Agent instance (fixed in 2.0 with stateless agents). This bug is in the **storage layer** — the DB write itself is a full-column replacement with no locking.
- **#3566** — concurrent modification of Team instruction template placeholders. Different layer entirely.
- **#6636** — `child_run_id` race on shared Team instance attribute. In-memory, not storage.
- **#7324** — session not persisted to DB early enough. About timing of creation, not concurrent overwrites.

None of these issues or PRs address the storage-layer race where `ON CONFLICT DO UPDATE SET runs = <full array>` loses concurrent writes.

## Approaches considered

**A. Atomic JSONB append** — Use `||` / `jsonb_insert` in SQL to append runs without reading. Rejected: only fixes the `runs` column. Updating an existing run by `run_id` within a JSONB array is awkward in pure SQL. Doesn't establish a pattern for other columns.

**B. `SELECT FOR UPDATE` on the full `upsert_session`** — Lock the session row, re-read current state, merge everything, write back. Rejected as full-session approach: the caller builds the entire session in memory — `upsert_session` has no way to distinguish new data from stale snapshots. Last-writer-wins is actually correct for `session_data`/`session_state` (latest run's state is the truth).

**C. Normalize runs into a separate table** — One row per run, no JSONB array. Rejected: schema migration required, changes the storage interface across all backends, much harder to merge. Right long-term but too invasive for a bug fix.

### Chosen: Dedicated `upsert_run()` with `SELECT FOR UPDATE`

Combines the best of A and B:
- New `upsert_run(session_id, session_type, run_data)` method on the storage interface
- PostgreSQL implementation uses `SELECT FOR UPDATE` → merge run by `run_id` → `UPDATE` — all in one transaction
- `upsert_session` modified to skip `runs` column when `None` (so the save path doesn't re-overwrite atomically-persisted runs)
- `BaseDb` / `AsyncBaseDb` provide default fallbacks (existing read-merge-upsert) so other backends aren't broken
- Row lock is per `session_id` — different sessions are fully concurrent
- Lock held only during the DB transaction (~ms), not the LLM run duration

## Changes

- `agno/db/base.py` — add `upsert_run()` (sync + async) with default fallback
- `agno/db/postgres/postgres.py` — `PostgresDb.upsert_run()` with `FOR UPDATE`; conditional `runs` in `upsert_session`
- `agno/db/postgres/async_postgres.py` — `AsyncPostgresDb.upsert_run()` with `FOR UPDATE`; conditional `runs` in `upsert_session`
- `agno/agent/_run.py` — split save: `upsert_run()` for the run, `save_session()` for metadata

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement

## Checklist

- [x] Code complies with style guidelines
- [x] Ran `./scripts/format.sh` and `./scripts/validate.sh`
- [x] Self-review completed
- [x] Tests added/updated
- [x] Tested in clean environment

## Tests

Integration tests added for both sync (`PostgresDb`) and async (`AsyncPostgresDb`):

- `test_upsert_run_appends_new_run` — basic append to existing session
- `test_upsert_run_updates_existing_run` — update by `run_id` without duplicating
- `test_upsert_run_concurrent_same_session` — **core race condition test**: two concurrent `asyncio.gather` writes to the same session, verifies both runs survive
- `test_upsert_run_cross_session_no_contention` — concurrent writes to different sessions don't block
- `test_upsert_session_with_none_runs_preserves_existing` — metadata-only save with `runs=None` doesn't clobber existing runs

All 14 async session tests pass (9 existing + 5 new). All 3 new sync tests pass. The one pre-existing failure (`test_session_type_polymorphism`) is unrelated to this change.