### PR TITLE
feat: add exclude_patterns to FileTools

### DIFF
--- a/cookbook/91_tools/TEST_LOG.md
+++ b/cookbook/91_tools/TEST_LOG.md
@@ -1,5 +1,15 @@
 # Test Log
 
+### file_tools.py (Examples 6-8: exclude_patterns)
+
+**Status:** PASS
+
+**Description:** Added three new examples (6-8) to the existing FileTools cookbook demonstrating the `exclude_patterns` parameter from PR #7618. Example 6 uses the default exclusion list (hides `.venv`, `.git`, `__pycache__`, etc.); Example 7 subtracts `.venv` from `DEFAULT_EXCLUDE_PATTERNS` so the agent can inspect installed packages while still filtering noise; Example 8 uses `exclude_patterns=[]` for full visibility. A `setup_exclusion_sandbox()` helper creates a deterministic fixture (real source + stub `.venv/lib/python3.12/site-packages/requests/` + `.git/HEAD`) so Examples 6-8 are reproducible. New examples use `model=OpenAIResponses(id="gpt-5.4")` per project convention.
+
+**Result:** Ran the three new agents end-to-end with `PYTHONPATH=/Users/coolm/Developer/agno-pr-7618/libs/agno timeout 120 .venvs/demo/bin/python cookbook/91_tools/file_tools.py` (PYTHONPATH needed because the demo venv's editable install resolves to main, but the PR's new `DEFAULT_EXCLUDE_PATTERNS` export lives on the PR branch). Default agent returned only `README.md` and `main.py`; the `.venv`-allowed agent read `__version__ = '2.31.0'` from `.venv/lib/python3.12/site-packages/requests/__init__.py`; the no-exclusions agent listed `.git/HEAD` and every `.venv` file. Module import also verified under importlib — all three agents wire up with the expected `exclude_patterns` lengths (47, 46, 0).
+
+---
+
 ### docling_tools/run.py
 
 **Status:** PASS

--- a/cookbook/91_tools/file_tools.py
+++ b/cookbook/91_tools/file_tools.py
@@ -9,7 +9,34 @@ Shows enable_ flag patterns for selective function access.
 from pathlib import Path
 
 from agno.agent import Agent
-from agno.tools.file import FileTools
+from agno.models.openai import OpenAIResponses
+from agno.tools.file import DEFAULT_EXCLUDE_PATTERNS, FileTools
+
+EXCLUSION_SANDBOX = Path("tmp/file_tools_exclusions")
+
+
+def setup_exclusion_sandbox() -> None:
+    EXCLUSION_SANDBOX.mkdir(parents=True, exist_ok=True)
+
+    (EXCLUSION_SANDBOX / "main.py").write_text("def hello():\n    return 'world'\n")
+    (EXCLUSION_SANDBOX / "README.md").write_text("# My Project\n\nDoes a thing.\n")
+
+    site_pkg = (
+        EXCLUSION_SANDBOX
+        / ".venv"
+        / "lib"
+        / "python3.12"
+        / "site-packages"
+        / "requests"
+    )
+    site_pkg.mkdir(parents=True, exist_ok=True)
+    (site_pkg / "__init__.py").write_text("__version__ = '2.31.0'\n")
+    (site_pkg / "api.py").write_text("def get(url):\n    pass\n")
+
+    git_dir = EXCLUSION_SANDBOX / ".git"
+    git_dir.mkdir(exist_ok=True)
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
+
 
 # ---------------------------------------------------------------------------
 # Create Agent
@@ -107,6 +134,70 @@ agent_content_search = Agent(
     markdown=True,
 )
 
