### PR TITLE
fix: suppress document citations when structured output is active

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -435,6 +435,7 @@ class Claude(Model):
             compress_tool_results=True,
             append_trailing_user_message=self.append_trailing_user_message,
             trailing_user_message_content=self.trailing_user_message_content,
+            enable_citations=self._build_output_format(response_format) is None,
         )
         anthropic_tools = None
         if tools:
@@ -461,6 +462,7 @@ class Claude(Model):
             compress_tool_results=True,
             append_trailing_user_message=self.append_trailing_user_message,
             trailing_user_message_content=self.trailing_user_message_content,
+            enable_citations=self._build_output_format(response_format) is None,
         )
         anthropic_tools = None
         if tools:
@@ -651,6 +653,7 @@ class Claude(Model):
                 compress_tool_results=compress_tool_results,
                 append_trailing_user_message=self.append_trailing_user_message,
                 trailing_user_message_content=self.trailing_user_message_content,
+                enable_citations=self._build_output_format(response_format) is None,
             )
             request_kwargs = self._prepare_request_kwargs(
                 system_message, tools=tools, response_format=response_format, messages=messages
@@ -710,6 +713,7 @@ class Claude(Model):
             compress_tool_results=compress_tool_results,
             append_trailing_user_message=self.append_trailing_user_message,
             trailing_user_message_content=self.trailing_user_message_content,
+            enable_citations=self._build_output_format(response_format) is None,
         )
         request_kwargs = self._prepare_request_kwargs(
             system_message, tools=tools, response_format=response_format, messages=messages
@@ -760,6 +764,7 @@ class Claude(Model):
                 compress_tool_results=compress_tool_results,
                 append_trailing_user_message=self.append_trailing_user_message,
                 trailing_user_message_content=self.trailing_user_message_content,
+                enable_citations=self._build_output_format(response_format) is None,
             )
             request_kwargs = self._prepare_request_kwargs(
                 system_message, tools=tools, response_format=response_format, messages=messages
@@ -818,6 +823,7 @@ class Claude(Model):
                 compress_tool_results=compress_tool_results,
                 append_trailing_user_message=self.append_trailing_user_message,
                 trailing_user_message_content=self.trailing_user_message_content,
+                enable_citations=self._build_output_format(response_format) is None,
             )
             request_kwargs = self._prepare_request_kwargs(
                 system_message, tools=tools, response_format=response_format, messages=messages

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -125,6 +125,11 @@ class Claude(Model):
         None  # e.g., [{"type": "anthropic", "skill_id": "pptx", "version": "latest"}]
     )
 
+    # Whether to attach citations to document blocks.
+    # Defaults to True. Automatically suppressed when structured output is active
+    # because Anthropic rejects citations + output_format together.
+    citations: bool = True
+
     # Claude 4.6+ does not support assistant message prefill.
     # Set to True to append a trailing user turn when the conversation ends with an assistant message.
     # Defaults to True for Claude 4.6+ models.
@@ -435,7 +440,7 @@ class Claude(Model):
             compress_tool_results=True,
             append_trailing_user_message=self.append_trailing_user_message,
             trailing_user_message_content=self.trailing_user_message_content,
-            enable_citations=self._build_output_format(response_format) is None,
+            enable_citations=self.citations and self._build_output_format(response_format) is None,
         )
         anthropic_tools = None
         if tools:
@@ -462,7 +467,7 @@ class Claude(Model):
             compress_tool_results=True,
             append_trailing_user_message=self.append_trailing_user_message,
             trailing_user_message_content=self.trailing_user_message_content,
-            enable_citations=self._build_output_format(response_format) is None,
+            enable_citations=self.citations and self._build_output_format(response_format) is None,
         )
         anthropic_tools = None
         if tools:
@@ -653,7 +658,7 @@ class Claude(Model):
                 compress_tool_results=compress_tool_results,
                 append_trailing_user_message=self.append_trailing_user_message,
                 trailing_user_message_content=self.trailing_user_message_content,
