### PR TITLE
fix: exclude framework-injected params from user_input_schema

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -492,7 +492,7 @@ class Function(BaseModel):
 
             # If the function requires user input, we should set the user_input_schema to all parameters
             # EXCEPT framework-injected ones which are never provided by the user or the model.
-            # We filter by both name AND type to handle cases like `my_ctx: RunContext`. See #7484.
+            # We filter by both name AND type to handle cases like `my_ctx: RunContext`.
             _framework_injected_params = {
                 "agent", "team", "run_context", "self",
                 "images", "videos", "audios", "files",

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -490,7 +490,24 @@ class Function(BaseModel):
                             param_descriptions[param_name] = param.description or ""
                         param_descriptions_clean[param_name] = param.description or ""
 
-            # If the function requires user input, we should set the user_input_schema to all parameters. The arguments provided by the model are filled in later.
+            # If the function requires user input, we should set the user_input_schema to all parameters
+            # EXCEPT framework-injected ones which are never provided by the user or the model.
+            # We filter by both name AND type to handle cases like `my_ctx: RunContext`. See #7484.
+            _framework_injected_params = {
+                "agent", "team", "run_context", "self",
+                "images", "videos", "audios", "files",
+            }
+            try:
+                from agno.agent.agent import Agent as _Agent
+                from agno.team.team import Team as _Team
+
+                _framework_types = (_Agent, _Team, RunContext, Image, Video, Audio, File)
+                for _pname, _phint in get_type_hints(self.entrypoint).items():
+                    if isinstance(_phint, type) and issubclass(_phint, _framework_types):
+                        _framework_injected_params.add(_pname)
+            except Exception:
+                pass
+
             if self.requires_user_input:
                 self.user_input_schema = [
                     UserInputField(
@@ -499,6 +516,7 @@ class Function(BaseModel):
                         field_type=type_hints.get(name, str),
                     )
                     for name in sig.parameters
+                    if name not in _framework_injected_params
                 ]
 
             # Get JSON schema for parameters only

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -491,7 +491,7 @@ class Function(BaseModel):
                         param_descriptions_clean[param_name] = param.description or ""
 
             # If the function requires user input, we should set the user_input_schema to all parameters
-            # EXCEPT framework-injected ones which are never provided by the user or the model.
+            # except framework-injected ones which are never provided by the user or the model.
             # We filter by both name AND type to handle cases like `my_ctx: RunContext`.
             _framework_injected_params = {
                 "agent", "team", "run_context", "self",

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -450,19 +450,25 @@ class Function(BaseModel):
                 "files",
             ]
 
-            # Also exclude parameters whose types are Agent or Team,
+            # Also exclude parameters whose types are framework-injected,
             # even if the parameter name differs (e.g. my_agent: Agent). See issue #6344.
             try:
                 from agno.agent.agent import Agent
                 from agno.team.team import Team
 
-                framework_types = (Agent, Team)
+                framework_types = (Agent, Team, RunContext, Image, Video, Audio, File)
                 for param_name, hint in list(type_hints.items()):
                     if isinstance(hint, type) and issubclass(hint, framework_types):
                         del type_hints[param_name]
                         excluded_params.append(param_name)
             except Exception:
                 pass
+
+            # Snapshot excluded_params before user_input_fields are added,
+            # so we can use it to filter user_input_schema later.
+            if self.requires_user_input:
+                _excluded_framework_params = list(excluded_params)
+
             if self.requires_user_input and self.user_input_fields:
                 if len(self.user_input_fields) == 0:
                     excluded_params.extend(list(type_hints.keys()))
@@ -490,24 +496,9 @@ class Function(BaseModel):
                             param_descriptions[param_name] = param.description or ""
                         param_descriptions_clean[param_name] = param.description or ""
 
-            # If the function requires user input, we should set the user_input_schema to all parameters
-            # except framework-injected ones which are never provided by the user or the model.
-            # We filter by both name AND type to handle cases like `my_ctx: RunContext`.
-            _framework_injected_params = {
-                "agent", "team", "run_context", "self",
-                "images", "videos", "audios", "files",
-            }
-            try:
-                from agno.agent.agent import Agent as _Agent
-                from agno.team.team import Team as _Team
-
-                _framework_types = (_Agent, _Team, RunContext, Image, Video, Audio, File)
-                for _pname, _phint in get_type_hints(self.entrypoint).items():
-                    if isinstance(_phint, type) and issubclass(_phint, _framework_types):
-                        _framework_injected_params.add(_pname)
-            except Exception:
-                pass
-
+            # If the function requires user input, set user_input_schema to all parameters
+            # except framework-injected ones (using the snapshot taken before user_input_fields
+            # were added to excluded_params, since those should remain in the schema).
             if self.requires_user_input:
                 self.user_input_schema = [
                     UserInputField(
@@ -516,7 +507,7 @@ class Function(BaseModel):
                         field_type=type_hints.get(name, str),
                     )
                     for name in sig.parameters
-                    if name not in _framework_injected_params
+                    if name not in _excluded_framework_params
                 ]
 
             # Get JSON schema for parameters only

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -194,6 +194,116 @@ def test_function_process_entrypoint_with_user_input():
     assert func.user_input_schema[1].field_type is int
 
 
+def test_function_process_entrypoint_with_user_input_excludes_run_context():
+    """Test that user_input_schema excludes run_context when requires_user_input=True (issue #7484)."""
+
+    def test_func(run_context: RunContext, param1: str, param2: int = 42) -> str:
+        """Test function with run_context and user input.
+
+        Args:
+            param1 (str): First parameter.
+            param2 (int): Second parameter.
+        """
+        return f"{param1}-{param2}"
+
+    func = Function(
+        name="test_func", entrypoint=test_func, requires_user_input=True, user_input_fields=["param1"]
+    )
+    func.process_entrypoint()
+
+    assert func.user_input_schema is not None
+    field_names = [f.name for f in func.user_input_schema]
+    assert "run_context" not in field_names
+    assert "param1" in field_names
+    assert "param2" in field_names
+    assert len(func.user_input_schema) == 2
+
+
+def test_function_process_entrypoint_with_user_input_excludes_all_framework_params():
+    """Test that user_input_schema excludes all framework-injected params (agent, team, self, media)."""
+    from agno.agent.agent import Agent
+    from agno.team.team import Team
+
+    def test_func(agent: Agent, team: Team, run_context: RunContext, param1: str) -> str:
+        """Test function.
+
+        Args:
+            param1 (str): First parameter.
+        """
+        return param1
+
+    func = Function(
+        name="test_func", entrypoint=test_func, requires_user_input=True, user_input_fields=[]
+    )
+    func.process_entrypoint()
+
+    assert func.user_input_schema is not None
+    field_names = [f.name for f in func.user_input_schema]
+    assert field_names == ["param1"]
+
+
+def test_function_process_entrypoint_with_user_input_excludes_by_type():
+    """Test that user_input_schema excludes params by type, not just name (e.g. my_ctx: RunContext)."""
+    from agno.agent.agent import Agent
+    from agno.team.team import Team
+
+    def test_func(my_ctx: RunContext, my_agent: Agent, my_team: Team, param1: str) -> str:
+        """Test function.
+
+        Args:
+            param1 (str): First parameter.
+        """
+        return param1
+
+    func = Function(
+        name="test_func", entrypoint=test_func, requires_user_input=True, user_input_fields=["param1"]
+    )
+    func.process_entrypoint()
+
+    assert func.user_input_schema is not None
+    field_names = [f.name for f in func.user_input_schema]
+    assert "my_ctx" not in field_names
+    assert "my_agent" not in field_names
+    assert "my_team" not in field_names
+    assert field_names == ["param1"]
+
+
+def test_user_input_with_run_context_execution():
+    """Test that a tool with requires_user_input=True and run_context executes without error (issue #7484)."""
+
+    @tool(requires_user_input=True, user_input_fields=["to_address"])
+    def send_email(run_context: RunContext, subject: str, body: str, to_address: str) -> str:
+        """Send an email.
+
+        Args:
+            subject (str): The subject.
+            body (str): The body.
+            to_address (str): The address.
+        """
+        count = run_context.session_state.get("sent", 0)
+        run_context.session_state["sent"] = count + 1
+        return f"Sent to {to_address}"
+
+    send_email.process_entrypoint()
+
+    # Verify run_context is not in user_input_schema
+    field_names = [f.name for f in (send_email.user_input_schema or [])]
+    assert "run_context" not in field_names
+    assert "subject" in field_names
+    assert "body" in field_names
+    assert "to_address" in field_names
+
+    # Verify execution succeeds without "multiple values for keyword argument" error
+    run_context = RunContext(run_id="test", session_id="test", session_state={"sent": 0})
+    send_email._run_context = run_context
+
+    fc = FunctionCall(function=send_email, arguments={"subject": "Hi", "body": "Hello", "to_address": "a@b.com"})
+    result = fc.execute()
+    assert result.status == "success"
+    assert result.result == "Sent to a@b.com"
+    assert run_context.session_state["sent"] == 1
+
+
 def test_function_process_entrypoint_skip_processing():
     """Test that entrypoint processing is skipped when skip_entrypoint_processing is True."""
 

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -195,7 +195,7 @@ def test_function_process_entrypoint_with_user_input():
 
 
 def test_function_process_entrypoint_with_user_input_excludes_run_context():
-    """Test that user_input_schema excludes run_context when requires_user_input=True (issue #7484)."""
+    """Test that user_input_schema excludes run_context when requires_user_input=True."""
 
     def test_func(run_context: RunContext, param1: str, param2: int = 42) -> str:
         """Test function with run_context and user input.
@@ -269,7 +269,7 @@ def test_function_process_entrypoint_with_user_input_excludes_by_type():
 
 
 def test_user_input_with_run_context_execution():
-    """Test that a tool with requires_user_input=True and run_context executes without error (issue #7484)."""
+    """Test that a tool with requires_user_input=True and run_context executes without error."""
 
     @tool(requires_user_input=True, user_input_fields=["to_address"])
     def send_email(run_context: RunContext, subject: str, body: str, to_address: str) -> str:


### PR DESCRIPTION
## Summary

- Fix `requires_user_input=True` failing with got multiple values for keyword argument 'run_context' when the tool also has a `run_context: RunContext` parameter
- Filter framework-injected params (`run_context, agent, team, media params`) from `user_input_schema` by both name and type.

Fixes: https://github.com/agno-agi/agno/issues/7484

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