+# Example 6: Default exclusions skip noise directories (.venv, .git, __pycache__,
+# node_modules, build artifacts, etc.) so agents don't waste context on installed
+# packages or VCS metadata. See DEFAULT_EXCLUDE_PATTERNS for the full list.
+agent_default_exclusions = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=[
+        FileTools(
+            base_dir=EXCLUSION_SANDBOX,
+            enable_list_files=True,
+            enable_search_files=True,
+            enable_search_content=True,
+        )
+    ],
+    description="You help users explore a project, skipping build and dependency noise.",
+    instructions=[
+        "Use list_files and search_content to answer questions about the project",
+    ],
+    markdown=True,
+)
+
+# Example 7: Custom exclusions - start from DEFAULT_EXCLUDE_PATTERNS and remove
+# the entries you want visible. Future additions to the default list apply
+# automatically. Here we keep the defaults but unhide .venv so the agent can
+# inspect installed packages.
+exclude_without_venv = [p for p in DEFAULT_EXCLUDE_PATTERNS if p != ".venv"]
+
+agent_can_read_venv = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=[
+        FileTools(
+            base_dir=EXCLUSION_SANDBOX,
+            exclude_patterns=exclude_without_venv,
+            enable_list_files=True,
+            enable_search_files=True,
+            enable_search_content=True,
+        )
+    ],
+    description="You inspect installed Python packages to answer version and source questions.",
+    instructions=[
+        "Use search_content and search_files to look inside .venv when asked",
+        "Report package versions and the file path where you found them",
+    ],
+    markdown=True,
+)
+
+# Example 8: Full opt-out with exclude_patterns=[]. Every file becomes visible,
+# including .git internals. Use only when you need forensic access to the tree.
+agent_sees_everything = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=[
+        FileTools(
+            base_dir=EXCLUSION_SANDBOX,
+            exclude_patterns=[],
+            enable_list_files=True,
+            enable_search_files=True,
+        )
+    ],
+    description="You audit the full project tree, including hidden and ignored directories.",
+    instructions=[
+        "Return the complete file inventory when asked",
+    ],
+    markdown=True,
+)
+
 # Example usage
 
 # ---------------------------------------------------------------------------
@@ -140,5 +231,26 @@ if __name__ == "__main__":
     print("\n=== Content Search Example ===")
     agent_content_search.print_response(
         "Search inside all files for the word 'Python' and summarize what you find",
+        markdown=True,
+    )
+
+    setup_exclusion_sandbox()
+
+    print("\n=== Default Exclusions Example (hides .venv, .git, etc.) ===")
+    agent_default_exclusions.print_response(
+        "List every file in this project and tell me what the project does.",
+        markdown=True,
+    )
+
+    print("\n=== Custom Exclusions Example (inspect .venv) ===")
+    agent_can_read_venv.print_response(
+        "Find the version of the `requests` package installed in this project. "
+        "Show the file path where you found the version string.",
+        markdown=True,
+    )
+
+    print("\n=== No Exclusions Example (see .git internals) ===")
+    agent_sees_everything.print_response(
+        "List every single file in the project, including git internals.",
         markdown=True,
     )

--- a/libs/agno/agno/tools/file.py
+++ b/libs/agno/agno/tools/file.py
@@ -1,4 +1,6 @@
 import json
+import os
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
 
@@ -26,6 +28,28 @@ TEXT_EXTENSIONS = {
     ".log",
     ".rst",
 }
+
+DEFAULT_EXCLUDE_PATTERNS = [
+    ".venv",
+    "venv",
+    ".env",
+    ".git",
+    ".hg",
+    ".svn",
+    "__pycache__",
+    "node_modules",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".pytest_cache",
+    ".tox",
+    ".nox",
+    "dist",
+    "build",
+    "*.egg-info",
+    ".next",
+    ".turbo",
+    ".DS_Store",
+]
 
 
 def _format_size(size: int) -> str:
@@ -55,6 +79,25 @@ def _extract_snippet(content: str, query: str, context_chars: int = 200) -> str:
 
 
 class FileTools(Toolkit):
