### PR TITLE
fix: persist Document.name and content_id in SurrealDB vector adapter

### DIFF
--- a/libs/agno/agno/vectordb/surrealdb/surrealdb.py
+++ b/libs/agno/agno/vectordb/surrealdb/surrealdb.py
@@ -27,13 +27,15 @@ class SurrealDb(VectorDb):
         DEFINE TABLE IF NOT EXISTS {collection} SCHEMAFUL;
         DEFINE FIELD IF NOT EXISTS content ON {collection} TYPE string;
         DEFINE FIELD IF NOT EXISTS embedding ON {collection} TYPE array<float>;
+        DEFINE FIELD IF NOT EXISTS name ON {collection} TYPE option<string>;
+        DEFINE FIELD IF NOT EXISTS content_id ON {collection} TYPE option<string>;
         DEFINE FIELD IF NOT EXISTS meta_data ON {collection} TYPE object FLEXIBLE;
         DEFINE INDEX IF NOT EXISTS vector_idx ON {collection} FIELDS embedding HNSW DIMENSION {dimensions} DIST {distance};
     """
 
     NAME_EXISTS_QUERY: Final[str] = """
         SELECT * FROM {collection}
-        WHERE meta_data.name = $name
+        WHERE name = $name
         LIMIT 1
     """
 
@@ -56,7 +58,7 @@ class SurrealDb(VectorDb):
 
     DELETE_BY_NAME_QUERY: Final[str] = """
         DELETE FROM {collection}
-        WHERE meta_data.name = $name
+        WHERE name = $name
     """
 
     DELETE_BY_METADATA_QUERY: Final[str] = """
@@ -73,12 +75,16 @@ class SurrealDb(VectorDb):
         UPSERT {thing}
         SET content = $content,
             embedding = $embedding,
+            name = $name,
+            content_id = $content_id,
             meta_data = $meta_data
     """
 
     SEARCH_QUERY: Final[str] = """
         SELECT
             content,
+            name,
+            content_id,
             meta_data,
             vector::distance::knn() as distance
         FROM {collection}
@@ -272,7 +278,13 @@ class SurrealDb(VectorDb):
             doc.embed(embedder=self.embedder)
             meta_data: Dict[str, Any] = doc.meta_data if isinstance(doc.meta_data, dict) else {}
             meta_data["content_hash"] = content_hash
-            data: Dict[str, Any] = {"content": doc.content, "embedding": doc.embedding, "meta_data": meta_data}
+            data: Dict[str, Any] = {
+                "content": doc.content,
+                "embedding": doc.embedding,
+                "name": doc.name,
+                "content_id": doc.content_id,
+                "meta_data": meta_data,
+            }
             if filters:
                 data["meta_data"].update(filters)
             self.client.create(self.collection, data)
@@ -290,7 +302,13 @@ class SurrealDb(VectorDb):
             doc.embed(embedder=self.embedder)
             meta_data: Dict[str, Any] = doc.meta_data if isinstance(doc.meta_data, dict) else {}
             meta_data["content_hash"] = content_hash
-            data: Dict[str, Any] = {"content": doc.content, "embedding": doc.embedding, "meta_data": meta_data}
+            data: Dict[str, Any] = {
+                "content": doc.content,
+                "embedding": doc.embedding,
+                "name": doc.name,
+                "content_id": doc.content_id,
+                "meta_data": meta_data,
+            }
             if filters:
                 data["meta_data"].update(filters)
             thing = f"{self.collection}:{doc.id}" if doc.id else self.collection
@@ -338,7 +356,9 @@ class SurrealDb(VectorDb):
         for item in response:
             if isinstance(item, dict):
                 doc = Document(
+                    name=item.get("name"),
                     content=item.get("content", ""),
+                    content_id=item.get("content_id"),
                     embedding=item.get("embedding", []),
                     meta_data=item.get("meta_data", {}),
                     embedder=self.embedder,
@@ -498,7 +518,13 @@ class SurrealDb(VectorDb):
             doc.embed(embedder=self.embedder)
             meta_data: Dict[str, Any] = doc.meta_data if isinstance(doc.meta_data, dict) else {}
             meta_data["content_hash"] = content_hash
-            data: Dict[str, Any] = {"content": doc.content, "embedding": doc.embedding, "meta_data": meta_data}
+            data: Dict[str, Any] = {
+                "content": doc.content,
+                "embedding": doc.embedding,
+                "name": doc.name,
+                "content_id": doc.content_id,
+                "meta_data": meta_data,
+            }
             if filters:
                 data["meta_data"].update(filters)
             log_debug(f"Inserting document asynchronously: {doc.name} ({doc.meta_data})")
@@ -519,7 +545,13 @@ class SurrealDb(VectorDb):
             doc.embed(embedder=self.embedder)
             meta_data: Dict[str, Any] = doc.meta_data if isinstance(doc.meta_data, dict) else {}
             meta_data["content_hash"] = content_hash
-            data: Dict[str, Any] = {"content": doc.content, "embedding": doc.embedding, "meta_data": meta_data}
+            data: Dict[str, Any] = {
+                "content": doc.content,
+                "embedding": doc.embedding,
+                "name": doc.name,
+                "content_id": doc.content_id,
+                "meta_data": meta_data,
+            }
             if filters:
                 data["meta_data"].update(filters)
             log_debug(f"Upserting document asynchronously: {doc.name} ({doc.meta_data})")
@@ -569,7 +601,9 @@ class SurrealDb(VectorDb):
         for item in response:
             if isinstance(item, dict):
                 doc = Document(
+                    name=item.get("name"),
                     content=item.get("content", ""),
+                    content_id=item.get("content_id"),
                     embedding=item.get("embedding", []),
                     meta_data=item.get("meta_data", {}),
                     embedder=self.embedder,


### PR DESCRIPTION
## Summary

The SurrealDB vector adapter silently drops `Document.name` and `Document.content_id` during `insert()` and `upsert()`. This breaks three user-facing behaviors that work correctly on every other vector DB adapter in the repo (ChromaDb, PgVector, MongoDb, ClickHouse):

1. **`name_exists(name)`** always returns `False` after a successful insert
2. **`delete_by_name(name)`** silently matches zero rows
3. **`search()`** returns `Document` objects whose `name` and `content_id` are always `None`

## Root Cause

`CREATE_TABLE_QUERY` only defines `content`, `embedding`, and `meta_data` as schema fields. Both `insert()` and `upsert()` only write those three keys. Meanwhile, `NAME_EXISTS_QUERY`, `DELETE_BY_NAME_QUERY`, and `DELETE_BY_CONTENT_ID_QUERY` reference `name` / `content_id` fields that are never populated.

## Fix

- Add `name` and `content_id` columns to `CREATE_TABLE_QUERY` schema
- Store `doc.name` and `doc.content_id` in `insert()`, `upsert()`, and their async variants
- Include `name` and `content_id` in `UPSERT_QUERY` SET clause
- Reconstruct `name` and `content_id` in `search()` and `async_search()` result documents
- Fix `NAME_EXISTS_QUERY` and `DELETE_BY_NAME_QUERY` to use top-level `name` field

This aligns SurrealDB with every other vector adapter in the repo.

Fixes #7510


Made with [Cursor](https://cursor.com)