### PR TITLE
feat: Slack interactive blocks + HITL approval flow

### DIFF
--- a/cookbook/05_agent_os/interfaces/slack/hitl_approval.py
+++ b/cookbook/05_agent_os/interfaces/slack/hitl_approval.py
@@ -1,0 +1,66 @@
+"""Slack HITL Approval Demo
+
+An agent with a tool that requires user confirmation before executing.
+When the agent calls the tool, Slack shows Approve/Reject buttons.
+The agent only proceeds after the user clicks Approve.
+
+Setup:
+1. Set env vars: SLACK_TOKEN, SLACK_SIGNING_SECRET, OPENAI_API_KEY
+2. Configure Slack app with:
+   - Event Subscriptions: <your_url>/slack/events
+   - Interactivity Request URL: <your_url>/slack/interactions
+   - Bot scopes: app_mentions:read, assistant:write, chat:write, im:history, im:read, im:write
+3. Run: .venvs/demo/bin/python cookbook/05_agent_os/interfaces/slack/hitl_approval.py
+4. Start ngrok: ngrok http 7778
+5. DM the bot: "send an email to alice@example.com saying hello"
+6. Bot will show an approval card with Approve/Reject buttons
+"""
+
+from agno.agent import Agent
+from agno.approval import approval
+from agno.models.openai import OpenAIChat
+from agno.os.app import AgentOS
+from agno.os.interfaces.slack import Slack
+from agno.tools import tool
+
+
+@approval
+@tool(
+    description="Send an email to the specified recipient. This is an irreversible action."
+)
+def send_email(to: str, subject: str, body: str) -> str:
+    return f"Email sent to {to} with subject '{subject}'"
+
+
+@tool(description="Draft an email without sending it.")
+def draft_email(to: str, subject: str, body: str) -> str:
+    return f"Draft created for {to}: subject='{subject}', body='{body[:50]}...'"
+
+
+agent = Agent(
+    name="Email Assistant",
+    model=OpenAIChat(id="gpt-4o-mini"),
+    tools=[send_email, draft_email],
+    instructions=[
+        "You are an email assistant.",
+        "When asked to send an email, use the send_email tool.",
+        "When asked to draft, use the draft_email tool.",
+    ],
+    tool_call_limit=5,
+)
+
+agent_os = AgentOS(
+    agents=[agent],
+    interfaces=[
+        Slack(
+            agent=agent,
+            reply_to_mentions_only=False,
+        ),
+    ],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=7777)

