### PR TITLE
fix: skip iteration of callable-factory tools in Agent.deep_copy

### DIFF
--- a/libs/agno/agno/agent/_utils.py
+++ b/libs/agno/agno/agent/_utils.py
@@ -165,13 +165,13 @@ def deep_copy_field(agent: Agent, field_name: str, field_value: Any) -> Any:
     if field_name == "reasoning_agent":
         return field_value.deep_copy()  # type: ignore
 
-    # For tools, share MCP tools but copy others
+    # For tools, return callable factories by reference; share MCP tools but copy others
     if field_name == "tools" and field_value is not None:
         from agno.tools import Toolkit
         from agno.tools.function import Function
         from agno.utils.callables import is_callable_factory
 
-        # Callable-factory tools are shared by reference; they are resolved per-run.
+        # Callable-factory tools are shared by reference and resolved per-run
         if is_callable_factory(field_value, excluded_types=(Toolkit, Function)):
             return field_value
 

--- a/libs/agno/agno/agent/_utils.py
+++ b/libs/agno/agno/agent/_utils.py
@@ -167,6 +167,14 @@ def deep_copy_field(agent: Agent, field_name: str, field_value: Any) -> Any:
 
     # For tools, share MCP tools but copy others
     if field_name == "tools" and field_value is not None:
+        from agno.tools import Toolkit
+        from agno.tools.function import Function
+        from agno.utils.callables import is_callable_factory
+
+        # Callable-factory tools are shared by reference; they are resolved per-run.
+        if is_callable_factory(field_value, excluded_types=(Toolkit, Function)):
+            return field_value
+
         try:
             copied_tools = []
             for tool in field_value:  # type: ignore

--- a/libs/agno/agno/team/_utils.py
+++ b/libs/agno/agno/team/_utils.py
@@ -165,7 +165,9 @@ def _deep_copy_field(team: Team, field_name: str, field_value: Any) -> Any:
 
     # For members, return callable factories by reference; deep copy static lists
     if field_name == "members" and field_value is not None:
-        if callable(field_value) and not isinstance(field_value, list):
+        from agno.utils.callables import is_callable_factory
+
+        if is_callable_factory(field_value):
             return field_value
         copied_members = []
         for member in field_value:
@@ -177,7 +179,11 @@ def _deep_copy_field(team: Team, field_name: str, field_value: Any) -> Any:
 
     # For tools, return callable factories by reference; share MCP tools but copy others
     if field_name == "tools" and field_value is not None:
-        if callable(field_value) and not isinstance(field_value, list):
+        from agno.tools import Toolkit
+        from agno.tools.function import Function
+        from agno.utils.callables import is_callable_factory
+
+        if is_callable_factory(field_value, excluded_types=(Toolkit, Function)):
             return field_value
         try:
             copied_tools = []

--- a/libs/agno/agno/team/_utils.py
+++ b/libs/agno/agno/team/_utils.py
@@ -163,10 +163,11 @@ def _deep_copy_field(team: Team, field_name: str, field_value: Any) -> Any:
 
     from pydantic import BaseModel
 
+    from agno.utils.callables import is_callable_factory
+
     # For members, return callable factories by reference; deep copy static lists
     if field_name == "members" and field_value is not None:
-        from agno.utils.callables import is_callable_factory
-
+        # No excluded_types: Agent and Team instances are not callable
         if is_callable_factory(field_value):
             return field_value
         copied_members = []
@@ -181,8 +182,8 @@ def _deep_copy_field(team: Team, field_name: str, field_value: Any) -> Any:
     if field_name == "tools" and field_value is not None:
         from agno.tools import Toolkit
         from agno.tools.function import Function
-        from agno.utils.callables import is_callable_factory
 
+        # Callable-factory tools are shared by reference and resolved per-run
         if is_callable_factory(field_value, excluded_types=(Toolkit, Function)):
             return field_value
         try:

--- a/libs/agno/tests/unit/agent/test_callable_resources.py
+++ b/libs/agno/tests/unit/agent/test_callable_resources.py
@@ -790,3 +790,54 @@ class TestAgentDeepCopyCallable:
         copied = agent.deep_copy()
         assert isinstance(copied.tools, list)
         assert len(copied.tools) == 1
