### PR TITLE
fix: include remote content source identity in content hash

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -2152,6 +2152,60 @@ class Knowledge(RemoteKnowledge):
     # PRIVATE - CONVERSION & DATA METHODS
     # ==========================================
 
+    @staticmethod
+    def _build_remote_content_identity(remote_content: Optional["RemoteContent"]) -> Optional[str]:
+        """Return a stable identity string for a remote content reference.
+
+        The reference's source scope (bucket, repo, site, container) plus its
+        in-scope path must be included in the content hash so that the same
+        filename pulled from two different sources does not collide.
+        """
+        if remote_content is None:
+            return None
+
+        from agno.knowledge.remote_content.remote_content import (
+            AzureBlobContent,
+            GCSContent,
+            GitHubContent,
+            S3Content,
+            SharePointContent,
+        )
+
+        if isinstance(remote_content, GitHubContent):
+            scope = remote_content.repo or ""
+            in_scope = remote_content.file_path or remote_content.folder_path or ""
+            branch = remote_content.branch or ""
+            return f"github:{scope}@{branch}:{in_scope}"
+
+        if isinstance(remote_content, S3Content):
+            scope = remote_content.bucket_name or (
+                remote_content.bucket.name if remote_content.bucket is not None else ""
+            )
+            in_scope = (
+                remote_content.key
+                or remote_content.prefix
+                or (remote_content.object.name if remote_content.object is not None else "")
+            )
+            return f"s3:{scope}:{in_scope}"
+
+        if isinstance(remote_content, GCSContent):
+            scope = remote_content.bucket_name or (
+                remote_content.bucket.name if remote_content.bucket is not None else ""
+            )
+            in_scope = remote_content.blob_name or remote_content.prefix or ""
+            return f"gcs:{scope}:{in_scope}"
+
+        if isinstance(remote_content, SharePointContent):
+            scope = f"{remote_content.site_path or ''}/{remote_content.drive_id or ''}"
+            in_scope = remote_content.file_path or remote_content.folder_path or ""
+            return f"sharepoint:{remote_content.config_id}:{scope}:{in_scope}"
+
+        if isinstance(remote_content, AzureBlobContent):
+            in_scope = remote_content.blob_name or remote_content.prefix or ""
+            return f"azureblob:{remote_content.config_id}:{in_scope}"
+
+        return None
+
     def _build_content_hash(self, content: Content) -> str:
         """
         Build the content hash from the content.
@@ -2172,6 +2226,10 @@ class Knowledge(RemoteKnowledge):
             hash_parts.append(content.name)
         if content.description:
             hash_parts.append(content.description)
+
+        remote_identity = self._build_remote_content_identity(content.remote_content)
+        if remote_identity:
+            hash_parts.append(remote_identity)
 
         if content.path:
             hash_parts.append(str(content.path))

--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -2177,7 +2177,7 @@ class Knowledge(RemoteKnowledge):
             branch = remote_content.branch or ""
             return f"github:{scope}@{branch}:{in_scope}"
 
-        if isinstance(remote_content, S3Content):
+        elif isinstance(remote_content, S3Content):
             scope = remote_content.bucket_name or (
                 remote_content.bucket.name if remote_content.bucket is not None else ""
             )
@@ -2188,19 +2188,19 @@ class Knowledge(RemoteKnowledge):
             )
             return f"s3:{scope}:{in_scope}"
 
-        if isinstance(remote_content, GCSContent):
+        elif isinstance(remote_content, GCSContent):
             scope = remote_content.bucket_name or (
                 remote_content.bucket.name if remote_content.bucket is not None else ""
             )
             in_scope = remote_content.blob_name or remote_content.prefix or ""
             return f"gcs:{scope}:{in_scope}"
 
-        if isinstance(remote_content, SharePointContent):
+        elif isinstance(remote_content, SharePointContent):
             scope = f"{remote_content.site_path or ''}/{remote_content.drive_id or ''}"
             in_scope = remote_content.file_path or remote_content.folder_path or ""
             return f"sharepoint:{remote_content.config_id}:{scope}:{in_scope}"
 
-        if isinstance(remote_content, AzureBlobContent):
+        elif isinstance(remote_content, AzureBlobContent):
             in_scope = remote_content.blob_name or remote_content.prefix or ""
             return f"azureblob:{remote_content.config_id}:{in_scope}"
 

--- a/libs/agno/tests/unit/knowledge/test_knowledge_content_hash.py
+++ b/libs/agno/tests/unit/knowledge/test_knowledge_content_hash.py
@@ -584,3 +584,107 @@ def test_document_content_hash_fallback_to_content_hash():
     assert hash1 != hash2
     # Same content should produce same hash
     assert hash1 == hash3
+
+
+def test_github_same_path_different_repos_produces_different_hashes():
+    """Two GitHub uploads with the same file path but different repos must not collide."""
+    from agno.knowledge.remote_content.github import GitHubConfig
+
+    knowledge = Knowledge(vector_db=MockVectorDb())
+    cfg = GitHubConfig(id="gh", name="GH", branch="main")
+
+    content_a = Content(name="README.md", remote_content=cfg.file("README.md", repo="orgA/x"))
+    content_b = Content(name="README.md", remote_content=cfg.file("README.md", repo="orgB/y"))
+
+    assert knowledge._build_content_hash(content_a) != knowledge._build_content_hash(content_b)
+
+
+def test_github_same_repo_same_path_produces_same_hash():
+    """Deduplication still works when the full source identity matches."""
+    from agno.knowledge.remote_content.github import GitHubConfig
+
+    knowledge = Knowledge(vector_db=MockVectorDb())
+    cfg = GitHubConfig(id="gh", name="GH", branch="main")
+
+    content_a = Content(name="README.md", remote_content=cfg.file("README.md", repo="orgA/x"))
+    content_b = Content(name="README.md", remote_content=cfg.file("README.md", repo="orgA/x"))
+
+    assert knowledge._build_content_hash(content_a) == knowledge._build_content_hash(content_b)
+
+
+def test_github_different_branches_produces_different_hashes():
+    """A branch override is part of the source identity and must affect the hash."""
+    from agno.knowledge.remote_content.github import GitHubConfig
+
+    knowledge = Knowledge(vector_db=MockVectorDb())
+    cfg = GitHubConfig(id="gh", name="GH", repo="orgA/x")
+
+    content_a = Content(name="README.md", remote_content=cfg.file("README.md", branch="main"))
+    content_b = Content(name="README.md", remote_content=cfg.file("README.md", branch="dev"))
+
+    assert knowledge._build_content_hash(content_a) != knowledge._build_content_hash(content_b)
+
+
+def test_s3_same_key_different_buckets_produces_different_hashes():
+    """Same S3 key pulled from two different buckets must not collide."""
+    from agno.knowledge.remote_content.remote_content import S3Content
+
+    knowledge = Knowledge(vector_db=MockVectorDb())
+
+    content_a = Content(name="report.pdf", remote_content=S3Content(bucket_name="bucket-a", key="report.pdf"))
+    content_b = Content(name="report.pdf", remote_content=S3Content(bucket_name="bucket-b", key="report.pdf"))
+
+    assert knowledge._build_content_hash(content_a) != knowledge._build_content_hash(content_b)
+
+
+def test_gcs_same_blob_different_buckets_produces_different_hashes():
+    """Same GCS blob name pulled from two different buckets must not collide."""
+    from agno.knowledge.remote_content.remote_content import GCSContent
+
+    knowledge = Knowledge(vector_db=MockVectorDb())
+
+    content_a = Content(name="data.csv", remote_content=GCSContent(bucket_name="bucket-a", blob_name="data.csv"))
+    content_b = Content(name="data.csv", remote_content=GCSContent(bucket_name="bucket-b", blob_name="data.csv"))
+
+    assert knowledge._build_content_hash(content_a) != knowledge._build_content_hash(content_b)
+
+
+def test_azure_blob_same_blob_different_configs_produces_different_hashes():
+    """Same Azure blob name from two different configs (different containers) must not collide."""
+    from agno.knowledge.remote_content.remote_content import AzureBlobContent
+
+    knowledge = Knowledge(vector_db=MockVectorDb())
+
+    content_a = Content(name="file.txt", remote_content=AzureBlobContent(config_id="az-a", blob_name="file.txt"))
+    content_b = Content(name="file.txt", remote_content=AzureBlobContent(config_id="az-b", blob_name="file.txt"))
+
+    assert knowledge._build_content_hash(content_a) != knowledge._build_content_hash(content_b)
+
+
+def test_sharepoint_same_path_different_sites_produces_different_hashes():
+    """Same SharePoint file path from two different sites must not collide."""
+    from agno.knowledge.remote_content.remote_content import SharePointContent
+
+    knowledge = Knowledge(vector_db=MockVectorDb())
+
+    content_a = Content(
+        name="spec.docx",
+        remote_content=SharePointContent(config_id="sp", site_path="/sites/a", file_path="spec.docx"),
+    )
+    content_b = Content(
+        name="spec.docx",
+        remote_content=SharePointContent(config_id="sp", site_path="/sites/b", file_path="spec.docx"),
+    )
+
+    assert knowledge._build_content_hash(content_a) != knowledge._build_content_hash(content_b)
+
+
+def test_non_remote_content_hash_unchanged():
+    """Pure URL / path content (no remote_content) retains its prior hash — backward compat."""
+    knowledge = Knowledge(vector_db=MockVectorDb())
+
+    content_a = Content(url="https://example.com/doc.pdf", name="Doc")
+    content_b = Content(url="https://example.com/doc.pdf", name="Doc")
+
+    # Identical (no remote_content on either) → identical hash, preserves dedup behavior.
+    assert knowledge._build_content_hash(content_a) == knowledge._build_content_hash(content_b)


### PR DESCRIPTION
## Summary

Fixes a bug where two uploads of the same filename from different remote sources (GitHub repos, S3 buckets, GCS buckets, etc.) produced identical `content_hash` values. PgVector's upsert path deletes existing rows by `content_hash` before inserting, so the second upload wiped the first upload's indexed document as flagged in https://github.com/agno-agi/agno/pull/7496. 

## Fix

Introduces `_build_remote_content_identity()` in knowledge that maps each remote content type to a stable identity string covering its source scope plus in-scope path. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