+    """Toolkit for read/write access to a local directory tree.
+
+    By default, results from ``list_files``, ``search_files``, and ``search_content``
+    skip common noise directories (``.venv``, ``.git``, ``__pycache__``,
+    ``node_modules``, etc.). See ``DEFAULT_EXCLUDE_PATTERNS`` for the full list.
+
+    To customize:
+    - Pass ``exclude_patterns=[...]`` with your own list of fnmatch-style patterns.
+    - Pass ``exclude_patterns=[]`` to disable exclusion entirely (prior behavior).
+
+    Each pattern is matched with ``fnmatch`` against *any path component* of the
+    file's path relative to ``base_dir``. A file is excluded if any component
+    matches any pattern, so ``.git`` will exclude both ``.git/`` at the root
+    and ``vendor/thing/.git/`` nested deep.
+
+    Note: ``exclude_patterns`` does not parse ``.gitignore`` files — it only
+    applies the literal patterns provided.
+    """
+
     def __init__(
         self,
         base_dir: Optional[Path] = None,
@@ -70,6 +113,7 @@ class FileTools(Toolkit):
         max_file_length: int = 10000000,
         max_file_lines: int = 100000,
         line_separator: str = "\n",
+        exclude_patterns: Optional[List[str]] = None,
         all: bool = False,
         **kwargs,
     ):
@@ -80,6 +124,9 @@ class FileTools(Toolkit):
         self.max_file_lines = max_file_lines
         self.line_separator = line_separator
         self.expose_base_directory = expose_base_directory
+        self.exclude_patterns: List[str] = (
+            exclude_patterns if exclude_patterns is not None else list(DEFAULT_EXCLUDE_PATTERNS)
+        )
         if all or enable_save_file:
             tools.append(self.save_file)
         if all or enable_read_file:
@@ -98,6 +145,16 @@ class FileTools(Toolkit):
             tools.append(self.search_content)
 
         super().__init__(name="file_tools", tools=tools, **kwargs)
+
+    def _is_excluded(self, path: Path) -> bool:
+        """Return True if any component of ``path`` (relative to ``base_dir``) matches an exclude pattern."""
+        if not self.exclude_patterns:
+            return False
+        try:
+            rel = path.relative_to(self.base_dir)
+        except ValueError:
+            return False
+        return any(fnmatch(part, pattern) for part in rel.parts for pattern in self.exclude_patterns)
 
     def check_escape(self, relative_path: str) -> Tuple[bool, Path]:
         """Check if the file path is within the base directory.
@@ -247,7 +304,14 @@ class FileTools(Toolkit):
             log_debug(f"Reading files in : {self.base_dir}/{directory}")
             safe, d = self.check_escape(directory)
             if safe:
-                return json.dumps([str(file_path.relative_to(self.base_dir)) for file_path in d.iterdir()], indent=4)
+                return json.dumps(
+                    [
+                        str(file_path.relative_to(self.base_dir))
+                        for file_path in d.iterdir()
+                        if not self._is_excluded(file_path)
+                    ],
+                    indent=4,
+                )
             else:
                 return "{}"
         except Exception as e:
@@ -265,7 +329,7 @@ class FileTools(Toolkit):
                 return "Error: Pattern cannot be empty"
 
             log_debug(f"Searching files in {self.base_dir} with pattern {pattern}")
-            matching_files = list(self.base_dir.glob(pattern))
+            matching_files = [p for p in self.base_dir.glob(pattern) if not self._is_excluded(p)]
             result = None
             if self.expose_base_directory:
                 file_paths = [str(file_path) for file_path in matching_files]
@@ -320,31 +384,42 @@ class FileTools(Toolkit):
             matches: List[dict] = []
             max_file_size = 500 * 1024  # 500KB
 
-            for file_path in search_dir.rglob("*"):
-                if len(matches) >= limit:
+            walk_done = False
+            for dirpath, dirnames, filenames in os.walk(search_dir):
+                if walk_done:
                     break
-                if not file_path.is_file():
-                    continue
-                if file_path.suffix.lower() not in TEXT_EXTENSIONS:
-                    continue
-                if file_path.stat().st_size > max_file_size:
-                    continue
+                # Prune excluded directories in place so os.walk doesn't descend into them.
+                dirnames[:] = [d for d in dirnames if not self._is_excluded(Path(dirpath) / d)]
+                for filename in filenames:
+                    if len(matches) >= limit:
+                        walk_done = True
+                        break
+                    file_path = Path(dirpath) / filename
+                    if self._is_excluded(file_path):
+                        continue
+                    if file_path.suffix.lower() not in TEXT_EXTENSIONS:
+                        continue
+                    try:
+                        if file_path.stat().st_size > max_file_size:
+                            continue
+                    except OSError:
+                        continue
 
-                try:
-                    content = file_path.read_text(encoding="utf-8", errors="ignore")
-                except Exception:
-                    continue
+                    try:
+                        content = file_path.read_text(encoding="utf-8", errors="ignore")
+                    except Exception:
+                        continue
 
-                if lower_query in content.lower():
-                    rel_path = str(file_path.relative_to(self.base_dir))
-                    snippet = _extract_snippet(content, query)
-                    matches.append(
-                        {
-                            "file": rel_path,
-                            "size": _format_size(file_path.stat().st_size),
-                            "snippet": snippet,
-                        }
-                    )
+                    if lower_query in content.lower():
+                        rel_path = str(file_path.relative_to(self.base_dir))
+                        snippet = _extract_snippet(content, query)
+                        matches.append(
+                            {
+                                "file": rel_path,
+                                "size": _format_size(file_path.stat().st_size),
+                                "snippet": snippet,
+                            }
+                        )
 
             result = {
                 "query": query,

--- a/libs/agno/agno/tools/file.py
+++ b/libs/agno/agno/tools/file.py
@@ -30,24 +30,64 @@ TEXT_EXTENSIONS = {
 }
 
 DEFAULT_EXCLUDE_PATTERNS = [
+    # Environments and secrets
     ".venv",
     "venv",
-    ".env",
+    ".env*",
+    "*.env",
+    # Version control
     ".git",
     ".hg",
     ".svn",
+    # Python caches and build artifacts
     "__pycache__",
-    "node_modules",
     ".mypy_cache",
     ".ruff_cache",
     ".pytest_cache",
     ".tox",
     ".nox",
+    ".ipynb_checkpoints",
     "dist",
     "build",
     "*.egg-info",
+    # JavaScript and TypeScript
+    "node_modules",
     ".next",
     ".turbo",
+    ".nuxt",
+    ".svelte-kit",
+    ".docusaurus",
+    ".parcel-cache",
+    ".nyc_output",
+    "*.tsbuildinfo",
+    ".serverless",
+    # JVM (Java, Kotlin, Android, Gradle)
+    ".gradle",
+    ".kotlin",
+    "*.class",
+    # Dart and Flutter
+    ".dart_tool",
+    ".flutter-plugins",
+    ".flutter-plugins-dependencies",
+    # Swift and Xcode
+    ".build",
+    "xcuserdata",
+    "*.xcuserstate",
+    # Ruby
+    ".bundle",
+    "*.gem",
+    ".yardoc",
+    # Elixir
+    "_build",
+    ".elixir_ls",
+    # .NET / Visual Studio
+    ".vs",
+    # Infrastructure as Code (state files hidden by default for security)
+    ".terraform",
+    "*.tfstate",
+    "*.tfstate.*",
+    ".terragrunt-cache",
+    # OS artifacts
     ".DS_Store",
 ]
 

--- a/libs/agno/tests/unit/tools/test_filetools.py
+++ b/libs/agno/tests/unit/tools/test_filetools.py
@@ -212,3 +212,108 @@ def test_search_content_limit():
         data = json.loads(result)
 
         assert data["matches_found"] == 2
+
+
+def test_default_exclude_patterns_hide_junk():
+    """By default, .venv and similar noise dirs are excluded from results."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        file_tools = FileTools(base_dir=base_dir)
+
+        tmp_sub = base_dir / "tmp"
+        tmp_sub.mkdir()
+        (tmp_sub / "foo.txt").write_text("foo")
+        venv_pkg = tmp_sub / ".venv" / "lib" / "site-packages"
+        venv_pkg.mkdir(parents=True)
+        (venv_pkg / "x.py").write_text("print('x')")
+
+        search_result = json.loads(file_tools.search_files(pattern="**/*.py"))
+        assert search_result["matches_found"] == 0
+
+        listed = json.loads(file_tools.list_files(directory="tmp"))
+        assert ".venv" not in [Path(p).name for p in listed]
+        assert "tmp/foo.txt" in listed
+
+
+def test_empty_exclude_patterns_opts_out():
+    """exclude_patterns=[] restores prior behavior: no exclusions."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        file_tools = FileTools(base_dir=base_dir, exclude_patterns=[])
+
+        venv_pkg = base_dir / ".venv" / "lib" / "site-packages"
+        venv_pkg.mkdir(parents=True)
+        (venv_pkg / "x.py").write_text("print('x')")
+
+        search_result = json.loads(file_tools.search_files(pattern="**/*.py"))
+        assert search_result["matches_found"] == 1
+        assert any(".venv" in p for p in search_result["files"])
+
+
+def test_custom_exclude_patterns():
+    """Custom patterns replace the default list."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        file_tools = FileTools(base_dir=base_dir, exclude_patterns=["node_modules"])
+
+        (base_dir / "node_modules").mkdir()
+        (base_dir / "node_modules" / "a.txt").write_text("a")
+        (base_dir / ".venv").mkdir()
+        (base_dir / ".venv" / "b.txt").write_text("b")
+
+        result = json.loads(file_tools.search_files(pattern="**/*.txt"))
+        files = result["files"]
+        assert not any("node_modules" in p for p in files)
+        assert any(".venv" in p for p in files)
+
+
+def test_exclude_patterns_match_nested_components():
+    """Patterns match on any path component, not just top-level dirs."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        file_tools = FileTools(base_dir=base_dir, exclude_patterns=[".git"])
+
+        nested = base_dir / "vendor" / "thing" / ".git"
+        nested.mkdir(parents=True)
+        (nested / "config").write_text("[core]")
+        (base_dir / "vendor" / "thing" / "readme.txt").write_text("hi")
+
+        result = json.loads(file_tools.search_files(pattern="**/*"))
+        files = result["files"]
+        assert not any(".git" in Path(p).parts for p in files)
+        assert "vendor/thing/readme.txt" in files
+
+
+def test_exclude_patterns_support_globs():
+    """Glob patterns like '*.egg-info' are honored."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        file_tools = FileTools(base_dir=base_dir, exclude_patterns=["*.egg-info"])
+
+        egg = base_dir / "foo.egg-info"
+        egg.mkdir()
+        (egg / "PKG-INFO").write_text("Name: foo")
+        (base_dir / "keep.txt").write_text("keep")
+
+        result = json.loads(file_tools.search_files(pattern="**/*"))
+        files = result["files"]
+        assert not any("egg-info" in p for p in files)
+        assert "keep.txt" in files
+
+
+def test_search_content_honors_exclusions():
+    """search_content should not return matches inside excluded directories."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        file_tools = FileTools(base_dir=base_dir)
+
+        venv_pkg = base_dir / ".venv" / "lib"
+        venv_pkg.mkdir(parents=True)
+        (venv_pkg / "hit.py").write_text("# TODO: something")
+        (base_dir / "real.py").write_text("# TODO: real work")
+
+        result = json.loads(file_tools.search_content(query="TODO"))
+        file_names = [m["file"] for m in result["files"]]
+        assert result["matches_found"] == 1
+        assert "real.py" in file_names
+        assert not any(".venv" in f for f in file_names)

--- a/libs/agno/tests/unit/tools/test_filetools.py
+++ b/libs/agno/tests/unit/tools/test_filetools.py
@@ -301,6 +301,32 @@ def test_exclude_patterns_support_globs():
         assert "keep.txt" in files
 
 
+def test_default_excludes_env_family():
+    """The '.env*' and '*.env' default patterns together hide both prefix
+    (.env.local) and suffix (local.env) naming conventions for env files."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        file_tools = FileTools(base_dir=base_dir)
+
+        # Prefix convention (Next.js / Vite / most modern web frameworks)
+        (base_dir / ".env").write_text("SECRET=1")
+        (base_dir / ".env.local").write_text("SECRET=2")
+        (base_dir / ".env.production").write_text("SECRET=3")
+        (base_dir / ".envrc").write_text("export FOO=bar")
+
+        # Suffix convention (Docker Compose --env-file, shell scripts)
+        (base_dir / "local.env").write_text("SECRET=4")
+        (base_dir / "prod.env").write_text("SECRET=5")
+
+        # Real code that happens to contain "env" - must stay visible
+        (base_dir / "environment.py").write_text("import os")
+        (base_dir / "env.yaml").write_text("key: value")
+        (base_dir / "keep.txt").write_text("visible")
+
+        listed = sorted(json.loads(file_tools.list_files()))
+        assert listed == ["env.yaml", "environment.py", "keep.txt"]
+
+
 def test_search_content_honors_exclusions():
     """search_content should not return matches inside excluded directories."""
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
## Summary

