### PR TITLE
feat: storage layer for multi-framework support

### DIFF
--- a/cookbook/frameworks/claude-agent-sdk/claude_session.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_session.py
@@ -1,0 +1,47 @@
+"""
+Claude Agent SDK with session persistence via SQLite.
+
+Demonstrates multi-turn conversations where chat history is persisted
+to Agno's DB. Each run is stored as a session with messages, so you
+can resume conversations and see history in the AgentOS UI.
+
+Requirements:
+    pip install claude-agent-sdk
+
+Usage:
+    python cookbook/frameworks/claude-agent-sdk/claude_session.py
+"""
+
+from agno.agents.claude import ClaudeAgentSDK
+from agno.db.postgres import PostgresDb
+db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
+pg_db = PostgresDb(db_url=db_url)
+
+agent = ClaudeAgentSDK(
+    agent_id="claude-chat",
+    agent_name="Claude Chat",
+    model="claude-sonnet-4-20250514",
+    allowed_tools=["WebSearch"],
+    permission_mode="acceptEdits",
+    max_turns=7,
+    db=pg_db,
+)
+
+SESSION_ID = "demo-session-1"
+
+# Turn 1
+agent.print_response(
+    "What are the latest developments in AI agents?",
+    stream=True,
+    session_id=SESSION_ID,
+)
+
+# Turn 2 — same session
+agent.print_response(
+    "Which companies are leading in this space?",
+    stream=True,
+    session_id=SESSION_ID,
+)
+
+print("\n--- Session persisted to tmp/claude_sessions.db ---")
+print(f"Session ID: {SESSION_ID}")

--- a/cookbook/frameworks/claude-agent-sdk/claude_session.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_session.py
@@ -1,5 +1,5 @@
 """
-Claude Agent SDK with session persistence via SQLite.
+Claude Agent SDK with session persistence.
 
 Demonstrates multi-turn conversations where chat history is persisted
 to Agno's DB. Each run is stored as a session with messages, so you

--- a/cookbook/frameworks/claude-agent-sdk/claude_session_agentos.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_session_agentos.py
@@ -1,0 +1,48 @@
+"""
+Claude Agent SDK with session persistence via SQLite.
+
+Demonstrates multi-turn conversations where chat history is persisted
+to Agno's DB. Each run is stored as a session with messages, so you
+can resume conversations and see history in the AgentOS UI.
+
+Requirements:
+    pip install claude-agent-sdk
+
+Usage:
+    python cookbook/frameworks/claude-agent-sdk/claude_session_agentos.py
+"""
+
+from agno.agents.claude import ClaudeAgentSDK
+from agno.db.postgres import PostgresDb
+from agno.os.app import AgentOS
+
+db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
+pg_db = PostgresDb(db_url=db_url)
+
+agent = ClaudeAgentSDK(
+    agent_id="claude-chat",
+    agent_name="Claude Chat",
+    model="claude-sonnet-4-20250514",
+    allowed_tools=["WebSearch"],
+    permission_mode="acceptEdits",
+    max_turns=7,
+    db=pg_db,
+)
+
+# ---------------------------------------------------------------------------
+# Setup AgentOS
+# ---------------------------------------------------------------------------
+agent_os = AgentOS(
+    id="claude-session-agentos",
+    name="Claude Agent SDK Example",
+    description="AgentOS serving a Claude Agent SDK agent",
+    agents=[agent],
+    db=pg_db,
+)
+app = agent_os.get_app()
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent_os.serve(app="claude_session_agentos:app", reload=True)

--- a/cookbook/frameworks/claude-agent-sdk/claude_session_agentos.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_session_agentos.py
@@ -37,7 +37,6 @@ agent_os = AgentOS(
     name="Claude Agent SDK Example",
     description="AgentOS serving a Claude Agent SDK agent",
     agents=[agent],
-    db=pg_db,
 )
 app = agent_os.get_app()
 

--- a/cookbook/frameworks/claude-agent-sdk/claude_session_agentos.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_session_agentos.py
@@ -1,5 +1,5 @@
 """
-Claude Agent SDK with session persistence via SQLite.
+Claude Agent SDK with session persistence.
 
 Demonstrates multi-turn conversations where chat history is persisted
 to Agno's DB. Each run is stored as a session with messages, so you

--- a/cookbook/frameworks/dspy/dspy_agentos.py
+++ b/cookbook/frameworks/dspy/dspy_agentos.py
@@ -36,7 +36,7 @@ from agno.os.app import AgentOS
 # ---------------------------------------------------------------------------
 # Configure DSPy LM (must be set on the main thread)
 # ---------------------------------------------------------------------------
-dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
+dspy.configure(lm=dspy.LM("openai/gpt-5.4"))
 
 # ---------------------------------------------------------------------------
 # Create the DSPy agent

--- a/cookbook/frameworks/dspy/dspy_basic.py
+++ b/cookbook/frameworks/dspy/dspy_basic.py
@@ -12,7 +12,7 @@ import dspy
 from agno.agents.dspy import DSPyAgent
 
 # ----- Configure DSPy LM (must be set on the main thread) -----
-lm = dspy.LM("openai/gpt-4o-mini")
+lm = dspy.LM("openai/gpt-5.4")
 dspy.configure(lm=lm)
 
 # ----- Basic Q&A with ChainOfThought -----

