### PR TITLE
fix: preserve parent_step_id through nested workflow enrichment layers

### DIFF
--- a/libs/agno/agno/os/routers/workflows/schema.py
+++ b/libs/agno/agno/os/routers/workflows/schema.py
@@ -117,6 +117,9 @@ class WorkflowResponse(BaseModel):
             if step.get("steps"):
                 step["steps"] = await cls._resolve_agents_and_teams_recursively(step["steps"])
 
+            if step.get("else_steps"):
+                step["else_steps"] = await cls._resolve_agents_and_teams_recursively(step["else_steps"])
+
             # Prune None values in the entire step
             steps[idx] = _prune_none(step)
 

--- a/libs/agno/agno/workflow/step.py
+++ b/libs/agno/agno/workflow/step.py
@@ -1001,8 +1001,10 @@ class Step:
                 if getattr(event, "step_name", None) is None:
                     event.step_name = self.name
         else:
-            # For nested events, set parent_step_id so consumers know which outer step contains them
-            if hasattr(event, "parent_step_id"):
+            # For nested events, set parent_step_id so consumers know which outer step contains them.
+            # Only set if not already set — the innermost enclosing step is the true host;
+            # outer layers must not overwrite it (breaks depth-2+ nesting).
+            if hasattr(event, "parent_step_id") and event.parent_step_id is None:
                 event.parent_step_id = self.step_id
         # Only set step_index if it's not already set (preserve parallel.py's tuples)
         if hasattr(event, "step_index") and step_index is not None:

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -1613,7 +1613,9 @@ class Workflow:
                 if event.step_index is None:
                     event.step_index = step_index
         else:
-            if hasattr(event, "parent_step_id") and step_id:
+            # Only set parent_step_id if not already set — the innermost enclosing
+            # workflow is the true host step; outer layers must not overwrite it.
+            if hasattr(event, "parent_step_id") and step_id and event.parent_step_id is None:
                 event.parent_step_id = step_id
 
         return event

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -7918,6 +7918,20 @@ class Workflow:
                 }
                 return step_dict
 