+        # The Toolkit must actually be deep-copied, not shared by reference.
+        assert copied.tools[0] is not tk
+        assert copied.tools is not agent.tools
+
+    def test_deep_copy_async_factory_preserved(self):
+        """An `async def` factory must be shared by reference, not deep-copied."""
+
+        async def afactory():
+            return [_dummy_tool]
+
+        agent = Agent(name="test", tools=afactory)
+        copied = agent.deep_copy()
+        assert copied.tools is afactory
+
+    def test_deep_copy_partial_factory_preserved(self):
+        """A functools.partial factory must be shared by reference."""
+        from functools import partial
+
+        def _fac(extra):
+            return [_dummy_tool]
+
+        pf = partial(_fac, extra=1)
+        agent = Agent(name="test", tools=pf)
+        copied = agent.deep_copy()
+        assert copied.tools is pf
+
+    def test_deep_copy_callable_instance_factory_preserved(self):
+        """A callable class instance (has __call__) must be shared by reference."""
+
+        class Factory:
+            def __call__(self):
+                return [_dummy_tool]
+
+        inst = Factory()
+        agent = Agent(name="test", tools=inst)
+        copied = agent.deep_copy()
+        assert copied.tools is inst
+
+    def test_deep_copy_bound_method_factory_preserved(self):
+        """A bound method factory is shared by reference and still resolves."""
+
+        class Builder:
+            def make(self):
+                return [_dummy_tool]
+
+        holder = Builder()
+        agent = Agent(name="test", tools=holder.make)
+        copied = agent.deep_copy()
+        # Bound methods are transient, so compare identity via the receiver
+        assert getattr(copied.tools, "__self__", None) is holder
+        assert copied.tools() == [_dummy_tool]

--- a/libs/agno/tests/unit/agent/test_callable_resources.py
+++ b/libs/agno/tests/unit/agent/test_callable_resources.py
@@ -735,3 +735,58 @@ class TestAgentDeepCopyCallable:
         copied = agent.deep_copy()
         # The factory should be shared by reference (not deep-copied)
         assert copied.tools is agent.tools
