### PR TITLE
fix: re-raise InputCheckError/OutputCheckError in non-streaming run functions

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -656,7 +656,7 @@ def _run(
                         user_id=user_id,
                     )
 
-                return run_response
+                raise
             except KeyboardInterrupt:
                 run_response = cast(RunOutput, run_response)
                 run_response.status = RunStatus.cancelled
@@ -1751,7 +1751,7 @@ async def _arun(
                         user_id=user_id,
                     )
 
-                return run_response
+                raise
 
             except KeyboardInterrupt:
                 run_response = cast(RunOutput, run_response)
@@ -3061,7 +3061,7 @@ def _continue_run(
                     agent, run_response=run_response, session=session, run_context=run_context, user_id=user_id
                 )
 
-                return run_response
+                raise
             except KeyboardInterrupt:
                 run_response = cast(RunOutput, run_response)
                 run_response.status = RunStatus.cancelled
@@ -3859,7 +3859,7 @@ async def _acontinue_run(
                         user_id=user_id,
                     )
 
-                return run_response
+                raise
 
             except KeyboardInterrupt:
                 run_response = cast(RunOutput, run_response)


### PR DESCRIPTION
## Summary

The documentation shows callers using `try/except OutputCheckError` around `agent.run()` and `agent.arun()` to handle output validation failures. This pattern was silently broken: the four non-streaming entry points (`_run`, `_arun`, `_continue_run`, `_acontinue_run`) caught the exception, logged it, and returned the run response as if nothing went wrong - the caller's except block was never reached.

Root cause: the except clause ended with `return run_response` instead of `raise`.

## Changes

- `libs/agno/agno/agent/_run.py`: In the `except (InputCheckError, OutputCheckError)` block of each non-streaming function, replace `return run_response` with `raise`.
  - `def _run` (~line 659)
  - `async def _arun` (~line 1754)
  - `def _continue_run` (~line 3064)
  - `async def _acontinue_run` (~line 3862)

Session cleanup and storage are performed **before** the re-raise, so persistence is unaffected.

## What stays the same

The streaming variants (`_run_stream`, `_arun_stream`, `_continue_run_stream`, `_acontinue_run_stream`) already surface the error correctly by yielding a `RunErrorEvent` to the caller's event loop. Those are unchanged.

## Reproduces fix for issue #7414

Before:
```python
try:
    result = await agent.arun("What is the capital of France?")
    print(result.content)  # prints "Paris" - validation failure ignored
except OutputCheckError as e:
    print(f"Validation failed: {e}")  # never reached
```

After:
```python
try:
    result = await agent.arun("What is the capital of France?")
    print(result.content)
except OutputCheckError as e:
    print(f"Validation failed: {e}")  # now correctly raised
```

Fixes #7414