+            # Handle Workflow passed directly as a step (auto-wrap shorthand)
+            if isinstance(step, Workflow):
+                nested_steps_list = []
+                if step.steps is not None and not callable(step.steps):
+                    nested_iter = step.steps.steps if isinstance(step.steps, Steps) else step.steps
+                    nested_steps_list = [serialize_step(s) for s in nested_iter]
+                return {
+                    "name": step.name or "unnamed_workflow",
+                    "description": step.description or "Nested workflow step",
+                    "type": StepType.WORKFLOW.value,
+                    "workflow_id": step.id,
+                    "steps": nested_steps_list,
+                }
+
             step_dict = {
                 "name": step.name if hasattr(step, "name") else f"unnamed_{type(step).__name__.lower()}",
                 "description": step.description if hasattr(step, "description") else "User-defined callable step",
@@ -7934,6 +7948,19 @@ class Workflow:
             if hasattr(step, "team"):
                 step_dict["team"] = step.team if hasattr(step, "team") else None  # type: ignore
 
+            # Handle Step wrapping a nested Workflow (Step(workflow=...))
+            nested_workflow = getattr(step, "workflow", None)
+            if isinstance(nested_workflow, Workflow):
+                step_dict["type"] = StepType.WORKFLOW.value
+                step_dict["workflow_id"] = nested_workflow.id
+                if nested_workflow.steps is not None and not callable(nested_workflow.steps):
+                    nested_iter = (
+                        nested_workflow.steps.steps
+                        if isinstance(nested_workflow.steps, Steps)
+                        else nested_workflow.steps
+                    )
+                    step_dict["steps"] = [serialize_step(s) for s in nested_iter]
+
             # Handle nested steps for Router/Loop
             if isinstance(step, Router):
                 step_dict["steps"] = (
@@ -7941,7 +7968,10 @@ class Workflow:
                 )
 
             elif isinstance(step, (Loop, Condition, Steps, Parallel)):
-                step_dict["steps"] = [serialize_step(step) for step in step.steps] if hasattr(step, "steps") else None
+                # Condition may also have else_steps
+                step_dict["steps"] = [serialize_step(s) for s in step.steps] if hasattr(step, "steps") else None
+                if isinstance(step, Condition) and getattr(step, "else_steps", None):
+                    step_dict["else_steps"] = [serialize_step(s) for s in step.else_steps]  # type: ignore
 
             return step_dict
 

--- a/libs/agno/tests/integration/workflows/test_nested_workflow.py
+++ b/libs/agno/tests/integration/workflows/test_nested_workflow.py
@@ -849,6 +849,208 @@ async def test_async_nested_depth_tracking(shared_db):
 
 
 # ============================================================================
+# PARENT_STEP_ID TESTS
+# ============================================================================
+
+
+def test_parent_step_id_two_level_nesting(shared_db):
+    """Test that inner workflow events have parent_step_id pointing to the outer step."""
+    inner = Workflow(
+        name="Inner Workflow",
+        steps=[
+            Step(name="inner_step_a", executor=step_a),
+            Step(name="inner_step_b", executor=step_b),
+        ],
+    )
+
+    outer = Workflow(
+        name="Outer Workflow",
+        db=shared_db,
+        steps=[
+            Step(name="nested", workflow=inner),
+            Step(name="final", executor=step_c),
+        ],
+    )
+
+    tracked = (WorkflowStartedEvent, WorkflowCompletedEvent, StepStartedEvent, StepCompletedEvent)
+    events = [e for e in outer.run(input="test", stream=True, stream_events=True) if isinstance(e, tracked)]
+
+    # Find the outer step_id for "nested"
+    outer_nested_step_id = None
+    for ev in events:
+        if isinstance(ev, StepStartedEvent) and ev.step_name == "nested" and ev.nested_depth == 0:
+            outer_nested_step_id = ev.step_id
+            break
+    assert outer_nested_step_id is not None, "Should find outer 'nested' step"
+
+    # All inner events (depth > 0) should have parent_step_id pointing to outer's nested step
+    inner_events = [e for e in events if getattr(e, "nested_depth", 0) > 0]
+    assert len(inner_events) > 0
+
+    for ev in inner_events:
+        assert ev.parent_step_id == outer_nested_step_id, (
+            f"Inner event {type(ev).__name__} (step={ev.step_name}) should have parent_step_id={outer_nested_step_id}, "
+            f"got {ev.parent_step_id}"
+        )
+
+    # Outer events should have parent_step_id = None
+    outer_events = [e for e in events if getattr(e, "nested_depth", 0) == 0]
+    for ev in outer_events:
+        assert ev.parent_step_id is None, (
+            f"Outer event {type(ev).__name__} should have parent_step_id=None, got {ev.parent_step_id}"
+        )
+
+
+def test_parent_step_id_three_level_nesting(shared_db):
+    """Test that parent_step_id is preserved through 3 levels of nesting.
+
+    Level 3 events should have parent_step_id pointing to the Level 2 step
+    that directly contains them — NOT the Level 1 step.
+    """
+    level3 = Workflow(
+        name="Level 3",
+        steps=[
+            Step(name="l3_step_a", executor=step_a),
+            Step(name="l3_step_b", executor=step_b),
+        ],
+    )
+
+    level2 = Workflow(
+        name="Level 2",
+        steps=[
+            Step(name="l2_nested_l3", workflow=level3),
+            Step(name="l2_step", executor=step_b),
+        ],
+    )
+
+    level1 = Workflow(
+        name="Level 1",
+        db=shared_db,
+        steps=[
+            Step(name="l1_nested_l2", workflow=level2),
+            Step(name="l1_step", executor=step_c),
+        ],
+    )
+
+    tracked = (WorkflowStartedEvent, WorkflowCompletedEvent, StepStartedEvent, StepCompletedEvent)
+    events = [e for e in level1.run(input="test", stream=True, stream_events=True) if isinstance(e, tracked)]
+
+    # Find step_ids for the container steps
+    l1_nested_step_id = None
+    l2_nested_step_id = None
+    for ev in events:
+        if isinstance(ev, StepStartedEvent) and ev.step_name == "l1_nested_l2" and ev.nested_depth == 0:
+            l1_nested_step_id = ev.step_id
+        if isinstance(ev, StepStartedEvent) and ev.step_name == "l2_nested_l3" and ev.nested_depth == 1:
+            l2_nested_step_id = ev.step_id
+    assert l1_nested_step_id is not None, "Should find l1_nested_l2 step"
+    assert l2_nested_step_id is not None, "Should find l2_nested_l3 step"
+
+    # Level 2 events (depth=1) should have parent_step_id = l1_nested_step_id
+    l2_events = [e for e in events if getattr(e, "nested_depth", 0) == 1]
+    assert len(l2_events) > 0
+    for ev in l2_events:
+        assert ev.parent_step_id == l1_nested_step_id, (
+            f"Level 2 event {type(ev).__name__} (step={ev.step_name}) should have "
+            f"parent_step_id={l1_nested_step_id[:8]}, got {ev.parent_step_id[:8] if ev.parent_step_id else None}"
+        )
+
+    # Level 3 events (depth=2) should have parent_step_id = l2_nested_step_id (NOT l1_nested_step_id)
+    l3_events = [e for e in events if getattr(e, "nested_depth", 0) == 2]
+    assert len(l3_events) > 0
+    for ev in l3_events:
+        assert ev.parent_step_id == l2_nested_step_id, (
+            f"Level 3 event {type(ev).__name__} (step={ev.step_name}) should have "
+            f"parent_step_id={l2_nested_step_id[:8]} (Level 2), "
+            f"got {ev.parent_step_id[:8] if ev.parent_step_id else None}"
+        )
+        # Make sure it's NOT the Level 1 step
+        assert ev.parent_step_id != l1_nested_step_id, (
+            f"Level 3 event should NOT have parent_step_id pointing to Level 1 step"
+        )
+
+
+def test_parent_step_id_inner_steps_have_own_step_id(shared_db):
+    """Test that inner workflow steps have their own step_id, not the outer step's."""
+    inner = Workflow(
+        name="Inner Workflow",
+        steps=[
+            Step(name="inner_a", executor=step_a),
+            Step(name="inner_b", executor=step_b),
+        ],
+    )
+
+    outer = Workflow(
+        name="Outer Workflow",
+        db=shared_db,
+        steps=[Step(name="nested", workflow=inner)],
+    )
+
+    tracked = (StepStartedEvent, StepCompletedEvent)
+    events = [e for e in outer.run(input="test", stream=True, stream_events=True) if isinstance(e, tracked)]
+
+    # Outer step
+    outer_step_id = None
+    for ev in events:
+        if ev.step_name == "nested" and ev.nested_depth == 0:
+            outer_step_id = ev.step_id
+            break
+
+    # Inner step events should have their own unique step_ids
+    inner_step_events = [e for e in events if getattr(e, "nested_depth", 0) > 0 and isinstance(e, StepStartedEvent)]
+    assert len(inner_step_events) >= 2, "Should have at least 2 inner StepStartedEvents"
+
+    inner_step_ids = set()
+    for ev in inner_step_events:
+        assert ev.step_id is not None, f"Inner step {ev.step_name} should have a step_id"
+        assert ev.step_id != outer_step_id, (
+            f"Inner step {ev.step_name} should have its own step_id, not the outer step's"
+        )
+        inner_step_ids.add(ev.step_id)
+
+    # inner_a and inner_b should have different step_ids
+    assert len(inner_step_ids) == 2, "inner_a and inner_b should have distinct step_ids"
+
+
+@pytest.mark.asyncio
+async def test_async_parent_step_id_preserved(shared_db):
+    """Test parent_step_id preservation in async streaming mode."""
+    inner = Workflow(
+        name="Inner Workflow",
+        steps=[Step(name="inner_step", executor=async_step_a)],
+    )
+
+    outer = Workflow(
+        name="Outer Workflow",
+        db=shared_db,
+        steps=[
+            Step(name="nested", workflow=inner),
+            Step(name="final", executor=async_step_b),
+        ],
+    )
+
+    tracked = (WorkflowStartedEvent, WorkflowCompletedEvent, StepStartedEvent, StepCompletedEvent)
+    events = []
+    async for event in outer.arun(input="test", stream=True, stream_events=True):
+        if isinstance(event, tracked):
+            events.append(event)
+
+    # Find outer step_id
+    outer_step_id = None
+    for ev in events:
+        if isinstance(ev, StepStartedEvent) and ev.step_name == "nested" and ev.nested_depth == 0:
+            outer_step_id = ev.step_id
+            break
+    assert outer_step_id is not None
+
+    # Inner events should have parent_step_id = outer step
+    inner_events = [e for e in events if getattr(e, "nested_depth", 0) > 0]
+    assert len(inner_events) > 0
+    for ev in inner_events:
+        assert ev.parent_step_id == outer_step_id
+
+
+# ============================================================================
 # ASYNC TESTS
 # ============================================================================
 

--- a/libs/agno/tests/integration/workflows/test_nested_workflow.py
+++ b/libs/agno/tests/integration/workflows/test_nested_workflow.py
@@ -966,7 +966,7 @@ def test_parent_step_id_three_level_nesting(shared_db):
         )
         # Make sure it's NOT the Level 1 step
         assert ev.parent_step_id != l1_nested_step_id, (
-            f"Level 3 event should NOT have parent_step_id pointing to Level 1 step"
+            "Level 3 event should NOT have parent_step_id pointing to Level 1 step"
         )
 
 


### PR DESCRIPTION
## Summary

For workflows nested 2+ levels deep, the `parent_step_id` on events emitted by the innermost workflow (e.g., `WorkflowStartedEvent`, `StepStartedEvent`) was being overwritten as the event bubbled up through outer enrichment layers. Consumers ended up receiving the **outermost** host step id instead of the **immediate** host step id, breaking tree-building in UIs that group events by `parent_step_id`.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
