### PR TITLE
[fix] relax guided structured schemas for OpenRouter Responses

### DIFF
--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -357,6 +357,7 @@ def parse_tools(
         output_schema is not None
         and (agent.structured_outputs or (not agent.use_json_mode))
         and model.supports_native_structured_outputs
+        and getattr(model, "strict_output", True)
     ):
         strict = True
 

--- a/libs/agno/agno/models/openrouter/responses.py
+++ b/libs/agno/agno/models/openrouter/responses.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from agno.exceptions import ModelAuthenticationError
 from agno.models.message import Message
 from agno.models.openai.open_responses import OpenResponses
+from agno.utils.models.schema_utils import get_response_schema_for_provider
 
 
 @dataclass
@@ -117,6 +118,12 @@ class OpenRouterResponses(OpenResponses):
 
         return client_params
 
+    def _response_schema_provider(self) -> str:
+        """Pick the schema normalizer that matches the downstream OpenRouter model."""
+        if self.id.startswith("openai/"):
+            return "openai"
+        return "openrouter"
+
     def get_request_params(
         self,
         messages: Optional[List[Message]] = None,
@@ -130,10 +137,25 @@ class OpenRouterResponses(OpenResponses):
         Returns:
             Dict[str, Any]: A dictionary of keyword arguments for API requests.
         """
+        normalized_response_format = response_format
+        if (
+            response_format is not None
+            and isinstance(response_format, type)
+            and issubclass(response_format, BaseModel)
+            and not self.strict_output
+        ):
+            schema = get_response_schema_for_provider(response_format, self._response_schema_provider())
+            normalized_response_format = {
+                "type": "json_schema",
+                "name": response_format.__name__,
+                "schema": schema,
+                "strict": self.strict_output,
+            }
+
         # Get base request params from parent class
         request_params = super().get_request_params(
             messages=messages,
-            response_format=response_format,
+            response_format=normalized_response_format,
             tools=tools,
             tool_choice=tool_choice,
         )

--- a/libs/agno/tests/unit/agent/test_tool_strict_output.py
+++ b/libs/agno/tests/unit/agent/test_tool_strict_output.py
@@ -1,0 +1,47 @@
+from unittest.mock import MagicMock
+
+from pydantic import BaseModel
+
+from agno.agent._tools import parse_tools
+from agno.agent.agent import Agent
+from agno.run.base import RunContext
+
+
+class _Decision(BaseModel):
+    action: str
+    reason: str
+
+
+def _mock_model(strict_output: bool):
+    model = MagicMock()
+    model.supports_native_structured_outputs = True
+    model.strict_output = strict_output
+    return model
+
+
+def test_parse_tools_does_not_force_strict_schemas_when_model_guides_output():
+    def choose(city: str) -> str:
+        return city
+
+    agent = Agent(tools=[choose])
+    run_context = RunContext(run_id="run", session_id="session", output_schema=_Decision)
+
+    functions = parse_tools(agent=agent, tools=agent.tools, model=_mock_model(strict_output=False), run_context=run_context)
+
+    assert len(functions) == 1
+    assert functions[0].strict is None
+    assert "additionalProperties" not in functions[0].parameters
+
+
+def test_parse_tools_keeps_strict_schemas_when_model_requires_strict_output():
+    def choose(city: str) -> str:
+        return city
+
+    agent = Agent(tools=[choose])
+    run_context = RunContext(run_id="run", session_id="session", output_schema=_Decision)
+
+    functions = parse_tools(agent=agent, tools=agent.tools, model=_mock_model(strict_output=True), run_context=run_context)
+
+    assert len(functions) == 1
+    assert functions[0].strict is True
+    assert functions[0].parameters["additionalProperties"] is False

--- a/libs/agno/tests/unit/models/openrouter_model/test_openrouter_responses.py
+++ b/libs/agno/tests/unit/models/openrouter_model/test_openrouter_responses.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from pydantic import BaseModel
 
 from agno.exceptions import ModelAuthenticationError
 from agno.models.openrouter import OpenRouterResponses
@@ -91,3 +92,28 @@ def test_openrouter_responses_client_params():
     assert params["base_url"] == "https://openrouter.ai/api/v1"
     assert params["timeout"] == 30.0
     assert params["max_retries"] == 3
+
+
+class _Decision(BaseModel):
+    action: str
+    reason: str
+
+
+def test_openrouter_responses_guided_mode_skips_openai_schema_sanitizing_for_non_openai_models():
+    model = OpenRouterResponses(api_key="test-key", id="x-ai/grok-4.20", strict_output=False)
+
+    request_params = model.get_request_params(response_format=_Decision)
+
+    schema = request_params["text"]["format"]["schema"]
+    assert request_params["text"]["format"]["strict"] is False
+    assert "additionalProperties" not in schema
+
+
+def test_openrouter_responses_guided_mode_keeps_openai_schema_sanitizing_for_openai_models():
+    model = OpenRouterResponses(api_key="test-key", id="openai/gpt-4o", strict_output=False)
+
+    request_params = model.get_request_params(response_format=_Decision)
+
+    schema = request_params["text"]["format"]["schema"]
+    assert request_params["text"]["format"]["strict"] is False
+    assert schema["additionalProperties"] is False


### PR DESCRIPTION
## Summary

Fixes #7455.

This keeps guided structured output permissive for non-OpenAI models routed through `OpenRouterResponses` while preserving the existing OpenAI schema path.
It also stops tool schemas from being forced into strict mode when a model is running with `strict_output=False`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Targeted validation run:
- `pytest tests/unit/models/openrouter_model/test_openrouter_responses.py tests/unit/agent/test_tool_strict_output.py`
- `ruff check agno/models/openrouter/responses.py agno/agent/_tools.py tests/unit/models/openrouter_model/test_openrouter_responses.py tests/unit/agent/test_tool_strict_output.py`

I did not claim full `./scripts/format.sh` / `./scripts/validate.sh` coverage here because I validated the touched paths in a small local environment instead.
