### PR TITLE
fix: multi-framework fixes

### DIFF
--- a/cookbook/frameworks/claude-agent-sdk/claude_agentos.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_agentos.py
@@ -12,7 +12,7 @@ Requirements:
     pip install claude-agent-sdk
 
 Usage:
-    .venvs/demo/bin/python cookbook/frameworks/claude_agentos.py
+    .venvs/demo/bin/python cookbook/frameworks/claude-agent-sdk/claude_agentos.py
 
 Then call the API:
     # List agents

--- a/cookbook/frameworks/claude-agent-sdk/claude_basic.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_basic.py
@@ -5,7 +5,7 @@ Requirements:
     pip install claude-agent-sdk
 
 Usage:
-    .venvs/demo/bin/python cookbook/frameworks/claude_basic.py
+    .venvs/demo/bin/python cookbook/frameworks/claude-agent-sdk/claude_basic.py
 """
 
 from agno.agents.claude import ClaudeAgent

--- a/cookbook/frameworks/claude-agent-sdk/claude_mcp_tools.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_mcp_tools.py
@@ -8,7 +8,7 @@ Requirements:
     pip install claude-agent-sdk
 
 Usage:
-    .venvs/demo/bin/python cookbook/frameworks/claude_mcp_tools.py
+    .venvs/demo/bin/python cookbook/frameworks/claude-agent-sdk/claude_mcp_tools.py
 """
 
 from agno.agents.claude import ClaudeAgent

--- a/cookbook/frameworks/claude-agent-sdk/claude_session.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_session.py
@@ -44,5 +44,4 @@ agent.print_response(
     session_id=SESSION_ID,
 )
 
-print("\n--- Session persisted to tmp/claude_sessions.db ---")
-print(f"Session ID: {SESSION_ID}")
+print(f"\n--- Session {SESSION_ID} persisted to Postgres ---")

--- a/cookbook/frameworks/claude-agent-sdk/claude_tools.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_tools.py
@@ -8,7 +8,7 @@ Requirements:
     pip install claude-agent-sdk
 
 Usage:
-    .venvs/demo/bin/python cookbook/frameworks/claude_tools.py
+    .venvs/demo/bin/python cookbook/frameworks/claude-agent-sdk/claude_tools.py
 """
 
 from agno.agents.claude import ClaudeAgent

--- a/cookbook/frameworks/dspy/dspy_session.py
+++ b/cookbook/frameworks/dspy/dspy_session.py
@@ -20,7 +20,7 @@ from agno.db.postgres import PostgresDb
 lm = dspy.LM("openai/gpt-5.4")
 dspy.configure(lm=lm)
 
-# ----- Create agent with SQLite persistence -----
+# ----- Create agent with Postgres persistence -----
 db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
 
 agent = DSPyAgent(
@@ -53,6 +53,5 @@ agent.print_response(
     session_id=SESSION_ID,
 )
 
-print("\n--- Session persisted to tmp/dspy_sessions.db ---")
-print(f"Session ID: {SESSION_ID}")
+print(f"\n--- Session {SESSION_ID} persisted to Postgres ---")
 print("You can inspect the DB to see all runs and messages stored.")

--- a/libs/agno/agno/agents/base.py
+++ b/libs/agno/agno/agents/base.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from dataclasses import dataclass
 from time import time
 from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, Sequence, Union
@@ -22,7 +23,7 @@ from agno.run.agent import (
 )
 from agno.run.base import RunStatus
 from agno.session.agent import AgentSession
-from agno.utils.log import logger
+from agno.utils.log import log_exception, log_warning
 
 
 @dataclass
@@ -468,20 +469,22 @@ class BaseExternalAgent:
     ) -> RunOutput:
         """Build a RunOutput with properly populated messages for chat history."""
         now = int(time())
-        messages: List[Message] = [
-            Message(role="user", content=str(input_text), created_at=now),
-        ]
+        messages: List[Message] = []
+        # Skip synthetic user messages for replay/fork (input is None)
+        if input_text is not None:
+            messages.append(Message(role="user", content=str(input_text), created_at=now))
 
         # Add tool call messages between user and assistant
         if tools:
             for tool in tools:
                 # Tool call request
+                tool_call_id = tool.tool_call_id or str(uuid4())
                 tool_call_data = {
-                    "id": tool.tool_call_id or str(uuid4()),
+                    "id": tool_call_id,
                     "type": "function",
                     "function": {
                         "name": tool.tool_name or "",
-                        "arguments": str(tool.tool_args or {}),
+                        "arguments": json.dumps(tool.tool_args or {}),
                     },
                 }
                 messages.append(
@@ -495,7 +498,7 @@ class BaseExternalAgent:
                 messages.append(
                     Message(
                         role="tool",
-                        tool_call_id=tool_call_data["id"],
+                        tool_call_id=tool_call_id,
                         content=str(tool.result or ""),
                         created_at=now,
                     )
@@ -511,7 +514,7 @@ class BaseExternalAgent:
             agent_name=self.name,
             session_id=session_id,
             user_id=user_id,
-            input=RunInput(input_content=str(input_text)),
+            input=RunInput(input_content=str(input_text)) if input_text is not None else None,
             content=content,
             messages=messages,
             tools=tools,
@@ -586,7 +589,7 @@ class BaseExternalAgent:
                 status=RunStatus.completed,
             )
         except Exception as e:
-            logger.error(f"Error in {self.framework} agent '{self.id}': {e}")
+            log_exception(f"Error in {self.framework} agent '{self.id}': {e}")
             run_output = self._build_run_output(
                 run_id=run_id,
                 session_id=session_id,
@@ -596,12 +599,16 @@ class BaseExternalAgent:
                 status=RunStatus.error,
             )
 
-        # Persist the run to the session
+        # Persist the run to the session. Swallow DB failures so the caller still
+        # receives the RunOutput — matching agent/_storage.aupsert_session semantics.
         if session is not None:
             if session.runs is None:
                 session.runs = []
             session.runs.append(run_output)
-            await self.aupsert_session(session)
+            try:
+                await self.aupsert_session(session)
+            except Exception as upsert_err:
+                log_warning(f"Failed to persist run for {self.framework} agent '{self.id}': {upsert_err}")
 
         return run_output
 
@@ -628,9 +635,11 @@ class BaseExternalAgent:
             session_id=session_id,
         )
 
+        accumulated_content = ""
+        accumulated_tools: List[ToolExecution] = []
+        run_error: Optional[Exception] = None
+
         try:
-            accumulated_content = ""
-            accumulated_tools: List[ToolExecution] = []
             # Map tool_call_id -> ToolExecution for merging started+completed
             tool_map: Dict[str, ToolExecution] = {}
 
@@ -653,38 +662,45 @@ class BaseExternalAgent:
                     else:
                         accumulated_tools.append(event.tool)
                 yield event
+        except Exception as e:
+            log_exception(f"Error in {self.framework} agent '{self.id}': {e}")
+            run_error = e
 
-            # Persist the run to the session
-            if session is not None:
-                run_output = self._build_run_output(
-                    run_id=run_id,
-                    session_id=session_id,
-                    user_id=user_id,
-                    input_text=input,
-                    content=accumulated_content,
-                    status=RunStatus.completed,
-                    tools=accumulated_tools if accumulated_tools else None,
-                )
-                if session.runs is None:
-                    session.runs = []
-                session.runs.append(run_output)
+        # Persist the run to the session. Swallow DB failures so the consumer
+        # still receives the terminal RunCompletedEvent / RunErrorEvent below.
+        if session is not None:
+            run_output = self._build_run_output(
+                run_id=run_id,
+                session_id=session_id,
+                user_id=user_id,
+                input_text=input,
+                content=str(run_error) if run_error is not None else accumulated_content,
+                status=RunStatus.error if run_error is not None else RunStatus.completed,
+                tools=accumulated_tools if accumulated_tools else None,
+            )
+            if session.runs is None:
+                session.runs = []
+            session.runs.append(run_output)
+            try:
                 await self.aupsert_session(session)
+            except Exception as upsert_err:
+                log_warning(f"Failed to persist run for {self.framework} agent '{self.id}': {upsert_err}")
 
+        if run_error is not None:
+            yield RunErrorEvent(
+                run_id=run_id,
+                agent_id=self.id,
+                agent_name=self.name or "",
+                session_id=session_id,
+                content=str(run_error),
+            )
+        else:
             yield RunCompletedEvent(
                 run_id=run_id,
                 agent_id=self.id,
                 agent_name=self.name or "",
                 session_id=session_id,
                 content=accumulated_content,
-            )
-        except Exception as e:
-            logger.error(f"Error in {self.framework} agent '{self.id}': {e}")
-            yield RunErrorEvent(
-                run_id=run_id,
-                agent_id=self.id,
-                agent_name=self.name or "",
-                session_id=session_id,
-                content=str(e),
             )
 
     def _run_stream(self, input: Any, **kwargs: Any) -> Iterator[RunOutputEvent]:
@@ -694,14 +710,21 @@ class BaseExternalAgent:
 
         event_queue: queue.Queue = queue.Queue()
         _sentinel = object()
+        thread_error: List[BaseException] = []
 
         def _run_async():
             async def _produce():
                 async for event in self._arun_stream(input, **kwargs):
                     event_queue.put(event)
-                event_queue.put(_sentinel)
 
-            asyncio.run(_produce())
+            # Sentinel goes out in finally so the consumer never blocks forever, even
+            # if anything above _arun_stream's own try/except raises (e.g. db load).
+            try:
+                asyncio.run(_produce())
+            except BaseException as e:
+                thread_error.append(e)
+            finally:
+                event_queue.put(_sentinel)
 
         thread = threading.Thread(target=_run_async, daemon=True)
         thread.start()
@@ -713,6 +736,8 @@ class BaseExternalAgent:
             yield item
 
         thread.join()
+        if thread_error:
+            raise thread_error[0]
 
     # ---------------------------------------------------------------------------
     # Subclass hooks (must be implemented by adapters)

--- a/libs/agno/agno/agents/claude/agent.py
+++ b/libs/agno/agno/agents/claude/agent.py
@@ -119,34 +119,55 @@ class ClaudeAgent(BaseExternalAgent):
         opts.update(self.options_kwargs)
         return sdk.ClaudeAgentOptions(**opts)
 
+    @staticmethod
+    def _check_result_message(sdk: Any, message: Any) -> None:
+        """Raise if the SDK reported an error result so the base class can surface it."""
+        if not isinstance(message, sdk.ResultMessage):
+            return
+        is_error = bool(getattr(message, "is_error", False))
+        subtype = getattr(message, "subtype", None)
+        if is_error or (subtype and subtype != "success"):
+            # `message.result` carries the human-readable error text in the
+            # invalid-model case where subtype="success" but is_error=True.
+            detail = (
+                getattr(message, "errors", None)
+                or getattr(message, "result", None)
+                or getattr(message, "stop_reason", None)
+            )
+            raise RuntimeError(f"Claude SDK error (is_error={is_error}, subtype={subtype}): {detail}")
+
     async def _arun_adapter(self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any) -> str:
         """Non-streaming: collect all messages and return final content."""
         sdk = _sdk()
 
         options = self._build_options(**kwargs)
         agno_session_id = kwargs.get("session_id")
-        result_text = ""
+        assistant_text = ""
+        final_result = ""
 
         async for message in sdk.query(prompt=str(input), options=options):
             if isinstance(message, sdk.SystemMessage):
                 if hasattr(message, "subtype") and message.subtype == "init":
                     data = getattr(message, "data", {}) or {}
-                    if "session_id" in data and agno_session_id:
-                        self._sdk_session_ids[agno_session_id] = data["session_id"]
+                    sdk_session_id = data.get("session_id")
+                    if sdk_session_id and agno_session_id:
+                        self._sdk_session_ids[agno_session_id] = sdk_session_id
 
             elif isinstance(message, sdk.AssistantMessage):
+                # Accumulate every text block; multiple blocks per message are valid
                 for block in message.content:
                     if isinstance(block, sdk.TextBlock):
-                        result_text = block.text
+                        assistant_text += block.text
 
             elif isinstance(message, sdk.ResultMessage):
+                self._check_result_message(sdk, message)
                 if hasattr(message, "session_id") and message.session_id and agno_session_id:
                     self._sdk_session_ids[agno_session_id] = message.session_id
-                # Use result text if available
                 if hasattr(message, "result") and message.result:
-                    result_text = str(message.result)
+                    final_result = str(message.result)
 
-        return result_text
+        # Prefer ResultMessage.result, fall back to accumulated assistant text
+        return final_result or assistant_text
 
     async def _arun_adapter_stream(
         self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any
@@ -196,8 +217,9 @@ class ClaudeAgent(BaseExternalAgent):
             elif isinstance(message, sdk.SystemMessage):
                 if hasattr(message, "subtype") and message.subtype == "init":
                     data = getattr(message, "data", {}) or {}
-                    if "session_id" in data and agno_session_id:
-                        self._sdk_session_ids[agno_session_id] = data["session_id"]
+                    sdk_session_id = data.get("session_id")
+                    if sdk_session_id and agno_session_id:
+                        self._sdk_session_ids[agno_session_id] = sdk_session_id
 
             elif isinstance(message, sdk.AssistantMessage):
                 # Always extract tool calls from complete AssistantMessage
@@ -257,5 +279,6 @@ class ClaudeAgent(BaseExternalAgent):
                             )
 
             elif isinstance(message, sdk.ResultMessage):
+                self._check_result_message(sdk, message)
                 if hasattr(message, "session_id") and message.session_id and agno_session_id:
                     self._sdk_session_ids[agno_session_id] = message.session_id

--- a/libs/agno/agno/agents/dspy/agent.py
+++ b/libs/agno/agno/agents/dspy/agent.py
@@ -56,6 +56,28 @@ class DSPyAgent(BaseExternalAgent):
     program_kwargs: Dict[str, Any] = field(default_factory=dict)
     framework: str = "dspy"
 
+    @staticmethod
+    def _clone_lm_without_cache(lm: Any) -> Any:
+        """Clone `lm` with caching disabled.
+
+        Prefers `dspy.LM.copy(**overrides)` — the idiomatic path — which deep-copies
+        and preserves num_retries, callbacks, launch_kwargs, and other top-level LM
+        attributes that aren't in `lm.kwargs`. Falls back to rebuilding from `lm.kwargs`
+        for custom LM subclasses that don't implement copy().
+        """
+        copy_fn = getattr(lm, "copy", None)
+        if callable(copy_fn):
+            return copy_fn(cache=False)
+
+        import dspy
+
+        preserved = {k: v for k, v in (getattr(lm, "kwargs", {}) or {}).items() if v is not None}
+        preserved["cache"] = False
+        model_type = getattr(lm, "model_type", None)
+        if model_type is not None:
+            preserved.setdefault("model_type", model_type)
+        return dspy.LM(lm.model, **preserved)
+
     async def _arun_adapter(self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any) -> str:
         """Non-streaming: run the DSPy program and return the output field."""
         try:
@@ -117,7 +139,7 @@ class DSPyAgent(BaseExternalAgent):
         # we temporarily scope a non-cached LM via dspy.context().
         current_lm = self.lm or dspy.settings.lm
         if current_lm and getattr(current_lm, "cache", True):
-            stream_lm = dspy.LM(current_lm.model, cache=False)
+            stream_lm = self._clone_lm_without_cache(current_lm)
         else:
             stream_lm = current_lm
 
@@ -127,21 +149,10 @@ class DSPyAgent(BaseExternalAgent):
             stream_listeners=[dspy.streaming.StreamListener(signature_field_name=self.output_field)],
         )
 
-        # Scope a cache-free LM so streaming always produces token chunks.
-        # Tool calls from ReAct are extracted from the final Prediction's
-        # trajectory dict (tool_name_N, tool_args_N, observation_N).
-        # We yield them before the streamed text content.
-        tool_events: List[RunOutputEvent] = []
-
+        # DSPy emits StreamResponse chunks first and Prediction last, so tool events land after text.
         with dspy.context(lm=stream_lm):
             async for chunk in streaming_program(**program_input):
                 if isinstance(chunk, dspy.streaming.StreamResponse):
-                    # Before first text token, flush any accumulated tool events
-                    if tool_events:
-                        for evt in tool_events:
-                            yield evt
-                        tool_events = []
-                    # Token-level text streaming
                     if chunk.chunk:
                         yield RunContentEvent(
                             run_id=run_id,
@@ -151,7 +162,6 @@ class DSPyAgent(BaseExternalAgent):
                         )
 
                 elif isinstance(chunk, dspy.Prediction):
-                    # Extract tool calls from the trajectory dict (ReAct pattern)
                     trajectory = getattr(chunk, "trajectory", {}) or {}
                     i = 0
                     while f"tool_name_{i}" in trajectory:
@@ -160,34 +170,26 @@ class DSPyAgent(BaseExternalAgent):
                         t_result = trajectory.get(f"observation_{i}", "")
                         if t_name != "finish":
                             t_id = str(uuid4())
-                            tool_events.append(
-                                ToolCallStartedEvent(
-                                    run_id=run_id,
-                                    agent_id=self.id,
-                                    agent_name=self.name or "",
-                                    tool=ToolExecution(
-                                        tool_call_id=t_id,
-                                        tool_name=str(t_name),
-                                        tool_args=t_args if isinstance(t_args, dict) else {"input": str(t_args)},
-                                    ),
-                                )
+                            yield ToolCallStartedEvent(
+                                run_id=run_id,
+                                agent_id=self.id,
+                                agent_name=self.name or "",
+                                tool=ToolExecution(
+                                    tool_call_id=t_id,
+                                    tool_name=str(t_name),
+                                    tool_args=t_args if isinstance(t_args, dict) else {"input": str(t_args)},
+                                ),
                             )
-                            tool_events.append(
-                                ToolCallCompletedEvent(
-                                    run_id=run_id,
-                                    agent_id=self.id,
-                                    agent_name=self.name or "",
-                                    tool=ToolExecution(
-                                        tool_call_id=t_id,
-                                        tool_name=str(t_name),
-                                        result=str(t_result),
-                                    ),
-                                )
+                            yield ToolCallCompletedEvent(
+                                run_id=run_id,
+                                agent_id=self.id,
+                                agent_name=self.name or "",
+                                tool=ToolExecution(
+                                    tool_call_id=t_id,
+                                    tool_name=str(t_name),
+                                    result=str(t_result),
+                                ),
                             )
                         i += 1
 
                 # StatusMessage — skip (internal DSPy execution status)
-
-        # Flush any tool events on the cache-hit path (no StreamResponse was yielded).
-        for evt in tool_events:
-            yield evt

--- a/libs/agno/agno/agents/langgraph/agent.py
+++ b/libs/agno/agno/agents/langgraph/agent.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Dict, Iterator, List, Optional, cast
+from typing import Any, AsyncIterator, Dict, List, Optional
 from uuid import uuid4
 
 from agno.agents.base import BaseExternalAgent
@@ -61,7 +61,14 @@ class LangGraphAgent(BaseExternalAgent):
     config: Optional[Dict[str, Any]] = field(default=None)
     framework: str = "langgraph"
 
-    async def _arun_adapter(self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any) -> Any:
+    async def _arun_adapter(
+        self,
+        input: Any,
+        *,
+        history: Optional[List[Dict[str, Any]]] = None,
+        _lg_config_override: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> Any:
         """Non-streaming LangGraph invocation."""
         try:
             from langchain_core.messages import AIMessage
@@ -72,7 +79,7 @@ class LangGraphAgent(BaseExternalAgent):
             graph_input = None
         else:
             graph_input = {self.input_key: build_messages_with_history(input, history)}
-        config = self._build_config(kwargs)
+        config = self._build_config(kwargs, override=_lg_config_override)
 
         result = await self.graph.ainvoke(graph_input, config=config)
 
@@ -84,7 +91,12 @@ class LangGraphAgent(BaseExternalAgent):
         return str(result)
 
     async def _arun_adapter_stream(
-        self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any
+        self,
+        input: Any,
+        *,
+        history: Optional[List[Dict[str, Any]]] = None,
+        _lg_config_override: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
     ) -> AsyncIterator[RunOutputEvent]:
         """Streaming LangGraph invocation with tool call visibility."""
         if self.graph is None:
@@ -96,7 +108,7 @@ class LangGraphAgent(BaseExternalAgent):
             graph_input = None
         else:
             graph_input = {self.input_key: build_messages_with_history(input, history)}
-        config = self._build_config(kwargs)
+        config = self._build_config(kwargs, override=_lg_config_override)
 
         async for event in self.graph.astream_events(graph_input, config=config, version="v2"):
             kind = event.get("event")
@@ -192,13 +204,10 @@ class LangGraphAgent(BaseExternalAgent):
             agent.replay("my-session", checkpoint_id, stream=True)
         """
         replay_config = self._build_config({"session_id": session_id})
