### PR TITLE
fix(gemini): apply timeout after client_params merge and support HttpOptions objects

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -187,14 +187,20 @@ class Gemini(Model):
 
         client_params = {k: v for k, v in client_params.items() if v is not None}
 
+        if self.client_params:
+            client_params.update(self.client_params)
+
         if self.timeout is not None:
             http_options = client_params.get("http_options", {})
             if isinstance(http_options, dict):
                 http_options["timeout"] = int(self.timeout * 1000)
                 client_params["http_options"] = http_options
-
-        if self.client_params:
-            client_params.update(self.client_params)
+            else:
+                # http_options is an HttpOptions object; set timeout attribute directly.
+                try:
+                    http_options.timeout = int(self.timeout * 1000)
+                except AttributeError:
+                    pass
 
         self.client = genai.Client(**client_params)
         return self.client


### PR DESCRIPTION
## Summary

Fixes #7599

`Gemini.get_client()` had two issues that caused the configured `timeout` to be silently ignored:

**Problem 1 - wrong ordering**: `client_params.update(self.client_params)` ran *after* the timeout injection block. Any `http_options` value provided in `self.client_params` would overwrite the dict we had already modified with the timeout value.

**Problem 2 - non-dict http_options skipped**: The guard `if isinstance(http_options, dict)` silently skipped timeout injection when `http_options` was already a `google.genai.types.HttpOptions` object (passed via `client_params`).

## Fix

1. Moved the timeout injection block to *after* `client_params.update(self.client_params)` so it always sees the final merged options.
2. Added an `else` branch that sets `http_options.timeout` directly when `http_options` is not a dict (i.e. is an `HttpOptions` object).
