### PR TITLE
fix: use POSIX paths in FileTools JSON output for cross-platform consistency

### DIFF
--- a/libs/agno/agno/tools/file.py
+++ b/libs/agno/agno/tools/file.py
@@ -247,7 +247,9 @@ class FileTools(Toolkit):
             log_debug(f"Reading files in : {self.base_dir}/{directory}")
             safe, d = self.check_escape(directory)
             if safe:
-                return json.dumps([str(file_path.relative_to(self.base_dir)) for file_path in d.iterdir()], indent=4)
+                return json.dumps(
+                    [file_path.relative_to(self.base_dir).as_posix() for file_path in d.iterdir()], indent=4
+                )
             else:
                 return "{}"
         except Exception as e:
@@ -276,7 +278,7 @@ class FileTools(Toolkit):
                     "files": file_paths,
                 }
             else:
-                file_paths = [str(file_path.relative_to(self.base_dir)) for file_path in matching_files]
+                file_paths = [file_path.relative_to(self.base_dir).as_posix() for file_path in matching_files]
 
                 result = {
                     "pattern": pattern,
@@ -336,7 +338,7 @@ class FileTools(Toolkit):
                     continue
 
                 if lower_query in content.lower():
-                    rel_path = str(file_path.relative_to(self.base_dir))
+                    rel_path = file_path.relative_to(self.base_dir).as_posix()
                     snippet = _extract_snippet(content, query)
                     matches.append(
                         {

--- a/libs/agno/tests/unit/tools/test_filetools.py
+++ b/libs/agno/tests/unit/tools/test_filetools.py
@@ -212,3 +212,35 @@ def test_search_content_limit():
         data = json.loads(result)
 
         assert data["matches_found"] == 2
+
+
+def test_paths_use_forward_slashes():
+    """Test that all path-returning methods use POSIX forward slashes, not OS-native separators.
+
+    Regression test for https://github.com/phidatahq/phidata/issues/7524
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        file_tools = FileTools(base_dir=base_dir)
+
+        # Create nested structure
+        subdir = base_dir / "subdir"
+        subdir.mkdir()
+        (subdir / "file.txt").write_text("nested content")
+
+        # list_files
+        result = json.loads(file_tools.list_files(directory="subdir"))
+        for p in result:
+            assert "\\" not in p, f"list_files returned backslash path: {p}"
+
+        # search_files
+        result = json.loads(file_tools.search_files(pattern="**/*.txt"))
+        for p in result["files"]:
+            assert "\\" not in p, f"search_files returned backslash path: {p}"
+        assert "subdir/file.txt" in result["files"]
+
+        # search_content
+        result = json.loads(file_tools.search_content(query="nested"))
+        for m in result["files"]:
+            assert "\\" not in m["file"], f"search_content returned backslash path: {m['file']}"
+        assert result["files"][0]["file"] == "subdir/file.txt"


### PR DESCRIPTION
## Summary

`FileTools.list_files`, `search_files`, and `search_content` emit OS-native path separators in their JSON output. On Windows, this means backslash paths (`subdir\file.txt`) leak into tool output that LLMs consume, causing escaping confusion (`\f`, `\t` look like escape sequences) and breaking downstream tool calls.

The fix replaces three `str(path.relative_to(base_dir))` calls with `.as_posix()` so JSON output always contains forward-slash paths regardless of host OS.

Closes #7524

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### Changes

- **`libs/agno/agno/tools/file.py`**: Replace `str(path.relative_to(base_dir))` with `path.relative_to(base_dir).as_posix()` in three methods:
  - `list_files` (line 250)
  - `search_files` (line 279)
  - `search_content` (line 339)

- **`libs/agno/tests/unit/tools/test_filetools.py`**: Add `test_paths_use_forward_slashes` regression test that verifies no backslashes appear in output from all three methods with nested directory structures.

### Root cause

`Path.__str__()` returns the OS-native separator. On Windows, `WindowsPath("subdir/file.txt").__str__()` returns `"subdir\\file.txt"`. `Path.as_posix()` always returns forward slashes.

### Test results

All 12 unit tests pass (11 existing + 1 new regression test). `ruff check` and `ruff format` pass cleanly.