### PR TITLE
fix: handle None headers when merging init headers in MCP tools

### DIFF
--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -346,7 +346,7 @@ class MCPTools(Toolkit):
                     sse_params["url"] = self.url
 
                 # Merge dynamic headers into existing headers
-                existing_headers = sse_params.get("headers", {})
+                existing_headers = sse_params.get("headers") or {}
                 sse_params["headers"] = {**existing_headers, **dynamic_headers}
 
                 context = sse_client(**sse_params)  # type: ignore
@@ -358,7 +358,7 @@ class MCPTools(Toolkit):
                     streamable_http_params["url"] = self.url
 
                 # Merge dynamic headers into existing headers
-                existing_headers = streamable_http_params.get("headers", {})
+                existing_headers = streamable_http_params.get("headers") or {}
                 streamable_http_params["headers"] = {**existing_headers, **dynamic_headers}
 
                 context = streamablehttp_client(**streamable_http_params)  # type: ignore

--- a/libs/agno/agno/tools/mcp/mcp.py
+++ b/libs/agno/agno/tools/mcp/mcp.py
@@ -493,7 +493,7 @@ class MCPTools(Toolkit):
             if "url" not in sse_params:
                 sse_params["url"] = self.url
             if init_headers:
-                existing_headers = sse_params.get("headers", {})
+                existing_headers = sse_params.get("headers") or {}
                 sse_params["headers"] = {**existing_headers, **init_headers}
             self._context = sse_client(**sse_params)  # type: ignore
             client_timeout = min(self.timeout_seconds, sse_params.get("timeout", self.timeout_seconds))
@@ -504,7 +504,7 @@ class MCPTools(Toolkit):
             if "url" not in streamable_http_params:
                 streamable_http_params["url"] = self.url
             if init_headers:
-                existing_headers = streamable_http_params.get("headers", {})
+                existing_headers = streamable_http_params.get("headers") or {}
                 streamable_http_params["headers"] = {**existing_headers, **init_headers}
             self._context = streamablehttp_client(**streamable_http_params)  # type: ignore
             params_timeout = streamable_http_params.get("timeout", self.timeout_seconds)

--- a/libs/agno/agno/tools/mcp/multi_mcp.py
+++ b/libs/agno/agno/tools/mcp/multi_mcp.py
@@ -506,7 +506,7 @@ class MultiMCPTools(Toolkit):
                 elif isinstance(server_params, SSEClientParams):
                     sse_params = asdict(server_params)
                     if init_headers:
-                        existing_headers = sse_params.get("headers", {})
+                        existing_headers = sse_params.get("headers") or {}
                         sse_params["headers"] = {**existing_headers, **init_headers}
                     client_connection = await self._async_exit_stack.enter_async_context(sse_client(**sse_params))
                     read, write = client_connection
@@ -518,7 +518,7 @@ class MultiMCPTools(Toolkit):
                 elif isinstance(server_params, StreamableHTTPClientParams):
                     streamable_http_params = asdict(server_params)
                     if init_headers:
-                        existing_headers = streamable_http_params.get("headers", {})
+                        existing_headers = streamable_http_params.get("headers") or {}
                         streamable_http_params["headers"] = {**existing_headers, **init_headers}
                     client_connection = await self._async_exit_stack.enter_async_context(
                         streamablehttp_client(**streamable_http_params)

--- a/libs/agno/tests/unit/tools/test_mcp.py
+++ b/libs/agno/tests/unit/tools/test_mcp.py
@@ -3,7 +3,23 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from agno.tools.mcp import MCPTools, MultiMCPTools
-from agno.tools.mcp.params import StreamableHTTPClientParams
+from agno.tools.mcp.params import SSEClientParams, StreamableHTTPClientParams
+
+
+class _AsyncContextManager:
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _AsyncExitStackStub:
+    async def enter_async_context(self, context):
+        return await context.__aenter__()
 
 
 @pytest.mark.asyncio
@@ -179,6 +195,86 @@ def test_call_header_provider_with_team():
     tools = MCPTools(url="http://localhost:8080/mcp", header_provider=provider)
     result = tools._call_header_provider(run_context=run_context, agent=agent, team=team)
     assert result == {"X-Agent": "member-agent", "X-Team": "test-team"}
+
+
+@pytest.mark.asyncio
+async def test_connect_merges_init_headers_when_streamable_http_headers_default_to_none():
+    tools = MCPTools(
+        server_params=StreamableHTTPClientParams(url="http://localhost:8080/mcp"),
+        transport="streamable-http",
+        header_provider=lambda: {"Authorization": "Bearer token"},
+    )
+
+    with (
+        patch(
+            "agno.tools.mcp.mcp.streamablehttp_client",
+            return_value=_AsyncContextManager(("read", "write")),
+        ) as streamable_http_mock,
+        patch("agno.tools.mcp.mcp.ClientSession", return_value=_AsyncContextManager(MagicMock())),
+        patch.object(MCPTools, "initialize", new=AsyncMock()),
+    ):
+        await tools._connect()
+
+    assert streamable_http_mock.call_args.kwargs["headers"] == {"Authorization": "Bearer token"}
+
+
+@pytest.mark.asyncio
+async def test_connect_merges_init_headers_when_sse_headers_default_to_none():
+    tools = MCPTools(
+        server_params=SSEClientParams(url="http://localhost:8080/sse"),
+        transport="sse",
+        header_provider=lambda: {"Authorization": "Bearer token"},
+    )
+
+    with (
+        patch("agno.tools.mcp.mcp.sse_client", return_value=_AsyncContextManager(("read", "write"))) as sse_client_mock,
+        patch("agno.tools.mcp.mcp.ClientSession", return_value=_AsyncContextManager(MagicMock())),
+        patch.object(MCPTools, "initialize", new=AsyncMock()),
+    ):
+        await tools._connect()
+
+    assert sse_client_mock.call_args.kwargs["headers"] == {"Authorization": "Bearer token"}
+
+
+@pytest.mark.asyncio
+async def test_multimcp_connect_merges_init_headers_when_streamable_http_headers_default_to_none():
+    tools = MultiMCPTools(
+        server_params_list=[StreamableHTTPClientParams(url="http://localhost:8080/mcp")],
+        header_provider=lambda: {"Authorization": "Bearer token"},
+    )
+    tools._async_exit_stack = _AsyncExitStackStub()
+
+    with (
+        patch(
+            "agno.tools.mcp.multi_mcp.streamablehttp_client",
+            return_value=_AsyncContextManager(("read", "write")),
+        ) as streamable_http_mock,
+        patch("agno.tools.mcp.multi_mcp.ClientSession", return_value=_AsyncContextManager(MagicMock())),
+        patch.object(MultiMCPTools, "initialize", new=AsyncMock()),
+        patch.object(MultiMCPTools, "build_tools", new=AsyncMock()),
+    ):
+        await tools._connect()
+
+    assert streamable_http_mock.call_args.kwargs["headers"] == {"Authorization": "Bearer token"}
+
+
+@pytest.mark.asyncio
+async def test_multimcp_connect_merges_init_headers_when_sse_headers_default_to_none():
+    tools = MultiMCPTools(
+        server_params_list=[SSEClientParams(url="http://localhost:8080/sse")],
+        header_provider=lambda: {"Authorization": "Bearer token"},
+    )
+    tools._async_exit_stack = _AsyncExitStackStub()
+
+    with (
+        patch("agno.tools.mcp.multi_mcp.sse_client", return_value=_AsyncContextManager(("read", "write"))) as sse_client_mock,
+        patch("agno.tools.mcp.multi_mcp.ClientSession", return_value=_AsyncContextManager(MagicMock())),
+        patch.object(MultiMCPTools, "initialize", new=AsyncMock()),
+        patch.object(MultiMCPTools, "build_tools", new=AsyncMock()),
+    ):
+        await tools._connect()
+
+    assert sse_client_mock.call_args.kwargs["headers"] == {"Authorization": "Bearer token"}
 
 
 # =============================================================================

--- a/libs/agno/tests/unit/tools/test_mcp.py
+++ b/libs/agno/tests/unit/tools/test_mcp.py
@@ -277,6 +277,66 @@ async def test_multimcp_connect_merges_init_headers_when_sse_headers_default_to_
     assert sse_client_mock.call_args.kwargs["headers"] == {"Authorization": "Bearer token"}
 
 
+@pytest.mark.asyncio
+async def test_get_session_for_run_merges_headers_when_sse_headers_default_to_none():
+    tools = MCPTools(
+        server_params=SSEClientParams(url="http://localhost:8080/sse"),
+        transport="sse",
+        header_provider=lambda run_context: {"Authorization": "Bearer token"},
+    )
+    # Provide a default session so the fast-path check passes
+    tools.session = MagicMock()
+
+    run_context = MagicMock()
+    run_context.run_id = "run-sse-none-headers"
+
+    with (
+        patch("agno.tools.mcp.mcp.sse_client", return_value=_AsyncContextManager(("read", "write"))) as sse_mock,
+        patch("agno.tools.mcp.mcp.ClientSession") as mock_session_cls,
+    ):
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock()
+        mock_session_context = AsyncMock()
+        mock_session_context.__aenter__.return_value = mock_session
+        mock_session_cls.return_value = mock_session_context
+
+        session = await tools.get_session_for_run(run_context=run_context)
+
+    assert sse_mock.call_args.kwargs["headers"] == {"Authorization": "Bearer token"}
+    assert session is mock_session
+
+
+@pytest.mark.asyncio
+async def test_get_session_for_run_merges_headers_when_streamable_http_headers_default_to_none():
+    tools = MCPTools(
+        server_params=StreamableHTTPClientParams(url="http://localhost:8080/mcp"),
+        transport="streamable-http",
+        header_provider=lambda run_context: {"Authorization": "Bearer token"},
+    )
+    tools.session = MagicMock()
+
+    run_context = MagicMock()
+    run_context.run_id = "run-http-none-headers"
+
+    with (
+        patch(
+            "agno.tools.mcp.mcp.streamablehttp_client",
+            return_value=_AsyncContextManager(("read", "write")),
+        ) as streamable_mock,
+        patch("agno.tools.mcp.mcp.ClientSession") as mock_session_cls,
+    ):
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock()
+        mock_session_context = AsyncMock()
+        mock_session_context.__aenter__.return_value = mock_session
+        mock_session_cls.return_value = mock_session_context
+
+        session = await tools.get_session_for_run(run_context=run_context)
+
+    assert streamable_mock.call_args.kwargs["headers"] == {"Authorization": "Bearer token"}
+    assert session is mock_session
+
+
 # =============================================================================
 # Session caching tests - verify no collisions between runs
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes the init-time `header_provider` merge regression introduced in #7507.

`MCPTools._connect()` and `MultiMCPTools._connect()` now apply `header_provider` during initialization so authenticated MCP servers can expose tools during discovery, but the new merge path assumes `server_params.headers` is already a mapping.

For both `SSEClientParams` and `StreamableHTTPClientParams`, `headers` defaults to `None`. When `header_provider` returns a non-empty dict, initialization crashes before the first network call with `TypeError: 'NoneType' object is not a mapping`.

This patch normalizes nullable headers to `{}` before merging in:
- `MCPTools` SSE
- `MCPTools` streamable-http
- `MultiMCPTools` SSE
- `MultiMCPTools` streamable-http

Fixes #7545

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach

---

## Additional Notes

### Test plan

- `PYTHONPATH=libs/agno /Users/jh0927/Workspace/agno-diff-audit/.venv/bin/pytest -q libs/agno/tests/unit/tools/test_mcp.py`
- `PYTHONPATH=libs/agno /Users/jh0927/Workspace/agno-diff-audit/.venv/bin/ruff check libs/agno/agno/tools/mcp/mcp.py libs/agno/agno/tools/mcp/multi_mcp.py libs/agno/tests/unit/tools/test_mcp.py`

### Why this scope is intentionally narrow

I kept this PR focused on the validated crash only:
- no transport behavior changes
- no dataclass default changes
- no session-management changes

That keeps the fix aligned with the existing `#7507` approach while covering the missing `headers=None` case with focused regression tests.