-                enable_citations=self._build_output_format(response_format) is None,
+                enable_citations=self.citations and self._build_output_format(response_format) is None,
             )
             request_kwargs = self._prepare_request_kwargs(
                 system_message, tools=tools, response_format=response_format, messages=messages
@@ -713,7 +718,7 @@ class Claude(Model):
             compress_tool_results=compress_tool_results,
             append_trailing_user_message=self.append_trailing_user_message,
             trailing_user_message_content=self.trailing_user_message_content,
-            enable_citations=self._build_output_format(response_format) is None,
+            enable_citations=self.citations and self._build_output_format(response_format) is None,
         )
         request_kwargs = self._prepare_request_kwargs(
             system_message, tools=tools, response_format=response_format, messages=messages
@@ -764,7 +769,7 @@ class Claude(Model):
                 compress_tool_results=compress_tool_results,
                 append_trailing_user_message=self.append_trailing_user_message,
                 trailing_user_message_content=self.trailing_user_message_content,
-                enable_citations=self._build_output_format(response_format) is None,
+                enable_citations=self.citations and self._build_output_format(response_format) is None,
             )
             request_kwargs = self._prepare_request_kwargs(
                 system_message, tools=tools, response_format=response_format, messages=messages
@@ -823,7 +828,7 @@ class Claude(Model):
                 compress_tool_results=compress_tool_results,
                 append_trailing_user_message=self.append_trailing_user_message,
                 trailing_user_message_content=self.trailing_user_message_content,
-                enable_citations=self._build_output_format(response_format) is None,
+                enable_citations=self.citations and self._build_output_format(response_format) is None,
             )
             request_kwargs = self._prepare_request_kwargs(
                 system_message, tools=tools, response_format=response_format, messages=messages

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -201,9 +201,15 @@ def _format_image_for_message(image: Image) -> Optional[Dict[str, Any]]:
         return None
 
 
-def _format_file_for_message(file: File) -> Optional[Dict[str, Any]]:
+def _format_file_for_message(file: File, enable_citations: bool = True) -> Optional[Dict[str, Any]]:
     """
     Add a document url or base64 encoded content to a message.
+
+    Args:
+        file: The file to format.
+        enable_citations: When False, citations are omitted from document blocks.
+            Anthropic rejects citations + output_format together, so callers must
+            disable citations when structured output is active.
     """
 
     mime_mapping: dict[str, str] = {
@@ -233,15 +239,16 @@ def _format_file_for_message(file: File) -> Optional[Dict[str, Any]]:
             },
         }
 
+    document: Optional[Dict[str, Any]] = None
+
     # Case 1: Document is a URL
     if file.url is not None:
-        return {
+        document = {
             "type": "document",
             "source": {
                 "type": "url",
                 "url": file.url,
             },
-            "citations": {"enabled": True},
         }
     # Case 2: Document is a local file path
     elif file.filepath is not None:
@@ -263,24 +270,22 @@ def _format_file_for_message(file: File) -> Optional[Dict[str, Any]]:
             source_type = mime_mapping.get(media_type, "base64")
 
             if source_type == "text":
-                return {
+                document = {
                     "type": "document",
                     "source": {
                         "type": "text",
                         "media_type": media_type,
                         "data": raw_bytes.decode("utf-8", errors="replace"),
                     },
-                    "citations": {"enabled": True},
                 }
             else:
-                return {
+                document = {
                     "type": "document",
                     "source": {
                         "type": "base64",
                         "media_type": media_type,
                         "data": base64.standard_b64encode(raw_bytes).decode("utf-8"),
                     },
-                    "citations": {"enabled": True},
                 }
         else:
             log_error(f"Document file not found: {file}")
@@ -292,28 +297,29 @@ def _format_file_for_message(file: File) -> Optional[Dict[str, Any]]:
         source_type = mime_mapping.get(media_type, "base64")
 
         if source_type == "text":
-            return {
+            document = {
                 "type": "document",
                 "source": {
                     "type": "text",
                     "media_type": media_type,
                     "data": file.content.decode("utf-8", errors="replace"),
                 },
-                "citations": {"enabled": True},
             }
         else:
             import base64
 
-            return {
+            document = {
                 "type": "document",
                 "source": {
                     "type": "base64",
                     "media_type": media_type,
                     "data": base64.standard_b64encode(file.content).decode("utf-8"),
                 },
-                "citations": {"enabled": True},
             }
-    return None
+
+    if document is not None and enable_citations:
+        document["citations"] = {"enabled": True}
+    return document
 
 
 def format_messages(
@@ -321,6 +327,7 @@ def format_messages(
     compress_tool_results: bool = False,
     append_trailing_user_message: Optional[bool] = False,
     trailing_user_message_content: str = "continue",
+    enable_citations: bool = True,
 ) -> Tuple[List[Dict[str, Union[str, list]]], str]:
     """
     Process the list of messages and separate them into API messages and system messages.
@@ -331,6 +338,8 @@ def format_messages(
         append_trailing_user_message: If True, append a dummy user message when the conversation
             ends with an assistant turn. Required for models that do not support assistant prefill.
         trailing_user_message_content: The text content of the injected trailing user message.
+        enable_citations: When True (default), document blocks include citations.
+            Set to False when structured output is active to avoid Anthropic API errors.
 
     Returns:
         Tuple[List[Dict[str, Union[str, list]]], str]: A tuple containing the list of API messages and the concatenated system messages.
@@ -362,7 +371,7 @@ def format_messages(
 
             if message.files is not None:
                 for file in message.files:
-                    file_content = _format_file_for_message(file)
+                    file_content = _format_file_for_message(file, enable_citations=enable_citations)
                     if file_content:
                         content.append(file_content)
 

--- a/libs/agno/tests/unit/utils/test_claude.py
+++ b/libs/agno/tests/unit/utils/test_claude.py
@@ -86,3 +86,31 @@ class TestFormatFileForMessage:
 
         assert result["source"]["data"] == csv_content
         assert result["source"]["data"] != base64.standard_b64encode(csv_content.encode()).decode()
+
+    def test_enable_citations_false_omits_citations(self, tmp_path):
+        """Anthropic rejects citations + output_format; caller must be able to suppress."""
+        p = tmp_path / "doc.pdf"
+        p.write_bytes(b"%PDF-1.4 fake")
+
+        result = _format_file_for_message(File(filepath=str(p), mime_type="application/pdf"), enable_citations=False)
+
+        assert "citations" not in result
+
+    def test_enable_citations_true_adds_citations(self, tmp_path):
+        p = tmp_path / "doc.pdf"
+        p.write_bytes(b"%PDF-1.4 fake")
+
+        result = _format_file_for_message(File(filepath=str(p), mime_type="application/pdf"), enable_citations=True)
+
+        assert result["citations"] == {"enabled": True}
+
+    def test_url_file_citations_suppressed_when_disabled(self):
+        result = _format_file_for_message(File(url="https://example.com/doc.pdf"), enable_citations=False)
+
+        assert result["source"]["type"] == "url"
+        assert "citations" not in result
+
+    def test_bytes_content_citations_suppressed_when_disabled(self):
+        result = _format_file_for_message(File(content=b"fake", mime_type="application/pdf"), enable_citations=False)
+
+        assert "citations" not in result


### PR DESCRIPTION
## Summary

Anthropic rejects `citations` + `output_format` together with a 400 error. This PR:

1. Adds a `citations` parameter to the `Claude` model (default `True`) so users can explicitly disable document citations: `Claude(id="claude-sonnet-4-5", citations=False)`
2. Automatically suppresses citations when structured output is active, preventing the 400 error

Alternative to #7511 -- keeps Anthropic-specific config on the `Claude` model instead of adding it to the shared `File` class in `media.py`.

**Files changed:**
- `libs/agno/agno/models/anthropic/claude.py` -- `citations: bool = True` field; all 6 `format_messages` call sites pass `enable_citations=self.citations and self._build_output_format(response_format) is None`
- `libs/agno/agno/utils/models/claude.py` -- `_format_file_for_message` and `format_messages` accept `enable_citations` param; citations dict conditionally attached
- `libs/agno/tests/unit/utils/test_claude.py` -- 4 new tests

Related: #7511

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

This is a less intrusive alternative to #7511. Key differences:
- Citation control lives on `Claude` model, not on the shared `File` class -- no Anthropic-specific fields leaking to other providers
- No new wrapper methods -- reuses existing `_build_output_format` directly
- Simpler: 3 files changed vs 5, ~60 lines vs ~300