### PR TITLE
Fix/qdrant native sparse vectors

### DIFF
--- a/libs/agno/agno/vectordb/qdrant/qdrant.py
+++ b/libs/agno/agno/vectordb/qdrant/qdrant.py
@@ -591,6 +591,8 @@ class Qdrant(VectorDb):
     ) -> List[models.ScoredPoint]:
         dense_embedding = self.embedder.get_embedding(query)
         sparse_embedding = self._get_sparse_vector(query)
+        if sparse_embedding is None:
+            raise ValueError("Sparse embedding could not be generated for hybrid search.")
         if hasattr(sparse_embedding, "as_object"):
             sparse_embedding = sparse_embedding.as_object()
         call = self.client.query_points(
@@ -649,6 +651,9 @@ class Qdrant(VectorDb):
         formatted_filters: Optional[models.Filter],
     ) -> List[models.ScoredPoint]:
         sparse_embedding = self._get_sparse_vector(query)
+        if sparse_embedding is None:
+            raise ValueError("Sparse embedding could not be generated for keyword search.")
+    
         if hasattr(sparse_embedding, "as_object"):
             sparse_embedding = sparse_embedding.as_object()
         call = self.client.query_points(
@@ -700,6 +705,8 @@ class Qdrant(VectorDb):
         formatted_filters: Optional[models.Filter],
     ) -> List[models.ScoredPoint]:
         sparse_embedding = self._get_sparse_vector(query)
+        if sparse_embedding is None:
+            raise ValueError("Sparse embedding could not be generated for keyword search.")
         if hasattr(sparse_embedding, "as_object"):
             sparse_embedding = sparse_embedding.as_object()
         call = await self.async_client.query_points(
@@ -721,6 +728,8 @@ class Qdrant(VectorDb):
     ) -> List[models.ScoredPoint]:
         dense_embedding = await self.embedder.async_get_embedding(query)
         sparse_embedding = self._get_sparse_vector(query)
+        if sparse_embedding is None:
+            raise ValueError("Sparse embedding could not be generated for hybrid search.")
         if hasattr(sparse_embedding, "as_object"):
             sparse_embedding = sparse_embedding.as_object()
         call = await self.async_client.query_points(

--- a/libs/agno/agno/vectordb/qdrant/qdrant.py
+++ b/libs/agno/agno/vectordb/qdrant/qdrant.py
@@ -590,12 +590,14 @@ class Qdrant(VectorDb):
         formatted_filters: Optional[models.Filter],
     ) -> List[models.ScoredPoint]:
         dense_embedding = self.embedder.get_embedding(query)
