### PR TITLE
fix(gemini): preserve error details when str(e) is empty in ModelProviderError

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -567,8 +567,8 @@ class Gemini(Model):
         except RetryableModelProviderError:
             raise
         except Exception as e:
-            log_error(f"Unknown error from Gemini API: {str(e)}")
-            raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
+            log_error(f"Unknown error from Gemini API: {str(e) or repr(e)}")
+            raise ModelProviderError(message=str(e) or repr(e), model_name=self.name, model_id=self.id) from e
 
     def invoke_stream(
         self,
@@ -621,8 +621,8 @@ class Gemini(Model):
         except RetryableModelProviderError:
             raise
         except Exception as e:
-            log_error(f"Unknown error from Gemini API: {str(e)}")
-            raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
+            log_error(f"Unknown error from Gemini API: {str(e) or repr(e)}")
+            raise ModelProviderError(message=str(e) or repr(e), model_name=self.name, model_id=self.id) from e
 
     async def ainvoke(
         self,
@@ -680,8 +680,8 @@ class Gemini(Model):
         except RetryableModelProviderError:
             raise
         except Exception as e:
-            log_error(f"Unknown error from Gemini API: {str(e)}")
-            raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
+            log_error(f"Unknown error from Gemini API: {str(e) or repr(e)}")
+            raise ModelProviderError(message=str(e) or repr(e), model_name=self.name, model_id=self.id) from e
 
     async def ainvoke_stream(
         self,
@@ -737,8 +737,8 @@ class Gemini(Model):
         except RetryableModelProviderError:
             raise
         except Exception as e:
-            log_error(f"Unknown error from Gemini API: {str(e)}")
-            raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
+            log_error(f"Unknown error from Gemini API: {str(e) or repr(e)}")
+            raise ModelProviderError(message=str(e) or repr(e), model_name=self.name, model_id=self.id) from e
 
     def _format_messages(self, messages: List[Message], compress_tool_results: bool = False):
         """


### PR DESCRIPTION
## Summary

Fixes #7600

When a generic exception has an empty `str()` representation (e.g. `asyncio.TimeoutError`, certain network errors), the four `except Exception` handlers in `Gemini` produce:

```
Unknown error from Gemini API:
```

with no actionable detail. Root-cause debugging becomes guesswork.

## Fix

Changed `str(e)` to `str(e) or repr(e)` in both the `log_error` call and the `ModelProviderError(message=...)` argument for all four handlers (`invoke`, `invoke_stream`, `ainvoke`, `ainvoke_stream`). When `str(e)` is empty, `repr(e)` surfaces at minimum the exception class name, e.g. `asyncio.TimeoutError()`.

No behavior change when `str(e)` is already non-empty.