Adds an `exclude_patterns: Optional[List[str]] = None` parameter to `FileTools` that filters matching paths out of `list_files`, `search_files`, and `search_content`.

**Motivation:** A `FileTools(base_dir=<repo_root>)` instance pointed at a real project returns noise from `.venv/`, `.git/`, `__pycache__/`, `node_modules/`, etc. A plain-English `search_content("growth")` call could easily return 20 hits from `.venv/lib/python3.12/site-packages/...` before any real signal. This is a near-universal pain point for agents operating against a repo root.

**Design:**

- `DEFAULT_EXCLUDE_PATTERNS` covers the usual suspects: `.venv`, `venv`, `.env`, `.git`, `.hg`, `.svn`, `__pycache__`, `node_modules`, `.mypy_cache`, `.ruff_cache`, `.pytest_cache`, `.tox`, `.nox`, `dist`, `build`, `*.egg-info`, `.next`, `.turbo`, `.DS_Store`.
- Each pattern is `fnmatch`-ed against any path component of the file's path relative to `base_dir`. A file is excluded if any component matches any pattern — so `.git` catches both `.git/` at the root and `vendor/thing/.git/` nested deep, and `*.egg-info` works as a glob.
- `search_content` switches from `Path.rglob("*")` to `os.walk` with in-place `dirnames` pruning so excluded directories aren't descended into at all (not just filtered after the fact).

