### PR TITLE
fix: preserve inner workflow event identity and add nested_depth to agent/team events

### DIFF
--- a/libs/agno/agno/run/agent.py
+++ b/libs/agno/agno/run/agent.py
@@ -209,6 +209,8 @@ class BaseAgentRunEvent(BaseRunOutputEvent):
     step_id: Optional[str] = None
     step_name: Optional[str] = None
     step_index: Optional[int] = None
+    # Nesting depth: 0 = top-level workflow, 1 = first nested, 2 = nested-in-nested, etc.
+    nested_depth: int = 0
     tools: Optional[List[ToolExecution]] = None
 
     # For backwards compatibility

--- a/libs/agno/agno/run/team.py
+++ b/libs/agno/agno/run/team.py
@@ -202,6 +202,8 @@ class BaseTeamRunEvent(BaseRunOutputEvent):
     step_id: Optional[str] = None
     step_name: Optional[str] = None
     step_index: Optional[int] = None
+    # Nesting depth: 0 = top-level workflow, 1 = first nested, 2 = nested-in-nested, etc.
+    nested_depth: int = 0
 
     # For backwards compatibility
     content: Optional[Any] = None

--- a/libs/agno/agno/workflow/step.py
+++ b/libs/agno/agno/workflow/step.py
@@ -993,11 +993,17 @@ class Step:
         # Set session_id to match workflow's session_id for consistent event tracking
         if hasattr(event, "session_id") and workflow_run_response.session_id:
             event.session_id = workflow_run_response.session_id
-        if hasattr(event, "step_id"):
-            event.step_id = self.step_id
-        if hasattr(event, "step_name") and self.name is not None:
-            if getattr(event, "step_name", None) is None:
-                event.step_name = self.name
+        # For nested events, preserve the inner workflow's step_id/step_name
+        if not is_nested_event:
+            if hasattr(event, "step_id"):
+                event.step_id = self.step_id
+            if hasattr(event, "step_name") and self.name is not None:
+                if getattr(event, "step_name", None) is None:
+                    event.step_name = self.name
+        else:
+            # For nested events, set parent_step_id so consumers know which outer step contains them
+            if hasattr(event, "parent_step_id"):
+                event.parent_step_id = self.step_id
         # Only set step_index if it's not already set (preserve parallel.py's tuples)
         if hasattr(event, "step_index") and step_index is not None:
             if event.step_index is None:

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -8420,6 +8420,8 @@ class Workflow:
                 step_kwargs["agent"] = step.agent.deep_copy() if hasattr(step.agent, "deep_copy") else step.agent
             if step.team:
                 step_kwargs["team"] = step.team.deep_copy() if hasattr(step.team, "deep_copy") else step.team