--- a/libs/agno/agno/os/interfaces/slack/blocks.py
+++ b/libs/agno/agno/os/interfaces/slack/blocks.py
@@ -1,0 +1,128 @@
+"""Block Kit message builders for interactive Slack components.
+
+Builds structured Block Kit payloads for approval cards, user input forms,
+and status updates. These complement the streaming task-card UX with
+interactive elements (buttons, modals).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+from agno.models.response import ToolExecution
+
+
+def approval_blocks(
+    tools: List[ToolExecution],
+    approval_id: str,
+    agent_name: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """Build Block Kit blocks for a tool approval request.
+
+    Shows what the agent wants to do and presents Approve/Reject buttons.
+    """
+    header = f"*{agent_name}* needs your approval" if agent_name else "Approval needed"
+
+    blocks: List[Dict[str, Any]] = [
+        {"type": "header", "text": {"type": "plain_text", "text": "Action Approval Required"}},
+        {"type": "section", "text": {"type": "mrkdwn", "text": header}},
+        {"type": "divider"},
+    ]
+
+    for tool in tools:
+        if not tool.is_paused:
+            continue
+
+        tool_name = tool.tool_name or "unknown tool"
+        args_str = ""
+        if tool.tool_args:
+            # Truncate long args for readability
+            formatted = json.dumps(tool.tool_args, indent=2)
+            if len(formatted) > 500:
+                formatted = formatted[:500] + "\n..."
+            args_str = f"\n```{formatted}```"
+
+        pause_label = "Confirmation"
+        if tool.requires_user_input:
+            pause_label = "User Input"
+        elif tool.external_execution_required:
+            pause_label = "External Execution"
+
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*{pause_label}:* `{tool_name}`{args_str}",
+                },
+            }
+        )
+
+    blocks.append({"type": "divider"})
+    blocks.append(
+        {
+            "type": "actions",
+            "block_id": f"approval_{approval_id}",
+            "elements": [
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Approve"},
+                    "style": "primary",
+                    "action_id": "hitl_approve",
+                    "value": approval_id,
+                },
+                {
+                    "type": "button",
+                    "text": {"type": "plain_text", "text": "Reject"},
+                    "style": "danger",
+                    "action_id": "hitl_reject",
+                    "value": approval_id,
+                },
+            ],
+        }
+    )
+
+    return blocks
+
+
+def approved_blocks(
+    original_blocks: List[Dict[str, Any]],
+    user_id: str,
+    approved: bool,
+) -> List[Dict[str, Any]]:
+    """Update approval blocks after user clicks Approve/Reject.
+
+    Replaces the action buttons with a resolved status message.
+    """
+    updated: List[Dict[str, Any]] = []
+    for block in original_blocks:
+        # Replace the actions block with a status context
+        if block.get("type") == "actions" and block.get("block_id", "").startswith("approval_"):
+            updated.append(
+                {
+                    "type": "context",
+                    "elements": [
+                        {
+                            "type": "mrkdwn",
+                            "text": f"{'*Approved*' if approved else '*Rejected*'} by <@{user_id}>",
+                        }
+                    ],
+                }
+            )
+        else:
+            updated.append(block)
+    return updated
+
+
+def status_blocks(text: str, status: str = "info") -> List[Dict[str, Any]]:
+    """Simple status message block."""
+    emoji = {"info": "information_source", "success": "white_check_mark", "error": "x"}.get(
+        status, "information_source"
+    )
+    return [
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": f":{emoji}: {text}"},
+        }
+    ]

--- a/libs/agno/agno/os/interfaces/slack/events.py
+++ b/libs/agno/agno/os/interfaces/slack/events.py
@@ -251,6 +251,15 @@ async def _on_memory_update_completed(chunk: BaseRunOutputEvent, state: StreamSt
     return False
 
 
+async def _on_run_paused(chunk: BaseRunOutputEvent, state: StreamState, stream: AsyncChatStream) -> bool:
+    # HITL: agent paused for tool confirmation. Signal the stream loop to stop
+    # and render an approval card. The actual Block Kit message is posted by
+    # the router after stream.stop(), using chunk data stored on state.
+    state.paused_event = chunk
+    state.terminal_status = "complete"  # Close cards cleanly, not as error
+    return True  # Break the stream loop
+
+
 async def _on_run_completed(chunk: BaseRunOutputEvent, state: StreamState, stream: AsyncChatStream) -> bool:
     return False  # Finalization handled by caller after stream ends
 
@@ -387,6 +396,7 @@ HANDLERS: Dict[str, _EventHandler] = {
     RunEvent.run_completed.value: _on_run_completed,
     RunEvent.run_error.value: _on_run_error,
     RunEvent.run_cancelled.value: _on_run_error,  # Treat cancellation as terminal error
+    RunEvent.run_paused.value: _on_run_paused,  # HITL: agent paused for confirmation
     # -------------------------------------------------------------------------
     # Workflow Lifecycle Events
     # -------------------------------------------------------------------------

--- a/libs/agno/agno/os/interfaces/slack/interactions.py
+++ b/libs/agno/agno/os/interfaces/slack/interactions.py
@@ -1,0 +1,267 @@
+"""Slack interactive payload handlers.
+
+Processes block_actions (button clicks) and view_submission (modal forms)
+from Slack's /interactions endpoint. Maps interactive events back to
+paused agent runs for HITL continuation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional
+
+from agno.os.interfaces.slack.blocks import approved_blocks
+from agno.os.interfaces.slack.helpers import send_slack_message_async, upload_response_media_async
+from agno.os.interfaces.slack.state import StreamState
+from agno.utils.log import log_debug, log_error
+
+if TYPE_CHECKING:
+    from ssl import SSLContext
+
+    from agno.run.agent import RunOutput
+
+
+@dataclass
+class PausedRun:
+    """State of a paused agent run, stored until user resolves via Slack interaction."""
+
+    entity: Any  # Agent | Team | Workflow
+    entity_type: Literal["agent", "team", "workflow"]
+    entity_name: str
+    run_response: RunOutput
+    # Context needed to resume the run
+    user_id: str
+    session_id: str
+    channel_id: str
+    thread_ts: str
+    team_id: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    dependencies: Optional[Dict[str, Any]] = None
+    # Slack message ts for the approval card (for updating it after resolution)
+    approval_message_ts: Optional[str] = None
+
+
+# In-memory store for paused runs. Keyed by approval_id.
+# Prototype only — production would use DB via approval.py
+_paused_runs: Dict[str, PausedRun] = {}
+
+
+def store_paused_run(approval_id: str, paused_run: PausedRun) -> None:
+    _paused_runs[approval_id] = paused_run
+    log_debug(f"Stored paused run: approval_id={approval_id}, run_id={paused_run.run_response.run_id}")
+
+
+def get_paused_run(approval_id: str) -> Optional[PausedRun]:
+    return _paused_runs.get(approval_id)
+
+
+def remove_paused_run(approval_id: str) -> Optional[PausedRun]:
+    return _paused_runs.pop(approval_id, None)
+
+
+async def handle_block_action(
+    action: Dict[str, Any],
+    body: Dict[str, Any],
+    token: str,
+    ssl: Optional[SSLContext] = None,
+    streaming: bool = True,
+    task_display_mode: str = "plan",
+    buffer_size: int = 100,
+) -> None:
+    """Handle a button click from an approval card."""
+    from slack_sdk.web.async_client import AsyncWebClient
+
+    action_id = action.get("action_id", "")
+    approval_id = action.get("value", "")
+    user_id = body.get("user", {}).get("id", "")
+    channel_id = body.get("channel", {}).get("id", "")
+    message_ts = body.get("message", {}).get("ts", "")
+    # thread_ts: the thread where the approval card lives
+    thread_ts = body.get("message", {}).get("thread_ts") or message_ts
+
+    if action_id not in ("hitl_approve", "hitl_reject"):
+        return
+
+    approved = action_id == "hitl_approve"
+    async_client = AsyncWebClient(token=token, ssl=ssl)
+
+    # Update the approval card to show resolved status
+    original_blocks = body.get("message", {}).get("blocks", [])
+    updated = approved_blocks(original_blocks, user_id, approved)
+    try:
+        await async_client.chat_update(
+            channel=channel_id,
+            ts=message_ts,
+            blocks=updated,
+            text="Approval resolved",
+        )
+    except Exception as e:
+        log_error(f"Failed to update approval card: {e}")
+
+    paused = remove_paused_run(approval_id)
+    if not paused:
+        await send_slack_message_async(
+            async_client,
+            channel=channel_id,
+            thread_ts=thread_ts,
+            message="This approval has already been resolved or has expired.",
+        )
+        return
+
+    # Apply the decision to the paused tool executions
+    run_response = paused.run_response
+    if run_response.tools:
+        for tool in run_response.tools:
+            if tool.is_paused:
+                if tool.requires_confirmation:
+                    tool.confirmed = approved
+
+    if not approved:
+        await send_slack_message_async(
+            async_client,
+            channel=channel_id,
+            thread_ts=thread_ts,
+            message="Action rejected. The agent will not proceed with this tool call.",
+        )
+        return
+
+    # Resume the agent run with streaming
+    log_debug(f"Resuming paused run: approval_id={approval_id}, run_id={run_response.run_id}")
+
+    if streaming:
+        await _continue_run_streaming(
+            paused,
+            async_client,
+            task_display_mode,
+            buffer_size,
+            ssl,
+        )
+    else:
+        await _continue_run_simple(paused, async_client)
+
+
+async def _continue_run_streaming(
+    paused: PausedRun,
+    async_client: Any,
+    task_display_mode: str,
+    buffer_size: int,
+    ssl: Optional[SSLContext] = None,
+) -> None:
+    """Resume a paused run with streaming output to Slack."""
+    from agno.os.interfaces.slack.events import process_event
+
+    entity = paused.entity
+    state = StreamState(entity_type=paused.entity_type, entity_name=paused.entity_name)
+
+    try:
+        await async_client.assistant_threads_setStatus(
+            channel_id=paused.channel_id,
+            thread_ts=paused.thread_ts,
+            status="Continuing...",
+        )
+    except Exception:
+        pass
+
+    stream = None
+    try:
+        response_stream = entity.acontinue_run(
+            run_response=paused.run_response,
+            stream=True,
+            stream_events=True,
+            user_id=paused.user_id,
+            session_id=paused.session_id,
+            metadata=paused.metadata,
+            dependencies=paused.dependencies,
+        )
+
+        if response_stream is None:
+            return
+
+        stream = await async_client.chat_stream(
+            channel=paused.channel_id,
+            thread_ts=paused.thread_ts,
+            recipient_team_id=paused.team_id,
+            recipient_user_id=paused.user_id,
+            task_display_mode=task_display_mode,
+            buffer_size=buffer_size,
+        )
+
+        async for chunk in response_stream:
+            state.collect_media(chunk)
+
+            ev = getattr(chunk, "event", None)
+            if ev:
+                if await process_event(ev, chunk, state, stream):
+                    break
+
+            if state.has_content():
+                content = state.flush()
+                await stream.append(markdown_text=content)
+                state.stream_chars_sent += len(content)
+
+        final_status = state.terminal_status or "complete"
+        completion_chunks = state.resolve_all_pending(final_status) if state.task_cards else []
+        stop_kwargs: Dict[str, Any] = {}
+        if state.has_content():
+            stop_kwargs["markdown_text"] = state.flush()
+        if completion_chunks:
+            stop_kwargs["chunks"] = completion_chunks
+        await stream.stop(**stop_kwargs)
+
+        await upload_response_media_async(async_client, state, paused.channel_id, paused.thread_ts)
+
+    except Exception as e:
+        log_error(f"Error continuing paused run: {e}")
+        if stream is not None:
+            try:
+                stop_kwargs_err: Dict[str, Any] = {}
+                if state.task_cards:
+                    stop_kwargs_err["chunks"] = state.resolve_all_pending("error")
+                await stream.stop(**stop_kwargs_err)
+            except Exception:
+                pass
+        await send_slack_message_async(
+            async_client,
+            channel=paused.channel_id,
+            thread_ts=paused.thread_ts,
+            message="Sorry, there was an error resuming the agent.",
+        )
+    finally:
+        try:
+            await async_client.assistant_threads_setStatus(
+                channel_id=paused.channel_id,
+                thread_ts=paused.thread_ts,
+                status="",
+            )
+        except Exception:
+            pass
+
+
+async def _continue_run_simple(paused: PausedRun, async_client: Any) -> None:
+    """Resume a paused run without streaming (simple message response)."""
+    entity = paused.entity
+
+    try:
+        response = await entity.acontinue_run(
+            run_response=paused.run_response,
+            user_id=paused.user_id,
+            session_id=paused.session_id,
+            metadata=paused.metadata,
+            dependencies=paused.dependencies,
+        )
+
+        if response and response.content:
+            await send_slack_message_async(
+                async_client,
+                channel=paused.channel_id,
+                thread_ts=paused.thread_ts,
+                message=str(response.content),
+            )
+    except Exception as e:
+        log_error(f"Error continuing paused run (simple): {e}")
+        await send_slack_message_async(
+            async_client,
+            channel=paused.channel_id,
+            thread_ts=paused.thread_ts,
+            message="Sorry, there was an error resuming the agent.",
+        )

