### PR TITLE
fix: use functools.wraps for toolkit bound methods to preserve metadata

### DIFF
--- a/libs/agno/agno/tools/toolkit.py
+++ b/libs/agno/agno/tools/toolkit.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from functools import wraps
 from inspect import iscoroutinefunction
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
@@ -241,20 +242,18 @@ class Toolkit:
             if is_async:
 
                 def make_bound_method(func, instance):
+                    @wraps(func)
                     async def bound(*args, **kwargs):
                         return await func(instance, *args, **kwargs)
 
-                    bound.__name__ = getattr(func, "__name__", tool_name)
-                    bound.__doc__ = getattr(func, "__doc__", None)
                     return bound
             else:
 
                 def make_bound_method(func, instance):
+                    @wraps(func)
                     def bound(*args, **kwargs):
                         return func(instance, *args, **kwargs)
 
-                    bound.__name__ = getattr(func, "__name__", tool_name)
-                    bound.__doc__ = getattr(func, "__doc__", None)
                     return bound
 
             bound_method = make_bound_method(original_func, self)

--- a/libs/agno/tests/unit/tools/test_toolkit.py
+++ b/libs/agno/tests/unit/tools/test_toolkit.py
@@ -795,3 +795,51 @@ def test_partial_async_get_async_functions():
     assert async_funcs["tool_a"].entrypoint == toolkit.atool_a
     # tool_b should still be sync version (no async variant)
     assert async_funcs["tool_b"].entrypoint == toolkit.tool_b
+
+
+def test_bound_method_preserves_metadata():
+    """Test that bound methods preserve __qualname__, __annotations__, __doc__, and __wrapped__."""
+
+    class MyToolkit(Toolkit):
+        def __init__(self):
+            super().__init__(name="test_toolkit", tools=[self.my_tool])
+
+        @tool()
+        def my_tool(self, x: int, y: str = "default") -> str:
+            """My tool docstring."""
+            return f"{x}-{y}"
+
+    toolkit = MyToolkit()
+    entrypoint = toolkit.functions["my_tool"].entrypoint
+
+    assert entrypoint.__name__ == "my_tool"
+    assert entrypoint.__doc__ == "My tool docstring."
+    assert "my_tool" in entrypoint.__qualname__
+    assert entrypoint.__annotations__ == {"x": int, "y": str, "return": str}
+    assert hasattr(entrypoint, "__wrapped__")
+
+    # Verify the tool still works correctly
+    result = entrypoint(5)
+    assert result == "5-default"
+
+
+def test_bound_async_method_preserves_metadata():
+    """Test that bound async methods preserve __qualname__, __annotations__, __doc__, and __wrapped__."""
+
+    class AsyncToolkit(Toolkit):
+        def __init__(self):
+            super().__init__(name="async_toolkit", tools=[self.async_tool])
+
+        @tool()
+        async def async_tool(self, x: int) -> int:
+            """Async tool docstring."""
+            return x * 2
+
+    toolkit = AsyncToolkit()
+    entrypoint = toolkit.async_functions["async_tool"].entrypoint
+
+    assert entrypoint.__name__ == "async_tool"
+    assert entrypoint.__doc__ == "Async tool docstring."
+    assert "async_tool" in entrypoint.__qualname__
+    assert entrypoint.__annotations__ == {"x": int, "return": int}
+    assert hasattr(entrypoint, "__wrapped__")


### PR DESCRIPTION
## Summary

When a `Toolkit` registers a method decorated with `@tool`, `_register_decorated_tool` wraps the original function into a closure to bind `self`. The current implementation manually copies only `__name__` and `__doc__`, losing `__qualname__`, `__annotations__`, and `__wrapped__`.

This breaks introspection, type checkers, and any downstream code that relies on function metadata (e.g. schema generation, signature inspection).

Fixes #7569

## Problem

In `tools/toolkit.py`, both sync and async `make_bound_method` closures:

```python
bound.__name__ = getattr(func, "__name__", tool_name)
bound.__doc__ = getattr(func, "__doc__", None)
```

Only `__name__` and `__doc__` are preserved. `__qualname__`, `__annotations__`, `__wrapped__`, `__dict__`, and `__module__` are all lost.

## Fix

Replace manual attribute copying with `@functools.wraps(func)` which preserves all standard function attributes and also sets `__wrapped__` for chaining.

## Tests

Added 2 new tests:
- `test_bound_method_preserves_metadata` — verifies sync bound method preserves `__name__`, `__doc__`, `__qualname__`, `__annotations__`, `__wrapped__`, and still executes correctly
- `test_bound_async_method_preserves_metadata` — same checks for async bound method

All 49 toolkit tests pass.

## Files changed

- `libs/agno/agno/tools/toolkit.py` — `@wraps(func)` on both sync/async bound closures (+1/-4)
- `libs/agno/tests/unit/tools/test_toolkit.py` — 2 new tests (+46)