+            if step.workflow:
+                step_kwargs["workflow"] = step.workflow.deep_copy() if hasattr(step.workflow, "deep_copy") else step.workflow
             # Copy Step configuration attributes
             for attr in [
                 "max_retries",
@@ -8443,6 +8445,10 @@ class Workflow:
         # Handle direct Team
         if isinstance(step, Team):
             return step.deep_copy() if hasattr(step, "deep_copy") else step
+
+        # Handle direct Workflow (auto-wrapped as a step)
+        if isinstance(step, Workflow):
+            return step.deep_copy()
 
         # Handle Parallel steps
         if isinstance(step, Parallel):

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -1605,15 +1605,21 @@ class Workflow:
         # Set session_id to match workflow's session_id for consistent event tracking
         if hasattr(event, "session_id") and workflow_run_response.session_id:
             event.session_id = workflow_run_response.session_id
-        if hasattr(event, "step_id") and step_id:
-            event.step_id = step_id
-        if hasattr(event, "step_name") and step_name is not None:
-            if event.step_name is None:
-                event.step_name = step_name
-        # Only set step_index if it's not already set (preserve parallel.py's tuples)
-        if hasattr(event, "step_index") and step_index is not None:
-            if event.step_index is None:
-                event.step_index = step_index
+        # For nested events, preserve the inner workflow's step_id/step_name/step_index.
+        # Set parent_step_id so consumers know which outer step contains them.
+        if not is_nested_event:
+            if hasattr(event, "step_id") and step_id:
+                event.step_id = step_id
+            if hasattr(event, "step_name") and step_name is not None:
+                if event.step_name is None:
+                    event.step_name = step_name
+            # Only set step_index if it's not already set (preserve parallel.py's tuples)
+            if hasattr(event, "step_index") and step_index is not None:
+                if event.step_index is None:
+                    event.step_index = step_index
+        else:
+            if hasattr(event, "parent_step_id") and step_id:
+                event.parent_step_id = step_id
 
         return event
 

--- a/libs/agno/tests/unit/os/test_per_request_isolation.py
+++ b/libs/agno/tests/unit/os/test_per_request_isolation.py
@@ -520,6 +520,62 @@ class TestWorkflowDeepCopyBasicSteps:
         assert copy.steps[0] is not basic_team
         assert copy.steps[0].id == basic_team.id
 
+    def test_workflow_with_workflow_as_step(self):
+        """Test deep copying a workflow where a Step uses workflow= to nest another workflow."""
+        inner_agent = Agent(name="inner-agent", id="inner-agent-id")
+        inner_workflow = Workflow(
+            name="inner-workflow",
+            id="inner-workflow-id",
+            steps=[Step(name="inner-step", agent=inner_agent)],
+        )
+
+        outer_workflow = Workflow(
+            name="outer-workflow",
+            id="outer-workflow-id",
+            steps=[
+                Step(name="nested-workflow-step", workflow=inner_workflow),
+                Step(name="final-step", agent=Agent(name="outer-agent", id="outer-agent-id")),
+            ],
+        )
+
+        copy = outer_workflow.deep_copy()
+
+        assert copy is not outer_workflow
+        assert copy.id == outer_workflow.id
+        assert len(copy.steps) == 2
+        # The nested workflow step should have its workflow copied
+        nested_step = copy.steps[0]
+        assert nested_step.workflow is not None
+        assert nested_step.workflow is not inner_workflow
+        assert nested_step.workflow.name == "inner-workflow"
+        assert nested_step.workflow.id == "inner-workflow-id"
+        # Inner agent should also be copied
+        assert nested_step.workflow.steps[0].agent is not inner_agent
+        assert nested_step.workflow.steps[0].agent.id == inner_agent.id
+
+    def test_workflow_with_direct_workflow_step(self):
+        """Test deep copying when a workflow is directly in steps list (auto-wrap shorthand)."""
+        inner_agent = Agent(name="direct-inner-agent", id="direct-inner-agent-id")
+        inner_workflow = Workflow(
+            name="direct-inner-workflow",
+            id="direct-inner-workflow-id",
+            steps=[Step(name="inner-step", agent=inner_agent)],
+        )
+
+        outer_workflow = Workflow(
+            name="outer-workflow",
+            id="outer-workflow-id",
+            steps=[inner_workflow],
+        )
+
+        copy = outer_workflow.deep_copy()
+
+        assert copy is not outer_workflow
+        # Direct workflow should be copied
+        assert copy.steps[0] is not inner_workflow
+        assert copy.steps[0].name == inner_workflow.name
+        assert copy.steps[0].id == inner_workflow.id
+
 
 # ============================================================================
 # Workflow Deep Copy - Step Container Types


### PR DESCRIPTION
## Summary

Fixes event metadata corruption in nested workflow streaming and adds `nested_depth` to agent/team events for frontend consumption.

## Changes

### Event identity preservation for nested workflows
- **step.py / workflow.py**: `_enrich_event_with_context()` and `_enrich_event_with_workflow_context()` were unconditionally overwriting `step_id`, `step_name`, and `step_index` on all events, including those from inner workflows. Inner workflow events now preserve their own step identity. The outer step's ID is set on `parent_step_id` instead, so consumers can still trace the parent-child relationship.
- Before: all inner events had `step_id` = outer step's ID (wrong)
- After: inner events keep their own `step_id`, `parent_step_id` points to outer step

### `nested_depth` on agent/team events
- **run/agent.py**: Added `nested_depth: int = 0` to `BaseAgentRunEvent`
- **run/team.py**: Added `nested_depth: int = 0` to `BaseTeamRunEvent`
- This allows `RunContentEvent` (streaming deltas) from agents/teams inside nested workflows to carry depth info, matching `BaseWorkflowRunOutputEvent` which already had it.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