--- a/libs/agno/agno/os/interfaces/slack/router.py
+++ b/libs/agno/agno/os/interfaces/slack/router.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from agno.agent import Agent, RemoteAgent
+from agno.os.interfaces.slack.blocks import approval_blocks
 from agno.os.interfaces.slack.events import process_event
 from agno.os.interfaces.slack.helpers import (
     build_run_metadata,
@@ -19,6 +20,7 @@ from agno.os.interfaces.slack.helpers import (
     strip_bot_mention,
     upload_response_media_async,
 )
+from agno.os.interfaces.slack.interactions import PausedRun, handle_block_action, store_paused_run
 from agno.os.interfaces.slack.security import verify_slack_signature
 from agno.os.interfaces.slack.state import StreamState
 from agno.team import RemoteTeam, Team
@@ -145,6 +147,52 @@ def attach_routes(
                 background_tasks.add_task(_stream_slack_response, data)
             else:
                 background_tasks.add_task(_process_slack_event, data)
+
+        return SlackEventResponse(status="ok")
+
+    @router.post(
+        "/interactions",
+        operation_id=f"slack_interactions_{op_suffix}",
+        name="slack_interactions",
+        description="Handle Slack interactive payloads (button clicks, modals)",
+        responses={200: {"description": "Interaction processed"}},
+    )
+    async def slack_interactions(request: Request, background_tasks: BackgroundTasks):
+        import json as _json
+        import urllib.parse
+
+        body_bytes = await request.body()
+        timestamp = request.headers.get("X-Slack-Request-Timestamp")
+        slack_signature = request.headers.get("X-Slack-Signature", "")
+
+        if not timestamp or not slack_signature:
+            raise HTTPException(status_code=400, detail="Missing Slack headers")
+
+        if not verify_slack_signature(body_bytes, timestamp, slack_signature, signing_secret=signing_secret):
+            raise HTTPException(status_code=403, detail="Invalid signature")
+
+        # Slack sends interactions as application/x-www-form-urlencoded with a "payload" field
+        body_str = body_bytes.decode("utf-8")
+        parsed = urllib.parse.parse_qs(body_str)
+        payload_str = parsed.get("payload", [""])[0]
+        if not payload_str:
+            raise HTTPException(status_code=400, detail="Missing payload")
+
+        payload = _json.loads(payload_str)
+        payload_type = payload.get("type", "")
+
+        if payload_type == "block_actions":
+            for action in payload.get("actions", []):
+                background_tasks.add_task(
+                    handle_block_action,
+                    action=action,
+                    body=payload,
+                    token=slack_tools.token,
+                    ssl=ssl,
+                    streaming=streaming,
+                    task_display_mode=task_display_mode,
+                    buffer_size=buffer_size,
+                )
 
         return SlackEventResponse(status="ok")
 
@@ -425,6 +473,75 @@ def attach_routes(
             if completion_chunks:
                 stop_kwargs["chunks"] = completion_chunks
             await stream.stop(**stop_kwargs)
+
+            # HITL: if the agent paused for confirmation, post a Block Kit
+            # approval card and store the paused state for later resumption
+            if state.paused_event is not None:
+                paused_chunk = state.paused_event
+                tools = getattr(paused_chunk, "tools", None) or []
+                # RunPausedEvent carries tools and the run_id from the agent
+                run_id = getattr(paused_chunk, "run_id", None)
+                approval_id = None
+                # Find the approval_id stamped by the agent's pause handler
+                for t in tools:
+                    if getattr(t, "approval_id", None):
+                        approval_id = t.approval_id
+                        break
+                if not approval_id:
+                    # Fallback: generate one
+                    from uuid import uuid4
+
+                    approval_id = str(uuid4())
+
+                blocks = approval_blocks(tools, approval_id, agent_name=entity_name)
+                try:
+                    resp = await async_client.chat_postMessage(
+                        channel=ctx["channel_id"],
+                        thread_ts=ctx["thread_id"],
+                        blocks=blocks,
+                        text="Approval needed",
+                    )
+                    approval_msg_ts = resp.get("ts")
+                except Exception as e:
+                    log_error(f"Failed to post approval card: {e}")
+                    approval_msg_ts = None
+
+                # We need the run_response to call acontinue_run later.
+                # The RunPausedEvent is yielded AFTER the agent stores session,
+                # so we can reconstruct from the last RunOutput in the stream.
+                # For prototype: grab run_response from the chunk's context
+                from agno.run.agent import RunOutput
+
+                # Build a minimal RunOutput from the paused event fields
+                paused_run_response = RunOutput(
+                    run_id=run_id or "",
+                    session_id=session_id,
+                    tools=tools,
+                    content=getattr(paused_chunk, "content", None),
+                )
+                paused_run_response.status = "paused"  # type: ignore[assignment]
+                # Copy requirements if present
+                reqs = getattr(paused_chunk, "requirements", None)
+                if reqs:
+                    paused_run_response.requirements = reqs
+
+                store_paused_run(
+                    approval_id,
+                    PausedRun(
+                        entity=entity,
+                        entity_type=entity_type,
+                        entity_name=entity_name,
+                        run_response=paused_run_response,
+                        user_id=resolved_user_id,
+                        session_id=session_id,
+                        channel_id=ctx["channel_id"],
+                        thread_ts=ctx["thread_id"],
+                        team_id=team_id,
+                        metadata=run_kwargs.get("metadata"),
+                        dependencies=run_kwargs.get("dependencies"),
+                        approval_message_ts=approval_msg_ts,
+                    ),
+                )
 
             await upload_response_media_async(async_client, state, ctx["channel_id"], ctx["thread_id"])
 

--- a/libs/agno/agno/os/interfaces/slack/state.py
+++ b/libs/agno/agno/os/interfaces/slack/state.py
@@ -59,6 +59,10 @@ class StreamState:
     # Total chars sent to the current Slack stream; reset on rotation
     stream_chars_sent: int = 0
 
+    # Set by _on_run_paused when agent pauses for HITL confirmation.
+    # Router reads this after stream loop to post Block Kit approval card.
+    paused_event: Optional["BaseRunOutputEvent"] = None
+
     def track_task(self, key: str, title: str) -> None:
         self.task_cards[key] = TaskCard(title=title)
 


### PR DESCRIPTION
## Summary

Adds Block Kit support and a human-in-the-loop (HITL) approval flow to the Slack interface.

- `libs/agno/agno/os/interfaces/slack/blocks.py` (new, ~4KB) — Block Kit message builders
- `libs/agno/agno/os/interfaces/slack/interactions.py` (new, ~9KB) — interaction payload handler (button clicks, select menus)
- `libs/agno/agno/os/interfaces/slack/events.py`, `router.py`, `state.py` — modifications to wire blocks + interactions into the Slack event loop
- `cookbook/05_agent_os/interfaces/slack/hitl_approval.py` — end-to-end example where the agent proposes an action and a human approves via Slack button

## Status: draft / needs review

Saved from a `slack-enhancements` worktree during cleanup. The original branch was merged to main via a different path; this is based on current `main` and needs:

- [ ] Verify that `router.py` changes compose cleanly with the latest Slack router refactor
- [ ] Test HITL approval end-to-end with a real Slack workspace
- [ ] Align state persistence for pending approvals with the existing `SlackInterface` state model

## Why

HITL approval is a common request for Slack-deployed agents (publishing, ticket creation, any destructive action). Block Kit gives the agent richer UI than plain text.