--- a/cookbook/frameworks/dspy/dspy_session.py
+++ b/cookbook/frameworks/dspy/dspy_session.py
@@ -1,5 +1,5 @@
 """
-DSPy agent with session persistence via SQLite.
+DSPy agent with session persistence.
 
 Demonstrates multi-turn conversations where chat history is persisted
 to Agno's DB. Each run is stored as a session with messages, so you

--- a/cookbook/frameworks/dspy/dspy_session.py
+++ b/cookbook/frameworks/dspy/dspy_session.py
@@ -18,7 +18,7 @@ from agno.agents.dspy import DSPyAgent
 from agno.db.postgres import PostgresDb
 
 # ----- Configure DSPy -----
-lm = dspy.LM("openai/gpt-4o-mini")
+lm = dspy.LM("openai/gpt-5.4")
 dspy.configure(lm=lm)
 
 # ----- Create agent with SQLite persistence -----

--- a/cookbook/frameworks/dspy/dspy_session.py
+++ b/cookbook/frameworks/dspy/dspy_session.py
@@ -1,0 +1,59 @@
+"""
+DSPy agent with session persistence via SQLite.
+
+Demonstrates multi-turn conversations where chat history is persisted
+to Agno's DB. Each run is stored as a session with messages, so you
+can resume conversations and see history in the AgentOS UI.
+
+Requirements:
+    pip install dspy
+
+Usage:
+    python cookbook/frameworks/dspy/dspy_session.py
+"""
+
+import dspy
+
+from agno.agents.dspy import DSPyAgent
+from agno.db.postgres import PostgresDb
+
+# ----- Configure DSPy -----
+lm = dspy.LM("openai/gpt-4o-mini")
+dspy.configure(lm=lm)
+
+# ----- Create agent with SQLite persistence -----
+db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
+
+agent = DSPyAgent(
+    agent_id="dspy-chat",
+    agent_name="DSPy Chat",
+    program=dspy.ChainOfThought("question -> answer"),
+    db=db,
+)
+
+SESSION_ID = "demo-session-1"
+
+# Turn 1
+agent.print_response(
+    "What is quantum computing?",
+    stream=True,
+    session_id=SESSION_ID,
+)
+
+# Turn 2 — same session, history is persisted
+agent.print_response(
+    "How is it different from classical computing?",
+    stream=True,
+    session_id=SESSION_ID,
+)
+
+# Turn 3
+agent.print_response(
+    "What are some real-world applications?",
+    stream=True,
+    session_id=SESSION_ID,
+)
+
+print("\n--- Session persisted to tmp/dspy_sessions.db ---")
+print(f"Session ID: {SESSION_ID}")
+print("You can inspect the DB to see all runs and messages stored.")

--- a/cookbook/frameworks/dspy/dspy_session_agentos.py
+++ b/cookbook/frameworks/dspy/dspy_session_agentos.py
@@ -1,0 +1,72 @@
+"""
+DSPy ReAct agent with web search, served through AgentOS.
+
+Uses DSPy's ReAct module with a live DuckDuckGo search tool.
+Multi-turn conversations are persisted to Postgres and visible
+in the AgentOS UI.
+
+Requirements:
+    pip install dspy ddgs
+
+Usage:
+    python cookbook/frameworks/dspy/dspy_session_agentos.py
+
+Then call the API:
+    # Streaming
+    curl -X POST http://localhost:7777/agents/dspy-search/runs \\
+        -F "message=What are the latest AI agent developments?" \\
+        -F "stream=true" \\
+        --no-buffer
+
+    # Non-streaming
+    curl -X POST http://localhost:7777/agents/dspy-search/runs \\
+        -F "message=What is quantum computing?" \\
+        -F "stream=false"
+
+    # List agents
+    curl http://localhost:7777/agents
+"""
+
+import dspy
+from ddgs import DDGS
+
+from agno.agents.dspy import DSPyAgent
+from agno.db.postgres import PostgresDb
+from agno.os.app import AgentOS
+
+
+# ----- Define a live web search tool -----
+def search_web(query: str) -> str:
+    """Search the web for current information using DuckDuckGo."""
+    results = DDGS().text(query, max_results=3)
+    if not results:
+        return f"No results found for: {query}"
+    return "\n\n".join(f"- {r['title']}: {r['body']}" for r in results)
+
+
+# ----- Configure DSPy (must be set on the main thread) -----
+dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
+
+# ----- Create the DSPy ReAct agent with search + persistence -----
+db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
+
+react_program = dspy.ReAct(
+    signature="question -> answer",
+    tools=[search_web],
+    max_iters=5,
+)
+
+agent = DSPyAgent(
+    agent_id="dspy-search",
+    agent_name="DSPy Search Agent",
+    description="A DSPy ReAct agent with live web search, served through AgentOS",
+    program=react_program,
+    db=db,
+)
+
+# ----- Serve through AgentOS -----
+agent_os = AgentOS(agents=[agent])
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="dspy_session_agentos:app", reload=True)

--- a/cookbook/frameworks/dspy/dspy_session_agentos.py
+++ b/cookbook/frameworks/dspy/dspy_session_agentos.py
@@ -45,7 +45,7 @@ def search_web(query: str) -> str:
 
 
 # ----- Configure DSPy (must be set on the main thread) -----
-dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
+dspy.configure(lm=dspy.LM("openai/gpt-5.4"))
 
 # ----- Create the DSPy ReAct agent with search + persistence -----
 db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")

--- a/cookbook/frameworks/dspy/dspy_tools.py
+++ b/cookbook/frameworks/dspy/dspy_tools.py
@@ -33,7 +33,7 @@ def search_web(query: str) -> str:
 
 
 # ----- Configure DSPy (must be set on the main thread) -----
-lm = dspy.LM("openai/gpt-4o-mini")
+lm = dspy.LM("openai/gpt-5.4")
 dspy.configure(lm=lm)
 
 # ----- ReAct agent with tools -----

--- a/cookbook/frameworks/langgraph/langgraph_agentos.py
+++ b/cookbook/frameworks/langgraph/langgraph_agentos.py
@@ -34,7 +34,7 @@ from langgraph.graph import MessagesState, StateGraph
 
 # ----- Build a LangGraph agent -----
 def chatbot(state: MessagesState):
-    return {"messages": [ChatOpenAI(model="gpt-4o-mini").invoke(state["messages"])]}
+    return {"messages": [ChatOpenAI(model="gpt-5.4").invoke(state["messages"])]}
 
 
 graph = StateGraph(MessagesState)

--- a/cookbook/frameworks/langgraph/langgraph_basic.py
+++ b/cookbook/frameworks/langgraph/langgraph_basic.py
@@ -15,7 +15,7 @@ from langgraph.graph import MessagesState, StateGraph
 
 # ----- Build a LangGraph agent -----
 def chatbot(state: MessagesState):
-    return {"messages": [ChatOpenAI(model="gpt-4o-mini").invoke(state["messages"])]}
+    return {"messages": [ChatOpenAI(model="gpt-5.4").invoke(state["messages"])]}
 
 
 graph = StateGraph(MessagesState)

--- a/cookbook/frameworks/langgraph/langgraph_session.py
+++ b/cookbook/frameworks/langgraph/langgraph_session.py
@@ -1,0 +1,67 @@
+"""
+LangGraph agent with session persistence via SQLite.
+
+Demonstrates multi-turn conversations where chat history is persisted
+to Agno's DB. Each run is stored as a session with messages, so you
+can resume conversations and see history in the AgentOS UI.
+
+Requirements:
+    pip install langchain-openai langgraph
+
+Usage:
+    python cookbook/frameworks/langgraph/langgraph_session.py
+"""
+
+from agno.agents.langgraph import LangGraphAgent
+from agno.db.postgres import PostgresDb
+from langchain_openai import ChatOpenAI
+from langgraph.graph import MessagesState, StateGraph
+
+# ----- Build a simple LangGraph chatbot -----
+llm = ChatOpenAI(model="gpt-4o-mini")
+
+
+def chatbot(state: MessagesState):
+    return {"messages": [llm.invoke(state["messages"])]}
+
+
+graph = StateGraph(MessagesState)
+graph.add_node("chatbot", chatbot)
+graph.set_entry_point("chatbot")
+compiled = graph.compile()
+
+# ----- Create agent with SQLite persistence -----
+db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
+
+agent = LangGraphAgent(
+    agent_id="langgraph-chat",
+    agent_name="LangGraph Chat",
+    graph=compiled,
+    db=db,
+)
+
+SESSION_ID = "demo-session-1"
+
+# Turn 1
+agent.print_response(
+    "What is quantum computing?",
+    stream=True,
+    session_id=SESSION_ID,
+)
+
+# Turn 2 — same session
+agent.print_response(
+    "How does it compare to classical computing?",
+    stream=True,
+    session_id=SESSION_ID,
+)
+
+# Turn 3
+agent.print_response(
+    "Summarize what we discussed",
+    stream=True,
+    session_id=SESSION_ID,
+)
+
+print("\n--- Session persisted to tmp/langgraph_sessions.db ---")
+print(f"Session ID: {SESSION_ID}")

--- a/cookbook/frameworks/langgraph/langgraph_session.py
+++ b/cookbook/frameworks/langgraph/langgraph_session.py
@@ -1,5 +1,5 @@
 """
-LangGraph agent with session persistence via SQLite.
+LangGraph agent with session persistence.
 
 Demonstrates multi-turn conversations where chat history is persisted
 to Agno's DB. Each run is stored as a session with messages, so you
@@ -18,7 +18,7 @@ from langchain_openai import ChatOpenAI
 from langgraph.graph import MessagesState, StateGraph
 
 # ----- Build a simple LangGraph chatbot -----
-llm = ChatOpenAI(model="gpt-4o-mini")
+llm = ChatOpenAI(model="gpt-5.4")
 
 
 def chatbot(state: MessagesState):

--- a/cookbook/frameworks/langgraph/langgraph_session_agentos.py
+++ b/cookbook/frameworks/langgraph/langgraph_session_agentos.py
@@ -1,0 +1,80 @@
+"""
+LangGraph agent with tools served through AgentOS.
+
+A LangGraph ReAct-style agent with web search, served through
+the same AgentOS runtime used for native Agno agents.
+
+Requirements:
+    pip install langgraph langchain-openai langchain-community
+
+Usage:
+    python cookbook/frameworks/langgraph/langgraph_tools_agentos.py
+
+Then call the API:
+    # Streaming
+    curl -X POST http://localhost:7777/agents/langgraph-search/runs \\
+        -F "message=What are the latest AI agent developments?" \\
+        -F "stream=true" \\
+        --no-buffer
+
+    # Non-streaming
+    curl -X POST http://localhost:7777/agents/langgraph-search/runs \\
+        -F "message=What is quantum computing?" \\
+        -F "stream=false"
+
+    # List agents
+    curl http://localhost:7777/agents
+"""
+
+from agno.agents.langgraph import LangGraphAgent
+from agno.db.postgres import PostgresDb
+from agno.os.app import AgentOS
+from langchain_community.tools import DuckDuckGoSearchResults
+from langchain_openai import ChatOpenAI
+from langgraph.graph import MessagesState, StateGraph
+from langgraph.prebuilt import ToolNode
+
+# ----- Tools -----
+search_tool = DuckDuckGoSearchResults(max_results=3)
+tools = [search_tool]
+
+# ----- Build the LangGraph with tools -----
+llm = ChatOpenAI(model="gpt-4o-mini").bind_tools(tools)
+
+
+def chatbot(state: MessagesState):
+    return {"messages": [llm.invoke(state["messages"])]}
+
+
+def should_continue(state: MessagesState):
+    last_message = state["messages"][-1]
+    if last_message.tool_calls:
+        return "tools"
+    return "end"
+
+
+graph = StateGraph(MessagesState)
+graph.add_node("chatbot", chatbot)
+graph.add_node("tools", ToolNode(tools))
+graph.set_entry_point("chatbot")
+graph.add_conditional_edges("chatbot", should_continue, {"tools": "tools", "end": "__end__"})
+graph.add_edge("tools", "chatbot")
+compiled = graph.compile()
+
+# ----- Wrap for AgentOS -----
+db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
+
+agent = LangGraphAgent(
+    agent_id="langgraph-search",
+    agent_name="LangGraph Search Agent",
+    description="A LangGraph agent with web search, served through AgentOS",
+    graph=compiled,
+    db=db,
+)
+
+# ----- Serve through AgentOS -----
+agent_os = AgentOS(agents=[agent])
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="langgraph_tools_agentos:app", reload=True)

--- a/cookbook/frameworks/langgraph/langgraph_session_agentos.py
+++ b/cookbook/frameworks/langgraph/langgraph_session_agentos.py
@@ -39,7 +39,7 @@ search_tool = DuckDuckGoSearchResults(max_results=3)
 tools = [search_tool]
 
 # ----- Build the LangGraph with tools -----
-llm = ChatOpenAI(model="gpt-4o-mini").bind_tools(tools)
+llm = ChatOpenAI(model="gpt-5.4").bind_tools(tools)
 
 
 def chatbot(state: MessagesState):

--- a/cookbook/frameworks/langgraph/langgraph_time_travel.py
+++ b/cookbook/frameworks/langgraph/langgraph_time_travel.py
@@ -20,7 +20,7 @@ from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import MessagesState, StateGraph
 
 # ----- Build a LangGraph with checkpointer -----
-llm = ChatOpenAI(model="gpt-4o-mini")
+llm = ChatOpenAI(model="gpt-5.4")
 
 
 def chatbot(state: MessagesState):

