### PR TITLE
fix: resolve factory workflow follow-ups

### DIFF
--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -1032,6 +1032,10 @@ def get_workflow_router(
         session_id: Optional[str] = Form(None, description="Session ID for the paused run"),
         user_id: Optional[str] = Form(None, description="User identifier for tracking and personalization"),
         stream: bool = Form(True, description="Enable streaming responses via Server-Sent Events (SSE)"),
+        factory_input: Optional[str] = Form(
+            None,
+            description="JSON object with factory-specific parameters for dynamic workflow reconstruction",
+        ),
     ):
         if hasattr(request.state, "user_id") and request.state.user_id is not None:
             user_id = request.state.user_id
@@ -1044,15 +1048,16 @@ def get_workflow_router(
         except json.JSONDecodeError:
             raise HTTPException(status_code=400, detail="Invalid JSON in step_requirements field")
 
-        workflow = get_workflow_by_id(
-            workflow_id=workflow_id,
-            workflows=os.workflows,
-            db=os.db,
-            registry=os.registry,
-            create_fresh=True,
+        workflow = await resolve_workflow(
+            workflow_id,
+            os.workflows,
+            os.db,
+            os.registry,
+            request=request,
+            user_id=user_id,
+            session_id=session_id,
+            factory_input=factory_input,
         )
-        if workflow is None:
-            raise HTTPException(status_code=404, detail="Workflow not found")
 
         if isinstance(workflow, RemoteWorkflow):
             raise HTTPException(status_code=400, detail="Continue is not supported for remote workflows")
@@ -1173,8 +1178,19 @@ def get_workflow_router(
     async def get_workflow_run(
         workflow_id: str,
         run_id: str,
+        request: Request,
         session_id: str = Query(..., description="Session ID for the run"),
+        factory_input: Optional[str] = Query(
+            None,
+            description="JSON object with factory-specific parameters for dynamic workflow reconstruction",
+        ),
     ):
+        user_id = getattr(request.state, "user_id", None)
+        if hasattr(request.state, "session_id") and request.state.session_id is not None:
+            if session_id and session_id != request.state.session_id:
+                log_warning("Session ID parameter passed in both request state and query params, using request state")
+            session_id = request.state.session_id
+
         # Factory workflows: resolve to get a real workflow for session lookup
         factory = find_factory_by_id(workflow_id, os.workflows)
         if factory:
@@ -1182,7 +1198,10 @@ def get_workflow_router(
                 workflow_id,
                 os.workflows,
                 factory.db,
+                request=request,
+                user_id=user_id,
                 session_id=session_id,
+                factory_input=factory_input,
             )
         else:
             try:
@@ -1220,18 +1239,34 @@ def get_workflow_router(
     )
     async def list_workflow_runs(
         workflow_id: str,
+        request: Request,
         session_id: str = Query(..., description="Session ID to list runs for"),
         status: Optional[str] = Query(
             None, description="Filter by run status (PENDING, RUNNING, COMPLETED, ERROR, PAUSED)"
         ),
+        factory_input: Optional[str] = Query(
+            None,
+            description="JSON object with factory-specific parameters for dynamic workflow reconstruction",
+        ),
     ):
         from agno.os.schema import WorkflowRunSchema
 
-        workflow = get_workflow_by_id(
-            workflow_id=workflow_id, workflows=os.workflows, db=os.db, registry=os.registry, create_fresh=True
+        user_id = getattr(request.state, "user_id", None)
+        if hasattr(request.state, "session_id") and request.state.session_id is not None:
+            if session_id and session_id != request.state.session_id:
+                log_warning("Session ID parameter passed in both request state and query params, using request state")
+            session_id = request.state.session_id
+
+        workflow = await resolve_workflow(
+            workflow_id,
+            os.workflows,
+            os.db,
+            os.registry,
+            request=request,
+            user_id=user_id,
+            session_id=session_id,
+            factory_input=factory_input,
         )
-        if workflow is None:
-            raise HTTPException(status_code=404, detail="Workflow not found")
         if isinstance(workflow, RemoteWorkflow):
             raise HTTPException(status_code=400, detail="Run listing is not supported for remote workflows")
 

--- a/libs/agno/tests/integration/os/test_workflow_continue.py
+++ b/libs/agno/tests/integration/os/test_workflow_continue.py
@@ -4,9 +4,11 @@ import json
 
 import pytest
 from fastapi.testclient import TestClient
+from pydantic import BaseModel
 
 from agno.db.sqlite import SqliteDb
 from agno.os import AgentOS
+from agno.workflow.factory import WorkflowFactory
 from agno.workflow import OnReject
 from agno.workflow.condition import Condition
 from agno.workflow.step import Step
@@ -40,6 +42,10 @@ def _report(si: StepInput) -> StepOutput:
     return StepOutput(content=f"Final report based on: {prev}")
 
 
+class WorkflowFactoryInput(BaseModel):
+    mode: str = "default"
+
+
 @pytest.fixture
 def hitl_client(temp_storage_db_file):
     """Create a TestClient with a HITL workflow containing two Conditions."""
@@ -70,6 +76,49 @@ def hitl_client(temp_storage_db_file):
         ],
     )
     app = AgentOS(workflows=[workflow]).get_app()
+    return TestClient(app)
+
+
+@pytest.fixture
+def factory_hitl_client(temp_storage_db_file):
+    """Create a TestClient with a HITL workflow factory."""
+    db = SqliteDb(db_file=temp_storage_db_file)
+
+    def build_workflow(ctx):
+        return Workflow(
+            name="decision-tree-factory",
+            id="generated-decision-tree",
+            db=db,
+            metadata={"mode": getattr(ctx.input, "mode", None)},
+            steps=[
+                Step(name="gather", executor=_gather),
+                Condition(
+                    name="first_decision",
+                    requires_confirmation=True,
+                    confirmation_message="Run detailed analysis?",
+                    on_reject=OnReject.else_branch,
+                    steps=[Step(name="detailed", executor=_detailed)],
+                    else_steps=[Step(name="quick", executor=_quick)],
+                ),
+                Condition(
+                    name="second_decision",
+                    requires_confirmation=True,
+                    confirmation_message="Deep dive or surface review?",
+                    on_reject=OnReject.else_branch,
+                    steps=[Step(name="deep", executor=_deep)],
+                    else_steps=[Step(name="surface", executor=_surface)],
+                ),
+                Step(name="report", executor=_report),
+            ],
+        )
+
+    workflow_factory = WorkflowFactory(
+        db=db,
+        id="decision-tree-factory",
+        factory=build_workflow,
+        input_schema=WorkflowFactoryInput,
+    )
+    app = AgentOS(workflows=[workflow_factory]).get_app()
     return TestClient(app)
 
 
@@ -163,6 +212,41 @@ def test_continue_confirm_both(hitl_client):
     assert d3["status"] == "COMPLETED"
     assert d3["step_results"][1]["steps"][0]["content"] == "Detailed analysis complete"
     assert d3["step_results"][2]["steps"][0]["content"] == "Deep dive complete"
+
+
+def test_continue_factory_workflow_with_factory_input(factory_hitl_client):
+    """Factory workflows should be resumable through /continue."""
+    run_response = factory_hitl_client.post(
+        "/workflows/decision-tree-factory/runs",
+        data={
+            "message": "go",
+            "stream": "false",
+            "factory_input": json.dumps({"mode": "guided"}),
+        },
+    )
+    assert run_response.status_code == 200
+    run_data = run_response.json()
+    assert run_data["status"] == "PAUSED"
+
+    run_id = run_data["run_id"]
+    session_id = run_data["session_id"]
+    requirements = run_data["step_requirements"]
+    requirements[0]["confirmed"] = True
+
+    continue_response = factory_hitl_client.post(
+        f"/workflows/decision-tree-factory/runs/{run_id}/continue",
+        data={
+            "stream": "false",
+            "session_id": session_id,
+            "factory_input": json.dumps({"mode": "guided"}),
+            "step_requirements": json.dumps(requirements),
+        },
+    )
+    assert continue_response.status_code == 200
+    continue_data = continue_response.json()
+    assert continue_data["status"] == "PAUSED"
+    assert continue_data["run_id"] == run_id
+    assert continue_data["step_requirements"]
 
 
 def test_continue_409_on_completed_run(hitl_client):

--- a/libs/agno/tests/integration/os/test_workflow_runs.py
+++ b/libs/agno/tests/integration/os/test_workflow_runs.py
@@ -7,11 +7,23 @@ import httpx
 import pytest
 from fastapi.testclient import TestClient
 from httpx import ASGITransport
+from pydantic import BaseModel
 
 from agno.db.base import ComponentType
 from agno.db.sqlite import SqliteDb
 from agno.os import AgentOS
+from agno.workflow.factory import WorkflowFactory
+from agno.workflow.step import Step
+from agno.workflow.types import StepInput, StepOutput
 from agno.workflow.workflow import Workflow
+
+
+def _factory_workflow_step(step_input: StepInput) -> StepOutput:
+    return StepOutput(content=f"Factory workflow handled: {step_input.message}")
+
+
+class FactoryWorkflowInput(BaseModel):
+    flavor: str = "default"
 
 
 def test_create_workflow_run(test_os_client, test_workflow: Workflow):
@@ -116,6 +128,66 @@ def test_create_workflow_run_with_kwargs(test_os_client, test_workflow: Workflow
         call_args = mock_arun.call_args
         assert call_args.kwargs["extra_field"] == "foo"
         assert call_args.kwargs["extra_field_two"] == "bar"
+
+
+@pytest.fixture
+def factory_workflow_client(temp_storage_db_file):
+    """Create a TestClient with a workflow factory registered in AgentOS."""
+    db = SqliteDb(db_file=temp_storage_db_file)
+
+    def build_workflow(ctx):
+        return Workflow(
+            name="factory-workflow",
+            id="generated-workflow",
+            steps=[Step(name="step1", executor=_factory_workflow_step)],
+            db=db,
+            metadata={"flavor": getattr(ctx.input, "flavor", None)},
+        )
+
+    workflow_factory = WorkflowFactory(
+        db=db,
+        id="factory-workflow",
+        factory=build_workflow,
+        input_schema=FactoryWorkflowInput,
+    )
+
+    app = AgentOS(workflows=[workflow_factory]).get_app()
+    return TestClient(app)
+
+
+def test_factory_workflow_get_run_and_list_runs(factory_workflow_client):
+    """Factory workflows should support run polling and run listing after creation."""
+    create_response = factory_workflow_client.post(
+        "/workflows/factory-workflow/runs",
+        data={
+            "message": "Hello from factory workflow",
+            "stream": "false",
+            "factory_input": json.dumps({"flavor": "vanilla"}),
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert create_response.status_code == 200
+
+    run_data = create_response.json()
+    run_id = run_data["run_id"]
+    session_id = run_data["session_id"]
+
+    get_response = factory_workflow_client.get(
+        f"/workflows/factory-workflow/runs/{run_id}",
+        params={"session_id": session_id, "factory_input": json.dumps({"flavor": "vanilla"})},
+    )
+    assert get_response.status_code == 200
+    get_data = get_response.json()
+    assert get_data["run_id"] == run_id
+    assert get_data["workflow_id"] == "factory-workflow"
+
+    list_response = factory_workflow_client.get(
+        "/workflows/factory-workflow/runs",
+        params={"session_id": session_id, "factory_input": json.dumps({"flavor": "vanilla"})},
+    )
+    assert list_response.status_code == 200
+    runs = list_response.json()
+    assert any(run["run_id"] == run_id for run in runs)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Fix factory workflow follow-up routes so they resolve workflows consistently after the initial `/runs` call.

This stacks on top of `feat/agent-factories` and addresses the HTTP follow-up flow for factory workflows:
- `/workflows/{workflow_id}/runs/{run_id}/continue`
- `/workflows/{workflow_id}/runs/{run_id}`
- `/workflows/{workflow_id}/runs`

The patch routes these handlers through `resolve_workflow(...)` like `create_workflow_run()` already does, threads request/user/session context into the resolver, and allows optional `factory_input` to be supplied on follow-up requests when a factory needs it for reconstruction.

It also adds integration coverage for:
- polling + listing runs for a factory workflow
- continuing a paused factory workflow

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

This PR is intentionally stacked on top of `feat/agent-factories`.

Targeted tests run:
- `python3 -m pytest libs/agno/tests/integration/os/test_workflow_runs.py::test_factory_workflow_get_run_and_list_runs -q`
- `python3 -m pytest libs/agno/tests/integration/os/test_workflow_continue.py::test_continue_factory_workflow_with_factory_input -q`

The broader integration files still have unrelated pre-existing failures on the current `feat/agent-factories` head, so I did not mark the full format/validate checklist items as complete.
