### PR TITLE
fix: catch RuntimeError instead of Exception in approval gate

### DIFF
--- a/libs/agno/agno/os/routers/approvals/router.py
+++ b/libs/agno/agno/os/routers/approvals/router.py
@@ -13,7 +13,7 @@ from agno.os.routers.approvals.schema import (
     ApprovalStatusResponse,
 )
 from agno.os.schema import PaginatedResponse, PaginationInfo
-from agno.utils.log import log_warning, logger
+from agno.utils.log import log_warning, log_debug
 
 
 def get_approval_router(os_db: Any, settings: Any) -> APIRouter:

--- a/libs/agno/agno/os/routers/approvals/router.py
+++ b/libs/agno/agno/os/routers/approvals/router.py
@@ -6,8 +6,6 @@ from typing import Any, Dict, Literal, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 
-from agno.utils.log import log_warning
-
 from agno.os.routers.approvals.schema import (
     ApprovalCountResponse,
     ApprovalResolve,
@@ -15,6 +13,7 @@ from agno.os.routers.approvals.schema import (
     ApprovalStatusResponse,
 )
 from agno.os.schema import PaginatedResponse, PaginationInfo
+from agno.utils.log import log_warning, logger
 
 
 def get_approval_router(os_db: Any, settings: Any) -> APIRouter:
@@ -197,6 +196,7 @@ def get_approval_router(os_db: Any, settings: Any) -> APIRouter:
                             break
         except Exception as exc:
             log_warning(f"Failed to update session with approval resolution: {exc}")
+            logger.debug("Session update error details", exc_info=True)
 
         return result
 

--- a/libs/agno/agno/os/routers/approvals/router.py
+++ b/libs/agno/agno/os/routers/approvals/router.py
@@ -196,7 +196,7 @@ def get_approval_router(os_db: Any, settings: Any) -> APIRouter:
                             break
         except Exception as exc:
             log_warning(f"Failed to update session with approval resolution: {exc}")
-            logger.debug("Session update error details", exc_info=True)
+            log_debug("Session update error details", exc_info=True)
 
         return result
 

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -5228,12 +5228,15 @@ def continue_run_dispatch(
 
         # Also apply any resolved approval
         if run_response.tools:
-            try:
-                from agno.run.approval import check_and_apply_approval_resolution
+            from agno.run.approval import check_and_apply_approval_resolution
 
+            try:
                 check_and_apply_approval_resolution(team.db, run_id_resolved, run_response)
-            except Exception:
-                pass
+            except RuntimeError:
+                raise ValueError(
+                    "To continue a run from a given run_id, the requirements parameter must be provided "
+                    "(or resolve an admin approval first)."
+                )
     elif run_response.tools:
         from agno.run.approval import check_and_apply_approval_resolution
 
@@ -6257,14 +6260,17 @@ async def _acontinue_run(
 
                     # Also apply any resolved approval
                     if run_response.tools:
-                        try:
-                            from agno.run.approval import acheck_and_apply_approval_resolution
+                        from agno.run.approval import acheck_and_apply_approval_resolution
 
+                        try:
                             await acheck_and_apply_approval_resolution(
                                 team.db, run_response.run_id or run_id or "", run_response
                             )
-                        except Exception:
-                            pass
+                        except RuntimeError:
+                            raise ValueError(
+                                "To continue a run from a given run_id, the requirements parameter must be provided "
+                                "(or resolve an admin approval first)."
+                            )
                 elif run_response.tools:
                     from agno.run.approval import acheck_and_apply_approval_resolution
 
@@ -6589,14 +6595,17 @@ async def _acontinue_run_stream(
 
                     # Also apply any resolved approval
                     if run_response.tools:
-                        try:
-                            from agno.run.approval import acheck_and_apply_approval_resolution
+                        from agno.run.approval import acheck_and_apply_approval_resolution
 
+                        try:
                             await acheck_and_apply_approval_resolution(
                                 team.db, run_response.run_id or run_id or "", run_response
                             )
-                        except Exception:
-                            pass
+                        except RuntimeError:
+                            raise ValueError(
+                                "To continue a run from a given run_id, the requirements parameter must be provided "
+                                "(or resolve an admin approval first)."
+                            )
                 elif run_response.tools:
                     from agno.run.approval import acheck_and_apply_approval_resolution
 


### PR DESCRIPTION
## Summary

Fixes a bug introduced in #7487 where the approval resolution check in team continue paths (`continue_run_dispatch`, `_acontinue_run`, `_acontinue_run_stream`) catches all exceptions and silently passes, defeating the gate semantics of `check_and_apply_approval_resolution`.

That function intentionally raises `RuntimeError` when an approval is still pending or missing - swallowing it means the continue path proceeds with unapproved tools.

**Changes:**
- Replace `except Exception: pass` with `except RuntimeError: raise ValueError(...)` in all 3 continue paths, matching the existing `elif` branch pattern
- Add debug-level traceback logging in the router session-update block for better diagnostics

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

This is a follow-up fix to #7487. The existing `elif` branches already handle `RuntimeError` correctly - the new code added by #7487 just needed to follow the same pattern.