--- a/cookbook/frameworks/langgraph/langgraph_tools.py
+++ b/cookbook/frameworks/langgraph/langgraph_tools.py
@@ -42,7 +42,7 @@ def get_population(city: str) -> str:
 
 # ----- Build graph with tools -----
 tools = [get_weather, get_population]
-llm = ChatOpenAI(model="gpt-4o-mini").bind_tools(tools)
+llm = ChatOpenAI(model="gpt-5.4").bind_tools(tools)
 
 
 def chatbot(state: MessagesState):

--- a/cookbook/frameworks/langgraph/langgraph_tools_session.py
+++ b/cookbook/frameworks/langgraph/langgraph_tools_session.py
@@ -1,0 +1,107 @@
+"""
+LangGraph agent with tools and session persistence.
+
+Demonstrates multi-turn conversations with tool calls, where the full
+conversation history (including tool results) is persisted to Agno's DB.
+
+Requirements:
+    pip install langchain-openai langgraph
+
+Usage:
+    python cookbook/frameworks/langgraph/langgraph_tools_session.py
+"""
+
+from agno.agents.langgraph import LangGraphAgent
+from agno.db.postgres import PostgresDb
+from langchain_core.tools import tool
+from langchain_openai import ChatOpenAI
+from langgraph.graph import MessagesState, StateGraph
+from langgraph.prebuilt import ToolNode
+
+
+# ----- Define tools -----
+@tool
+def get_weather(city: str) -> str:
+    """Get the current weather for a city."""
+    weather_data = {
+        "new york": "72F, partly cloudy",
+        "london": "58F, rainy",
+        "tokyo": "80F, sunny",
+        "paris": "65F, overcast",
+        "san francisco": "60F, foggy",
+    }
+    return weather_data.get(city.lower(), f"Weather data not available for {city}")
+
+
+@tool
+def get_population(city: str) -> str:
+    """Get the population of a city."""
+    pop_data = {
+        "new york": "8.3 million",
+        "london": "8.9 million",
+        "tokyo": "13.9 million",
+        "paris": "2.1 million",
+        "san francisco": "870,000",
+    }
+    return pop_data.get(city.lower(), f"Population data not available for {city}")
+
+
+# ----- Build the LangGraph with tools -----
+tools = [get_weather, get_population]
+llm = ChatOpenAI(model="gpt-4o-mini").bind_tools(tools)
+
+
+def chatbot(state: MessagesState):
+    return {"messages": [llm.invoke(state["messages"])]}
+
+
+def should_continue(state: MessagesState):
+    last_message = state["messages"][-1]
+    if last_message.tool_calls:
+        return "tools"
+    return "end"
+
+
+graph = StateGraph(MessagesState)
+graph.add_node("chatbot", chatbot)
+graph.add_node("tools", ToolNode(tools))
+graph.set_entry_point("chatbot")
+graph.add_conditional_edges("chatbot", should_continue, {"tools": "tools", "end": "__end__"})
+graph.add_edge("tools", "chatbot")
+compiled = graph.compile()
+
+# ----- Create agent with Postgres persistence -----
+db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
+
+agent = LangGraphAgent(
+    agent_id="langgraph-tools",
+    agent_name="LangGraph Tools Agent",
+    graph=compiled,
+    db=db,
+)
+
+SESSION_ID = "tools-session-1"
+
+# Turn 1 — triggers tool calls
+agent.print_response(
+    "What's the weather in Tokyo?",
+    stream=True,
+    session_id=SESSION_ID,
+)
+
+# Turn 2 — follow-up in same session, triggers different tool
+agent.print_response(
+    "What about the population there?",
+    stream=True,
+    session_id=SESSION_ID,
+)
+
+# Turn 3 — summary, uses history context
+agent.print_response(
+    "Summarize everything you told me about Tokyo",
+    stream=True,
+    session_id=SESSION_ID,
+)
+
+print(f"\nSession ID: {SESSION_ID}")
+print("Check the DB to see tool calls stored in session history.")

--- a/cookbook/frameworks/langgraph/langgraph_tools_session.py
+++ b/cookbook/frameworks/langgraph/langgraph_tools_session.py
@@ -48,7 +48,7 @@ def get_population(city: str) -> str:
 
 # ----- Build the LangGraph with tools -----
 tools = [get_weather, get_population]
-llm = ChatOpenAI(model="gpt-4o-mini").bind_tools(tools)
+llm = ChatOpenAI(model="gpt-5.4").bind_tools(tools)
 
 
 def chatbot(state: MessagesState):

--- a/libs/agno/agno/agents/base.py
+++ b/libs/agno/agno/agents/base.py
@@ -540,14 +540,15 @@ class BaseExternalAgent:
         session_id = kwargs.get("session_id") or str(uuid4())
         user_id = kwargs.get("user_id")
 
-        # Load session and provide history to the adapter
+        # Load session and extract history for the adapter
         session = None
+        history: Optional[List[Dict[str, Any]]] = None
         if self.db is not None:
             session = await self.aread_or_create_session(session_id, user_id)
-            kwargs["history"] = self._get_history_from_session(session)
+            history = self._get_history_from_session(session)
 
         try:
