### PR TITLE
fix: build knowledge dbs live in config API

### DIFF
--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -1268,6 +1268,8 @@ class AgentOS:
 
         # Track seen knowledge IDs to deduplicate
         seen_knowledge_ids: set[str] = set()
+        # Collect db_id → table_names from knowledge instances for building dbs below
+        discovered_db_tables: Dict[str, set] = {}
 
         # Build flat list of knowledge instances
         for knowledge in self.knowledge_instances:
@@ -1282,6 +1284,11 @@ class AgentOS:
             table_name = getattr(contents_db, "knowledge_table_name", "unknown")
             knowledge_name = getattr(knowledge, "name", None) or f"knowledge_{db_id}"
             knowledge_id = _generate_knowledge_id(knowledge_name, db_id, table_name)
+
+            # Collect table names per db_id for building dbs list
+            if db_id not in discovered_db_tables:
+                discovered_db_tables[db_id] = set()
+            discovered_db_tables[db_id].add(table_name)
 
             # Skip if already processed (deduplicate by knowledge_id)
             if knowledge_id in seen_knowledge_ids:
@@ -1300,16 +1307,13 @@ class AgentOS:
         # Build KnowledgeDatabaseConfig for each db with its tables (as strings)
         dbs_with_specific_config = [db.db_id for db in knowledge_config.dbs]
 
-        for db_id, dbs in self.knowledge_dbs.items():
+        for db_id, table_names in discovered_db_tables.items():
             if db_id not in dbs_with_specific_config:
-                # Get all unique table names for this db
-                unique_tables = list(set(db.knowledge_table_name for db in dbs))
-
                 knowledge_config.dbs.append(
                     KnowledgeDatabaseConfig(
                         db_id=db_id,
                         domain_config=KnowledgeDomainConfig(display_name=db_id),
-                        tables=unique_tables,
+                        tables=list(table_names),
                     )
                 )
 

--- a/libs/agno/tests/integration/os/test_built_in_endpoints.py
+++ b/libs/agno/tests/integration/os/test_built_in_endpoints.py
@@ -176,3 +176,46 @@ def test_config_endpoint_with_knowledge_tables(test_os_client_with_knowledge: Te
     assert sorted(response_data["knowledge"]["dbs"][0]["tables"]) == sorted(
         ["knowledge_contents1", "knowledge_contents2"]
     )
+
+
+def test_config_knowledge_dbs_consistent_when_contents_db_set_after_init():
+    """Tests knowledge dbs now built live, consistent with knowledge instances."""
+
+    # Create Knowledge without contents_db
+    knowledge = Knowledge(name="patient_kb")
+    assert knowledge.contents_db is None
+
+    # Build AgentOS and get app, self.knowledge_dbs stays empty
+    agent = Agent(name="test-agent", knowledge=knowledge)
+    agent_os = AgentOS(
+        id="test-os-late-init",
+        agents=[agent],
+    )
+    app = agent_os.get_app()
+
+    # Set contents_db
+    db = SqliteDb("tmp/test.db", id="patient-db", knowledge_table="patient_knowledge")
+    knowledge.contents_db = db
+
+    # Add to knowledge_instances
+    if knowledge not in agent_os.knowledge_instances:
+        agent_os.knowledge_instances.append(knowledge)
+
+    # Hit /config — both knowledge_instances and dbs should be populated
+    client = TestClient(app)
+    response = client.get("/config")
+    assert response.status_code == 200
+    data = response.json()
+
+    knowledge_config = data.get("knowledge", {})
+    knowledge_instances = knowledge_config.get("knowledge_instances") or []
+    knowledge_dbs = knowledge_config.get("dbs") or []
+
+    assert len(knowledge_instances) == 1
+    assert knowledge_instances[0]["name"] == "patient_kb"
+    assert knowledge_instances[0]["db_id"] == "patient-db"
+
+    # dbs is built live from knowledge_instances, so it's consistent
+    assert len(knowledge_dbs) == 1
+    assert knowledge_dbs[0]["db_id"] == "patient-db"
+    assert knowledge_dbs[0]["tables"] == ["patient_knowledge"]


### PR DESCRIPTION
## Summary

Fixes an edge case where config api returns no knowledge dbs even when knowledge instances are populated, causing the frontend to show no-db error state.

## Root cause

`_get_knowledge_config()` built knowledge dbs which is frozen at startup by `_auto_discover_databases()`. If contents db is not yet set when AgentOS initializes (e.g., placeholder teams replaced during `app_lifespan`), knowledge dbs stays empty. However, knowledge instances reads contents_db live at request time, so it picks up the late set value. This creates a mismatch where instances are visible but dbs are not.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