**Behavior change:** by default, users will no longer see `.venv` / `.git` / etc. in results. This is almost always what they want, and it's documented in the class docstring. Pass `exclude_patterns=[]` to restore prior behavior.

**Non-goals:** no `.gitignore` parsing (documented explicitly), no new methods, no symlink-following changes.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

Note: default behavior of existing methods changes (noise dirs hidden by default). This is opt-outable with `exclude_patterns=[]`.

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

**Tests** (in `libs/agno/tests/unit/tools/test_filetools.py`):

- `test_default_exclude_patterns_hide_junk` — default excludes hide `.venv` from `search_files` and `list_files`.
- `test_empty_exclude_patterns_opts_out` — `exclude_patterns=[]` restores prior no-exclusion behavior.
- `test_custom_exclude_patterns` — custom list replaces the default.
- `test_exclude_patterns_match_nested_components` — `.git` excludes `vendor/thing/.git/config`.
- `test_exclude_patterns_support_globs` — `*.egg-info` matches `foo.egg-info/`.
- `test_search_content_honors_exclusions` — `search_content` skips matches inside excluded dirs.

All 17 tests (11 existing + 6 new) pass. `./scripts/format.sh` and `./scripts/validate.sh` run clean on the touched files — the 8 pre-existing mypy errors in `libs/agno/agno/tools/slack.py` are unrelated and on `main`.

**Smoke test:**

```python
from pathlib import Path
from agno.tools.file import FileTools

tools = FileTools(base_dir=Path.cwd())
# Before: returns .venv/site-packages/* noise
# After: clean results scoped to actual source tree
print(tools.search_content(query="TODO"))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)