-            content = await self._arun_adapter(input, run_id=run_id, **kwargs)
+            content = await self._arun_adapter(input, history=history, run_id=run_id, **kwargs)
             run_output = self._build_run_output(
                 run_id=run_id,
                 session_id=session_id,
@@ -585,11 +586,12 @@ class BaseExternalAgent:
         session_id = kwargs.get("session_id") or str(uuid4())
         user_id = kwargs.get("user_id")
 
-        # Load session and provide history to the adapter
+        # Load session and extract history for the adapter
         session = None
+        history: Optional[List[Dict[str, Any]]] = None
         if self.db is not None:
             session = await self.aread_or_create_session(session_id, user_id)
-            kwargs["history"] = self._get_history_from_session(session)
+            history = self._get_history_from_session(session)
 
         yield RunStartedEvent(
             run_id=run_id,
@@ -604,7 +606,7 @@ class BaseExternalAgent:
             # Map tool_call_id -> ToolExecution for merging started+completed
             tool_map: Dict[str, ToolExecution] = {}
 
-            async for event in self._arun_adapter_stream(input, run_id=run_id, **kwargs):
+            async for event in self._arun_adapter_stream(input, history=history, run_id=run_id, **kwargs):
                 if isinstance(event, RunContentEvent):
                     accumulated_content += event.content or ""
                 elif isinstance(event, ToolCallStartedEvent) and event.tool:
@@ -688,11 +690,15 @@ class BaseExternalAgent:
     # Subclass hooks (must be implemented by adapters)
     # ---------------------------------------------------------------------------
 
-    async def _arun_adapter(self, input: Any, **kwargs: Any) -> Any:
+    async def _arun_adapter(
+        self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any
+    ) -> Any:
         """Non-streaming execution. Return the response content."""
         raise NotImplementedError(f"{self.__class__.__name__} must implement _arun_adapter")
 
-    async def _arun_adapter_stream(self, input: Any, **kwargs: Any) -> AsyncIterator[RunOutputEvent]:
+    async def _arun_adapter_stream(
+        self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any
+    ) -> AsyncIterator[RunOutputEvent]:
         """Streaming execution. Yield RunContentEvent, ToolCallStartedEvent, etc.
 
         Do NOT yield RunStartedEvent or RunCompletedEvent -- those are handled by the base class.

--- a/libs/agno/agno/agents/base.py
+++ b/libs/agno/agno/agents/base.py
@@ -52,9 +52,6 @@ class BaseExternalAgent:
     markdown: bool = True
     db: Optional[Union[BaseDb, AsyncBaseDb]] = None
 
-    # Session cache to avoid repeated DB reads within a session
-    _session_cache: Optional[AgentSession] = field(default=None, init=False, repr=False)
-
     @property
     def id(self) -> str:
         return self.agent_id
@@ -389,9 +386,6 @@ class BaseExternalAgent:
 
     def read_or_create_session(self, session_id: str, user_id: Optional[str] = None) -> AgentSession:
         """Read a session from the DB, or create a new one."""
-        if self._session_cache and self._session_cache.session_id == session_id:
-            return self._session_cache
-
         session = None
         if self.db is not None and isinstance(self.db, BaseDb):
             session = self.db.get_session(session_id=session_id, session_type=SessionType.AGENT)
@@ -402,14 +396,10 @@ class BaseExternalAgent:
         if session is None or not isinstance(session, AgentSession):
             session = self._create_session(session_id, user_id)
 
-        self._session_cache = session
         return session
 
     async def aread_or_create_session(self, session_id: str, user_id: Optional[str] = None) -> AgentSession:
         """Async read a session from the DB, or create a new one."""
-        if self._session_cache and self._session_cache.session_id == session_id:
-            return self._session_cache
-
         session = None
         if self.db is not None:
             if isinstance(self.db, AsyncBaseDb):
@@ -423,7 +413,6 @@ class BaseExternalAgent:
         if session is None or not isinstance(session, AgentSession):
             session = self._create_session(session_id, user_id)
 
-        self._session_cache = session
         return session
 
     def upsert_session(self, session: AgentSession) -> None:

--- a/libs/agno/agno/agents/base.py
+++ b/libs/agno/agno/agents/base.py
@@ -374,8 +374,39 @@ class BaseExternalAgent:
     # Session persistence helpers
     # ---------------------------------------------------------------------------
 
-    async def _load_or_create_session(self, session_id: str, user_id: Optional[str] = None) -> AgentSession:
-        """Load an existing session from the DB, or create a new one."""
+    def _create_session(self, session_id: str, user_id: Optional[str] = None) -> AgentSession:
+        """Create a new AgentSession."""
+        return AgentSession(
+            session_id=session_id,
+            agent_id=self.id,
+            user_id=user_id,
+            session_data={},
+            agent_data={"agent_id": self.id, "agent_name": self.name, "framework": self.framework},
+            metadata={},
+            runs=[],
+            created_at=int(time()),
+        )
+
+    def read_or_create_session(self, session_id: str, user_id: Optional[str] = None) -> AgentSession:
+        """Read a session from the DB, or create a new one."""
+        if self._session_cache and self._session_cache.session_id == session_id:
+            return self._session_cache
+
+        session = None
+        if self.db is not None and isinstance(self.db, BaseDb):
+            session = self.db.get_session(session_id=session_id, session_type=SessionType.AGENT)
+
+        if session is not None and isinstance(session, dict):
+            session = AgentSession.from_dict(session)
+
+        if session is None or not isinstance(session, AgentSession):
+            session = self._create_session(session_id, user_id)
+
+        self._session_cache = session
+        return session
+
+    async def aread_or_create_session(self, session_id: str, user_id: Optional[str] = None) -> AgentSession:
+        """Async read a session from the DB, or create a new one."""
         if self._session_cache and self._session_cache.session_id == session_id:
             return self._session_cache
 
@@ -383,35 +414,33 @@ class BaseExternalAgent:
         if self.db is not None:
             if isinstance(self.db, AsyncBaseDb):
                 session = await self.db.get_session(session_id=session_id, session_type=SessionType.AGENT)
-            else:
+            elif isinstance(self.db, BaseDb):
                 session = self.db.get_session(session_id=session_id, session_type=SessionType.AGENT)
 
         if session is not None and isinstance(session, dict):
             session = AgentSession.from_dict(session)
 
-        if session is None:
-            session = AgentSession(
-                session_id=session_id,
-                agent_id=self.id,
-                user_id=user_id,
-                session_data={},
-                agent_data={"agent_id": self.id, "agent_name": self.name, "framework": self.framework},
-                metadata={},
-                runs=[],
-                created_at=int(time()),
-            )
+        if session is None or not isinstance(session, AgentSession):
+            session = self._create_session(session_id, user_id)
 
-        self._session_cache = session  # type: ignore[assignment]
-        return session  # type: ignore[return-value]
+        self._session_cache = session
+        return session
 
-    async def _save_session(self, session: AgentSession) -> None:
-        """Persist a session to the DB."""
+    def upsert_session(self, session: AgentSession) -> None:
+        """Persist a session to the DB (sync)."""
+        if self.db is None or not isinstance(self.db, BaseDb):
+            return
+        session.updated_at = int(time())
+        self.db.upsert_session(session)
+
+    async def aupsert_session(self, session: AgentSession) -> None:
+        """Persist a session to the DB (async)."""
         if self.db is None:
             return
         session.updated_at = int(time())
         if isinstance(self.db, AsyncBaseDb):
             await self.db.upsert_session(session)
-        else:
+        elif isinstance(self.db, BaseDb):
             self.db.upsert_session(session)
 
     def _build_run_output(
@@ -525,7 +554,7 @@ class BaseExternalAgent:
         # Load session and provide history to the adapter
         session = None
         if self.db is not None:
-            session = await self._load_or_create_session(session_id, user_id)
+            session = await self.aread_or_create_session(session_id, user_id)
             kwargs["history"] = self._get_history_from_session(session)
 
         try:
@@ -554,7 +583,7 @@ class BaseExternalAgent:
             if session.runs is None:
                 session.runs = []
             session.runs.append(run_output)
-            await self._save_session(session)
+            await self.aupsert_session(session)
 
         return run_output
 
@@ -570,7 +599,7 @@ class BaseExternalAgent:
         # Load session and provide history to the adapter
         session = None
         if self.db is not None:
-            session = await self._load_or_create_session(session_id, user_id)
+            session = await self.aread_or_create_session(session_id, user_id)
             kwargs["history"] = self._get_history_from_session(session)
 
         yield RunStartedEvent(
@@ -620,7 +649,7 @@ class BaseExternalAgent:
                 if session.runs is None:
                     session.runs = []
                 session.runs.append(run_output)
-                await self._save_session(session)
+                await self.aupsert_session(session)
 
             yield RunCompletedEvent(
                 run_id=run_id,

--- a/libs/agno/agno/agents/base.py
+++ b/libs/agno/agno/agents/base.py
@@ -477,20 +477,39 @@ class BaseExternalAgent:
             created_at=now,
         )
 
-    def _get_history_from_session(self, session: AgentSession) -> List[Dict[str, str]]:
+    def _get_history_from_session(self, session: AgentSession) -> List[Dict[str, Any]]:
         """Extract conversation history from session runs for adapters to use.
 
         Includes user, assistant, and tool messages so adapters have full
         context of prior turns including tool call results.
+
+        Each entry has:
+        - role: "user", "assistant", or "tool"
+        - content: message text
+        - tool_calls: (assistant only) list of tool call dicts if present
+        - tool_call_id: (tool only) ID linking to the assistant's tool_call
         """
-        history: List[Dict[str, str]] = []
+        history: List[Dict[str, Any]] = []
         if not session.runs:
             return history
         for run in session.runs:
             if not isinstance(run, RunOutput) or not run.messages:
                 continue
             for msg in run.messages:
-                if msg.role in ("user", "assistant", "tool") and msg.content:
+                if msg.role == "assistant" and msg.tool_calls:
+                    # Assistant message with tool calls (no text content)
+                    history.append({
+                        "role": "assistant",
+                        "content": str(msg.content) if msg.content else "",
+                        "tool_calls": msg.tool_calls,
+                    })
+                elif msg.role == "tool" and msg.content:
+                    history.append({
+                        "role": "tool",
+                        "content": str(msg.content),
+                        "tool_call_id": msg.tool_call_id or "",
+                    })
+                elif msg.role in ("user", "assistant") and msg.content:
                     history.append({"role": msg.role, "content": str(msg.content)})
         return history
 

--- a/libs/agno/agno/agents/base.py
+++ b/libs/agno/agno/agents/base.py
@@ -41,8 +41,8 @@ class BaseExternalAgent:
     - Session persistence via Agno's DB (when db is configured)
 
     Subclasses must implement:
-    - _arun_impl(input, **kwargs) -> str  (non-streaming)
-    - _arun_stream_impl(input, **kwargs) -> AsyncIterator[RunOutputEvent]  (streaming)
+    - _arun_adapter(input, **kwargs) -> str  (non-streaming)
+    - _arun_adapter_stream(input, **kwargs) -> AsyncIterator[RunOutputEvent]  (streaming)
     """
 
     agent_id: str
@@ -529,7 +529,7 @@ class BaseExternalAgent:
             kwargs["history"] = self._get_history_from_session(session)
 
         try:
-            content = await self._arun_impl(input, run_id=run_id, **kwargs)
+            content = await self._arun_adapter(input, run_id=run_id, **kwargs)
             run_output = self._build_run_output(
                 run_id=run_id,
                 session_id=session_id,
@@ -586,7 +586,7 @@ class BaseExternalAgent:
             # Map tool_call_id -> ToolExecution for merging started+completed
             tool_map: Dict[str, ToolExecution] = {}
 
-            async for event in self._arun_stream_impl(input, run_id=run_id, **kwargs):
+            async for event in self._arun_adapter_stream(input, run_id=run_id, **kwargs):
                 if isinstance(event, RunContentEvent):
                     accumulated_content += event.content or ""
                 elif isinstance(event, ToolCallStartedEvent) and event.tool:
@@ -670,14 +670,14 @@ class BaseExternalAgent:
     # Subclass hooks (must be implemented by adapters)
     # ---------------------------------------------------------------------------
 
-    async def _arun_impl(self, input: Any, **kwargs: Any) -> Any:
+    async def _arun_adapter(self, input: Any, **kwargs: Any) -> Any:
         """Non-streaming execution. Return the response content."""
-        raise NotImplementedError(f"{self.__class__.__name__} must implement _arun_impl")
+        raise NotImplementedError(f"{self.__class__.__name__} must implement _arun_adapter")
 
-    async def _arun_stream_impl(self, input: Any, **kwargs: Any) -> AsyncIterator[RunOutputEvent]:
+    async def _arun_adapter_stream(self, input: Any, **kwargs: Any) -> AsyncIterator[RunOutputEvent]:
         """Streaming execution. Yield RunContentEvent, ToolCallStartedEvent, etc.
 
         Do NOT yield RunStartedEvent or RunCompletedEvent -- those are handled by the base class.
         """
-        raise NotImplementedError(f"{self.__class__.__name__} must implement _arun_stream_impl")
+        raise NotImplementedError(f"{self.__class__.__name__} must implement _arun_adapter_stream")
         yield  # type: ignore  # make this a generator

--- a/libs/agno/agno/agents/base.py
+++ b/libs/agno/agno/agents/base.py
@@ -401,8 +401,8 @@ class BaseExternalAgent:
                 created_at=int(time()),
             )
 
-        self._session_cache = session
-        return session
+        self._session_cache = session  # type: ignore[assignment]
+        return session  # type: ignore[return-value]
 
     async def _save_session(self, session: AgentSession) -> None:
         """Persist a session to the DB."""

--- a/libs/agno/agno/agents/base.py
+++ b/libs/agno/agno/agents/base.py
@@ -1,21 +1,27 @@
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from time import time
-from typing import Any, AsyncIterator, Iterator, List, Optional, Sequence, Union
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Sequence, Union
 from uuid import uuid4
 
+from agno.db.base import AsyncBaseDb, BaseDb, SessionType
 from agno.media import Audio, File, Image, Video
+from agno.models.message import Message
 from agno.models.response import ToolExecution
 from agno.run.agent import (
     RunCompletedEvent,
     RunContentEvent,
     RunErrorEvent,
     RunEvent,
+    RunInput,
     RunOutput,
     RunOutputEvent,
     RunStartedEvent,
+    ToolCallCompletedEvent,
+    ToolCallStartedEvent,
 )
 from agno.run.base import RunStatus
+from agno.session.agent import AgentSession
 from agno.utils.log import logger
 
 
@@ -32,6 +38,7 @@ class BaseExternalAgent:
     - Run lifecycle event emission (RunStarted, RunCompleted, RunError)
     - Tool call event wrapping
     - Sync/async run and print_response methods
+    - Session persistence via Agno's DB (when db is configured)
 
     Subclasses must implement:
     - _arun_impl(input, **kwargs) -> str  (non-streaming)
@@ -43,6 +50,10 @@ class BaseExternalAgent:
     description: Optional[str] = None
     framework: str = "external"
     markdown: bool = True
+    db: Optional[Union[BaseDb, AsyncBaseDb]] = None
+
+    # Session cache to avoid repeated DB reads within a session
+    _session_cache: Optional[AgentSession] = field(default=None, init=False, repr=False)
 
     @property
     def id(self) -> str:
@@ -360,37 +371,173 @@ class BaseExternalAgent:
             console.print(Group(*panels))
 
     # ---------------------------------------------------------------------------
+    # Session persistence helpers
+    # ---------------------------------------------------------------------------
+
+    async def _load_or_create_session(self, session_id: str, user_id: Optional[str] = None) -> AgentSession:
+        """Load an existing session from the DB, or create a new one."""
+        if self._session_cache and self._session_cache.session_id == session_id:
+            return self._session_cache
+
+        session = None
+        if self.db is not None:
+            if isinstance(self.db, AsyncBaseDb):
+                session = await self.db.get_session(session_id=session_id, session_type=SessionType.AGENT)
+            else:
+                session = self.db.get_session(session_id=session_id, session_type=SessionType.AGENT)
+
+        if session is not None and isinstance(session, dict):
+            session = AgentSession.from_dict(session)
+
+        if session is None:
+            session = AgentSession(
+                session_id=session_id,
+                agent_id=self.id,
+                user_id=user_id,
+                session_data={},
+                agent_data={"agent_id": self.id, "agent_name": self.name, "framework": self.framework},
+                metadata={},
+                runs=[],
+                created_at=int(time()),
+            )
+
+        self._session_cache = session
+        return session
+
+    async def _save_session(self, session: AgentSession) -> None:
+        """Persist a session to the DB."""
+        if self.db is None:
+            return
+        session.updated_at = int(time())
+        if isinstance(self.db, AsyncBaseDb):
+            await self.db.upsert_session(session)
+        else:
+            self.db.upsert_session(session)
+
+    def _build_run_output(
+        self,
+        run_id: str,
+        session_id: Optional[str],
+        user_id: Optional[str],
+        input_text: Any,
+        content: Any,
+        status: RunStatus,
+        tools: Optional[List[ToolExecution]] = None,
+    ) -> RunOutput:
+        """Build a RunOutput with properly populated messages for chat history."""
+        now = int(time())
+        messages: List[Message] = [
+            Message(role="user", content=str(input_text), created_at=now),
+        ]
+
+        # Add tool call messages between user and assistant
+        if tools:
+            for tool in tools:
+                # Tool call request
+                tool_call_data = {
+                    "id": tool.tool_call_id or str(uuid4()),
+                    "type": "function",
+                    "function": {
+                        "name": tool.tool_name or "",
+                        "arguments": str(tool.tool_args or {}),
+                    },
+                }
+                messages.append(
+                    Message(
+                        role="assistant",
+                        tool_calls=[tool_call_data],
+                        created_at=now,
+                    )
+                )
+                # Tool result
+                messages.append(
+                    Message(
+                        role="tool",
+                        tool_call_id=tool_call_data["id"],
+                        content=str(tool.result or ""),
+                        created_at=now,
+                    )
+                )
+
+        messages.append(
+            Message(role="assistant", content=str(content), created_at=now),
+        )
+
+        return RunOutput(
+            run_id=run_id,
+            agent_id=self.id,
+            agent_name=self.name,
+            session_id=session_id,
+            user_id=user_id,
+            input=RunInput(input_content=str(input_text)),
+            content=content,
+            messages=messages,
+            tools=tools,
+            status=status,
+            created_at=now,
+        )
+
+    def _get_history_from_session(self, session: AgentSession) -> List[Dict[str, str]]:
+        """Extract conversation history from session runs for adapters to use.
+
+        Includes user, assistant, and tool messages so adapters have full
+        context of prior turns including tool call results.
+        """
+        history: List[Dict[str, str]] = []
+        if not session.runs:
+            return history
+        for run in session.runs:
+            if not isinstance(run, RunOutput) or not run.messages:
+                continue
+            for msg in run.messages:
+                if msg.role in ("user", "assistant", "tool") and msg.content:
+                    history.append({"role": msg.role, "content": str(msg.content)})
+        return history
+
+    # ---------------------------------------------------------------------------
     # Internal: non-streaming
     # ---------------------------------------------------------------------------
 
     async def _arun_non_stream(self, input: Any, **kwargs: Any) -> RunOutput:
         run_id = str(uuid4())
-        session_id = kwargs.get("session_id")
+        session_id = kwargs.get("session_id") or str(uuid4())
         user_id = kwargs.get("user_id")
+
+        # Load session and provide history to the adapter
+        session = None
+        if self.db is not None:
+            session = await self._load_or_create_session(session_id, user_id)
+            kwargs["history"] = self._get_history_from_session(session)
+
         try:
             content = await self._arun_impl(input, run_id=run_id, **kwargs)
-            return RunOutput(
+            run_output = self._build_run_output(
                 run_id=run_id,
-                agent_id=self.id,
-                agent_name=self.name,
                 session_id=session_id,
                 user_id=user_id,
+                input_text=input,
                 content=content,
                 status=RunStatus.completed,
-                created_at=int(time()),
             )
         except Exception as e:
             logger.error(f"Error in {self.framework} agent '{self.id}': {e}")
-            return RunOutput(
+            run_output = self._build_run_output(
                 run_id=run_id,
-                agent_id=self.id,
-                agent_name=self.name,
                 session_id=session_id,
                 user_id=user_id,
+                input_text=input,
                 content=str(e),
                 status=RunStatus.error,
-                created_at=int(time()),
             )
+
+        # Persist the run to the session
+        if session is not None:
+            if session.runs is None:
+                session.runs = []
+            session.runs.append(run_output)
+            await self._save_session(session)
+
+        return run_output
 
     # ---------------------------------------------------------------------------
     # Internal: streaming
@@ -398,7 +545,14 @@ class BaseExternalAgent:
 
     async def _arun_stream(self, input: Any, **kwargs: Any) -> AsyncIterator[RunOutputEvent]:
         run_id = str(uuid4())
-        session_id = kwargs.get("session_id")
+        session_id = kwargs.get("session_id") or str(uuid4())
+        user_id = kwargs.get("user_id")
+
+        # Load session and provide history to the adapter
+        session = None
+        if self.db is not None:
+            session = await self._load_or_create_session(session_id, user_id)
+            kwargs["history"] = self._get_history_from_session(session)
 
         yield RunStartedEvent(
             run_id=run_id,
@@ -409,10 +563,45 @@ class BaseExternalAgent:
 
         try:
             accumulated_content = ""
+            accumulated_tools: List[ToolExecution] = []
+            # Map tool_call_id -> ToolExecution for merging started+completed
+            tool_map: Dict[str, ToolExecution] = {}
+
             async for event in self._arun_stream_impl(input, run_id=run_id, **kwargs):
                 if isinstance(event, RunContentEvent):
                     accumulated_content += event.content or ""
+                elif isinstance(event, ToolCallStartedEvent) and event.tool:
+                    tool = ToolExecution(
+                        tool_call_id=event.tool.tool_call_id,
+                        tool_name=event.tool.tool_name,
+                        tool_args=event.tool.tool_args,
+                    )
+                    tool_map[event.tool.tool_call_id or ""] = tool
+                    accumulated_tools.append(tool)
+                elif isinstance(event, ToolCallCompletedEvent) and event.tool:
+                    # Merge result into the existing tool entry
+                    existing = tool_map.get(event.tool.tool_call_id or "")
+                    if existing:
+                        existing.result = event.tool.result
+                    else:
+                        accumulated_tools.append(event.tool)
                 yield event
+
+            # Persist the run to the session
+            if session is not None:
+                run_output = self._build_run_output(
+                    run_id=run_id,
+                    session_id=session_id,
+                    user_id=user_id,
+                    input_text=input,
+                    content=accumulated_content,
+                    status=RunStatus.completed,
+                    tools=accumulated_tools if accumulated_tools else None,
+                )
+                if session.runs is None:
+                    session.runs = []
+                session.runs.append(run_output)
+                await self._save_session(session)
 
             yield RunCompletedEvent(
                 run_id=run_id,

--- a/libs/agno/agno/agents/claude/agent.py
+++ b/libs/agno/agno/agents/claude/agent.py
@@ -110,7 +110,9 @@ class ClaudeAgentSDK(BaseExternalAgent):
         opts.update(self.options_kwargs)
         return ClaudeAgentOptions(**opts)
 
-    async def _arun_adapter(self, input: Any, **kwargs: Any) -> str:
+    async def _arun_adapter(
+        self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any
+    ) -> str:
         """Non-streaming: collect all messages and return final content."""
         try:
             from claude_agent_sdk import AssistantMessage, ResultMessage, SystemMessage, TextBlock, query
@@ -141,7 +143,9 @@ class ClaudeAgentSDK(BaseExternalAgent):
 
         return result_text
 
-    async def _arun_adapter_stream(self, input: Any, **kwargs: Any) -> AsyncIterator[RunOutputEvent]:
+    async def _arun_adapter_stream(
+        self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any
+    ) -> AsyncIterator[RunOutputEvent]:
         """Streaming: yield token-level events using include_partial_messages.
 
         With include_partial_messages=True, the SDK yields StreamEvent objects

--- a/libs/agno/agno/agents/claude/agent.py
+++ b/libs/agno/agno/agents/claude/agent.py
@@ -176,6 +176,8 @@ class ClaudeAgentSDK(BaseExternalAgent):
         got_stream_events = False
         # Track tool call IDs already emitted via AssistantMessage to avoid duplicates
         emitted_tool_ids: set = set()
+        # Map tool_use_id -> (tool_name, tool_args) for carrying forward to ToolCallCompleted
+        tool_info_map: Dict[str, Dict[str, Any]] = {}
 
         async for message in query(prompt=str(input), options=options):
             if isinstance(message, StreamEvent):
@@ -222,6 +224,8 @@ class ClaudeAgentSDK(BaseExternalAgent):
                         tool_id = getattr(block, "id", str(uuid4()))
                         if tool_id not in emitted_tool_ids:
                             emitted_tool_ids.add(tool_id)
+                            tool_args = tool_input if isinstance(tool_input, dict) else {"input": tool_input}
+                            tool_info_map[tool_id] = {"name": tool_name, "args": tool_args}
                             yield ToolCallStartedEvent(
                                 run_id=run_id,
                                 agent_id=self.id,
@@ -229,7 +233,7 @@ class ClaudeAgentSDK(BaseExternalAgent):
                                 tool=ToolExecution(
                                     tool_call_id=tool_id,
                                     tool_name=tool_name,
-                                    tool_args=tool_input if isinstance(tool_input, dict) else {"input": tool_input},
+                                    tool_args=tool_args,
                                 ),
                             )
 
@@ -245,13 +249,16 @@ class ClaudeAgentSDK(BaseExternalAgent):
                                 result_str = " ".join(getattr(item, "text", str(item)) for item in result_content)
                             else:
                                 result_str = str(result_content) if result_content else ""
+                            # Look up tool name from the corresponding ToolCallStarted
+                            info = tool_info_map.get(tool_use_id, {})
                             yield ToolCallCompletedEvent(
                                 run_id=run_id,
                                 agent_id=self.id,
                                 agent_name=self.name or "",
                                 tool=ToolExecution(
                                     tool_call_id=tool_use_id,
-                                    tool_name="",
+                                    tool_name=info.get("name", ""),
+                                    tool_args=info.get("args"),
                                     result=result_str,
                                 ),
                             )

--- a/libs/agno/agno/agents/claude/agent.py
+++ b/libs/agno/agno/agents/claude/agent.py
@@ -110,7 +110,7 @@ class ClaudeAgentSDK(BaseExternalAgent):
         opts.update(self.options_kwargs)
         return ClaudeAgentOptions(**opts)
 
-    async def _arun_impl(self, input: Any, **kwargs: Any) -> str:
+    async def _arun_adapter(self, input: Any, **kwargs: Any) -> str:
         """Non-streaming: collect all messages and return final content."""
         try:
             from claude_agent_sdk import AssistantMessage, ResultMessage, SystemMessage, TextBlock, query
@@ -141,7 +141,7 @@ class ClaudeAgentSDK(BaseExternalAgent):
 
         return result_text
 
-    async def _arun_stream_impl(self, input: Any, **kwargs: Any) -> AsyncIterator[RunOutputEvent]:
+    async def _arun_adapter_stream(self, input: Any, **kwargs: Any) -> AsyncIterator[RunOutputEvent]:
         """Streaming: yield token-level events using include_partial_messages.
 
         With include_partial_messages=True, the SDK yields StreamEvent objects

--- a/libs/agno/agno/agents/dspy/agent.py
+++ b/libs/agno/agno/agents/dspy/agent.py
@@ -56,7 +56,7 @@ class DSPyAgent(BaseExternalAgent):
     program_kwargs: Dict[str, Any] = field(default_factory=dict)
     framework: str = "dspy"
 
-    async def _arun_impl(self, input: Any, **kwargs: Any) -> str:
+    async def _arun_adapter(self, input: Any, **kwargs: Any) -> str:
         """Non-streaming: run the DSPy program and return the output field."""
         try:
             import dspy
@@ -89,7 +89,7 @@ class DSPyAgent(BaseExternalAgent):
             return str(result)
         return str(output)
 
-    async def _arun_stream_impl(self, input: Any, **kwargs: Any) -> AsyncIterator[RunOutputEvent]:
+    async def _arun_adapter_stream(self, input: Any, **kwargs: Any) -> AsyncIterator[RunOutputEvent]:
         """Streaming: use dspy.streamify() for token-level streaming.
 
         dspy.streamify() yields three types:

--- a/libs/agno/agno/agents/dspy/agent.py
+++ b/libs/agno/agno/agents/dspy/agent.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Dict, List
+from typing import Any, AsyncIterator, Dict, List, Optional
 from uuid import uuid4
 
 from agno.agents.base import BaseExternalAgent
@@ -70,6 +70,22 @@ class DSPyAgent(BaseExternalAgent):
                 # This is fine; the global config from the main thread will be used.
                 pass
 
+    def _build_input_with_history(self, input: Any, history: Optional[List[Dict[str, str]]] = None) -> str:
+        """Prepend conversation history to the input for multi-turn context."""
+        if not history:
+            return str(input)
+
+        parts: List[str] = []
+        for msg in history:
+            if msg["role"] == "user":
+                parts.append(f"User: {msg['content']}")
+            elif msg["role"] == "tool":
+                parts.append(f"Tool Result: {msg['content']}")
+            else:
+                parts.append(f"Assistant: {msg['content']}")
+        parts.append(f"User: {input}")
+        return "\n\n".join(parts)
+
     async def _arun_impl(self, input: Any, **kwargs: Any) -> str:
         """Non-streaming: run the DSPy program and return the output field."""
         try:
@@ -80,8 +96,10 @@ class DSPyAgent(BaseExternalAgent):
         if self.program is None:
             raise ValueError("No program provided to DSPyAgent")
 
-        # Build input kwargs
-        program_input = {self.input_field: str(input)}
+        history = kwargs.pop("history", None)
+
+        # Build input kwargs with history prepended
+        program_input = {self.input_field: self._build_input_with_history(input, history)}
         program_input.update(self.program_kwargs)
 
         # DSPy modules are sync by default — use asyncify
@@ -119,9 +137,10 @@ class DSPyAgent(BaseExternalAgent):
             raise ValueError("No program provided to DSPyAgent")
 
         run_id = kwargs.get("run_id", str(uuid4()))
+        history = kwargs.pop("history", None)
 
-        # Build input kwargs
-        program_input = {self.input_field: str(input)}
+        # Build input kwargs with history prepended
+        program_input = {self.input_field: self._build_input_with_history(input, history)}
         program_input.update(self.program_kwargs)
 
         # DSPy caches LLM responses by default. Cached results skip token-level

--- a/libs/agno/agno/agents/dspy/agent.py
+++ b/libs/agno/agno/agents/dspy/agent.py
@@ -3,6 +3,7 @@ from typing import Any, AsyncIterator, Dict, List, Optional
 from uuid import uuid4
 
 from agno.agents.base import BaseExternalAgent
+from agno.agents.dspy.utils import build_input_with_history
 from agno.models.response import ToolExecution
 from agno.run.agent import (
     RunContentEvent,
@@ -55,37 +56,6 @@ class DSPyAgent(BaseExternalAgent):
     program_kwargs: Dict[str, Any] = field(default_factory=dict)
     framework: str = "dspy"
 
-    def _configure_lm(self) -> None:
-        """Configure DSPy LM on the current thread if provided."""
-        if self.lm is not None:
-            import dspy
-
-            # Use dspy.configure only from the main thread (at init time).
-            # For cross-thread safety, callers should configure at module level
-            # or use dspy.context(lm=...) which is thread-safe.
-            try:
-                dspy.configure(lm=self.lm)
-            except Exception:
-                # Thread-safety error — LM was already configured on another thread.
-                # This is fine; the global config from the main thread will be used.
-                pass
-
-    def _build_input_with_history(self, input: Any, history: Optional[List[Dict[str, str]]] = None) -> str:
-        """Prepend conversation history to the input for multi-turn context."""
-        if not history:
-            return str(input)
-
-        parts: List[str] = []
-        for msg in history:
-            if msg["role"] == "user":
-                parts.append(f"User: {msg['content']}")
-            elif msg["role"] == "tool":
-                parts.append(f"Tool Result: {msg['content']}")
-            else:
-                parts.append(f"Assistant: {msg['content']}")
-        parts.append(f"User: {input}")
-        return "\n\n".join(parts)
-
     async def _arun_impl(self, input: Any, **kwargs: Any) -> str:
         """Non-streaming: run the DSPy program and return the output field."""
         try:
@@ -99,7 +69,7 @@ class DSPyAgent(BaseExternalAgent):
         history = kwargs.pop("history", None)
 
         # Build input kwargs with history prepended
-        program_input = {self.input_field: self._build_input_with_history(input, history)}
+        program_input = {self.input_field: build_input_with_history(input, history)}
         program_input.update(self.program_kwargs)
 
         # DSPy modules are sync by default — use asyncify
@@ -140,7 +110,7 @@ class DSPyAgent(BaseExternalAgent):
         history = kwargs.pop("history", None)
 
         # Build input kwargs with history prepended
-        program_input = {self.input_field: self._build_input_with_history(input, history)}
+        program_input = {self.input_field: build_input_with_history(input, history)}
         program_input.update(self.program_kwargs)
 
         # DSPy caches LLM responses by default. Cached results skip token-level

--- a/libs/agno/agno/agents/dspy/agent.py
+++ b/libs/agno/agno/agents/dspy/agent.py
@@ -56,7 +56,9 @@ class DSPyAgent(BaseExternalAgent):
     program_kwargs: Dict[str, Any] = field(default_factory=dict)
     framework: str = "dspy"
 
-    async def _arun_adapter(self, input: Any, **kwargs: Any) -> str:
+    async def _arun_adapter(
+        self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any
+    ) -> str:
         """Non-streaming: run the DSPy program and return the output field."""
         try:
             import dspy
@@ -65,8 +67,6 @@ class DSPyAgent(BaseExternalAgent):
 
         if self.program is None:
             raise ValueError("No program provided to DSPyAgent")
-
-        history = kwargs.pop("history", None)
 
         # Build input kwargs with history prepended
         program_input = {self.input_field: build_input_with_history(input, history)}
@@ -89,7 +89,9 @@ class DSPyAgent(BaseExternalAgent):
             return str(result)
         return str(output)
 
-    async def _arun_adapter_stream(self, input: Any, **kwargs: Any) -> AsyncIterator[RunOutputEvent]:
+    async def _arun_adapter_stream(
+        self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any
+    ) -> AsyncIterator[RunOutputEvent]:
         """Streaming: use dspy.streamify() for token-level streaming.
 
         dspy.streamify() yields three types:
@@ -107,7 +109,6 @@ class DSPyAgent(BaseExternalAgent):
             raise ValueError("No program provided to DSPyAgent")
 
         run_id = kwargs.get("run_id", str(uuid4()))
-        history = kwargs.pop("history", None)
 
         # Build input kwargs with history prepended
         program_input = {self.input_field: build_input_with_history(input, history)}

--- a/libs/agno/agno/agents/dspy/utils.py
+++ b/libs/agno/agno/agents/dspy/utils.py
@@ -1,0 +1,24 @@
+"""Utility functions for the DSPy adapter."""
+
+from typing import Any, Dict, List, Optional
+
+
+def build_input_with_history(input: Any, history: Optional[List[Dict[str, Any]]] = None) -> str:
+    """Prepend conversation history to the input for multi-turn context.
+
+    Formats prior messages as a labeled conversation transcript that DSPy
+    can use as context for the current question.
+    """
+    if not history:
+        return str(input)
+
+    parts: List[str] = []
+    for msg in history:
+        if msg["role"] == "user":
+            parts.append(f"User: {msg['content']}")
+        elif msg["role"] == "tool":
+            parts.append(f"Tool Result: {msg['content']}")
+        else:
+            parts.append(f"Assistant: {msg['content']}")
+    parts.append(f"User: {input}")
+    return "\n\n".join(parts)

--- a/libs/agno/agno/agents/langgraph/agent.py
+++ b/libs/agno/agno/agents/langgraph/agent.py
@@ -61,17 +61,14 @@ class LangGraphAgent(BaseExternalAgent):
     config: Optional[Dict[str, Any]] = field(default=None)
     framework: str = "langgraph"
 
-    async def _arun_adapter(self, input: Any, **kwargs: Any) -> Any:
+    async def _arun_adapter(
+        self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any
+    ) -> Any:
         """Non-streaming LangGraph invocation."""
         try:
             from langchain_core.messages import AIMessage
         except ImportError:
             raise ImportError("langchain-core is required: pip install langchain-core langgraph")
-
-        if self.graph is None:
-            raise ValueError("No graph provided to LangGraphAgent")
-
-        history = kwargs.pop("history", None)
         # None input means replay/fork from checkpoint
         if input is None:
             graph_input = None
@@ -88,13 +85,14 @@ class LangGraphAgent(BaseExternalAgent):
                 return msg.content
         return str(result)
 
-    async def _arun_adapter_stream(self, input: Any, **kwargs: Any) -> AsyncIterator[RunOutputEvent]:
+    async def _arun_adapter_stream(
+        self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any
+    ) -> AsyncIterator[RunOutputEvent]:
         """Streaming LangGraph invocation with tool call visibility."""
         if self.graph is None:
             raise ValueError("No graph provided to LangGraphAgent")
 
         run_id = kwargs.get("run_id", str(uuid4()))
-        history = kwargs.pop("history", None)
         # None input means replay/fork from checkpoint
         if input is None:
             graph_input = None

--- a/libs/agno/agno/agents/langgraph/agent.py
+++ b/libs/agno/agno/agents/langgraph/agent.py
@@ -60,9 +60,9 @@ class LangGraphAgent(BaseExternalAgent):
     config: Optional[Dict[str, Any]] = field(default=None)
     framework: str = "langgraph"
 
-    def _build_messages_with_history(self, input: Any, history: Optional[List[Dict[str, str]]] = None) -> List[Any]:
+    def _build_messages_with_history(self, input: Any, history: Optional[List[Dict[str, Any]]] = None) -> List[Any]:
         """Build LangChain message list with conversation history prepended."""
-        from langchain_core.messages import AIMessage, HumanMessage
+        from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
         messages: List[Any] = []
         if history:
@@ -70,7 +70,32 @@ class LangGraphAgent(BaseExternalAgent):
                 if msg["role"] == "user":
                     messages.append(HumanMessage(content=msg["content"]))
                 elif msg["role"] == "assistant":
-                    messages.append(AIMessage(content=msg["content"]))
+                    tool_calls = msg.get("tool_calls")
+                    if tool_calls:
+                        # Convert from stored format {"type":"function","function":{"name","arguments"}}
+                        # to LangChain format {"id","name","args"}
+                        lc_tool_calls = []
+                        for tc in tool_calls:
+                            func = tc.get("function", {})
+                            args = func.get("arguments", "{}")
+                            if isinstance(args, str):
+                                import json
+
+                                try:
+                                    args = json.loads(args)
+                                except (json.JSONDecodeError, TypeError):
+                                    args = {"input": args}
+                            lc_tool_calls.append({
+                                "id": tc.get("id", ""),
+                                "name": func.get("name", ""),
+                                "args": args,
+                            })
+                        messages.append(AIMessage(content=msg.get("content", ""), tool_calls=lc_tool_calls))
+                    else:
+                        messages.append(AIMessage(content=msg["content"]))
+                elif msg["role"] == "tool":
+                    tool_call_id = msg.get("tool_call_id", "")
+                    messages.append(ToolMessage(content=msg["content"], tool_call_id=tool_call_id))
         if input is not None:
             messages.append(HumanMessage(content=str(input)))
         return messages

--- a/libs/agno/agno/agents/langgraph/agent.py
+++ b/libs/agno/agno/agents/langgraph/agent.py
@@ -78,7 +78,7 @@ class LangGraphAgent(BaseExternalAgent):
     async def _arun_impl(self, input: Any, **kwargs: Any) -> Any:
         """Non-streaming LangGraph invocation."""
         try:
-            from langchain_core.messages import AIMessage, HumanMessage
+            from langchain_core.messages import AIMessage
         except ImportError:
             raise ImportError("langchain-core is required: pip install langchain-core langgraph")
 
@@ -104,11 +104,6 @@ class LangGraphAgent(BaseExternalAgent):
 
     async def _arun_stream_impl(self, input: Any, **kwargs: Any) -> AsyncIterator[RunOutputEvent]:
         """Streaming LangGraph invocation with tool call visibility."""
-        try:
-            from langchain_core.messages import HumanMessage
-        except ImportError:
-            raise ImportError("langchain-core is required: pip install langchain-core langgraph")
-
         if self.graph is None:
             raise ValueError("No graph provided to LangGraphAgent")
 

--- a/libs/agno/agno/agents/langgraph/agent.py
+++ b/libs/agno/agno/agents/langgraph/agent.py
@@ -61,7 +61,7 @@ class LangGraphAgent(BaseExternalAgent):
     config: Optional[Dict[str, Any]] = field(default=None)
     framework: str = "langgraph"
 
-    async def _arun_impl(self, input: Any, **kwargs: Any) -> Any:
+    async def _arun_adapter(self, input: Any, **kwargs: Any) -> Any:
         """Non-streaming LangGraph invocation."""
         try:
             from langchain_core.messages import AIMessage
@@ -88,7 +88,7 @@ class LangGraphAgent(BaseExternalAgent):
                 return msg.content
         return str(result)
 
-    async def _arun_stream_impl(self, input: Any, **kwargs: Any) -> AsyncIterator[RunOutputEvent]:
+    async def _arun_adapter_stream(self, input: Any, **kwargs: Any) -> AsyncIterator[RunOutputEvent]:
         """Streaming LangGraph invocation with tool call visibility."""
         if self.graph is None:
             raise ValueError("No graph provided to LangGraphAgent")

--- a/libs/agno/agno/agents/langgraph/agent.py
+++ b/libs/agno/agno/agents/langgraph/agent.py
@@ -3,6 +3,7 @@ from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, cast
 from uuid import uuid4
 
 from agno.agents.base import BaseExternalAgent
+from agno.agents.langgraph.utils import build_messages_with_history
 from agno.models.response import ToolExecution
 from agno.run.agent import (
     RunContentEvent,
@@ -60,46 +61,6 @@ class LangGraphAgent(BaseExternalAgent):
     config: Optional[Dict[str, Any]] = field(default=None)
     framework: str = "langgraph"
 
-    def _build_messages_with_history(self, input: Any, history: Optional[List[Dict[str, Any]]] = None) -> List[Any]:
-        """Build LangChain message list with conversation history prepended."""
-        from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
-
-        messages: List[Any] = []
-        if history:
-            for msg in history:
-                if msg["role"] == "user":
-                    messages.append(HumanMessage(content=msg["content"]))
-                elif msg["role"] == "assistant":
-                    tool_calls = msg.get("tool_calls")
-                    if tool_calls:
-                        # Convert from stored format {"type":"function","function":{"name","arguments"}}
-                        # to LangChain format {"id","name","args"}
-                        lc_tool_calls = []
-                        for tc in tool_calls:
-                            func = tc.get("function", {})
-                            args = func.get("arguments", "{}")
-                            if isinstance(args, str):
-                                import json
-
-                                try:
-                                    args = json.loads(args)
-                                except (json.JSONDecodeError, TypeError):
-                                    args = {"input": args}
-                            lc_tool_calls.append({
-                                "id": tc.get("id", ""),
-                                "name": func.get("name", ""),
-                                "args": args,
-                            })
-                        messages.append(AIMessage(content=msg.get("content", ""), tool_calls=lc_tool_calls))
-                    else:
-                        messages.append(AIMessage(content=msg["content"]))
-                elif msg["role"] == "tool":
-                    tool_call_id = msg.get("tool_call_id", "")
-                    messages.append(ToolMessage(content=msg["content"], tool_call_id=tool_call_id))
-        if input is not None:
-            messages.append(HumanMessage(content=str(input)))
-        return messages
-
     async def _arun_impl(self, input: Any, **kwargs: Any) -> Any:
         """Non-streaming LangGraph invocation."""
         try:
@@ -115,7 +76,7 @@ class LangGraphAgent(BaseExternalAgent):
         if input is None:
             graph_input = None
         else:
-            graph_input = {self.input_key: self._build_messages_with_history(input, history)}
+            graph_input = {self.input_key: build_messages_with_history(input, history)}
         config = self._build_config(kwargs)
 
         result = await self.graph.ainvoke(graph_input, config=config)
@@ -138,7 +99,7 @@ class LangGraphAgent(BaseExternalAgent):
         if input is None:
             graph_input = None
         else:
-            graph_input = {self.input_key: self._build_messages_with_history(input, history)}
+            graph_input = {self.input_key: build_messages_with_history(input, history)}
         config = self._build_config(kwargs)
 
         async for event in self.graph.astream_events(graph_input, config=config, version="v2"):

--- a/libs/agno/agno/agents/langgraph/agent.py
+++ b/libs/agno/agno/agents/langgraph/agent.py
@@ -60,6 +60,21 @@ class LangGraphAgent(BaseExternalAgent):
     config: Optional[Dict[str, Any]] = field(default=None)
     framework: str = "langgraph"
 
+    def _build_messages_with_history(self, input: Any, history: Optional[List[Dict[str, str]]] = None) -> List[Any]:
+        """Build LangChain message list with conversation history prepended."""
+        from langchain_core.messages import AIMessage, HumanMessage
+
+        messages: List[Any] = []
+        if history:
+            for msg in history:
+                if msg["role"] == "user":
+                    messages.append(HumanMessage(content=msg["content"]))
+                elif msg["role"] == "assistant":
+                    messages.append(AIMessage(content=msg["content"]))
+        if input is not None:
+            messages.append(HumanMessage(content=str(input)))
+        return messages
+
     async def _arun_impl(self, input: Any, **kwargs: Any) -> Any:
         """Non-streaming LangGraph invocation."""
         try:
@@ -70,8 +85,12 @@ class LangGraphAgent(BaseExternalAgent):
         if self.graph is None:
             raise ValueError("No graph provided to LangGraphAgent")
 
+        history = kwargs.pop("history", None)
         # None input means replay/fork from checkpoint
-        graph_input = None if input is None else {self.input_key: [HumanMessage(content=str(input))]}
+        if input is None:
+            graph_input = None
+        else:
+            graph_input = {self.input_key: self._build_messages_with_history(input, history)}
         config = self._build_config(kwargs)
 
         result = await self.graph.ainvoke(graph_input, config=config)
@@ -94,8 +113,12 @@ class LangGraphAgent(BaseExternalAgent):
             raise ValueError("No graph provided to LangGraphAgent")
 
         run_id = kwargs.get("run_id", str(uuid4()))
+        history = kwargs.pop("history", None)
         # None input means replay/fork from checkpoint
-        graph_input = None if input is None else {self.input_key: [HumanMessage(content=str(input))]}
+        if input is None:
+            graph_input = None
+        else:
+            graph_input = {self.input_key: self._build_messages_with_history(input, history)}
         config = self._build_config(kwargs)
 
         async for event in self.graph.astream_events(graph_input, config=config, version="v2"):

--- a/libs/agno/agno/agents/langgraph/utils.py
+++ b/libs/agno/agno/agents/langgraph/utils.py
@@ -1,0 +1,48 @@
+"""Utility functions for the LangGraph adapter."""
+
+import json
+from typing import Any, Dict, List, Optional
+
+
+def build_messages_with_history(input: Any, history: Optional[List[Dict[str, Any]]] = None) -> List[Any]:
+    """Build a LangChain message list with conversation history prepended.
+
+    Converts the generic history format from BaseExternalAgent into proper
+    LangChain message types (HumanMessage, AIMessage, ToolMessage) with
+    correct tool_call linking.
+    """
+    from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+    messages: List[Any] = []
+    if history:
+        for msg in history:
+            if msg["role"] == "user":
+                messages.append(HumanMessage(content=msg["content"]))
+            elif msg["role"] == "assistant":
+                tool_calls = msg.get("tool_calls")
+                if tool_calls:
+                    # Convert from stored format {"type":"function","function":{"name","arguments"}}
+                    # to LangChain format {"id","name","args"}
+                    lc_tool_calls = []
+                    for tc in tool_calls:
+                        func = tc.get("function", {})
+                        args = func.get("arguments", "{}")
+                        if isinstance(args, str):
+                            try:
+                                args = json.loads(args)
+                            except (json.JSONDecodeError, TypeError):
+                                args = {"input": args}
+                        lc_tool_calls.append({
+                            "id": tc.get("id", ""),
+                            "name": func.get("name", ""),
+                            "args": args,
+                        })
+                    messages.append(AIMessage(content=msg.get("content", ""), tool_calls=lc_tool_calls))
+                else:
+                    messages.append(AIMessage(content=msg["content"]))
+            elif msg["role"] == "tool":
+                tool_call_id = msg.get("tool_call_id", "")
+                messages.append(ToolMessage(content=msg["content"], tool_call_id=tool_call_id))
+    if input is not None:
+        messages.append(HumanMessage(content=str(input)))
+    return messages

--- a/libs/agno/agno/os/app.py
+++ b/libs/agno/agno/os/app.py
@@ -516,7 +516,11 @@ class AgentOS:
             return
         for agent in self.agents:
             if not isinstance(agent, Agent):
-                # Skip RemoteAgent and external framework agents
+                # Inject db into external framework agents for session persistence.
+                # Skip RemoteAgent — it has its own remote storage.
+                if not isinstance(agent, RemoteAgent) and hasattr(agent, "db"):
+                    if self.db is not None and getattr(agent, "db", None) is None:
+                        agent.db = self.db
                 continue
             # Set the default db to agents without their own
             if self.db is not None and agent.db is None:

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -698,11 +698,13 @@ def get_agent_router(
                     agents.append(agent_response)
                 else:
                     # External framework agent -- create minimal response
+                    agent_db = getattr(agent, "db", None)
                     agents.append(
                         AgentResponse(
                             id=agent.id,
                             name=agent.name,
                             description=getattr(agent, "description", None),
+                            db_id=agent_db.id if agent_db else None,
                             metadata={"framework": getattr(agent, "framework", "external")},
                         )
                     )


### PR DESCRIPTION
## Summary

Adds support for running agents built with external frameworks (Claude Agent SDK, LangGraph, DSPy) through AgentOS — getting the full runtime (API, SSE streaming, UI, session persistence) without rewriting agent logic.

What's new:

- Session persistence — external agents store runs/messages in Agno's DB, with conversation history passed back to adapters for multi-turn context
- AgentOS integration — db injection, db_id in agent config

<img width="1726" height="1023" alt="image" src="https://github.com/user-attachments/assets/e298fb02-ba51-400f-91ee-37db5a4e9e8f" />

follow-up for: #7186 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
