### PR TITLE
fix: preserve custom db table names when loading components

### DIFF
--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from agno.agent.agent import Agent
 
 from agno.db.base import BaseDb, ComponentType, SessionType
-from agno.db.utils import db_from_dict
+from agno.db.utils import resolve_db_from_config
 from agno.metrics import RunMetrics, SessionMetrics
 from agno.models.base import Model
 from agno.models.message import Message
@@ -790,21 +790,11 @@ def from_dict(cls: Type[Agent], data: Dict[str, Any], registry: Optional[Registr
 
     # --- Handle DB reconstruction ---
     if "db" in config and isinstance(config["db"], dict):
-        db_data = config["db"]
-        db_id = db_data.get("id")
-
-        # First try to get the db from the registry (preferred - reuses existing connection)
-        if registry and db_id:
-            registry_db = registry.get_db(db_id)
-            if registry_db is not None:
-                config["db"] = registry_db
-            else:
-                del config["db"]
+        resolved = resolve_db_from_config(config["db"], registry=registry)
+        if resolved is not None:
+            config["db"] = resolved
         else:
-            # No registry or no db_id, fall back to creating from dict
-            config["db"] = db_from_dict(db_data)
-            if config["db"] is None:
-                del config["db"]
+            del config["db"]
 
     # --- Handle Schema reconstruction ---
     if "input_schema" in config and isinstance(config["input_schema"], str):

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -1077,7 +1077,11 @@ def load(
 
     agent = cls.from_dict(config, registry=registry)
     agent.id = id
-    agent.db = db
+    # Only fall back to the caller-provided db if the config didn't
+    # reconstruct one. Otherwise we'd clobber any custom table names
+    # (session_table, memory_table, ...) that were serialized with the agent.
+    if agent.db is None:
+        agent.db = db
 
     return agent
 

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -220,6 +220,53 @@ def db_from_dict(db_data: Dict[str, Any]) -> Optional[Union["BaseDb"]]:
         return None
 
 
+def _clone_db_with_table_overrides(
+    source_db: "BaseDb",
+    db_data: Dict[str, Any],
+) -> Optional["BaseDb"]:
+    """Create a new ``BaseDb`` that shares ``source_db``'s engine but
+    applies the table-name overrides from ``db_data``.
+
+    Sharing the underlying SQLAlchemy engine is critical: otherwise every
+    component load would spin up its own connection pool and blow past
+    backend connection limits. This helper is used when the stored
+    config references a known db (same id) but customizes table names.
+
+    Returns ``None`` if the source db type is not recognized, so the
+    caller can fall back to a fresh ``db_from_dict`` construction.
+    """
+    overrides: Dict[str, Any] = {key: db_data[key] for key in DB_TABLE_NAME_KEYS if key in db_data}
+
+    try:
+        from agno.db.postgres import PostgresDb
+
+        if isinstance(source_db, PostgresDb):
+            return PostgresDb(
+                db_engine=source_db.db_engine,
+                db_schema=source_db.db_schema,
+                id=source_db.id,
+                **overrides,
+            )
+    except Exception as e:
+        log_error(f"Error cloning PostgresDb with table overrides: {str(e)}")
+        return None
+
+    try:
+        from agno.db.sqlite import SqliteDb
+
+        if isinstance(source_db, SqliteDb):
+            return SqliteDb(
+                db_engine=source_db.db_engine,
+                id=source_db.id,
+                **overrides,
+            )
+    except Exception as e:
+        log_error(f"Error cloning SqliteDb with table overrides: {str(e)}")
+        return None
+
+    return None
+
+
 def resolve_db_from_config(
     db_data: Dict[str, Any],
     registry: Optional["Registry"] = None,
@@ -228,9 +275,13 @@ def resolve_db_from_config(
 
     Prefers a registered db instance (for connection reuse) when the
     serialized config does not override any table names. If it does, a
-    fresh instance is built via :func:`db_from_dict` so that those
-    overrides are honored without mutating the shared registered
-    instance.
+    clone of the registered instance is returned that **shares the same
+    engine/connection pool** but carries the table-name overrides, so
+    component reloads don't proliferate engines.
+
+    Only when there is no registry match (or the registered db type is
+    unknown to the cloner) do we fall through to :func:`db_from_dict`,
+    which builds a fresh instance with its own engine.
 
     Args:
         db_data: Serialized db config dict (as produced by
@@ -252,8 +303,11 @@ def resolve_db_from_config(
             )
             if not has_table_overrides:
                 return registry_db
-            # Fall through: the stored config customizes table names, so
-            # we need a fresh instance rather than the shared registered
-            # one (which would expose default table names).
+            # Stored config customizes table names. Clone the registered
+            # db so we reuse its engine/pool and only swap table names.
+            clone = _clone_db_with_table_overrides(registry_db, db_data)
+            if clone is not None:
+                return clone
+            # Unknown db type: fall through to a fresh instance.
 
     return db_from_dict(db_data)

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -232,8 +232,13 @@ def _clone_db_with_table_overrides(
     backend connection limits. This helper is used when the stored
     config references a known db (same id) but customizes table names.
 
+    Connection metadata (``db_url`` / ``db_file`` / ``db_schema``) is
+    carried over from ``source_db`` so the clone's ``to_dict`` still
+    round-trips to a usable config if it is re-saved and later loaded
+    without a registry.
+
     Returns ``None`` if the source db type is not recognized, so the
-    caller can fall back to a fresh ``db_from_dict`` construction.
+    caller can decide how to fall back.
     """
     overrides: Dict[str, Any] = {key: db_data[key] for key in DB_TABLE_NAME_KEYS if key in db_data}
 
@@ -242,6 +247,7 @@ def _clone_db_with_table_overrides(
 
         if isinstance(source_db, PostgresDb):
             return PostgresDb(
+                db_url=source_db.db_url,
                 db_engine=source_db.db_engine,
                 db_schema=source_db.db_schema,
                 id=source_db.id,
@@ -256,6 +262,8 @@ def _clone_db_with_table_overrides(
 
         if isinstance(source_db, SqliteDb):
             return SqliteDb(
+                db_file=source_db.db_file,
+                db_url=source_db.db_url,
                 db_engine=source_db.db_engine,
                 id=source_db.id,
                 **overrides,
@@ -308,6 +316,18 @@ def resolve_db_from_config(
             clone = _clone_db_with_table_overrides(registry_db, db_data)
             if clone is not None:
                 return clone
-            # Unknown db type: fall through to a fresh instance.
+            # The registered db type isn't one the cloner knows how to
+            # rebuild (e.g. JsonDb, RedisDb, FirestoreDb, DynamoDb, ...).
+            # Fall back to the registered instance rather than building
+            # a fresh one via db_from_dict, which only handles postgres
+            # and sqlite and would return None for these backends. This
+            # means table overrides are silently ignored for unsupported
+            # types, but the component still gets a working db — same as
+            # the pre-override behavior for those backends.
+            log_warning(
+                f"Cannot apply table-name overrides to db of type {type(registry_db).__name__}; "
+                "reusing the registered instance with its configured table names."
+            )
+            return registry_db
 
     return db_from_dict(db_data)

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -11,6 +11,31 @@ from agno.utils.log import log_error, log_warning
 
 if TYPE_CHECKING:
     from agno.db.base import BaseDb
+    from agno.os.registry import Registry
+
+
+# Keys in a serialized db dict that correspond to table-name overrides.
+# Matches the parameters BaseDb.__init__ accepts for customizing table names.
+DB_TABLE_NAME_KEYS: frozenset = frozenset(
+    {
+        "session_table",
+        "culture_table",
+        "memory_table",
+        "metrics_table",
+        "eval_table",
+        "knowledge_table",
+        "traces_table",
+        "spans_table",
+        "versions_table",
+        "components_table",
+        "component_configs_table",
+        "component_links_table",
+        "learnings_table",
+        "schedules_table",
+        "schedule_runs_table",
+        "approvals_table",
+    }
+)
 
 
 def get_sort_value(record: Dict[str, Any], sort_by: str) -> Any:
@@ -193,3 +218,42 @@ def db_from_dict(db_data: Dict[str, Any]) -> Optional[Union["BaseDb"]]:
     else:
         log_warning(f"Unknown database type: {db_type}")
         return None
+
+
+def resolve_db_from_config(
+    db_data: Dict[str, Any],
+    registry: Optional["Registry"] = None,
+) -> Optional["BaseDb"]:
+    """Resolve a serialized db config to a concrete ``BaseDb`` instance.
+
+    Prefers a registered db instance (for connection reuse) when the
+    serialized config does not override any table names. If it does, a
+    fresh instance is built via :func:`db_from_dict` so that those
+    overrides are honored without mutating the shared registered
+    instance.
+
+    Args:
+        db_data: Serialized db config dict (as produced by
+            ``BaseDb.to_dict``). Expected to carry a ``type`` plus any
+            table-name overrides.
+        registry: Optional ``Registry`` to look up an already-constructed
+            db instance by id.
+
+    Returns:
+        A ``BaseDb`` instance, or ``None`` if reconstruction fails.
+    """
+    db_id = db_data.get("id")
+    if registry is not None and db_id:
+        registry_db = registry.get_db(db_id)
+        if registry_db is not None:
+            registry_dict = registry_db.to_dict()
+            has_table_overrides = any(
+                key in db_data and db_data[key] != registry_dict.get(key) for key in DB_TABLE_NAME_KEYS
+            )
+            if not has_table_overrides:
+                return registry_db
+            # Fall through: the stored config customizes table names, so
+            # we need a fresh instance rather than the shared registered
+            # one (which would expose default table names).
+
+    return db_from_dict(db_data)

--- a/libs/agno/agno/db/utils.py
+++ b/libs/agno/agno/db/utils.py
@@ -11,7 +11,7 @@ from agno.utils.log import log_error, log_warning
 
 if TYPE_CHECKING:
     from agno.db.base import BaseDb
-    from agno.os.registry import Registry
+    from agno.registry.registry import Registry
 
 
 # Keys in a serialized db dict that correspond to table-name overrides.

--- a/libs/agno/agno/os/routers/components/components.py
+++ b/libs/agno/agno/os/routers/components/components.py
@@ -42,7 +42,11 @@ def _resolve_db_in_config(
     If config contains a db dict with an id, this function will:
     1. Check if the id matches the OS db
     2. Check if the id exists in the registry
-    3. Convert the found db to a dict for serialization
+    3. Merge the resolved db's connection details with the caller-provided
+       fields, with caller-provided fields (e.g. custom table names) taking
+       precedence. This preserves user-specified overrides like
+       ``session_table`` / ``memory_table`` while still reusing the resolved
+       db's connection configuration.
 
     Args:
         config: The config dict that may contain a db reference
@@ -64,9 +68,13 @@ def _resolve_db_in_config(
             elif registry is not None:
                 resolved_db = registry.get_db(component_db_id)
 
-            # Store the full db dict for serialization
+            # Merge resolved db with caller-provided fields. Caller wins so
+            # that custom table names (e.g. session_table, memory_table) are
+            # preserved instead of being clobbered by the resolved db's
+            # defaults.
             if resolved_db is not None:
-                config["db"] = resolved_db.to_dict()
+                resolved_dict = resolved_db.to_dict()
+                config["db"] = {**resolved_dict, **component_db}
             else:
                 log_error(f"Could not resolve db with id: {component_db_id}")
     elif component_db is None and "db" in config:

--- a/libs/agno/agno/os/routers/components/components.py
+++ b/libs/agno/agno/os/routers/components/components.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query
 
 from agno.db.base import AsyncBaseDb, BaseDb
 from agno.db.base import ComponentType as DbComponentType
+from agno.db.utils import DB_TABLE_NAME_KEYS
 from agno.os.auth import get_authentication_dependency
 from agno.os.schema import (
     BadRequestResponse,
@@ -68,13 +69,15 @@ def _resolve_db_in_config(
             elif registry is not None:
                 resolved_db = registry.get_db(component_db_id)
 
-            # Merge resolved db with caller-provided fields. Caller wins so
-            # that custom table names (e.g. session_table, memory_table) are
-            # preserved instead of being clobbered by the resolved db's
-            # defaults.
+            # Merge resolved db with caller-provided table-name overrides.
+            # Connection-defining fields (type, db_url, db_file, db_schema,
+            # id, ...) always come from the resolved db so the caller can't
+            # redirect a referenced db to a different backend. Only the
+            # whitelisted table-name keys are taken from the caller.
             if resolved_db is not None:
                 resolved_dict = resolved_db.to_dict()
-                config["db"] = {**resolved_dict, **component_db}
+                table_overrides = {key: component_db[key] for key in DB_TABLE_NAME_KEYS if key in component_db}
+                config["db"] = {**resolved_dict, **table_overrides}
             else:
                 log_error(f"Could not resolve db with id: {component_db_id}")
     elif component_db is None and "db" in config:

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel
 
 from agno.agent import Agent
 from agno.db.base import AsyncBaseDb, BaseDb, ComponentType, SessionType
-from agno.db.utils import db_from_dict
+from agno.db.utils import resolve_db_from_config
 from agno.metrics import RunMetrics, SessionMetrics
 from agno.models.base import Model
 from agno.models.message import Message
@@ -815,21 +815,11 @@ def from_dict(
 
     # --- Handle DB reconstruction ---
     if "db" in config and isinstance(config["db"], dict):
-        db_data = config["db"]
-        db_id = db_data.get("id")
-
-        # First try to get the db from the registry (preferred - reuses existing connection)
-        if registry and db_id:
-            registry_db = registry.get_db(db_id)
-            if registry_db is not None:
-                config["db"] = registry_db
-            else:
-                del config["db"]
+        resolved = resolve_db_from_config(config["db"], registry=registry)
+        if resolved is not None:
+            config["db"] = resolved
         else:
-            # No registry or no db_id, fall back to creating from dict
-            config["db"] = db_from_dict(db_data)
-            if config["db"] is None:
-                del config["db"]
+            del config["db"]
 
     # --- Handle Schema reconstruction ---
     if "input_schema" in config and isinstance(config["input_schema"], str):

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -1104,7 +1104,11 @@ def _hydrate_from_graph(
 
     team = cls.from_dict(config, db=db, registry=registry)
     team.id = graph["component"]["component_id"]
-    team.db = db
+    # Only fall back to the caller-provided db if the config didn't
+    # reconstruct one. Otherwise we'd clobber any custom table names
+    # (session_table, memory_table, ...) that were serialized with the team.
+    if team.db is None:
+        team.db = db
 
     # Hydrate members from graph children
     team.members = []
@@ -1123,7 +1127,8 @@ def _hydrate_from_graph(
         if member_type == "agent":
             agent = Agent.from_dict(child_config)
             agent.id = child_graph["component"]["component_id"]
-            agent.db = db
+            if agent.db is None:
+                agent.db = db
             team.members.append(agent)
         elif member_type == "team":
             # Recursively hydrate nested teams from the already-loaded child graph

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 from agno.agent.agent import Agent
 from agno.db.base import AsyncBaseDb, BaseDb, ComponentType, SessionType
-from agno.db.utils import db_from_dict
+from agno.db.utils import resolve_db_from_config
 from agno.exceptions import InputCheckError, OutputCheckError, RunCancelledException
 from agno.media import Audio, File, Image, Video
 from agno.models.message import Message
@@ -774,21 +774,11 @@ class Workflow:
 
         # --- Handle DB reconstruction ---
         if "db" in config and isinstance(config["db"], dict):
-            db_data = config["db"]
-            db_id = db_data.get("id")
-
-            # Try to get the db from the registry
-            if registry and db_id:
-                registry_db = registry.get_db(db_id)
-                if registry_db is not None:
-                    config["db"] = registry_db
-                else:
-                    del config["db"]
+            resolved = resolve_db_from_config(config["db"], registry=registry)
+            if resolved is not None:
+                config["db"] = resolved
             else:
-                # No registry or no db_id, fall back to creating from dict
-                config["db"] = db_from_dict(db_data)
-                if config["db"] is None:
-                    del config["db"]
+                del config["db"]
 
         # --- Handle Schema reconstruction ---
         if "input_schema" in config and isinstance(config["input_schema"], str):

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -976,7 +976,12 @@ class Workflow:
         workflow = cls.from_dict(config, db=db, registry=registry)
 
         workflow.id = id
-        workflow.db = db
+        # Only fall back to the caller-provided db if the config didn't
+        # reconstruct one. Otherwise we'd clobber any custom table names
+        # (session_table, memory_table, ...) that were serialized with the
+        # workflow.
+        if workflow.db is None:
+            workflow.db = db
 
         return workflow
 

--- a/libs/agno/tests/unit/db/test_resolve_db_from_config.py
+++ b/libs/agno/tests/unit/db/test_resolve_db_from_config.py
@@ -1,0 +1,254 @@
+"""Tests for resolve_db_from_config and _clone_db_with_table_overrides.
+
+These cover the db-resolution path used when agents / teams / workflows
+are reloaded from persisted component configs, specifically the cases
+that have needed follow-up fixes on PR #7508:
+
+- custom table names persist across a registry-backed reload
+- the engine/connection pool is shared across reloads (no pool
+  proliferation)
+- connection metadata (db_url / db_file / db_schema) survives a clone
+  round-trip so a re-save isn't unusable
+- non-SQL registered db types aren't regressed to db=None
+- the registry-miss path falls back to db_from_dict (not a silent drop)
+"""
+
+from unittest.mock import Mock
+
+from sqlalchemy import create_engine
+
+from agno.db.postgres.postgres import PostgresDb
+from agno.db.sqlite.sqlite import SqliteDb
+from agno.db.utils import (
+    DB_TABLE_NAME_KEYS,
+    _clone_db_with_table_overrides,
+    resolve_db_from_config,
+)
+
+
+class _FakeRegistry:
+    """Minimal stand-in for agno.registry.Registry used by these tests."""
+
+    def __init__(self, db=None):
+        self._db = db
+
+    def get_db(self, db_id):
+        if self._db is not None and getattr(self._db, "id", None) == db_id:
+            return self._db
+        return None
+
+
+class TestResolveDbFromConfigSqlite:
+    def test_no_overrides_returns_registered_instance(self, tmp_path):
+        os_db = SqliteDb(db_file=str(tmp_path / "os.db"))
+        registry = _FakeRegistry(os_db)
+
+        resolved = resolve_db_from_config(os_db.to_dict(), registry=registry)
+
+        # Same Python object: no clone needed, no new engine allocated.
+        assert resolved is os_db
+
+    def test_overrides_return_clone_sharing_engine(self, tmp_path):
+        os_db = SqliteDb(db_file=str(tmp_path / "os.db"))
+        registry = _FakeRegistry(os_db)
+
+        data = dict(os_db.to_dict())
+        data["session_table"] = "custom_sessions"
+        data["memory_table"] = "custom_memories"
+
+        resolved = resolve_db_from_config(data, registry=registry)
+
+        assert resolved is not os_db, "expected a clone, not the registered instance"
+        assert isinstance(resolved, SqliteDb)
+        assert resolved.session_table_name == "custom_sessions"
+        assert resolved.memory_table_name == "custom_memories"
+        # Non-overridden fields inherit from the registered db.
+        assert resolved.knowledge_table_name == os_db.knowledge_table_name
+        # Engine / pool is SHARED — repeated loads must not allocate new pools.
+        assert resolved.db_engine is os_db.db_engine
+        assert resolved.id == os_db.id
+
+    def test_repeated_reloads_share_one_engine(self, tmp_path):
+        os_db = SqliteDb(db_file=str(tmp_path / "os.db"))
+        registry = _FakeRegistry(os_db)
+
+        data = dict(os_db.to_dict())
+        data["session_table"] = "custom_sessions"
+
+        engines = {id(resolve_db_from_config(data, registry=registry).db_engine) for _ in range(5)}
+
+        assert len(engines) == 1, "engine should be shared across reloads, not reallocated"
+
+    def test_clone_carries_db_file_for_roundtrip(self, tmp_path):
+        """Regression: the clone must carry db_file so a re-save of the
+        component produces a usable config on a subsequent load without
+        the registry.
+        """
+        os_db = SqliteDb(db_file=str(tmp_path / "os.db"))
+        registry = _FakeRegistry(os_db)
+
+        data = dict(os_db.to_dict())
+        data["session_table"] = "custom_sessions"
+
+        clone = resolve_db_from_config(data, registry=registry)
+        assert clone is not None
+        assert clone.db_file == os_db.db_file
+
+        # Round-trip: re-serialize and make sure db_file survives so a
+        # registry-less from_dict can rebuild the connection.
+        reserialized = clone.to_dict()
+        assert reserialized["db_file"] == os_db.db_file
+        assert reserialized["session_table"] == "custom_sessions"
+
+    def test_no_registry_falls_back_to_db_from_dict(self, tmp_path):
+        db_data = {
+            "type": "sqlite",
+            "db_file": str(tmp_path / "standalone.db"),
+            "session_table": "s",
+            "memory_table": "m",
+        }
+
+        resolved = resolve_db_from_config(db_data, registry=None)
+
+        assert isinstance(resolved, SqliteDb)
+        assert resolved.session_table_name == "s"
+        assert resolved.memory_table_name == "m"
+
+    def test_registry_miss_falls_back_to_db_from_dict(self, tmp_path):
+        # Registry exists but does not hold the id referenced in db_data.
+        other_db = SqliteDb(db_file=str(tmp_path / "other.db"))
+        registry = _FakeRegistry(other_db)
+
+        db_data = {
+            "type": "sqlite",
+            "db_file": str(tmp_path / "standalone.db"),
+            "id": "not-in-registry",
+            "session_table": "s",
+        }
+
+        resolved = resolve_db_from_config(db_data, registry=registry)
+
+        # Pre-fix, this path used to silently drop config["db"]; now it
+        # rebuilds a fresh instance from the serialized fields.
+        assert isinstance(resolved, SqliteDb)
+        assert resolved.session_table_name == "s"
+
+
+class TestResolveDbFromConfigPostgres:
+    def test_clone_shares_engine_and_preserves_connection_metadata(self):
+        # A real postgres connection isn't available in unit tests, so
+        # inject a sqlite engine as a stand-in to exercise the clone
+        # logic without hitting the network. We only care about attribute
+        # carry-over here.
+        engine = create_engine("sqlite:///:memory:")
+        os_db = PostgresDb(
+            db_url="postgresql://user:pass@host/db",
+            db_engine=engine,
+            db_schema="ai",
+        )
+        registry = _FakeRegistry(os_db)
+
+        data = dict(os_db.to_dict())
+        data["session_table"] = "custom_pg_sessions"
+
+        clone = resolve_db_from_config(data, registry=registry)
+
+        assert clone is not os_db
+        assert isinstance(clone, PostgresDb)
+        assert clone.db_engine is os_db.db_engine
+        # Connection metadata must round-trip through to_dict so a
+        # re-save isn't unusable.
+        assert clone.db_url == os_db.db_url
+        assert clone.db_schema == os_db.db_schema
+        redict = clone.to_dict()
+        assert redict["db_url"] == os_db.db_url
+        assert redict["db_schema"] == os_db.db_schema
+        assert redict["session_table"] == "custom_pg_sessions"
+
+
+class TestResolveDbFromConfigNonSqlBackend:
+    def test_non_sql_registered_db_returns_registered_instance_not_none(self):
+        """Regression: non-SQL backends (JsonDb, RedisDb, FirestoreDb,
+        DynamoDb, ...) that are in the registry must not regress to
+        db=None when the stored config has table-name overrides. The
+        cloner doesn't know how to rebuild them, so we fall back to the
+        registered instance (with a warning, not a silent drop).
+        """
+        # Fake a non-SQL BaseDb subclass that the cloner doesn't handle.
+        fake_db = Mock()
+        fake_db.id = "fake-nosql"
+        fake_db.to_dict.return_value = {
+            "id": "fake-nosql",
+            "type": "redis",
+            "session_table": "json_sessions",
+            "memory_table": "json_memories",
+            "knowledge_table": "agno_knowledge",
+        }
+        registry = _FakeRegistry(fake_db)
+
+        data = dict(fake_db.to_dict())
+        data["session_table"] = "overridden_sessions"
+
+        resolved = resolve_db_from_config(data, registry=registry)
+
+        # Crucially: must not be None. Overrides are silently ignored
+        # for non-SQL backends (pre-fix behavior preserved).
+        assert resolved is fake_db
+
+
+class TestCloneDbWithTableOverrides:
+    def test_sqlite_clone_applies_overrides(self, tmp_path):
+        src = SqliteDb(db_file=str(tmp_path / "src.db"))
+        data = {"session_table": "new_s", "memory_table": "new_m"}
+
+        clone = _clone_db_with_table_overrides(src, data)
+
+        assert isinstance(clone, SqliteDb)
+        assert clone.session_table_name == "new_s"
+        assert clone.memory_table_name == "new_m"
+        assert clone.db_engine is src.db_engine
+        assert clone.db_file == src.db_file
+
+    def test_only_whitelisted_keys_pass_through(self, tmp_path):
+        src = SqliteDb(db_file=str(tmp_path / "src.db"))
+        # db_data contains BOTH a legitimate override and a nonsense key;
+        # the cloner must ignore unknown keys instead of blowing up.
+        data = {
+            "session_table": "new_s",
+            "bogus_key": "should-be-ignored",
+            "db_url": "postgresql://attacker/evil",  # not a table-name key
+        }
+
+        clone = _clone_db_with_table_overrides(src, data)
+
+        assert clone is not None
+        assert clone.session_table_name == "new_s"
+        # Connection metadata comes from src, not from db_data.
+        assert clone.db_engine is src.db_engine
+        assert clone.db_file == src.db_file
+
+    def test_returns_none_for_unknown_type(self):
+        fake = Mock()
+        # Not a PostgresDb or SqliteDb — cloner should bail out.
+        assert _clone_db_with_table_overrides(fake, {"session_table": "x"}) is None
+
+
+class TestDbTableNameKeys:
+    def test_constant_matches_basedb_init_signature(self):
+        """DB_TABLE_NAME_KEYS is consumed by the components router
+        whitelist and by override detection. If BaseDb grows a new table
+        parameter, this constant must grow with it or overrides will be
+        silently dropped for the new table.
+        """
+        import inspect
+
+        from agno.db.base import BaseDb
+
+        sig = inspect.signature(BaseDb.__init__)
+        table_params = {name for name in sig.parameters if name.endswith("_table")}
+
+        assert table_params == set(DB_TABLE_NAME_KEYS), (
+            f"DB_TABLE_NAME_KEYS is out of sync with BaseDb.__init__ table parameters.\n"
+            f"In BaseDb but missing from constant: {table_params - set(DB_TABLE_NAME_KEYS)}\n"
+            f"In constant but missing from BaseDb: {set(DB_TABLE_NAME_KEYS) - table_params}"
+        )

--- a/libs/agno/tests/unit/os/routers/test_components_router.py
+++ b/libs/agno/tests/unit/os/routers/test_components_router.py
@@ -560,3 +560,123 @@ class TestSetCurrentConfig:
         response = client.post("/components/agent-1/configs/1/set-current")
 
         assert response.status_code == 400
+
+
+# =============================================================================
+# _resolve_db_in_config Tests
+# =============================================================================
+#
+# These cover the components-router-specific merge behavior when a payload
+# references a db by id: only whitelisted table-name fields are accepted from
+# the caller; connection-defining fields (type / db_url / db_file / db_schema /
+# id) always come from the resolved db so a caller cannot redirect a
+# referenced db to a different backend through this path.
+
+
+class TestResolveDbInConfig:
+    """Tests for the _resolve_db_in_config helper in the components router."""
+
+    def _make_os_db(self, tmp_path):
+        from agno.db.sqlite.sqlite import SqliteDb
+
+        return SqliteDb(db_file=str(tmp_path / "os.db"))
+
+    def test_no_db_in_config_is_noop(self, tmp_path):
+        from agno.os.routers.components.components import _resolve_db_in_config
+
+        os_db = self._make_os_db(tmp_path)
+        config = {"name": "agent"}
+
+        out = _resolve_db_in_config(dict(config), os_db, None)
+
+        assert out == config
+
+    def test_db_none_is_removed(self, tmp_path):
+        from agno.os.routers.components.components import _resolve_db_in_config
+
+        os_db = self._make_os_db(tmp_path)
+
+        out = _resolve_db_in_config({"name": "agent", "db": None}, os_db, None)
+
+        assert "db" not in out
+
+    def test_db_without_id_is_passed_through(self, tmp_path):
+        from agno.os.routers.components.components import _resolve_db_in_config
+
+        os_db = self._make_os_db(tmp_path)
+        payload = {"db": {"type": "sqlite", "session_table": "custom"}}
+
+        out = _resolve_db_in_config(dict(payload), os_db, None)
+
+        assert out["db"] == payload["db"]
+
+    def test_matching_id_merges_table_overrides_onto_resolved_db(self, tmp_path):
+        """The reported bug: table-name overrides in the payload were being
+        replaced with the resolved db's defaults."""
+        from agno.os.routers.components.components import _resolve_db_in_config
+
+        os_db = self._make_os_db(tmp_path)
+        payload = {
+            "db": {
+                "id": os_db.id,
+                "session_table": "custom_sessions",
+                "memory_table": "custom_memories",
+            },
+        }
+
+        out = _resolve_db_in_config(dict(payload), os_db, None)
+
+        assert out["db"]["session_table"] == "custom_sessions"
+        assert out["db"]["memory_table"] == "custom_memories"
+        # Connection metadata is filled in from the resolved db.
+        assert out["db"]["type"] == "sqlite"
+        assert out["db"]["db_file"] == os_db.db_file
+        # Fields the caller didn't override inherit os_db's values.
+        assert out["db"]["knowledge_table"] == os_db.knowledge_table_name
+
+    def test_matching_id_rejects_caller_override_of_connection_fields(self, tmp_path):
+        """Whitelist: a caller cannot redirect a referenced db by
+        supplying type / db_url / db_file / db_schema."""
+        from agno.os.routers.components.components import _resolve_db_in_config
+
+        os_db = self._make_os_db(tmp_path)
+        payload = {
+            "db": {
+                "id": os_db.id,
+                "type": "postgres",
+                "db_url": "postgresql://attacker/evil",
+                "db_file": "/evil.db",
+                "db_schema": "public",
+                "session_table": "custom_sessions",
+            },
+        }
+
+        out = _resolve_db_in_config(dict(payload), os_db, None)
+
+        resolved_db_dict = out["db"]
+        # Connection fields MUST come from os_db, never from the caller.
+        assert resolved_db_dict["type"] == "sqlite"
+        assert resolved_db_dict["db_file"] == os_db.db_file
+        assert resolved_db_dict.get("db_url") == os_db.db_url
+        assert resolved_db_dict["id"] == os_db.id
+        # The only caller-provided field that is allowed through is the
+        # whitelisted table-name override.
+        assert resolved_db_dict["session_table"] == "custom_sessions"
+
+    def test_matching_id_ignores_non_whitelisted_keys(self, tmp_path):
+        """Unknown keys in the payload must not leak into the stored config."""
+        from agno.os.routers.components.components import _resolve_db_in_config
+
+        os_db = self._make_os_db(tmp_path)
+        payload = {
+            "db": {
+                "id": os_db.id,
+                "session_table": "custom_sessions",
+                "arbitrary_extension": "something",
+            },
+        }
+
+        out = _resolve_db_in_config(dict(payload), os_db, None)
+
+        assert "arbitrary_extension" not in out["db"]
+        assert out["db"]["session_table"] == "custom_sessions"

--- a/libs/agno/tests/unit/workflow/test_workflow_custom_table_names.py
+++ b/libs/agno/tests/unit/workflow/test_workflow_custom_table_names.py
@@ -1,0 +1,131 @@
+"""End-to-end regression test for PR #7508.
+
+Mirrors the original bug report: create a workflow through the
+Components API path with custom ``session_table`` in its db config,
+execute it, and verify the session row lands in the configured custom
+table rather than the default ``agno_sessions`` table.
+"""
+
+import asyncio
+import sqlite3
+
+import pytest
+
+from agno.db.base import ComponentType
+from agno.db.sqlite.sqlite import SqliteDb
+from agno.workflow import Step, StepOutput
+from agno.workflow.workflow import get_workflow_by_id
+
+
+class _FakeRegistry:
+    """Minimal registry stand-in that exposes a single registered db."""
+
+    def __init__(self, db):
+        self._db = db
+        # The workflow from_dict logic only uses get_db; the other
+        # attributes are accessed by other code paths in some tests.
+        self.agents = []
+        self.teams = []
+
+    def get_db(self, db_id):
+        if self._db is not None and getattr(self._db, "id", None) == db_id:
+            return self._db
+        return None
+
+    def get_all_component_ids(self):
+        return set()
+
+
+def _dummy_step(step_input):
+    return StepOutput(content="ok")
+
+
+class TestWorkflowCustomSessionTable:
+    def test_custom_session_table_survives_components_api_roundtrip(self, tmp_path):
+        """Regression for agno-agi/agno#7508.
+
+        The workflow is persisted via the Components API (``upsert_component``
+        + ``upsert_config``) with a db block that overrides ``session_table``
+        and references os_db's id. On reload via ``get_workflow_by_id``
+        through the registry-backed path, execution must write sessions
+        to the custom table, not the default ``agno_sessions``.
+        """
+        db_path = tmp_path / "e2e.db"
+        os_db = SqliteDb(db_file=str(db_path))
+        registry = _FakeRegistry(os_db)
+
+        os_db.upsert_component(
+            component_id="wf-custom",
+            component_type=ComponentType.WORKFLOW,
+            name="wf with custom session table",
+        )
+        # The stored config references os_db by id so the registry-backed
+        # load path is exercised — this is the branch that regressed.
+        os_db.upsert_config(
+            component_id="wf-custom",
+            config={
+                "db": {
+                    **os_db.to_dict(),
+                    "session_table": "custom_workflow_sessions",
+                },
+                "id": "wf-custom",
+                "name": "wf with custom session table",
+            },
+            stage="published",
+        )
+
+        workflow = get_workflow_by_id(db=os_db, id="wf-custom", registry=registry)
+        assert workflow is not None
+        # Table name from the stored config, not os_db's default.
+        assert workflow.db.session_table_name == "custom_workflow_sessions"
+        # Engine is shared with os_db so repeated loads don't proliferate pools.
+        assert workflow.db.db_engine is os_db.db_engine
+
+        workflow.steps = [Step(name="noop", executor=_dummy_step)]
+        asyncio.run(workflow.arun(input="hello", session_id="sess-1"))
+
+        with sqlite3.connect(str(db_path)) as conn:
+            tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+
+        assert "custom_workflow_sessions" in tables, "custom session table was not created"
+        assert "agno_sessions" not in tables, "default session table must not be used when an override is configured"
+
+        # Repeated loads must all share one engine (Codex P1 concern).
+        seen_engines = set()
+        for _ in range(5):
+            reloaded = get_workflow_by_id(db=os_db, id="wf-custom", registry=registry)
+            assert reloaded is not None
+            seen_engines.add(id(reloaded.db.db_engine))
+        assert len(seen_engines) == 1
+
+    def test_workflow_without_override_reuses_registered_db_instance(self, tmp_path):
+        """Sanity check: when the stored config has no table-name overrides,
+        the load path returns the registered db instance directly (no clone),
+        which is the fast path we want to preserve."""
+        db_path = tmp_path / "noop.db"
+        os_db = SqliteDb(db_file=str(db_path))
+        registry = _FakeRegistry(os_db)
+
+        os_db.upsert_component(
+            component_id="wf-plain",
+            component_type=ComponentType.WORKFLOW,
+            name="wf plain",
+        )
+        os_db.upsert_config(
+            component_id="wf-plain",
+            config={
+                "db": os_db.to_dict(),
+                "id": "wf-plain",
+                "name": "wf plain",
+            },
+            stage="published",
+        )
+
+        workflow = get_workflow_by_id(db=os_db, id="wf-plain", registry=registry)
+        assert workflow is not None
+        # No clone needed — same Python object as os_db.
+        assert workflow.db is os_db
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes a bug where custom db table names (`session_table`, `memory_table`, etc.) specified on an agent / team / workflow were silently dropped when the component was persisted via the Components API. The reported symptom was: create a workflow through the Components API with `memory_table` / `session_table` overrides in the db config, execute it, and observe that sessions land in the default `agno_sessions` table and the custom memory table is never created.

Two layers were losing the overrides:

1. The components router's `_resolve_db_in_config` was replacing the caller-supplied db dict wholesale with `resolved_db.to_dict()` whenever the payload referenced a known db id, so table-name overrides were wiped out before storage.
2. The `Agent` / `Team` / `Workflow` reload paths (including the OS's registry-backed path) were unconditionally using the caller-provided db handle after `from_dict`, so even when the stored config carried overrides, the loaded component's `db` was replaced with the shared default-table-names instance.

## What changed

- **Components router (`os/routers/components/components.py`)**: `_resolve_db_in_config` now merges only a whitelisted set of table-name keys from the caller onto `resolved_db.to_dict()`. Connection-defining fields (`type`, `db_url`, `db_file`, `db_schema`, `id`) always come from the resolved db — a caller can't redirect a referenced db to a different backend through this path.
- **New `resolve_db_from_config` helper (`db/utils.py`)**: centralizes db reconstruction for the three `from_dict` sites. When a registry is present and the stored config references a known db id:
  - No table-name overrides → return the registered instance (unchanged behavior).
  - Has table-name overrides → return a clone of the registered instance that **shares the same SQLAlchemy engine / connection pool** but carries the stored table-name overrides. Connection metadata (`db_url` / `db_file` / `db_schema`) is carried over so `to_dict()` round-trips cleanly if the component is re-saved.
  - Unsupported (non-SQL) backend → return the registered instance with a warning. Table overrides are ignored for these backends (matching pre-fix behavior), but the component still gets a working db.
  - Unknown id / no registry → fall back to `db_from_dict`, which also fixes a latent bug where a registry miss used to silently delete `config["db"]`.
- **Agent / Team / Workflow load paths (`agent/_storage.py`, `team/_storage.py`, `workflow/workflow.py`)**: now delegate db resolution to `resolve_db_from_config`. The caller-provided `db` is used as a fallback only when reconstruction didn't produce one, so stored table-name overrides on the component survive the load.
- **New `DB_TABLE_NAME_KEYS` constant (`db/utils.py`)**: canonical list of the 16 table-name fields a db config can override, used both by the components router whitelist and the override detection in `resolve_db_from_config`.

## Expected behavior now

- Components saved via the Components API with custom `session_table` / `memory_table` / etc. honor those overrides when the workflow / agent / team runs. Sessions, memories, etc. land in the configured tables, not the OS db defaults.
- Repeated component loads against a registry-backed OS db **do not proliferate connection pools** — the clone reuses the registered db's engine, so you get one engine/pool regardless of how many times a component is hydrated.
- Callers cannot use the `db` block in a components payload to redirect to a different backend; only table-name fields are accepted as overrides.
- Non-SQL db backends (`JsonDb`, `RedisDb`, `FirestoreDb`, `DynamoDb`, `GcsJsonDb`, `SurrealDb`, ...) continue to work through the registry-backed load path. Table-name overrides are silently ignored for these backends (with a warning logged); implementing per-component overrides for them is left for a follow-up if needed.
- A load → re-save round-trip of a component preserves the db's connection metadata (`db_url` / `db_file` / `db_schema`), so the re-saved config is usable on a subsequent registry-less load.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### Test plan

- End-to-end (sqlite): create a workflow via `upsert_component` + `upsert_config` with a db config overriding `session_table`, load it via the registry-backed path, run it. Sessions land in the overridden table; the default `agno_sessions` table is never created.
- Engine sharing: 5 repeated `get_workflow_by_id` calls against a registry-backed os_db yield 5 workflow objects pointing at the **same** `db_engine` object (verified via identity check).
- `_resolve_db_in_config` whitelist: a payload attempting to redirect `type` / `db_url` / `db_file` / `db_schema` is rejected; only table-name keys merge through.
- Non-SQL fallback: a fake non-SQL registered db with a stored override returns the registered instance (not `None`), with a warning logged.
- Clone round-trip: a cloned `SqliteDb` / `PostgresDb` carries `db_file` / `db_url` / `db_schema` from the source, so `clone.to_dict()` produces a usable config.
- Existing unit tests: 170 passing across `tests/unit/os/routers/test_components_router.py`, `tests/unit/workflow`, `tests/unit/agent`, `tests/unit/team` (including the `test_load_sets_db_on_team` test that covers the fallback branch where the stored config has no `db` key).