-        sparse_embedding = next(iter(self.sparse_encoder.embed([query]))).as_object()
+        sparse_embedding = self._get_sparse_vector(query)
+        if hasattr(sparse_embedding, "as_object"):
+            sparse_embedding = sparse_embedding.as_object()
         call = self.client.query_points(
             collection_name=self.collection,
             prefetch=[
                 models.Prefetch(
-                    query=models.SparseVector(**sparse_embedding),  # type: ignore  # type: ignore
+                    query=models.SparseVector(**sparse_embedding),   # type: ignore
                     limit=limit,
                     using=self.sparse_vector_name,
                 ),
@@ -714,7 +716,9 @@ class Qdrant(VectorDb):
         formatted_filters: Optional[models.Filter],
     ) -> List[models.ScoredPoint]:
         dense_embedding = await self.embedder.async_get_embedding(query)
-        sparse_embedding = next(iter(self.sparse_encoder.embed([query]))).as_object()
+        sparse_embedding = self._get_sparse_vector(query)
+        if hasattr(sparse_embedding, "as_object"):
+            sparse_embedding = sparse_embedding.as_object()
         call = await self.async_client.query_points(
             collection_name=self.collection,
             prefetch=[

--- a/libs/agno/agno/vectordb/qdrant/qdrant.py
+++ b/libs/agno/agno/vectordb/qdrant/qdrant.py
@@ -304,6 +304,29 @@ class Qdrant(VectorDb):
             )
             return len(scroll_result[0]) > 0
         return False
+    def _get_sparse_vector(self, text: str):
+        """
+        Return a sparse vector for the given text.
+
+        Priority:
+        1. Native sparse embeddings from the configured embedder
+        2. FastEmbed sparse encoder fallback
+        """
+        if not text:
+            return None
+
+        # Prefer native sparse embeddings from the configured embedder
+        if self.embedder is not None and hasattr(self.embedder, "get_sparse_embedding"):
+            sparse_vector = self.embedder.get_sparse_embedding(text)
+            if sparse_vector is not None:
+                return sparse_vector
+
+        # Fallback to FastEmbed sparse encoder, if available
+        if getattr(self, "sparse_encoder", None) is not None:
+            sparse_vectors = list(self.sparse_encoder.embed([text]))
+            if sparse_vectors:
+                return sparse_vectors[0]
+        return None
 
     def insert(
         self,

--- a/libs/agno/agno/vectordb/qdrant/qdrant.py
+++ b/libs/agno/agno/vectordb/qdrant/qdrant.py
@@ -648,7 +648,9 @@ class Qdrant(VectorDb):
         limit: int,
         formatted_filters: Optional[models.Filter],
     ) -> List[models.ScoredPoint]:
-        sparse_embedding = next(iter(self.sparse_encoder.embed([query]))).as_object()
+        sparse_embedding = self._get_sparse_vector(query)
+        if hasattr(sparse_embedding, "as_object"):
+            sparse_embedding = sparse_embedding.as_object()
         call = self.client.query_points(
             collection_name=self.collection,
             query=models.SparseVector(**sparse_embedding),  # type: ignore
@@ -697,7 +699,9 @@ class Qdrant(VectorDb):
         limit: int,
         formatted_filters: Optional[models.Filter],
     ) -> List[models.ScoredPoint]:
-        sparse_embedding = next(iter(self.sparse_encoder.embed([query]))).as_object()
+        sparse_embedding = self._get_sparse_vector(query)
+        if hasattr(sparse_embedding, "as_object"):
+            sparse_embedding = sparse_embedding.as_object()
         call = await self.async_client.query_points(
             collection_name=self.collection,
             query=models.SparseVector(**sparse_embedding),  # type: ignore

--- a/libs/agno/agno/vectordb/qdrant/qdrant.py
+++ b/libs/agno/agno/vectordb/qdrant/qdrant.py
@@ -304,6 +304,7 @@ class Qdrant(VectorDb):
             )
             return len(scroll_result[0]) > 0
         return False
+
     def _get_sparse_vector(self, text: str):
         """
         Return a sparse vector for the given text.
@@ -367,12 +368,13 @@ class Qdrant(VectorDb):
                 if self.search_type in [SearchType.hybrid]:
                     document.embed(embedder=self.embedder)
                     vector[self.dense_vector_name] = document.embedding
-
                 if self.search_type in [SearchType.keyword, SearchType.hybrid]:
-                    vector[self.sparse_vector_name] = next(
-                        iter(self.sparse_encoder.embed([document.content]))
-                    ).as_object()  # type: ignore
-
+                    sparse_embedding = self._get_sparse_vector(document.content)
+                    if sparse_embedding is None:
+                        raise ValueError("Sparse embedding could not be generated for document insert.")
+                    if hasattr(sparse_embedding, "as_object"):
+                        sparse_embedding = sparse_embedding.as_object()
+                    vector[self.sparse_vector_name] = sparse_embedding  # type: ignore
             # Create payload with document properties
             payload = {
                 "name": document.name,
@@ -472,13 +474,16 @@ class Qdrant(VectorDb):
             else:
                 # For other search types, use named vectors
                 vector = {}
-                if self.search_type in [SearchType.hybrid]:
-                    vector[self.dense_vector_name] = document.embedding  # Already embedded above
-
                 if self.search_type in [SearchType.keyword, SearchType.hybrid]:
-                    vector[self.sparse_vector_name] = next(
-                        iter(self.sparse_encoder.embed([document.content]))
-                    ).as_object()  # type: ignore
+                    sparse_embedding = self._get_sparse_vector(document.content)
+
+                    if sparse_embedding is None:
+                        raise ValueError("Sparse embedding could not be generated for async document insert.")
+
+                    if hasattr(sparse_embedding, "as_object"):
+                        sparse_embedding = sparse_embedding.as_object()
+
+                    vector[self.sparse_vector_name] = sparse_embedding  # type: ignore
 
             if self.search_type in [SearchType.keyword, SearchType.hybrid]:
                 vector[self.sparse_vector_name] = next(iter(self.sparse_encoder.embed([document.content]))).as_object()
@@ -599,7 +604,7 @@ class Qdrant(VectorDb):
             collection_name=self.collection,
             prefetch=[
                 models.Prefetch(
-                    query=models.SparseVector(**sparse_embedding),   # type: ignore
+                    query=models.SparseVector(**sparse_embedding),  # type: ignore
                     limit=limit,
                     using=self.sparse_vector_name,
                 ),
@@ -653,7 +658,7 @@ class Qdrant(VectorDb):
         sparse_embedding = self._get_sparse_vector(query)
         if sparse_embedding is None:
             raise ValueError("Sparse embedding could not be generated for keyword search.")
-    
+
         if hasattr(sparse_embedding, "as_object"):
             sparse_embedding = sparse_embedding.as_object()
         call = self.client.query_points(

--- a/libs/agno/tests/unit/vectordb/test_qdrantdb.py
+++ b/libs/agno/tests/unit/vectordb/test_qdrantdb.py
@@ -6,6 +6,7 @@ import pytest
 
 from agno.knowledge.document import Document
 from agno.vectordb.qdrant import Qdrant
+from agno.vectordb.search import SearchType
 
 
 @pytest.fixture
@@ -453,6 +454,7 @@ def tracking_embedder():
         return mock_embedding
 
     mock.get_embedding = sync_get_embedding
+    mock.get_sparse_embedding = Mock(return_value=None)
 
     async def async_get_embedding(text: str):
         mock.async_call_count += 1
@@ -491,6 +493,9 @@ async def test_async_hybrid_search_uses_async_embedder(tracking_embedder):
     Verify async hybrid search uses async embedder, not sync.
     """
     db = Qdrant(embedder=tracking_embedder, collection="test_collection")
+
+    # Force fallback to sparse encoder
+    db.embedder.get_sparse_embedding = Mock(return_value=None)
 
     # Mock the sparse encoder
     mock_sparse_embedding = Mock()
@@ -540,3 +545,109 @@ async def test_concurrent_async_searches_no_blocking(tracking_embedder):
     # All should use async embedder
     assert tracking_embedder.async_call_count == 5, "async_get_embedding should be called 5 times"
     assert tracking_embedder.sync_call_count == 0, "sync get_embedding should NOT be called"
+
+
+def test_get_sparse_vector_returns_native_sparse_embedding(mock_embedder):
+    db = Qdrant(embedder=mock_embedder, collection="test_collection")
+    native_sparse = {"indices": [1, 3], "values": [0.5, 0.8]}
+
+    mock_embedder.get_sparse_embedding = Mock(return_value=native_sparse)
+    db.sparse_encoder = Mock()
+
+    result = db._get_sparse_vector("hello world")
+
+    assert result == native_sparse
+    mock_embedder.get_sparse_embedding.assert_called_once_with("hello world")
+    db.sparse_encoder.embed.assert_not_called()
+
+
+def test_get_sparse_vector_falls_back_to_sparse_encoder_when_native_is_none(mock_embedder):
+    db = Qdrant(embedder=mock_embedder, collection="test_collection")
+    mock_embedder.get_sparse_embedding = Mock(return_value=None)
+
+    sparse_obj = Mock()
+    db.sparse_encoder = Mock()
+    db.sparse_encoder.embed.return_value = iter([sparse_obj])
+
+    result = db._get_sparse_vector("hello world")
+
+    assert result == sparse_obj
+    mock_embedder.get_sparse_embedding.assert_called_once_with("hello world")
+    db.sparse_encoder.embed.assert_called_once_with(["hello world"])
+
+
+def test_get_sparse_vector_returns_none_for_empty_text(mock_embedder):
+    db = Qdrant(embedder=mock_embedder, collection="test_collection")
+    mock_embedder.get_sparse_embedding = Mock()
+    db.sparse_encoder = Mock()
+
+    result = db._get_sparse_vector("")
+
+    assert result is None
+    mock_embedder.get_sparse_embedding.assert_not_called()
+    db.sparse_encoder.embed.assert_not_called()
+
+
+def test_run_keyword_search_sync_uses_sparse_helper(mock_embedder):
+    db = Qdrant(embedder=mock_embedder, collection="test_collection")
+    db.search_type = SearchType.keyword
+    db.sparse_vector_name = "sparse"
+
+    sparse_obj = Mock()
+    sparse_obj.as_object.return_value = {"indices": [1], "values": [0.7]}
+
+    db._get_sparse_vector = Mock(return_value=sparse_obj)
+    db._client = Mock()
+
+    query_response = Mock()
+    query_response.points = []
+    db._client.query_points.return_value = query_response
+
+    results = db._run_keyword_search_sync("hello", limit=5, formatted_filters=None)
+
+    db._get_sparse_vector.assert_called_once_with("hello")
+    db._client.query_points.assert_called_once()
+    assert results == []
+
+
+def test_run_hybrid_search_sync_uses_sparse_helper(mock_embedder):
+    db = Qdrant(embedder=mock_embedder, collection="test_collection")
+    db.search_type = SearchType.hybrid
+    db.sparse_vector_name = "sparse"
+    db.dense_vector_name = "dense"
+
+    mock_embedder.get_embedding = Mock(return_value=[0.1] * 1024)
+
+    sparse_obj = Mock()
+    sparse_obj.as_object.return_value = {"indices": [1], "values": [0.7]}
+
+    db._get_sparse_vector = Mock(return_value=sparse_obj)
+    db._client = Mock()
+
+    query_response = Mock()
+    query_response.points = []
+    db._client.query_points.return_value = query_response
+
+    results = db._run_hybrid_search_sync("hello", limit=5, formatted_filters=None)
+
+    mock_embedder.get_embedding.assert_called_once_with("hello")
+    db._get_sparse_vector.assert_called_once_with("hello")
+    db._client.query_points.assert_called_once()
+    assert results == []
+
+
+def test_run_keyword_search_sync_raises_when_sparse_embedding_is_none(mock_embedder):
+    db = Qdrant(embedder=mock_embedder, collection="test_collection")
+    db._get_sparse_vector = Mock(return_value=None)
+
+    with pytest.raises(ValueError, match="Sparse embedding could not be generated for keyword search."):
+        db._run_keyword_search_sync("hello", limit=5, formatted_filters=None)
+
+
+def test_run_hybrid_search_sync_raises_when_sparse_embedding_is_none(mock_embedder):
+    db = Qdrant(embedder=mock_embedder, collection="test_collection")
+    mock_embedder.get_embedding = Mock(return_value=[0.1] * 1024)
+    db._get_sparse_vector = Mock(return_value=None)
+
+    with pytest.raises(ValueError, match="Sparse embedding could not be generated for hybrid search."):
+        db._run_hybrid_search_sync("hello", limit=5, formatted_filters=None)


### PR DESCRIPTION
## Summary

This PR fixes Qdrant sparse vector handling by preferring embedder-native sparse vectors when available, while preserving the existing FastEmbed BM25 fallback.

fixes #7432

## Problem

Currently, the Agno Qdrant integration always relies on FastEmbed's `SparseTextEmbedding` for keyword and hybrid sparse vector generation, even when the configured embedder already provides sparse vectors natively.

This creates two issues:

1. hybrid retrieval may combine dense vectors from the configured embedder with sparse vectors from a different representation space
2. FastEmbed becomes an unnecessary dependency for embedders that already support sparse output

A real example is `bge-m3`, which can produce sparse vectors natively.

## Type of change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Summary of Changes
- Added `_get_sparse_vector()`, which prioritizes native sparse embeddings from the configured embedder and only uses FastEmbed as a fallback.
- Updated both hybrid and keyword search paths to use the new sparse resolution logic.
- Updated document insert and async insert paths to use the same native-sparse-first resolution as retrieval.
- Ensured sparse vector handling is consistent across both indexing and search paths.
- Added unit tests covering native sparse priority, fallback behavior, and the updated sparse resolution flow.

## Checklist

- [X] Code complies with style guidelines
- [X] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [X] Self-review completed
- [X] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [X] Tested in clean environment
- [X] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [X] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Validation

Added unit tests covering the native sparse vector resolution changes introduced in this PR.

Tests added/updated cover:

- `_get_sparse_vector()` behavior:
  - native sparse embedding is preferred when available
  - FastEmbed is used as fallback when native sparse output is unavailable
  - empty input returns `None`

- keyword and hybrid search paths:
  - both use the new sparse helper
  - both raise a clear error when sparse vectors cannot be generated

- async hybrid search behavior:
  - continues using the async dense embedder path correctly
  - works with the updated sparse resolution flow

This fixes the issue where Qdrant always depended on FastEmbed-style sparse generation even when the configured embedder already provides sparse vectors natively.