+
+    def test_deep_copy_no_warning_on_callable_factory(self):
+        """Regression: deep_copy() must not try to iterate a callable factory."""
+        import logging
+
+        def factory():
+            return [_dummy_tool]
+
+        agent = Agent(name="test", tools=factory, cache_callables=False)
+
+        records: list = []
+
+        class _Recorder(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        agno_logger = logging.getLogger("agno")
+        handler = _Recorder(level=logging.WARNING)
+        agno_logger.addHandler(handler)
+        try:
+            copied = agent.deep_copy()
+        finally:
+            agno_logger.removeHandler(handler)
+
+        assert copied.tools is factory
+        offenders = [r.getMessage() for r in records if "Failed to process tools for deep copy" in r.getMessage()]
+        assert not offenders, f"Unexpected warning(s) emitted: {offenders}"
+
+    def test_deep_copy_callable_factory_still_resolves(self):
+        """After deep_copy, the factory should still resolve to the expected tool list."""
+        sentinel = _dummy_tool
+
+        def factory():
+            return [sentinel]
+
+        agent = Agent(name="test", tools=factory, cache_callables=False)
+        copied = agent.deep_copy()
+
+        ctx = _make_run_context(user_id="u1")
+        resolve_callable_tools(copied, ctx)
+        assert ctx.tools == [sentinel]
+
+    def test_deep_copy_lambda_factory_preserved(self):
+        factory = lambda: [_dummy_tool]  # noqa: E731
+        agent = Agent(name="test", tools=factory)
+        copied = agent.deep_copy()
+        assert copied.tools is factory
+
+    def test_deep_copy_toolkit_not_treated_as_factory(self):
+        """A Toolkit instance is callable-adjacent but must still be deep-copied as a tool."""
+        tk = Toolkit(name="tk", tools=[Function.from_callable(_dummy_tool)])
+        agent = Agent(name="test", tools=[tk])
+        copied = agent.deep_copy()
+        assert isinstance(copied.tools, list)
+        assert len(copied.tools) == 1

--- a/libs/agno/tests/unit/team/test_callable_resources.py
+++ b/libs/agno/tests/unit/team/test_callable_resources.py
@@ -569,3 +569,65 @@ class TestTeamDeepCopyCallableFactories:
         offenders = [r.getMessage() for r in records if "Failed to process tools for deep copy" in r.getMessage()]
         assert not offenders, f"Unexpected warning(s) emitted: {offenders}"
         assert copied.members[0].tools is member_tools_factory
+
+    def test_deep_copy_callable_tools_still_resolves(self):
+        """After deep_copy, the tools factory must still resolve to the expected list."""
+        sentinel = _dummy_tool
+
+        def tools_factory():
+            return [sentinel]
+
+        team = _make_team(tools=tools_factory, cache_callables=False)
+        copy = team.deep_copy()
+
+        ctx = _make_run_context(user_id="u1")
+        resolve_callable_tools(copy, ctx)
+        assert ctx.tools == [sentinel]
+
+    def test_deep_copy_callable_members_still_resolves(self):
+        """After deep_copy, the members factory must still resolve to the expected list."""
+        agent = Agent(name="m")
+
+        def members_factory():
+            return [agent]
+
+        team = _make_team(members=members_factory, cache_callables=False)
+        copy = team.deep_copy()
+
+        ctx = _make_run_context(user_id="u1")
+        resolve_callable_members(copy, ctx)
+        assert ctx.members == [agent]
+
+    def test_deep_copy_async_tools_factory_preserved(self):
+        """An `async def` factory on team.tools must be shared by reference."""
+
+        async def afactory():
+            return [_dummy_tool]
+
+        team = _make_team(tools=afactory)
+        copy = team.deep_copy()
+        assert copy.tools is afactory
+
+    def test_deep_copy_partial_tools_factory_preserved(self):
+        """A functools.partial team tools factory must be shared by reference."""
+        from functools import partial
+
+        def _fac(extra):
+            return [_dummy_tool]
+
+        pf = partial(_fac, extra=1)
+        team = _make_team(tools=pf)
+        copy = team.deep_copy()
+        assert copy.tools is pf
+
+    def test_deep_copy_callable_instance_tools_factory_preserved(self):
+        """A callable class instance as team.tools must be shared by reference."""
+
+        class Factory:
+            def __call__(self):
+                return [_dummy_tool]
+
+        inst = Factory()
+        team = _make_team(tools=inst)
+        copy = team.deep_copy()
+        assert copy.tools is inst

--- a/libs/agno/tests/unit/team/test_callable_resources.py
+++ b/libs/agno/tests/unit/team/test_callable_resources.py
@@ -514,3 +514,58 @@ class TestTeamDeepCopyCallableFactories:
         team = _make_team(members=agents)
         copy = team.deep_copy()
         assert isinstance(copy.members, list)
+
+    def test_deep_copy_no_warning_on_callable_tools(self):
+        """Regression: Team.deep_copy() must not iterate a callable tools factory."""
+        import logging
+
+        def tools_factory():
+            return [_dummy_tool]
+
+        team = _make_team(tools=tools_factory, cache_callables=False)
+
+        records: list = []
+
+        class _Recorder(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        agno_logger = logging.getLogger("agno")
+        handler = _Recorder(level=logging.WARNING)
+        agno_logger.addHandler(handler)
+        try:
+            copied = team.deep_copy()
+        finally:
+            agno_logger.removeHandler(handler)
+
+        assert copied.tools is tools_factory
+        offenders = [r.getMessage() for r in records if "Failed to process tools for deep copy" in r.getMessage()]
+        assert not offenders, f"Unexpected warning(s) emitted: {offenders}"
+
+    def test_deep_copy_with_member_using_callable_tools(self):
+        """Regression: a Team member Agent with callable tools should not warn during deep_copy."""
+        import logging
+
+        def member_tools_factory():
+            return [_dummy_tool]
+
+        member = Agent(name="member", tools=member_tools_factory, cache_callables=False)
+        team = _make_team(members=[member])
+
+        records: list = []
+
+        class _Recorder(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                records.append(record)
+
+        agno_logger = logging.getLogger("agno")
+        handler = _Recorder(level=logging.WARNING)
+        agno_logger.addHandler(handler)
+        try:
+            copied = team.deep_copy()
+        finally:
+            agno_logger.removeHandler(handler)
+
+        offenders = [r.getMessage() for r in records if "Failed to process tools for deep copy" in r.getMessage()]
+        assert not offenders, f"Unexpected warning(s) emitted: {offenders}"
+        assert copied.members[0].tools is member_tools_factory


### PR DESCRIPTION
## Summary

`Agent.deep_copy()` (via `agno.agent._utils.deep_copy_field`) tries to iterate
`self.tools` unconditionally. When `tools` is a callable factory (the supported
`tools=my_factory` form that `Agent.__init__` accepts), the loop raises
`'function' object is not iterable`, which the outer `except` swallows — but it
still logs:

```
WARNING  Failed to process tools for deep copy: 'function' object is not iterable
```

on every `Team.run` / `Team.arun` that includes such a member Agent. Noisy, and
it masks real deep-copy failures.

The Team side (`agno.team._utils._deep_copy_field`) already short-circuits
callable factories for both `tools` and `members`; only the Agent side was
missing the mirror-fix. This PR adds it, and also aligns both sides on
`is_callable_factory` (from `agno.utils.callables`) so that `Agent.__init__`,
`Team.__init__`, and the two deep-copy helpers agree on one predicate.

Reported against 2.5.17.

### Minimal repro

```python
from agno.agent import Agent

def my_tools():
    return []

agent = Agent(id="x", tools=my_tools, cache_callables=False)
agent.deep_copy()   # before: logs the warning; after: no warning
```

### Scope check

I audited other `Union[List, Callable]` fields for the same bug shape:

- `tools` (Agent) — **fixed here**.
- `tools` / `members` (Team) — already handled; re-expressed via `is_callable_factory` for consistency.
- `knowledge` (Agent/Team) — already returned by reference via the "share heavy resources" list; no bug.
- `pre_hooks` / `post_hooks` / `tool_hooks` — typed as `List[Callable]`, not `Union[List, Callable]`. Not affected.
- `instructions` / `system_message` / `knowledge_retriever` — single-callable fields; `copy()` on a function returns the same object. Not affected.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — no new cookbook needed; existing [`cookbook/02_agents/04_tools/01_callable_tools.py`](cookbook/02_agents/04_tools/01_callable_tools.py) and [`03_team_callable_members.py`](cookbook/02_agents/04_tools/03_team_callable_members.py) already demonstrate the feature
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Regression tests added

- `TestAgentDeepCopyCallable::test_deep_copy_no_warning_on_callable_factory` — captures records off the `agno` logger and asserts the "Failed to process tools for deep copy" warning does not fire.
- `TestAgentDeepCopyCallable::test_deep_copy_callable_factory_still_resolves` — asserts the copied agent's factory still resolves to the expected tool list at run time.
- `TestAgentDeepCopyCallable::test_deep_copy_lambda_factory_preserved` — lambdas preserved by identity.
- `TestAgentDeepCopyCallable::test_deep_copy_toolkit_not_treated_as_factory` — `Toolkit` instances (which are callable-adjacent) must still deep-copy as tools, not short-circuit.
- `TestTeamDeepCopyCallableFactories::test_deep_copy_no_warning_on_callable_tools` — Team parallel of the Agent no-warning test.
- `TestTeamDeepCopyCallableFactories::test_deep_copy_with_member_using_callable_tools` — the real-world path that produced the warning: a Team member Agent constructed with callable-factory tools.

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

The `caplog` fixture is not used because the `agno` logger is configured with
`propagate=False`, so records don't reach pytest's root-level capture. The new
tests attach a small `logging.Handler` directly to the `agno` logger and remove
it in a `finally` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)