### PR TITLE
fix: multi-framework support fixes 

### DIFF
--- a/cookbook/05_agent_os/workflow/workflow_with_workflow_as_step.py
+++ b/cookbook/05_agent_os/workflow/workflow_with_workflow_as_step.py
@@ -94,7 +94,9 @@ data_collection_workflow = Workflow(
     description="Gathers raw data and then analyzes it",
     steps=[
         Step(name="gather", agent=data_gatherer, description="Gather raw data"),
-        Step(name="analyze", agent=data_analyzer, description="Analyze the gathered data"),
+        Step(
+            name="analyze", agent=data_analyzer, description="Analyze the gathered data"
+        ),
     ],
 )
 
@@ -114,13 +116,29 @@ inner_workflow = Workflow(
                 name="fact_check_gate",
                 description="Fact-check if the topic likely contains numbers or statistics",
                 evaluator=needs_fact_check,
-                steps=[Step(name="fact_check", agent=fact_checker, description="Verify facts and claims")],
-                else_steps=[Step(name="pass_through", executor=pass_through, description="Pass topic through")],
+                steps=[
+                    Step(
+                        name="fact_check",
+                        agent=fact_checker,
+                        description="Verify facts and claims",
+                    )
+                ],
+                else_steps=[
+                    Step(
+                        name="pass_through",
+                        executor=pass_through,
+                        description="Pass topic through",
+                    )
+                ],
             ),
             name="parallel_research",
             description="Collect data and fact-check in parallel",
         ),
-        Step(name="merge", executor=merge_parallel_results, description="Merge parallel research outputs"),
+        Step(
+            name="merge",
+            executor=merge_parallel_results,
+            description="Merge parallel research outputs",
+        ),
     ],
 )
 
@@ -130,7 +148,11 @@ outer_workflow = Workflow(
     name="Research and Write",
     description="Researches a topic (with parallel data collection and fact-checking), then writes a polished article",
     steps=[
-        Step(name="research_phase", workflow=inner_workflow, description="Run the research sub-workflow"),
+        Step(
+            name="research_phase",
+            workflow=inner_workflow,
+            description="Run the research sub-workflow",
+        ),
         Step(name="writing_phase", agent=writer, description="Write the final article"),
     ],
     db=db,

--- a/cookbook/frameworks/claude-agent-sdk/claude_agentos.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_agentos.py
@@ -30,13 +30,13 @@ Then call the API:
         -F "stream=false"
 """
 
-from agno.agents.claude import ClaudeAgentSDK
+from agno.agents.claude import ClaudeAgent
 from agno.os.app import AgentOS
 
 # ---------------------------------------------------------------------------
 # Create the Claude Agent SDK agent
 # ---------------------------------------------------------------------------
-claude_agent = ClaudeAgentSDK(
+claude_agent = ClaudeAgent(
     agent_id="claude-assistant",
     agent_name="Claude Assistant",
     description="A Claude-powered assistant served through AgentOS",

--- a/cookbook/frameworks/claude-agent-sdk/claude_basic.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_basic.py
@@ -8,10 +8,10 @@ Usage:
     .venvs/demo/bin/python cookbook/frameworks/claude_basic.py
 """
 
-from agno.agents.claude import ClaudeAgentSDK
+from agno.agents.claude import ClaudeAgent
 
 # ----- Wrap Claude Agent SDK for Agno -----
-agent = ClaudeAgentSDK(
+agent = ClaudeAgent(
     agent_id="claude-assistant",
     agent_name="Claude Assistant",
     model="claude-sonnet-4-20250514",

--- a/cookbook/frameworks/claude-agent-sdk/claude_mcp_tools.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_mcp_tools.py
@@ -1,5 +1,5 @@
 """
-Claude Agent SDK with custom MCP tools, wrapped in Agno's ClaudeAgentSDK.
+Claude Agent SDK with custom MCP tools, wrapped in Agno's ClaudeAgent.
 
 Shows how to add custom tools via in-process MCP servers — the Claude Agent SDK
 pattern for user-defined tools.
@@ -11,7 +11,7 @@ Usage:
     .venvs/demo/bin/python cookbook/frameworks/claude_mcp_tools.py
 """
 
-from agno.agents.claude import ClaudeAgentSDK
+from agno.agents.claude import ClaudeAgent
 
 # ----- Define custom tools via MCP server -----
 # The Claude Agent SDK uses MCP servers for custom tools.
@@ -49,7 +49,7 @@ try:
     )
 
     # ----- Agent with custom MCP tools -----
-    agent = ClaudeAgentSDK(
+    agent = ClaudeAgent(
         agent_id="claude-city-agent",
         agent_name="Claude City Agent",
         model="claude-sonnet-4-20250514",

--- a/cookbook/frameworks/claude-agent-sdk/claude_session.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_session.py
@@ -12,12 +12,13 @@ Usage:
     python cookbook/frameworks/claude-agent-sdk/claude_session.py
 """
 
-from agno.agents.claude import ClaudeAgentSDK
+from agno.agents.claude import ClaudeAgent
 from agno.db.postgres import PostgresDb
+
 db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
 pg_db = PostgresDb(db_url=db_url)
 
-agent = ClaudeAgentSDK(
+agent = ClaudeAgent(
     agent_id="claude-chat",
     agent_name="Claude Chat",
     model="claude-sonnet-4-20250514",

--- a/cookbook/frameworks/claude-agent-sdk/claude_session_agentos.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_session_agentos.py
@@ -12,14 +12,14 @@ Usage:
     python cookbook/frameworks/claude-agent-sdk/claude_session_agentos.py
 """
 
-from agno.agents.claude import ClaudeAgentSDK
+from agno.agents.claude import ClaudeAgent
 from agno.db.postgres import PostgresDb
 from agno.os.app import AgentOS
 
 db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
 pg_db = PostgresDb(db_url=db_url)
 
-agent = ClaudeAgentSDK(
+agent = ClaudeAgent(
     agent_id="claude-chat",
     agent_name="Claude Chat",
     model="claude-sonnet-4-20250514",

--- a/cookbook/frameworks/claude-agent-sdk/claude_tools.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_tools.py
@@ -1,5 +1,5 @@
 """
-Claude Agent SDK with built-in tool calls, wrapped in Agno's ClaudeAgentSDK.
+Claude Agent SDK with built-in tool calls, wrapped in Agno's ClaudeAgent.
 
 The Claude Agent SDK has built-in tools (Read, Edit, Bash, Glob, Grep, WebSearch, etc.)
 that are executed internally by the SDK. You just specify which tools to allow.
@@ -11,10 +11,10 @@ Usage:
     .venvs/demo/bin/python cookbook/frameworks/claude_tools.py
 """
 
-from agno.agents.claude import ClaudeAgentSDK
+from agno.agents.claude import ClaudeAgent
 
 # ----- Agent with built-in tools -----
-agent = ClaudeAgentSDK(
+agent = ClaudeAgent(
     agent_id="claude-coder",
     agent_name="Claude Coder",
     model="claude-sonnet-4-20250514",

--- a/cookbook/frameworks/dspy/dspy_session.py
+++ b/cookbook/frameworks/dspy/dspy_session.py
@@ -13,7 +13,6 @@ Usage:
 """
 
 import dspy
-
 from agno.agents.dspy import DSPyAgent
 from agno.db.postgres import PostgresDb
 

--- a/cookbook/frameworks/dspy/dspy_session_agentos.py
+++ b/cookbook/frameworks/dspy/dspy_session_agentos.py
@@ -28,11 +28,10 @@ Then call the API:
 """
 
 import dspy
-from ddgs import DDGS
-
 from agno.agents.dspy import DSPyAgent
 from agno.db.postgres import PostgresDb
 from agno.os.app import AgentOS
+from ddgs import DDGS
 
 
 # ----- Define a live web search tool -----

--- a/cookbook/frameworks/langgraph/langgraph_session_agentos.py
+++ b/cookbook/frameworks/langgraph/langgraph_session_agentos.py
@@ -57,7 +57,9 @@ graph = StateGraph(MessagesState)
 graph.add_node("chatbot", chatbot)
 graph.add_node("tools", ToolNode(tools))
 graph.set_entry_point("chatbot")
-graph.add_conditional_edges("chatbot", should_continue, {"tools": "tools", "end": "__end__"})
+graph.add_conditional_edges(
+    "chatbot", should_continue, {"tools": "tools", "end": "__end__"}
+)
 graph.add_edge("tools", "chatbot")
 compiled = graph.compile()
 

--- a/cookbook/frameworks/langgraph/langgraph_tools_session.py
+++ b/cookbook/frameworks/langgraph/langgraph_tools_session.py
@@ -66,7 +66,9 @@ graph = StateGraph(MessagesState)
 graph.add_node("chatbot", chatbot)
 graph.add_node("tools", ToolNode(tools))
 graph.set_entry_point("chatbot")
-graph.add_conditional_edges("chatbot", should_continue, {"tools": "tools", "end": "__end__"})
+graph.add_conditional_edges(
+    "chatbot", should_continue, {"tools": "tools", "end": "__end__"}
+)
 graph.add_edge("tools", "chatbot")
 compiled = graph.compile()
 

--- a/cookbook/frameworks/multi_framework_agentos.py
+++ b/cookbook/frameworks/multi_framework_agentos.py
@@ -35,16 +35,15 @@ Or call them via API:
 """
 
 import dspy
-from langchain_openai import ChatOpenAI
-from langgraph.graph import MessagesState, StateGraph
-
 from agno.agent import Agent
-from agno.agents.claude import ClaudeAgentSDK
+from agno.agents.claude import ClaudeAgent
 from agno.agents.dspy import DSPyAgent
 from agno.agents.langgraph import LangGraphAgent
 from agno.db.postgres import PostgresDb
 from agno.models.openai import OpenAIResponses
 from agno.os.app import AgentOS
+from langchain_openai import ChatOpenAI
+from langgraph.graph import MessagesState, StateGraph
 
 # ---------------------------------------------------------------------------
 # Shared database for session persistence
@@ -66,7 +65,7 @@ agno_agent = Agent(
 # ---------------------------------------------------------------------------
 # 2. Claude Agent SDK
 # ---------------------------------------------------------------------------
-claude_agent = ClaudeAgentSDK(
+claude_agent = ClaudeAgent(
     agent_id="claude-assistant",
     agent_name="Claude Assistant",
     description="A Claude-powered assistant with web search",

--- a/libs/agno/agno/agent/protocol.py
+++ b/libs/agno/agno/agent/protocol.py
@@ -18,6 +18,7 @@ class AgentProtocol(Protocol):
     @property
     def name(self) -> Optional[str]: ...
 
+    # def (not async def) because arun returns either a coroutine or an async iterator.
     def arun(
         self,
         input: Any,

--- a/libs/agno/agno/agents/base.py
+++ b/libs/agno/agno/agents/base.py
@@ -107,7 +107,7 @@ class BaseExternalAgent:
         user_id: Optional[str] = None,
         **kwargs: Any,
     ) -> Union[RunOutput, Iterator[RunOutputEvent]]:
-        """Synchronous run. Returns RunOutput (non-streaming) or Iterator[RunOutputEvent] (streaming)."""
+        """Synchronous run. Dispatches to the async internals."""
         if stream:
             return self._run_stream(input, session_id=session_id, user_id=user_id, **kwargs)
         else:
@@ -432,6 +432,30 @@ class BaseExternalAgent:
         elif isinstance(self.db, BaseDb):
             self.db.upsert_session(session)
 
+    # Run inspection (used by AgentOS /agents/{id}/runs/{run_id} for external agents)
+
+    @staticmethod
+    def _find_run_in_session(session: AgentSession, run_id: str) -> Optional[RunOutput]:
+        """Find a persisted run by id within the given session."""
+        for run in session.runs or []:
+            if isinstance(run, RunOutput) and run.run_id == run_id:
+                return run
+        return None
+
+    def get_run_output(self, run_id: str, session_id: Optional[str] = None) -> Optional[RunOutput]:
+        """Get a persisted RunOutput for this adapter."""
+        if not session_id:
+            return None
+        session = self.read_or_create_session(session_id)
+        return self._find_run_in_session(session, run_id)
+
+    async def aget_run_output(self, run_id: str, session_id: Optional[str] = None) -> Optional[RunOutput]:
+        """Get a persisted RunOutput for this adapter."""
+        if not session_id:
+            return None
+        session = await self.aread_or_create_session(session_id)
+        return self._find_run_in_session(session, run_id)
+
     def _build_run_output(
         self,
         run_id: str,
@@ -516,17 +540,21 @@ class BaseExternalAgent:
             for msg in run.messages:
                 if msg.role == "assistant" and msg.tool_calls:
                     # Assistant message with tool calls (no text content)
-                    history.append({
-                        "role": "assistant",
-                        "content": str(msg.content) if msg.content else "",
-                        "tool_calls": msg.tool_calls,
-                    })
+                    history.append(
+                        {
+                            "role": "assistant",
+                            "content": str(msg.content) if msg.content else "",
+                            "tool_calls": msg.tool_calls,
+                        }
+                    )
                 elif msg.role == "tool" and msg.content:
-                    history.append({
-                        "role": "tool",
-                        "content": str(msg.content),
-                        "tool_call_id": msg.tool_call_id or "",
-                    })
+                    history.append(
+                        {
+                            "role": "tool",
+                            "content": str(msg.content),
+                            "tool_call_id": msg.tool_call_id or "",
+                        }
+                    )
                 elif msg.role in ("user", "assistant") and msg.content:
                     history.append({"role": msg.role, "content": str(msg.content)})
         return history
@@ -660,7 +688,7 @@ class BaseExternalAgent:
             )
 
     def _run_stream(self, input: Any, **kwargs: Any) -> Iterator[RunOutputEvent]:
-        """Sync streaming wrapper that yields events in real-time using a background thread."""
+        """Sync streaming wrapper. Runs the async stream on a background thread."""
         import queue
         import threading
 
@@ -690,9 +718,7 @@ class BaseExternalAgent:
     # Subclass hooks (must be implemented by adapters)
     # ---------------------------------------------------------------------------
 
-    async def _arun_adapter(
-        self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any
-    ) -> Any:
+    async def _arun_adapter(self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any) -> Any:
         """Non-streaming execution. Return the response content."""
         raise NotImplementedError(f"{self.__class__.__name__} must implement _arun_adapter")
 

--- a/libs/agno/agno/agents/claude/__init__.py
+++ b/libs/agno/agno/agents/claude/__init__.py
@@ -1,3 +1,3 @@
-from agno.agents.claude.agent import ClaudeAgentSDK
+from agno.agents.claude.agent import ClaudeAgent
 
-__all__ = ["ClaudeAgentSDK"]
+__all__ = ["ClaudeAgent"]

--- a/libs/agno/agno/agents/claude/agent.py
+++ b/libs/agno/agno/agents/claude/agent.py
@@ -12,8 +12,18 @@ from agno.run.agent import (
 )
 
 
+def _sdk() -> Any:
+    """Lazy-import the claude_agent_sdk module."""
+    try:
+        import claude_agent_sdk  # type: ignore
+
+        return claude_agent_sdk
+    except ImportError as e:
+        raise ImportError("claude-agent-sdk is required: pip install claude-agent-sdk") from e
+
+
 @dataclass
-class ClaudeAgentSDK(BaseExternalAgent):
+class ClaudeAgent(BaseExternalAgent):
     """Adapter for the Claude Agent SDK (claude-agent-sdk).
 
     Wraps the Claude Agent SDK's query() function so it can be used with AgentOS
@@ -25,7 +35,7 @@ class ClaudeAgentSDK(BaseExternalAgent):
     Args:
         agent_id: Unique identifier for this agent.
         agent_name: Display name for this agent.
-        prompt: Optional system prompt for the agent.
+        system_prompt: Optional system prompt for the agent.
         model: Model to use (e.g. "claude-sonnet-4-20250514"). Defaults to SDK default.
         allowed_tools: List of tools the agent can use (e.g. ["Read", "Bash", "WebSearch"]).
         disallowed_tools: List of tools to block.
@@ -37,9 +47,9 @@ class ClaudeAgentSDK(BaseExternalAgent):
         options_kwargs: Additional kwargs passed to ClaudeAgentOptions.
 
     Example:
-        from agno.agents.claude import ClaudeAgentSDK
+        from agno.agents.claude import ClaudeAgent
 
-        agent = ClaudeAgentSDK(
+        agent = ClaudeAgent(
             agent_id="claude-coder",
             agent_name="Claude Coder",
             allowed_tools=["Read", "Edit", "Bash"],
@@ -55,7 +65,7 @@ class ClaudeAgentSDK(BaseExternalAgent):
         AgentOS(agents=[agent])
     """
 
-    prompt: Optional[str] = None
+    system_prompt: Optional[str] = None
     model: Optional[str] = None
     allowed_tools: Optional[List[str]] = None
     disallowed_tools: Optional[List[str]] = None
@@ -67,20 +77,17 @@ class ClaudeAgentSDK(BaseExternalAgent):
     options_kwargs: Dict[str, Any] = field(default_factory=dict)
     framework: str = "claude-agent-sdk"
 
-    # Session tracking: last session_id from the SDK
-    _last_session_id: Optional[str] = field(default=None, init=False, repr=False)
+    # Maps Agno session_id -> SDK session id. Keyed per session to avoid cross-session bleed.
+    _sdk_session_ids: Dict[str, str] = field(default_factory=dict, init=False, repr=False)
 
     def _build_options(self, *, streaming: bool = False, **kwargs: Any) -> Any:
         """Build ClaudeAgentOptions from agent config."""
-        try:
-            from claude_agent_sdk import ClaudeAgentOptions
-        except ImportError:
-            raise ImportError("claude-agent-sdk is required: pip install claude-agent-sdk")
+        sdk = _sdk()
 
         opts: Dict[str, Any] = {}
 
-        if self.prompt:
-            opts["system_prompt"] = self.prompt
+        if self.system_prompt:
+            opts["system_prompt"] = self.system_prompt
         if self.model:
             opts["model"] = self.model
         if self.allowed_tools:
@@ -102,41 +109,39 @@ class ClaudeAgentSDK(BaseExternalAgent):
         if streaming:
             opts["include_partial_messages"] = True
 
-        # Resume session if session_id provided
+        # Resume only the SDK session tied to this Agno session_id.
         session_id = kwargs.get("session_id")
-        if session_id and self._last_session_id:
-            opts["resume"] = self._last_session_id
+        if session_id:
+            sdk_session_id = self._sdk_session_ids.get(session_id)
+            if sdk_session_id:
+                opts["resume"] = sdk_session_id
 
         opts.update(self.options_kwargs)
-        return ClaudeAgentOptions(**opts)
+        return sdk.ClaudeAgentOptions(**opts)
 
-    async def _arun_adapter(
-        self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any
-    ) -> str:
+    async def _arun_adapter(self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any) -> str:
         """Non-streaming: collect all messages and return final content."""
-        try:
-            from claude_agent_sdk import AssistantMessage, ResultMessage, SystemMessage, TextBlock, query
-        except ImportError:
-            raise ImportError("claude-agent-sdk is required: pip install claude-agent-sdk")
+        sdk = _sdk()
 
         options = self._build_options(**kwargs)
+        agno_session_id = kwargs.get("session_id")
         result_text = ""
 
-        async for message in query(prompt=str(input), options=options):
-            if isinstance(message, SystemMessage):
+        async for message in sdk.query(prompt=str(input), options=options):
+            if isinstance(message, sdk.SystemMessage):
                 if hasattr(message, "subtype") and message.subtype == "init":
                     data = getattr(message, "data", {}) or {}
-                    if "session_id" in data:
-                        self._last_session_id = data["session_id"]
+                    if "session_id" in data and agno_session_id:
+                        self._sdk_session_ids[agno_session_id] = data["session_id"]
 
-            elif isinstance(message, AssistantMessage):
+            elif isinstance(message, sdk.AssistantMessage):
                 for block in message.content:
-                    if isinstance(block, TextBlock):
+                    if isinstance(block, sdk.TextBlock):
                         result_text = block.text
 
-            elif isinstance(message, ResultMessage):
-                if hasattr(message, "session_id") and message.session_id:
-                    self._last_session_id = message.session_id
+            elif isinstance(message, sdk.ResultMessage):
+                if hasattr(message, "session_id") and message.session_id and agno_session_id:
+                    self._sdk_session_ids[agno_session_id] = message.session_id
                 # Use result text if available
                 if hasattr(message, "result") and message.result:
                     result_text = str(message.result)
@@ -154,22 +159,10 @@ class ClaudeAgentSDK(BaseExternalAgent):
         streaming and tool call tracking, while still handling complete messages
         for tool results and session management.
         """
-        try:
-            from claude_agent_sdk import (
-                AssistantMessage,
-                ResultMessage,
-                StreamEvent,
-                SystemMessage,
-                TextBlock,
-                ToolResultBlock,
-                ToolUseBlock,
-                UserMessage,
-                query,
-            )
-        except ImportError:
-            raise ImportError("claude-agent-sdk is required: pip install claude-agent-sdk")
+        sdk = _sdk()
 
         run_id = kwargs.get("run_id", str(uuid4()))
+        agno_session_id = kwargs.get("session_id")
         options = self._build_options(streaming=True, **kwargs)
 
         # Track whether we got any StreamEvents (token-level streaming)
@@ -179,8 +172,8 @@ class ClaudeAgentSDK(BaseExternalAgent):
         # Map tool_use_id -> (tool_name, tool_args) for carrying forward to ToolCallCompleted
         tool_info_map: Dict[str, Dict[str, Any]] = {}
 
-        async for message in query(prompt=str(input), options=options):
-            if isinstance(message, StreamEvent):
+        async for message in sdk.query(prompt=str(input), options=options):
+            if isinstance(message, sdk.StreamEvent):
                 got_stream_events = True
                 event = message.event
                 event_type = event.get("type", "")
@@ -200,17 +193,17 @@ class ClaudeAgentSDK(BaseExternalAgent):
                                 content=text,
                             )
 
-            elif isinstance(message, SystemMessage):
+            elif isinstance(message, sdk.SystemMessage):
                 if hasattr(message, "subtype") and message.subtype == "init":
                     data = getattr(message, "data", {}) or {}
-                    if "session_id" in data:
-                        self._last_session_id = data["session_id"]
+                    if "session_id" in data and agno_session_id:
+                        self._sdk_session_ids[agno_session_id] = data["session_id"]
 
-            elif isinstance(message, AssistantMessage):
+            elif isinstance(message, sdk.AssistantMessage):
                 # Always extract tool calls from complete AssistantMessage
                 # (has full name + args). For text, only use if no StreamEvents.
                 for block in message.content:
-                    if isinstance(block, TextBlock):
+                    if isinstance(block, sdk.TextBlock):
                         if not got_stream_events and block.text:
                             yield RunContentEvent(
                                 run_id=run_id,
@@ -218,7 +211,7 @@ class ClaudeAgentSDK(BaseExternalAgent):
                                 agent_name=self.name or "",
                                 content=block.text,
                             )
-                    elif isinstance(block, ToolUseBlock):
+                    elif isinstance(block, sdk.ToolUseBlock):
                         tool_name = getattr(block, "name", "unknown")
                         tool_input = getattr(block, "input", {})
                         tool_id = getattr(block, "id", str(uuid4()))
@@ -237,12 +230,12 @@ class ClaudeAgentSDK(BaseExternalAgent):
                                 ),
                             )
 
-            elif isinstance(message, UserMessage):
+            elif isinstance(message, sdk.UserMessage):
                 # Tool results arrive as ToolResultBlock inside UserMessage
                 content = message.content
                 if isinstance(content, list):
                     for block in content:
-                        if isinstance(block, ToolResultBlock):
+                        if isinstance(block, sdk.ToolResultBlock):
                             tool_use_id = getattr(block, "tool_use_id", str(uuid4()))
                             result_content = getattr(block, "content", "")
                             if isinstance(result_content, list):
@@ -263,6 +256,6 @@ class ClaudeAgentSDK(BaseExternalAgent):
                                 ),
                             )
 
-            elif isinstance(message, ResultMessage):
-                if hasattr(message, "session_id") and message.session_id:
-                    self._last_session_id = message.session_id
+            elif isinstance(message, sdk.ResultMessage):
+                if hasattr(message, "session_id") and message.session_id and agno_session_id:
+                    self._sdk_session_ids[agno_session_id] = message.session_id

--- a/libs/agno/agno/agents/dspy/agent.py
+++ b/libs/agno/agno/agents/dspy/agent.py
@@ -56,9 +56,7 @@ class DSPyAgent(BaseExternalAgent):
     program_kwargs: Dict[str, Any] = field(default_factory=dict)
     framework: str = "dspy"
 
-    async def _arun_adapter(
-        self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any
-    ) -> str:
+    async def _arun_adapter(self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any) -> str:
         """Non-streaming: run the DSPy program and return the output field."""
         try:
             import dspy
@@ -190,6 +188,6 @@ class DSPyAgent(BaseExternalAgent):
 
                 # StatusMessage — skip (internal DSPy execution status)
 
-        # Flush any remaining tool events (e.g., if no text was streamed)
+        # Flush any tool events on the cache-hit path (no StreamResponse was yielded).
         for evt in tool_events:
             yield evt

--- a/libs/agno/agno/agents/langgraph/agent.py
+++ b/libs/agno/agno/agents/langgraph/agent.py
@@ -61,9 +61,7 @@ class LangGraphAgent(BaseExternalAgent):
     config: Optional[Dict[str, Any]] = field(default=None)
     framework: str = "langgraph"
 
-    async def _arun_adapter(
-        self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any
-    ) -> Any:
+    async def _arun_adapter(self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any) -> Any:
         """Non-streaming LangGraph invocation."""
         try:
             from langchain_core.messages import AIMessage
@@ -196,17 +194,11 @@ class LangGraphAgent(BaseExternalAgent):
         replay_config = self._build_config({"session_id": session_id})
         replay_config.setdefault("configurable", {})["checkpoint_id"] = checkpoint_id
 
-        # Set config for the duration of the run (must persist through streaming)
-        original_config = self.config
-        self.config = replay_config
-        try:
-            result = self.run(None, stream=stream, session_id=session_id, **kwargs)
-            if stream:
-                # Consume the iterator before restoring config
-                return list(cast(Iterator, result))
-            return result
-        finally:
-            self.config = original_config
+        # Pass config through kwargs; self.config stays untouched.
+        result = self.run(None, stream=stream, session_id=session_id, _lg_config_override=replay_config, **kwargs)
+        if stream:
+            return list(cast(Iterator, result))
+        return result
 
     def print_replay(
         self,
@@ -219,13 +211,7 @@ class LangGraphAgent(BaseExternalAgent):
         """Replay from a checkpoint and print the response with Rich formatting."""
         replay_config = self._build_config({"session_id": session_id})
         replay_config.setdefault("configurable", {})["checkpoint_id"] = checkpoint_id
-
-        original_config = self.config
-        self.config = replay_config
-        try:
-            self.print_response(None, stream=stream, session_id=session_id, **kwargs)
-        finally:
-            self.config = original_config
+        self.print_response(None, stream=stream, session_id=session_id, _lg_config_override=replay_config, **kwargs)
 
     def fork(
         self,
@@ -253,15 +239,11 @@ class LangGraphAgent(BaseExternalAgent):
             update_kwargs["as_node"] = as_node
         new_config = self.graph.update_state(fork_config_base, **update_kwargs)
 
-        original_config = self.config
-        self.config = new_config
-        try:
-            result = self.run(None, stream=stream, session_id=session_id, **kwargs)
-            if stream:
-                return list(cast(Iterator, result))
-            return result
-        finally:
-            self.config = original_config
+        # Pass config through kwargs; self.config stays untouched.
+        result = self.run(None, stream=stream, session_id=session_id, _lg_config_override=new_config, **kwargs)
+        if stream:
+            return list(cast(Iterator, result))
+        return result
 
     def print_fork(
         self,
@@ -281,20 +263,19 @@ class LangGraphAgent(BaseExternalAgent):
         if as_node:
             update_kwargs["as_node"] = as_node
         new_config = self.graph.update_state(fork_config_base, **update_kwargs)
-
-        original_config = self.config
-        self.config = new_config
-        try:
-            self.print_response(None, stream=stream, session_id=session_id, **kwargs)
-        finally:
-            self.config = original_config
+        self.print_response(None, stream=stream, session_id=session_id, _lg_config_override=new_config, **kwargs)
 
     def _build_config(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
-        """Build LangGraph config, mapping session_id to thread_id."""
-        config: Dict[str, Any] = dict(self.config or {})
+        """Build a LangGraph config mapping session_id to thread_id."""
+        # Replay/fork pass a prebuilt config via _lg_config_override so self.config stays untouched.
+        override = kwargs.pop("_lg_config_override", None)
+        base = override if override is not None else self.config
+        config: Dict[str, Any] = dict(base or {})
+        # Rebuild the configurable subdict so mutations don't leak back into self.config.
+        config["configurable"] = dict(config.get("configurable") or {})
         session_id = kwargs.get("session_id")
         if session_id:
-            configurable = config.setdefault("configurable", {})
+            configurable = config["configurable"]
             configurable["thread_id"] = session_id
             configurable.setdefault("checkpoint_ns", "")
         return config

--- a/libs/agno/agno/agents/langgraph/utils.py
+++ b/libs/agno/agno/agents/langgraph/utils.py
@@ -32,11 +32,13 @@ def build_messages_with_history(input: Any, history: Optional[List[Dict[str, Any
                                 args = json.loads(args)
                             except (json.JSONDecodeError, TypeError):
                                 args = {"input": args}
-                        lc_tool_calls.append({
-                            "id": tc.get("id", ""),
-                            "name": func.get("name", ""),
-                            "args": args,
-                        })
+                        lc_tool_calls.append(
+                            {
+                                "id": tc.get("id", ""),
+                                "name": func.get("name", ""),
+                                "args": args,
+                            }
+                        )
                     messages.append(AIMessage(content=msg.get("content", ""), tool_calls=lc_tool_calls))
                 else:
                     messages.append(AIMessage(content=msg["content"]))

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -56,6 +56,12 @@ if TYPE_CHECKING:
     from agno.os.app import AgentOS
 
 
+def _require_capability(agent: Any, method: str, feature: str) -> None:
+    """Raise 501 if the agent does not expose the given method."""
+    if not callable(getattr(agent, method, None)):
+        raise HTTPException(status_code=501, detail=f"This agent does not support {feature}")
+
+
 async def agent_response_streamer(
     agent: Union[Agent, RemoteAgent, AgentProtocol],
     message: str,
@@ -475,9 +481,7 @@ def get_agent_router(
         if agent is None:
             raise HTTPException(status_code=404, detail="Agent not found")
 
-        # External framework agents do not support cancel_run
-        if not hasattr(agent, "acancel_run"):
-            raise HTTPException(status_code=501, detail="This agent does not support cancel_run")
+        _require_capability(agent, "acancel_run", "cancel_run")
 
         # cancel_run always stores cancellation intent (even for not-yet-registered runs
         # in cancel-before-start scenarios), so we always return success.
@@ -548,9 +552,7 @@ def get_agent_router(
         if agent is None:
             raise HTTPException(status_code=404, detail="Agent not found")
 
-        # External framework agents do not support continue_run
-        if not isinstance(agent, (Agent, RemoteAgent)) and not hasattr(agent, "acontinue_run"):
-            raise HTTPException(status_code=501, detail="This agent does not support continue_run")
+        _require_capability(agent, "acontinue_run", "continue_run")
 
         if session_id is None or session_id == "":
             log_warning(
@@ -689,25 +691,24 @@ def get_agent_router(
             accessible_agents = os.agents or []
 
         agents: List[AgentResponse] = []
-        if accessible_agents:
-            for agent in accessible_agents:
-                if isinstance(agent, RemoteAgent):
-                    agents.append(await agent.get_agent_config())
-                elif isinstance(agent, Agent):
-                    agent_response = await AgentResponse.from_agent(agent=agent, is_component=False)
-                    agents.append(agent_response)
-                else:
-                    # External framework agent -- create minimal response
-                    agent_db = getattr(agent, "db", None)
-                    agents.append(
-                        AgentResponse(
-                            id=agent.id,
-                            name=agent.name,
-                            description=getattr(agent, "description", None),
-                            db_id=agent_db.id if agent_db else None,
-                            metadata={"framework": getattr(agent, "framework", "external")},
-                        )
-                    )
+        for agent in accessible_agents or []:
+            if isinstance(agent, RemoteAgent):
+                agents.append(await agent.get_agent_config())
+                continue
+            if isinstance(agent, Agent):
+                agents.append(await AgentResponse.from_agent(agent=agent, is_component=False))
+                continue
+            # External framework adapter: build a minimal response
+            agent_db = getattr(agent, "db", None)
+            agents.append(
+                AgentResponse(
+                    id=agent.id,
+                    name=agent.name,
+                    description=getattr(agent, "description", None),
+                    db_id=agent_db.id if agent_db else None,
+                    metadata={"framework": getattr(agent, "framework", "external")},
+                )
+            )
 
         if os.db and isinstance(os.db, BaseDb):
             from agno.agent.agent import get_agents
@@ -804,8 +805,7 @@ def get_agent_router(
             raise HTTPException(status_code=404, detail="Agent not found")
         if isinstance(agent, RemoteAgent):
             raise HTTPException(status_code=400, detail="Run polling is not supported for remote agents")
-        if not hasattr(agent, "aget_run_output"):
-            raise HTTPException(status_code=501, detail="This agent does not support run polling")
+        _require_capability(agent, "aget_run_output", "run polling")
 
         run_output = await agent.aget_run_output(run_id=run_id, session_id=session_id)  # type: ignore[union-attr]
         if run_output is None:
@@ -840,13 +840,16 @@ def get_agent_router(
             raise HTTPException(status_code=404, detail="Agent not found")
         if isinstance(agent, RemoteAgent):
             raise HTTPException(status_code=400, detail="Run listing is not supported for remote agents")
-        if not isinstance(agent, Agent):
+
+        # Load session: native Agent uses the storage helper, external adapters have their own method.
+        if isinstance(agent, Agent):
+            from agno.agent._storage import aread_or_create_session
+
+            session = await aread_or_create_session(agent, session_id=session_id)
+        elif hasattr(agent, "aread_or_create_session"):
+            session = await agent.aread_or_create_session(session_id=session_id)
+        else:
             raise HTTPException(status_code=501, detail="This agent does not support run listing")
-
-        # Load the session to get its runs
-        from agno.agent._storage import aread_or_create_session
-
-        session = await aread_or_create_session(agent, session_id=session_id)
         runs = session.runs or []
 
         # Convert to dicts and optionally filter by status

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -6,8 +6,6 @@ from agno.media import File, Image
 from agno.models.message import Message
 from agno.utils.log import log_error, log_info, log_warning
 
-
-
 # Models that support assistant message prefill. This is a closed set —
 # prefill was deprecated starting with Claude 4.6 and all future models
 # are expected to reject it.

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -8454,7 +8454,9 @@ class Workflow:
             if step.team:
                 step_kwargs["team"] = step.team.deep_copy() if hasattr(step.team, "deep_copy") else step.team
             if step.workflow:
-                step_kwargs["workflow"] = step.workflow.deep_copy() if hasattr(step.workflow, "deep_copy") else step.workflow
+                step_kwargs["workflow"] = (
+                    step.workflow.deep_copy() if hasattr(step.workflow, "deep_copy") else step.workflow
+                )
             # Copy Step configuration attributes
             for attr in [
                 "max_retries",

--- a/libs/agno/tests/unit/tools/test_mcp.py
+++ b/libs/agno/tests/unit/tools/test_mcp.py
@@ -267,7 +267,9 @@ async def test_multimcp_connect_merges_init_headers_when_sse_headers_default_to_
     tools._async_exit_stack = _AsyncExitStackStub()
 
     with (
-        patch("agno.tools.mcp.multi_mcp.sse_client", return_value=_AsyncContextManager(("read", "write"))) as sse_client_mock,
+        patch(
+            "agno.tools.mcp.multi_mcp.sse_client", return_value=_AsyncContextManager(("read", "write"))
+        ) as sse_client_mock,
         patch("agno.tools.mcp.multi_mcp.ClientSession", return_value=_AsyncContextManager(MagicMock())),
         patch.object(MultiMCPTools, "initialize", new=AsyncMock()),
         patch.object(MultiMCPTools, "build_tools", new=AsyncMock()),


### PR DESCRIPTION
## Summary

Builds on #7186 with bug fixes                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                 
  **Changes:**                                                                                                                                                                                                                                                                                                                                                   
  - Rename `ClaudeAgentSDK` → `ClaudeAgent` to match `DSPyAgent` / `LangGraphAgent`.
  - Rename Claude adapter field `prompt` → `system_prompt` to match the SDK.                                                                                                                                                                                                                                                                                     
  - Fix cross-session ID bleed in the Claude adapter by keying SDK session IDs per Agno session.                                                                                                                                                                                                                                                                 
  - Fix `self.config` mutation in LangGraph `replay()` / `fork()` so concurrent calls don't race.                                                                                                                                                                                                                                                                
  - Enable `GET /agents/{id}/runs/{run_id}` and `GET /agents/{id}/runs` for external agents.                                                                                                                                                                                                                                                                     
  - Clean up scattered `hasattr` / `isinstance` checks in the agents router with a shared helper.                                                                                                                                                                                                                                                                
  - Consolidate duplicated `claude_agent_sdk` imports into a single lazy helper.                                                                                                                                                                                                                                                                                 
  - Minor docstring and comment improvements.                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                 
  **Cookbooks:** all `cookbook/frameworks/*` updated for the rename

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
