### PR TITLE
fix: skip test_scrapegraph when scrapegraph-py is not installed

### DIFF
--- a/libs/agno/tests/unit/tools/test_scrapegraph.py
+++ b/libs/agno/tests/unit/tools/test_scrapegraph.py
@@ -6,7 +6,9 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from agno.tools.scrapegraph import ScrapeGraphTools
+pytest.importorskip("scrapegraph_py")
+
+from agno.tools.scrapegraph import ScrapeGraphTools  # noqa: E402
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Pytest collection errored in CI when the optional `scrapegraph-py` dependency was not available:

```
ERROR libs/agno/tests/unit/tools/test_scrapegraph.py
ModuleNotFoundError: No module named 'scrapegraph_py'
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

Adds `pytest.importorskip("scrapegraph_py")` so the module is skipped cleanly when the optional dep is missing, matching the existing pattern in `test_docling.py`, `test_wikipedia.py`, and `test_llms_txt.py`.

Verified locally: `pytest libs/agno/tests/unit/tools/test_scrapegraph.py` now reports `1 skipped` instead of erroring during collection.

Note: the other warnings in the CI log (`zep_cloud` invalid escape sequences, `authlib` deprecation) are upstream bugs in third-party packages and are not addressed here.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

One-line change plus a `# noqa: E402` on the now-late import.