-        replay_config.setdefault("configurable", {})["checkpoint_id"] = checkpoint_id
+        replay_config["configurable"]["checkpoint_id"] = checkpoint_id
 
         # Pass config through kwargs; self.config stays untouched.
-        result = self.run(None, stream=stream, session_id=session_id, _lg_config_override=replay_config, **kwargs)
-        if stream:
-            return list(cast(Iterator, result))
-        return result
+        return self.run(None, stream=stream, session_id=session_id, _lg_config_override=replay_config, **kwargs)
 
     def print_replay(
         self,
@@ -210,7 +219,7 @@ class LangGraphAgent(BaseExternalAgent):
     ) -> None:
         """Replay from a checkpoint and print the response with Rich formatting."""
         replay_config = self._build_config({"session_id": session_id})
-        replay_config.setdefault("configurable", {})["checkpoint_id"] = checkpoint_id
+        replay_config["configurable"]["checkpoint_id"] = checkpoint_id
         self.print_response(None, stream=stream, session_id=session_id, _lg_config_override=replay_config, **kwargs)
 
     def fork(
@@ -232,7 +241,7 @@ class LangGraphAgent(BaseExternalAgent):
             agent.fork("my-session", checkpoint_id, {"topic": "cats"}, stream=True)
         """
         fork_config_base = self._build_config({"session_id": session_id})
-        fork_config_base.setdefault("configurable", {})["checkpoint_id"] = checkpoint_id
+        fork_config_base["configurable"]["checkpoint_id"] = checkpoint_id
 
         update_kwargs: Dict[str, Any] = {"values": values}
         if as_node:
@@ -240,10 +249,7 @@ class LangGraphAgent(BaseExternalAgent):
         new_config = self.graph.update_state(fork_config_base, **update_kwargs)
 
         # Pass config through kwargs; self.config stays untouched.
-        result = self.run(None, stream=stream, session_id=session_id, _lg_config_override=new_config, **kwargs)
-        if stream:
-            return list(cast(Iterator, result))
-        return result
+        return self.run(None, stream=stream, session_id=session_id, _lg_config_override=new_config, **kwargs)
 
     def print_fork(
         self,
@@ -257,7 +263,7 @@ class LangGraphAgent(BaseExternalAgent):
     ) -> None:
         """Fork from a checkpoint with modified state and print the response."""
         fork_config_base = self._build_config({"session_id": session_id})
-        fork_config_base.setdefault("configurable", {})["checkpoint_id"] = checkpoint_id
+        fork_config_base["configurable"]["checkpoint_id"] = checkpoint_id
 
         update_kwargs: Dict[str, Any] = {"values": values}
         if as_node:
@@ -265,13 +271,11 @@ class LangGraphAgent(BaseExternalAgent):
         new_config = self.graph.update_state(fork_config_base, **update_kwargs)
         self.print_response(None, stream=stream, session_id=session_id, _lg_config_override=new_config, **kwargs)
 
-    def _build_config(self, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    def _build_config(self, kwargs: Dict[str, Any], *, override: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Build a LangGraph config mapping session_id to thread_id."""
-        # Replay/fork pass a prebuilt config via _lg_config_override so self.config stays untouched.
-        override = kwargs.pop("_lg_config_override", None)
+        # Shallow copy: configs commonly carry non-deepcopyable callbacks/tracers at the top level.
         base = override if override is not None else self.config
         config: Dict[str, Any] = dict(base or {})
-        # Rebuild the configurable subdict so mutations don't leak back into self.config.
         config["configurable"] = dict(config.get("configurable") or {})
         session_id = kwargs.get("session_id")
         if session_id:


### PR DESCRIPTION
## Summary

fixes on top of #7186

### `libs/agno/agno/agents/base.py`
- Serialize `tool_calls[].function.arguments` as JSON instead of Python repr (`str({'a':1})` → `'{"a": 1}'`)
- Skip the synthetic `role="user"` message when `input_text is None` so LangGraph replay/fork history isn't polluted with phantom `"None"` turns
- Persist streamed runs with `RunStatus.error` when the adapter raises mid-stream (the errored run used to vanish because persistence lived inside the `try:` block). Also wrap `aupsert_session` in try/except + `log_warning` so DB failures don't swallow the terminal `RunCompletedEvent` / `RunErrorEvent`
- Sync `_run_stream` — move sentinel into `finally:`, capture thread exceptions into a list and re-raise on the main thread. Prevents hangs when anything above `_arun_stream`'s own try/except raises (e.g. session load failure)
- Switch to `log_exception` / `log_warning` helpers so tracebacks are captured when `AGNO_LOG_TRACEBACKS` is enabled

### `libs/agno/agno/agents/claude/agent.py`
- Guard SDK session id capture against empty-string / `None` values
- Accumulate `AssistantMessage` text blocks instead of overwriting; multi-block replies with interleaved tool use no longer drop earlier text
- New `_check_result_message` raises on `ResultMessage` errors (`is_error=True` or non-success subtype) so the base class emits `RunErrorEvent` with the real SDK reason. Covers the invalid-model case where `subtype="success"` but `is_error=True`

### `libs/agno/agno/agents/dspy/agent.py`
- `_clone_lm_without_cache` uses `dspy.LM.copy(cache=False)` as the primary path so streaming preserves `num_retries`, `callbacks`, `api_base`, `temperature`, and every other LM attribute that wasn't in `lm.kwargs`. Falls back to kwargs-based rebuild for custom LM subclasses that don't implement `copy()`
- Remove dead `tool_events` accumulator; yield `ToolCallStartedEvent` / `ToolCallCompletedEvent` directly from the `Prediction` branch. Same observable behaviour, simpler code

### `libs/agno/agno/agents/langgraph/agent.py`
- Declare `_lg_config_override` as an explicit typed kwarg on `_arun_adapter` / `_arun_adapter_stream`; `_build_config` takes it as a named parameter. Matches the `_attempt=0` / `_retries=0` style already used in `generate_session_name`
- `replay()` / `fork()` return the iterator instead of materialising it with `list(cast(Iterator, result))`, so `stream=True` actually streams
- Simplify `setdefault("configurable", {})` to direct indexing now that `_build_config` always ensures the key

### Cookbooks (6 files)
- Correct `Usage:` paths (`cookbook/frameworks/claude_*.py` → `cookbook/frameworks/claude-agent-sdk/claude_*.py`)
- Replace stale `tmp/*.db` / "SQLite persistence" messages with accurate Postgres text in `claude-agent-sdk/claude_session.py` and `dspy/dspy_session.py`

(If applicable, issue number: #____)

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes
