### PR TITLE
perfect json structure decode for complex string

### DIFF
--- a/libs/agno/agno/utils/string.py
+++ b/libs/agno/agno/utils/string.py
@@ -83,15 +83,45 @@ def _extract_json_objects(text: str) -> list[str]:
     return objs
 
 
+def _extract_json_code_block(content: str) -> Optional[str]:
+    """Extract a full json fenced code block, supporting nested fenced blocks."""
+    # Only treat standalone fenced lines as markdown fences:
+    #   ```json
+    #   ```
+    # This avoids false positives for inline values like: "value": "```json ... ```"
+    fence_pattern = re.compile(r"(?m)^[ \t]*```([A-Za-z0-9_-]+)?[ \t]*$")
+    fence_stack: list[str] = []
+    json_block_start: Optional[int] = None
+
+    for fence_match in fence_pattern.finditer(content):
+        fence_lang = (fence_match.group(1) or "").lower()
+        is_opening_fence = bool(fence_lang)
+
+        if not fence_stack:
+            if is_opening_fence:
+                fence_stack.append(fence_lang)
+                if fence_lang.startswith("json"):
+                    json_block_start = fence_match.end()
+        else:
+            if is_opening_fence:
+                fence_stack.append(fence_lang)
+            else:
+                fence_stack.pop()
+                if not fence_stack and json_block_start is not None:
+                    return content[json_block_start : fence_match.start()].strip()
+
+    return None
+
+
 def _clean_json_content(content: str) -> str:
     """Clean and prepare JSON content for parsing."""
     # Handle code blocks
     if "```json" in content:
-        content = content.split("```json")[-1].strip()
-        parts = content.split("```")
-        if len(parts) > 1:
-            parts.pop(-1)
-        content = "".join(parts)
+        extracted_json_content = _extract_json_code_block(content)
+        if extracted_json_content is not None:
+            content = extracted_json_content
+        else:
+            content = content.split("```json")[-1].strip()
     elif "```" in content:
         content = content.split("```")[1].strip()
 

--- a/libs/agno/tests/unit/utils/test_string.py
+++ b/libs/agno/tests/unit/utils/test_string.py
@@ -194,6 +194,94 @@ def test_parse_json_with_code_blocks_in_fields():
     assert result.description == "A function that prints hello"
 
 
+def test_parse_json_with_nested_json_code_blocks_in_field():
+    """Test parsing when a json code block contains nested json code blocks."""
+    content = """
+    ```json
+    {
+        "name": "test",
+        "value": "```json
+    {
+        "nested": true
+    }
+    ```",
+        "description": "Outer JSON remains parseable"
+    }
+    ```
+    """
+
+
+
+
+    result = parse_response_model_str(content, MockModel)
+    assert result is not None
+    assert result.name == "test"
+    assert '"nested": true' in result.value
+    assert result.description == "Outer JSON remains parseable"
+
+
+def test_parse_json_with_markdown_containing_code_block():
+    """Test parsing when JSON value contains markdown text with a nested code block."""
+    content = """Model output:
+    ```json
+    {
+        "name": "test",
+        "value": "### Notes
+    Use the following snippet:
+    ```python
+    def greet():
+        print('hello')
+    ```",
+        "description": "Markdown includes python code block"
+    }
+    ```
+    """
+
+    result = parse_response_model_str(content, MockModel)
+    assert result is not None
+    assert result.name == "test"
+    assert "### Notes" in result.value
+    assert "def greet()" in result.value
+    assert "print('hello')" in result.value
+    assert result.description == "Markdown includes python code block"
+
+
+def test_parse_complex_llm_output_with_multiple_sections():
+    """Test parsing realistic noisy LLM output containing multiple markdown sections."""
+    content = """I reviewed your request and prepared the response below.
+
+    Plan:
+    ```text
+    1. Analyze
+    2. Generate
+    3. Validate
+    ```
+
+    Final structured output:
+    ```json
+    {
+        "name": "test",
+        "value": "### Summary
+    - item one
+    - item two
+    Inline `code` and a \\"quoted\\" phrase.",
+        "description": "Complex LLM output remains parseable"
+    }
+    ```
+
+    Additional notes: let me know if you want alternatives.
+    """
+
+    result = parse_response_model_str(content, MockModel)
+    assert result is not None
+    assert result.name == "test"
+    assert "### Summary" in result.value
+    assert "- item one" in result.value
+    assert "Inline `code`" in result.value
+    assert '"quoted"' in result.value
+    assert result.description == "Complex LLM output remains parseable"
+
+
 def test_parse_complex_markdown():
     """Test parsing JSON embedded in complex markdown"""
     content = """# Title


### PR DESCRIPTION
## Summary

Fixes #5901 

parse_response_model_str and parse_response_dict_str fail when JSON string values contain fenced code blocks (e.g. json、java、python) because _clean_json_content aggressively strips them.

```
Model output:
```json
    {
        "name": "test",
        "value": "### Notes
    Use the following snippet:
    ```python
    def greet():
        print('hello')
    ```",
        "description": "Markdown includes python code block"
    }
    ```

```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

