### PR TITLE
fix: use correct role for ReasoningMessageStartEvent in AGUI

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/utils.py
+++ b/libs/agno/agno/os/interfaces/agui/utils.py
@@ -381,7 +381,7 @@ def _create_events_from_chunk(
         events_to_emit.append(ReasoningStartEvent(type=EventType.REASONING_START, message_id=reasoning_id))
         events_to_emit.append(
             ReasoningMessageStartEvent(
-                type=EventType.REASONING_MESSAGE_START, message_id=reasoning_id, role="reasoning"
+                type=EventType.REASONING_MESSAGE_START, message_id=reasoning_id, role="assistant"
             )
         )
 
@@ -392,7 +392,7 @@ def _create_events_from_chunk(
             events_to_emit.append(ReasoningStartEvent(type=EventType.REASONING_START, message_id=reasoning_id))
             events_to_emit.append(
                 ReasoningMessageStartEvent(
-                    type=EventType.REASONING_MESSAGE_START, message_id=reasoning_id, role="reasoning"
+                    type=EventType.REASONING_MESSAGE_START, message_id=reasoning_id, role="assistant"
                 )
             )
         if chunk.reasoning_content:
@@ -410,7 +410,7 @@ def _create_events_from_chunk(
             events_to_emit.append(ReasoningStartEvent(type=EventType.REASONING_START, message_id=reasoning_id))
             events_to_emit.append(
                 ReasoningMessageStartEvent(
-                    type=EventType.REASONING_MESSAGE_START, message_id=reasoning_id, role="reasoning"
+                    type=EventType.REASONING_MESSAGE_START, message_id=reasoning_id, role="assistant"
                 )
             )
         step_num = event_buffer.next_reasoning_step()


### PR DESCRIPTION
## Summary

`ReasoningMessageStartEvent` expects `role="assistant"` per the AGUI protocol schema, but agno passes `role="reasoning"` in three places, causing a Pydantic `literal_error` validation failure at runtime:

```
1 validation error for ReasoningMessageStartEvent
role
  Input should be 'assistant' [type=literal_error, input_val='reasoning']
```

Fixes #7556

## Fix

Replace all three occurrences of `role="reasoning"` with `role="assistant"` in `agno/os/interfaces/agui/utils.py`:

- Line 384 — `AgentReasoningStartedEvent` / `TeamReasoningStartedEvent` handler
- Line 395 — `AgentReasoningContentDeltaEvent` / `TeamReasoningContentDeltaEvent` handler  
- Line 413 — `AgentReasoningStepEvent` / `TeamReasoningStepEvent` handler

## Files changed

- `libs/agno/agno/os/interfaces/agui/utils.py` — 3 role values (+3/-3)