### PR TITLE
fix: harden SSE resume reliability (timeout + cleanup ordering)

### DIFF
--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -2013,23 +2013,23 @@ async def _arun_background_stream(
                 log_error(f"Failed to persist error state for background stream run {run_id}", exc_info=True)
 
         finally:
+            # Signal primary queue FIRST — unblocks the original client
+            try:
+                await sse_queue.put(None)
+            except Exception:
+                log_warning(f"Failed to signal primary queue for run {run_id} completion")
+
             # Mark run completed in event buffer (status is set by _arun_stream/acleanup_and_store)
             try:
                 event_buffer.set_run_completed(run_id, run_response.status or RunStatus.completed)
             except Exception:
                 log_warning(f"Failed to mark run {run_id} as completed in event buffer")
 
-            # Signal SSE subscribers that run is done
+            # Signal SSE subscribers that run is done (shielded to survive task cancellation)
             try:
-                await sse_subscriber_manager.complete(run_id)
-            except Exception:
+                await asyncio.shield(sse_subscriber_manager.complete(run_id))
+            except (Exception, asyncio.CancelledError):
                 log_warning(f"Failed to signal SSE subscribers for run {run_id} completion")
-
-            # Signal primary queue that run is done
-            try:
-                await sse_queue.put(None)
-            except Exception:
-                log_warning(f"Failed to signal primary queue for run {run_id} completion")
 
     task = asyncio.create_task(_background_producer())
     _background_tasks.add(task)
@@ -3829,6 +3829,12 @@ async def _acontinue_run_background_stream(
                 log_error(f"Failed to persist error state for background continue-run stream {_run_id}", exc_info=True)
 
         finally:
+            # Signal primary queue FIRST — unblocks the original client
+            try:
+                await sse_queue.put(None)
+            except Exception:
+                log_warning(f"Failed to signal primary queue for continue-run {_run_id} completion")
+
             # Mark run completed in event buffer
             try:
                 final_status = (run_response.status if run_response else None) or RunStatus.completed
@@ -3836,17 +3842,11 @@ async def _acontinue_run_background_stream(
             except Exception:
                 log_warning(f"Failed to mark continue-run {_run_id} as completed in event buffer")
 
-            # Signal SSE subscribers that run is done
+            # Signal SSE subscribers that run is done (shielded to survive task cancellation)
             try:
-                await sse_subscriber_manager.complete(_run_id)
-            except Exception:
+                await asyncio.shield(sse_subscriber_manager.complete(_run_id))
+            except (Exception, asyncio.CancelledError):
                 log_warning(f"Failed to signal SSE subscribers for continue-run {_run_id} completion")
-
-            # Signal primary queue that run is done
-            try:
-                await sse_queue.put(None)
-            except Exception:
-                log_warning(f"Failed to signal primary queue for continue-run {_run_id} completion")
 
     task = asyncio.create_task(_background_producer())
     _background_tasks.add(task)

--- a/libs/agno/agno/os/managers.py
+++ b/libs/agno/agno/os/managers.py
@@ -292,6 +292,17 @@ class EventsBuffer:
         """Get the current number of events for a run"""
         return len(self.events.get(run_id, []))
 
+    def get_last_index(self, run_id: str) -> int:
+        """Get the monotonic index of the last event added for a run.
+
+        Returns -1 if no events have been added for this run.
+        Unlike get_event_count(), this survives buffer trims.
+        """
+        next_idx = self._next_index.get(run_id)
+        if next_idx is None or next_idx == 0:
+            return -1
+        return next_idx - 1
+
     def set_run_completed(self, run_id: str, status: RunStatus) -> None:
         """Mark a run as completed/cancelled/error for future cleanup"""
         if run_id in self.run_metadata:

--- a/libs/agno/agno/os/managers.py
+++ b/libs/agno/agno/os/managers.py
@@ -14,7 +14,7 @@ import asyncio
 import json
 from dataclasses import dataclass
 from time import time
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from starlette.websockets import WebSocket
 
@@ -249,7 +249,7 @@ class EventsBuffer:
 
     def get_events(
         self, run_id: str, last_event_index: Optional[int] = None
-    ) -> List[Union[WorkflowRunOutputEvent, RunOutputEvent, TeamRunOutputEvent]]:
+    ) -> List[Tuple[int, Union[WorkflowRunOutputEvent, RunOutputEvent, TeamRunOutputEvent]]]:
         """
         Get events since the last received event index.
 
@@ -258,20 +258,20 @@ class EventsBuffer:
             last_event_index: Monotonic index of last event received by client (0-based)
 
         Returns:
-            List of events since last_event_index, or all events if None
+            List of (monotonic_index, event) tuples since last_event_index, or all if None
         """
         events = self.events.get(run_id, [])
         if not events:
             return []
 
-        if last_event_index is None:
-            # Client has no events, send all
-            return events
-
         # The buffer may have been trimmed, so list positions don't match event indices.
         # first_index is the monotonic index of the oldest event still in the buffer.
         next_idx = self._next_index.get(run_id, len(events))
         first_index = next_idx - len(events)
+
+        if last_event_index is None:
+            # Client has no events, send all with their real indices
+            return [(first_index + i, e) for i, e in enumerate(events)]
 
         # Client wants events after last_event_index
         start_index = last_event_index + 1
@@ -282,11 +282,11 @@ class EventsBuffer:
 
         if start_index <= first_index:
             # Client is behind the buffer — return everything we have
-            return events
+            return [(first_index + i, e) for i, e in enumerate(events)]
 
         # Convert monotonic index to list position
         list_offset = start_index - first_index
-        return events[list_offset:]
+        return [(start_index + i, e) for i, e in enumerate(events[list_offset:])]
 
     def get_event_count(self, run_id: str) -> int:
         """Get the current number of events for a run"""

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -370,10 +370,9 @@ async def _resume_stream_generator(
         }
         yield f"event: replay\ndata: {json.dumps(meta)}\n\n"
 
-        start_index = (last_event_index + 1) if last_event_index is not None else 0
-        for idx, buffered_event in enumerate(missed_events):
+        for ev_index, buffered_event in missed_events:
             event_dict = buffered_event.to_dict()
-            event_dict["event_index"] = start_index + idx
+            event_dict["event_index"] = ev_index
             if "run_id" not in event_dict:
                 event_dict["run_id"] = run_id
             event_type = event_dict.get("event", "message")
@@ -401,16 +400,14 @@ async def _resume_stream_generator(
             }
             yield f"event: catch_up\ndata: {json.dumps(meta)}\n\n"
 
-            start_index = (last_event_index + 1) if last_event_index is not None else 0
-            for idx, buffered_event in enumerate(missed_events):
-                current_idx = start_index + idx
+            for ev_index, buffered_event in missed_events:
                 event_dict = buffered_event.to_dict()
-                event_dict["event_index"] = current_idx
+                event_dict["event_index"] = ev_index
                 if "run_id" not in event_dict:
                     event_dict["run_id"] = run_id
                 event_type = event_dict.get("event", "message")
                 yield f"event: {event_type}\ndata: {json.dumps(event_dict, separators=(',', ':'), default=json_serializer, ensure_ascii=False)}\n\n"
-                last_replayed_index = current_idx
+                last_replayed_index = ev_index
 
         # Re-check buffer status after subscribing: the run may have completed
         # between our initial status check and now. If so, replay remaining events
@@ -421,11 +418,9 @@ async def _resume_stream_generator(
             # Run completed while we were catching up -- replay remaining from buffer
             remaining = event_buffer.get_events(run_id, last_event_index=last_replayed_index)
             if remaining:
-                replay_start = last_replayed_index + 1
-                for idx, buffered_event in enumerate(remaining):
-                    current_idx = replay_start + idx
+                for ev_index, buffered_event in remaining:
                     event_dict = buffered_event.to_dict()
-                    event_dict["event_index"] = current_idx
+                    event_dict["event_index"] = ev_index
                     if "run_id" not in event_dict:
                         event_dict["run_id"] = run_id
                     event_type = event_dict.get("event", "message")
@@ -454,16 +449,13 @@ async def _resume_stream_generator(
                 if status is None or status != RunStatus.running:
                     # Run ended - replay any remaining events from buffer
                     remaining = event_buffer.get_events(run_id, last_event_index=last_replayed_index)
-                    if remaining:
-                        replay_start = last_replayed_index + 1
-                        for idx, buffered_event in enumerate(remaining):
-                            current_idx = replay_start + idx
-                            event_dict = buffered_event.to_dict()
-                            event_dict["event_index"] = current_idx
-                            if "run_id" not in event_dict:
-                                event_dict["run_id"] = run_id
-                            event_type = event_dict.get("event", "message")
-                            yield f"event: {event_type}\ndata: {json.dumps(event_dict, separators=(',', ':'), default=json_serializer, ensure_ascii=False)}\n\n"
+                    for ev_index, buffered_event in remaining:
+                        event_dict = buffered_event.to_dict()
+                        event_dict["event_index"] = ev_index
+                        if "run_id" not in event_dict:
+                            event_dict["run_id"] = run_id
+                        event_type = event_dict.get("event", "message")
+                        yield f"event: {event_type}\ndata: {json.dumps(event_dict, separators=(',', ':'), default=json_serializer, ensure_ascii=False)}\n\n"
                     break
                 # Still running - send heartbeat to keep connection alive
                 yield ": heartbeat\n\n"

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -446,7 +446,28 @@ async def _resume_stream_generator(
 
         # Read from queue, dedup events already replayed by event_index
         while True:
-            item = await queue.get()
+            try:
+                item = await asyncio.wait_for(queue.get(), timeout=30.0)
+            except asyncio.TimeoutError:
+                # Check if run ended without sending sentinel
+                status = event_buffer.get_run_status(run_id)
+                if status is None or status != RunStatus.running:
+                    # Run ended - replay any remaining events from buffer
+                    remaining = event_buffer.get_events(run_id, last_event_index=last_replayed_index)
+                    if remaining:
+                        replay_start = last_replayed_index + 1
+                        for idx, buffered_event in enumerate(remaining):
+                            current_idx = replay_start + idx
+                            event_dict = buffered_event.to_dict()
+                            event_dict["event_index"] = current_idx
+                            if "run_id" not in event_dict:
+                                event_dict["run_id"] = run_id
+                            event_type = event_dict.get("event", "message")
+                            yield f"event: {event_type}\ndata: {json.dumps(event_dict, separators=(',', ':'), default=json_serializer, ensure_ascii=False)}\n\n"
+                    break
+                # Still running - send heartbeat to keep connection alive
+                yield ": heartbeat\n\n"
+                continue
             if item is None:
                 # Sentinel: run completed
                 break

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -467,6 +467,8 @@ async def _resume_stream_generator(
             # Dedup: skip events already replayed during catch-up
             if ev_idx >= 0 and ev_idx <= last_replayed_index:
                 continue
+            if ev_idx >= 0:
+                last_replayed_index = ev_idx
             yield sse_data
     finally:
         sse_subscriber_manager.unsubscribe(run_id, queue)

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -369,6 +369,8 @@ async def _resume_stream_generator(
             # Dedup: skip events already replayed during catch-up
             if ev_idx >= 0 and ev_idx <= last_replayed_index:
                 continue
+            if ev_idx >= 0:
+                last_replayed_index = ev_idx
             yield sse_data
     finally:
         sse_subscriber_manager.unsubscribe(run_id, queue)

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -272,10 +272,9 @@ async def _resume_stream_generator(
         }
         yield f"event: replay\ndata: {json.dumps(meta)}\n\n"
 
-        start_index = (last_event_index + 1) if last_event_index is not None else 0
-        for idx, buffered_event in enumerate(missed_events):
+        for ev_index, buffered_event in missed_events:
             event_dict = buffered_event.to_dict()
-            event_dict["event_index"] = start_index + idx
+            event_dict["event_index"] = ev_index
             if "run_id" not in event_dict:
                 event_dict["run_id"] = run_id
             event_type = event_dict.get("event", "message")
@@ -303,16 +302,14 @@ async def _resume_stream_generator(
             }
             yield f"event: catch_up\ndata: {json.dumps(meta)}\n\n"
 
-            start_index = (last_event_index + 1) if last_event_index is not None else 0
-            for idx, buffered_event in enumerate(missed_events):
-                current_idx = start_index + idx
+            for ev_index, buffered_event in missed_events:
                 event_dict = buffered_event.to_dict()
-                event_dict["event_index"] = current_idx
+                event_dict["event_index"] = ev_index
                 if "run_id" not in event_dict:
                     event_dict["run_id"] = run_id
                 event_type = event_dict.get("event", "message")
                 yield f"event: {event_type}\ndata: {json.dumps(event_dict, separators=(',', ':'), default=json_serializer, ensure_ascii=False)}\n\n"
-                last_replayed_index = current_idx
+                last_replayed_index = ev_index
 
         # Re-check buffer status after subscribing: the run may have completed
         # between our initial status check and now. If so, replay remaining events
@@ -323,11 +320,9 @@ async def _resume_stream_generator(
             # Run completed while we were catching up -- replay remaining from buffer
             remaining = event_buffer.get_events(run_id, last_event_index=last_replayed_index)
             if remaining:
-                replay_start = last_replayed_index + 1
-                for idx, buffered_event in enumerate(remaining):
-                    current_idx = replay_start + idx
+                for ev_index, buffered_event in remaining:
                     event_dict = buffered_event.to_dict()
-                    event_dict["event_index"] = current_idx
+                    event_dict["event_index"] = ev_index
                     if "run_id" not in event_dict:
                         event_dict["run_id"] = run_id
                     event_type = event_dict.get("event", "message")
@@ -356,16 +351,13 @@ async def _resume_stream_generator(
                 if status is None or status != RunStatus.running:
                     # Run ended - replay any remaining events from buffer
                     remaining = event_buffer.get_events(run_id, last_event_index=last_replayed_index)
-                    if remaining:
-                        replay_start = last_replayed_index + 1
-                        for idx, buffered_event in enumerate(remaining):
-                            current_idx = replay_start + idx
-                            event_dict = buffered_event.to_dict()
-                            event_dict["event_index"] = current_idx
-                            if "run_id" not in event_dict:
-                                event_dict["run_id"] = run_id
-                            event_type = event_dict.get("event", "message")
-                            yield f"event: {event_type}\ndata: {json.dumps(event_dict, separators=(',', ':'), default=json_serializer, ensure_ascii=False)}\n\n"
+                    for ev_index, buffered_event in remaining:
+                        event_dict = buffered_event.to_dict()
+                        event_dict["event_index"] = ev_index
+                        if "run_id" not in event_dict:
+                            event_dict["run_id"] = run_id
+                        event_type = event_dict.get("event", "message")
+                        yield f"event: {event_type}\ndata: {json.dumps(event_dict, separators=(',', ':'), default=json_serializer, ensure_ascii=False)}\n\n"
                     break
                 # Still running - send heartbeat to keep connection alive
                 yield ": heartbeat\n\n"

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -348,7 +348,28 @@ async def _resume_stream_generator(
 
         # Read from queue, dedup events already replayed by event_index
         while True:
-            item = await queue.get()
+            try:
+                item = await asyncio.wait_for(queue.get(), timeout=30.0)
+            except asyncio.TimeoutError:
+                # Check if run ended without sending sentinel
+                status = event_buffer.get_run_status(run_id)
+                if status is None or status != RunStatus.running:
+                    # Run ended - replay any remaining events from buffer
+                    remaining = event_buffer.get_events(run_id, last_event_index=last_replayed_index)
+                    if remaining:
+                        replay_start = last_replayed_index + 1
+                        for idx, buffered_event in enumerate(remaining):
+                            current_idx = replay_start + idx
+                            event_dict = buffered_event.to_dict()
+                            event_dict["event_index"] = current_idx
+                            if "run_id" not in event_dict:
+                                event_dict["run_id"] = run_id
+                            event_type = event_dict.get("event", "message")
+                            yield f"event: {event_type}\ndata: {json.dumps(event_dict, separators=(',', ':'), default=json_serializer, ensure_ascii=False)}\n\n"
+                    break
+                # Still running - send heartbeat to keep connection alive
+                yield ": heartbeat\n\n"
+                continue
             if item is None:
                 # Sentinel: run completed
                 break

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -215,12 +215,12 @@ async def handle_workflow_subscription(websocket: WebSocket, message: dict, os: 
             )
 
             # Send all events
-            for idx, buffered_event in enumerate(all_events):
+            for ev_index, buffered_event in all_events:
                 # Convert event to dict and add event_index
                 event_dict = (
                     buffered_event.model_dump() if hasattr(buffered_event, "model_dump") else buffered_event.to_dict()
                 )
-                event_dict["event_index"] = idx
+                event_dict["event_index"] = ev_index
                 if "run_id" not in event_dict:
                     event_dict["run_id"] = run_id
 
@@ -247,13 +247,12 @@ async def handle_workflow_subscription(websocket: WebSocket, message: dict, os: 
             )
 
             # Send missed events
-            start_index = (last_event_index + 1) if last_event_index is not None else 0
-            for idx, buffered_event in enumerate(missed_events):
+            for ev_index, buffered_event in missed_events:
                 # Convert event to dict and add event_index
                 event_dict = (
                     buffered_event.model_dump() if hasattr(buffered_event, "model_dump") else buffered_event.to_dict()
                 )
-                event_dict["event_index"] = start_index + idx
+                event_dict["event_index"] = ev_index
                 if "run_id" not in event_dict:
                     event_dict["run_id"] = run_id
 
@@ -674,10 +673,9 @@ async def _resume_stream_generator(
         }
         yield f"event: replay\ndata: {json.dumps(meta)}\n\n"
 
-        start_index = (last_event_index + 1) if last_event_index is not None else 0
-        for idx, buffered_event in enumerate(missed_events):
+        for ev_index, buffered_event in missed_events:
             event_dict = buffered_event.to_dict()
-            event_dict["event_index"] = start_index + idx
+            event_dict["event_index"] = ev_index
             if "run_id" not in event_dict:
                 event_dict["run_id"] = run_id
             event_type = event_dict.get("event", "message")
@@ -705,27 +703,23 @@ async def _resume_stream_generator(
             }
             yield f"event: catch_up\ndata: {json.dumps(meta)}\n\n"
 
-            start_index = (last_event_index + 1) if last_event_index is not None else 0
-            for idx, buffered_event in enumerate(missed_events):
-                current_idx = start_index + idx
+            for ev_index, buffered_event in missed_events:
                 event_dict = buffered_event.to_dict()
-                event_dict["event_index"] = current_idx
+                event_dict["event_index"] = ev_index
                 if "run_id" not in event_dict:
                     event_dict["run_id"] = run_id
                 event_type = event_dict.get("event", "message")
                 yield f"event: {event_type}\ndata: {json.dumps(event_dict, separators=(',', ':'), default=json_serializer, ensure_ascii=False)}\n\n"
-                last_replayed_index = current_idx
+                last_replayed_index = ev_index
 
         # Re-check buffer status after subscribing
         updated_status = event_buffer.get_run_status(run_id)
         if updated_status is not None and updated_status != RunStatus.running:
             remaining = event_buffer.get_events(run_id, last_event_index=last_replayed_index)
             if remaining:
-                replay_start = last_replayed_index + 1
-                for idx, buffered_event in enumerate(remaining):
-                    current_idx = replay_start + idx
+                for ev_index, buffered_event in remaining:
                     event_dict = buffered_event.to_dict()
-                    event_dict["event_index"] = current_idx
+                    event_dict["event_index"] = ev_index
                     if "run_id" not in event_dict:
                         event_dict["run_id"] = run_id
                     event_type = event_dict.get("event", "message")
@@ -742,16 +736,13 @@ async def _resume_stream_generator(
                 if status is None or status != RunStatus.running:
                     # Run ended - replay any remaining events from buffer
                     remaining = event_buffer.get_events(run_id, last_event_index=last_replayed_index)
-                    if remaining:
-                        replay_start = last_replayed_index + 1
-                        for idx, buffered_event in enumerate(remaining):
-                            current_idx = replay_start + idx
-                            event_dict = buffered_event.to_dict()
-                            event_dict["event_index"] = current_idx
-                            if "run_id" not in event_dict:
-                                event_dict["run_id"] = run_id
-                            event_type = event_dict.get("event", "message")
-                            yield f"event: {event_type}\ndata: {json.dumps(event_dict, separators=(',', ':'), default=json_serializer, ensure_ascii=False)}\n\n"
+                    for ev_index, buffered_event in remaining:
+                        event_dict = buffered_event.to_dict()
+                        event_dict["event_index"] = ev_index
+                        if "run_id" not in event_dict:
+                            event_dict["run_id"] = run_id
+                        event_type = event_dict.get("event", "message")
+                        yield f"event: {event_type}\ndata: {json.dumps(event_dict, separators=(',', ':'), default=json_serializer, ensure_ascii=False)}\n\n"
                     break
                 # Still running - send heartbeat to keep connection alive
                 yield ": heartbeat\n\n"

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -734,7 +734,28 @@ async def _resume_stream_generator(
 
         # Stream live events from queue (dedup by event_index)
         while True:
-            item = await queue.get()
+            try:
+                item = await asyncio.wait_for(queue.get(), timeout=30.0)
+            except asyncio.TimeoutError:
+                # Check if run ended without sending sentinel
+                status = event_buffer.get_run_status(run_id)
+                if status is None or status != RunStatus.running:
+                    # Run ended - replay any remaining events from buffer
+                    remaining = event_buffer.get_events(run_id, last_event_index=last_replayed_index)
+                    if remaining:
+                        replay_start = last_replayed_index + 1
+                        for idx, buffered_event in enumerate(remaining):
+                            current_idx = replay_start + idx
+                            event_dict = buffered_event.to_dict()
+                            event_dict["event_index"] = current_idx
+                            if "run_id" not in event_dict:
+                                event_dict["run_id"] = run_id
+                            event_type = event_dict.get("event", "message")
+                            yield f"event: {event_type}\ndata: {json.dumps(event_dict, separators=(',', ':'), default=json_serializer, ensure_ascii=False)}\n\n"
+                    break
+                # Still running - send heartbeat to keep connection alive
+                yield ": heartbeat\n\n"
+                continue
             if item is None:
                 break
             event_index, sse_data = item

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -527,7 +527,9 @@ class WorkflowRunSchema(BaseModel):
     status: Optional[str] = Field(None, description="Status of the workflow run")
     step_results: Optional[list[dict]] = Field(None, description="Results from each workflow step")
     step_executor_runs: Optional[list[dict]] = Field(None, description="Executor runs for each step")
-    step_requirements: Optional[list[dict]] = Field(None, description="HITL step requirements (resolved state for historical display)")
+    step_requirements: Optional[list[dict]] = Field(
+        None, description="HITL step requirements (resolved state for historical display)"
+    )
     pause_kind: Optional[str] = Field(None, description="Kind of HITL pause: 'step' or 'executor'")
     paused_step_name: Optional[str] = Field(None, description="Name of the step that caused the pause")
     paused_step_index: Optional[int] = Field(None, description="Index of the step that caused the pause")

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -3363,23 +3363,23 @@ async def _arun_background_stream(
                 log_error(f"Failed to persist error state for background stream run {run_id}", exc_info=True)
 
         finally:
+            # Signal primary queue FIRST — unblocks the original client
+            try:
+                await sse_queue.put(None)
+            except Exception:
+                log_warning(f"Failed to signal primary queue for run {run_id} completion")
+
             # Mark run completed in event buffer (status is set by _arun_stream/acleanup_and_store)
             try:
                 event_buffer.set_run_completed(run_id, run_response.status or RunStatus.completed)
             except Exception:
                 log_warning(f"Failed to mark run {run_id} as completed in event buffer")
 
-            # Signal SSE subscribers that run is done
+            # Signal SSE subscribers that run is done (shielded to survive task cancellation)
             try:
-                await sse_subscriber_manager.complete(run_id)
-            except Exception:
+                await asyncio.shield(sse_subscriber_manager.complete(run_id))
+            except (Exception, asyncio.CancelledError):
                 log_warning(f"Failed to signal SSE subscribers for run {run_id} completion")
-
-            # Signal primary queue that run is done
-            try:
-                await sse_queue.put(None)
-            except Exception:
-                log_warning(f"Failed to signal primary queue for run {run_id} completion")
 
     task = asyncio.create_task(_background_producer())
     _background_tasks.add(task)

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -6,8 +6,6 @@ from agno.media import File, Image
 from agno.models.message import Message
 from agno.utils.log import log_error, log_info, log_warning
 
-
-
 # Models that support assistant message prefill. This is a closed set —
 # prefill was deprecated starting with Claude 4.6 and all future models
 # are expected to reject it.

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -134,7 +134,6 @@ STEP_TYPE_MAPPING = {
 }
 
 
-
 # Any step-like component that can appear in a workflow (top-level or nested).
 # Matches what callers iterate over in ``Workflow.steps`` (see ``WorkflowSteps``
 # below): Step + composite step types + nested Workflow + callable step.
@@ -4093,23 +4092,23 @@ class Workflow:
                     )
 
             finally:
+                # Signal primary queue FIRST — unblocks the original client
+                try:
+                    await sse_queue.put(None)
+                except Exception:
+                    log_warning(f"Failed to signal primary queue for workflow run {run_id} completion")
+
                 # Mark run completed in event buffer
                 try:
                     event_buffer.set_run_completed(run_id, workflow_run_response.status or RunStatus.completed)
                 except Exception:
                     log_warning(f"Failed to mark workflow run {run_id} as completed in event buffer")
 
-                # Signal SSE subscribers that run is done
+                # Signal SSE subscribers that run is done (shielded to survive task cancellation)
                 try:
-                    await sse_subscriber_manager.complete(run_id)
-                except Exception:
+                    await asyncio.shield(sse_subscriber_manager.complete(run_id))
+                except (Exception, asyncio.CancelledError):
                     log_warning(f"Failed to signal SSE subscribers for workflow run {run_id} completion")
-
-                # Signal primary queue that run is done
-                try:
-                    await sse_queue.put(None)
-                except Exception:
-                    log_warning(f"Failed to signal primary queue for workflow run {run_id} completion")
 
         task = asyncio.create_task(_background_producer())
         _workflow_background_tasks.add(task)
@@ -5117,21 +5116,13 @@ class Workflow:
         # Detect post-execution review (step already ran) — only on active requirement
         is_post_execution_review = any(req.is_post_execution for req in _active_reqs)
         # Detect loop iteration review specifically (confirmed = continue loop, not advance past it)
-        is_loop_iteration_review = any(
-            req.is_post_execution and req.step_type == "Loop" for req in _active_reqs
-        )
+        is_loop_iteration_review = any(req.is_post_execution and req.step_type == "Loop" for req in _active_reqs)
         # Detect router output review (reject = re-route to a different branch)
-        is_router_output_review = any(
-            req.is_post_execution and req.step_type == "Router" for req in _active_reqs
-        )
+        is_router_output_review = any(req.is_post_execution and req.step_type == "Router" for req in _active_reqs)
         retry_step = False
 
         # Check if active step was rejected
-        rejected_steps = [
-            req
-            for req in _active_reqs
-            if req.requires_confirmation and req.confirmed is False
-        ]
+        rejected_steps = [req for req in _active_reqs if req.requires_confirmation and req.confirmed is False]
 
         # Handle rejected steps based on on_reject policy
         skip_rejected_step = False
@@ -7015,21 +7006,13 @@ class Workflow:
         # Detect post-execution review (step already ran) — only on active requirement
         is_post_execution_review = any(req.is_post_execution for req in _active_reqs)
         # Detect loop iteration review specifically (confirmed = continue loop, not advance past it)
-        is_loop_iteration_review = any(
-            req.is_post_execution and req.step_type == "Loop" for req in _active_reqs
-        )
+        is_loop_iteration_review = any(req.is_post_execution and req.step_type == "Loop" for req in _active_reqs)
         # Detect router output review (reject = re-route to a different branch)
-        is_router_output_review = any(
-            req.is_post_execution and req.step_type == "Router" for req in _active_reqs
-        )
+        is_router_output_review = any(req.is_post_execution and req.step_type == "Router" for req in _active_reqs)
         retry_step = False
 
         # Check if active step was rejected
-        rejected_steps = [
-            req
-            for req in _active_reqs
-            if req.requires_confirmation and req.confirmed is False
-        ]
+        rejected_steps = [req for req in _active_reqs if req.requires_confirmation and req.confirmed is False]
 
         # Handle rejected steps based on on_reject policy
         skip_rejected_step = False

--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -4019,8 +4019,8 @@ class Workflow:
                         if isinstance(event, WfRunOutput):
                             continue
 
-                        # Get the event_index that _handle_event already assigned
-                        event_index = event_buffer.get_event_count(run_id) - 1
+                        # Get the monotonic index that _handle_event already assigned
+                        event_index = event_buffer.get_last_index(run_id)
 
                         # Format as SSE
                         sse_data = format_sse_event_with_index(event, event_index=event_index, run_id=run_id)
@@ -4052,8 +4052,8 @@ class Workflow:
                         if isinstance(event, WfRunOutput):
                             continue
 
-                        # Get the event_index that _handle_event already assigned
-                        event_index = event_buffer.get_event_count(run_id) - 1
+                        # Get the monotonic index that _handle_event already assigned
+                        event_index = event_buffer.get_last_index(run_id)
 
                         # Format as SSE
                         sse_data = format_sse_event_with_index(event, event_index=event_index, run_id=run_id)

--- a/libs/agno/tests/integration/workflows/test_hitl_requirements_persistence.py
+++ b/libs/agno/tests/integration/workflows/test_hitl_requirements_persistence.py
@@ -23,7 +23,6 @@ from agno.workflow.step import Step
 from agno.workflow.types import StepInput, StepOutput
 from agno.workflow.workflow import Workflow
 
-
 # =============================================================================
 # Test Step Functions
 # =============================================================================

--- a/libs/agno/tests/unit/os/test_events_buffer.py
+++ b/libs/agno/tests/unit/os/test_events_buffer.py
@@ -3,6 +3,7 @@
 from agno.os.managers import EventsBuffer
 from agno.run.agent import RunContentEvent
 
+
 def _make_event(content: str) -> RunContentEvent:
     return RunContentEvent(content=content)
 

--- a/libs/agno/tests/unit/os/test_events_buffer.py
+++ b/libs/agno/tests/unit/os/test_events_buffer.py
@@ -33,7 +33,7 @@ class TestMonotonicIndex:
 
 
 class TestGetEventsAfterTrim:
-    """get_events must return correct events using monotonic indices after trims."""
+    """get_events must return correct (index, event) tuples using monotonic indices after trims."""
 
     def test_get_all_events_no_trim(self):
         buf = EventsBuffer(max_events_per_run=100)
@@ -41,6 +41,9 @@ class TestGetEventsAfterTrim:
             buf.add_event("r1", _make_event(f"e{i}"))
         events = buf.get_events("r1")
         assert len(events) == 5
+        # Should return tuples with correct monotonic indices
+        assert events[0] == (0, events[0][1])
+        assert events[4] == (4, events[4][1])
 
     def test_get_events_since_index_no_trim(self):
         buf = EventsBuffer(max_events_per_run=100)
@@ -49,8 +52,10 @@ class TestGetEventsAfterTrim:
         # Client has 0,1,2 — wants 3,4
         events = buf.get_events("r1", last_event_index=2)
         assert len(events) == 2
-        assert events[0].content == "e3"
-        assert events[1].content == "e4"
+        assert events[0][0] == 3
+        assert events[0][1].content == "e3"
+        assert events[1][0] == 4
+        assert events[1][1].content == "e4"
 
     def test_get_events_since_index_after_trim(self):
         buf = EventsBuffer(max_events_per_run=5)
@@ -59,8 +64,10 @@ class TestGetEventsAfterTrim:
         # Buffer holds e5..e9 (indices 5-9). Client has up to index 7.
         events = buf.get_events("r1", last_event_index=7)
         assert len(events) == 2
-        assert events[0].content == "e8"
-        assert events[1].content == "e9"
+        assert events[0][0] == 8
+        assert events[0][1].content == "e8"
+        assert events[1][0] == 9
+        assert events[1][1].content == "e9"
 
     def test_get_events_client_behind_buffer(self):
         """Client's last index is older than what the buffer still holds."""
@@ -68,10 +75,13 @@ class TestGetEventsAfterTrim:
         for i in range(10):
             buf.add_event("r1", _make_event(f"e{i}"))
         # Buffer holds e7,e8,e9. Client has index 2 — way behind.
-        # Should return everything in the buffer.
+        # Should return everything in the buffer with correct indices.
         events = buf.get_events("r1", last_event_index=2)
         assert len(events) == 3
-        assert events[0].content == "e7"
+        assert events[0][0] == 7
+        assert events[0][1].content == "e7"
+        assert events[2][0] == 9
+        assert events[2][1].content == "e9"
 
     def test_get_events_client_caught_up(self):
         buf = EventsBuffer(max_events_per_run=5)
@@ -87,7 +97,9 @@ class TestGetEventsAfterTrim:
             buf.add_event("r1", _make_event(f"e{i}"))
         events = buf.get_events("r1", last_event_index=None)
         assert len(events) == 3
-        assert events[0].content == "e4"
+        # After trim, buffer holds e4,e5,e6 with indices 4,5,6
+        assert events[0][0] == 4
+        assert events[0][1].content == "e4"
 
     def test_get_events_unknown_run(self):
         buf = EventsBuffer(max_events_per_run=10)
@@ -136,8 +148,10 @@ class TestMultipleRuns:
         # Run "a": buffer has a2,a3,a4 (indices 2-4)
         events_a = buf.get_events("a", last_event_index=3)
         assert len(events_a) == 1
-        assert events_a[0].content == "a4"
+        assert events_a[0][0] == 4
+        assert events_a[0][1].content == "a4"
         # Run "b": buffer has b5,b6,b7 (indices 5-7)
         events_b = buf.get_events("b", last_event_index=5)
         assert len(events_b) == 2
-        assert events_b[0].content == "b6"
+        assert events_b[0][0] == 6
+        assert events_b[0][1].content == "b6"


### PR DESCRIPTION
## Summary

Fixes three reliability issues in the SSE reconnection feature from #6849:

- **Timeout + heartbeat on `/resume` queue reads**: If the background producer crashes without sending a `None` sentinel, resumed clients previously hung forever on `await queue.get()`. Now uses `asyncio.wait_for(..., timeout=30.0)`. On timeout, checks buffer status: if the run ended, replays remaining events from buffer; if still running, sends an SSE heartbeat comment (`: heartbeat\n\n`) to keep the connection alive through proxies/load balancers.

- **Reorder `finally` block + `asyncio.shield`**: The `_background_producer` `finally` block previously called `sse_subscriber_manager.complete()` before `sse_queue.put(None)`. During task cancellation, `CancelledError` (a `BaseException`, not caught by `except Exception`) could abort the `await` on `complete()`, preventing the sentinel from ever reaching the primary client's queue. Fix: put `sse_queue.put(None)` first (most critical - unblocks the original client), and wrap `complete()` in `asyncio.shield()` with a `(Exception, asyncio.CancelledError)` catch.

- **Fix corrupted event_index after buffer trim**: `EventsBuffer.get_events()` returned bare events without their monotonic indices. The `/resume` callers reconstructed indices as `last_event_index + idx`, which is wrong after buffer trims. If the buffer held events 7..9 and the client last saw index 2, replayed events were labeled 3..5 instead of 7..9, corrupting the client's checkpoint. Fix: `get_events()` now returns `List[Tuple[int, event]]` carrying the real monotonic index. All callers updated across agents, teams, and workflows (SSE and WebSocket).

All fixes applied consistently across agents, teams, and workflows.

Related: addresses unanswered review comment by @Mustafa-Esoofally on #6849 regarding `asyncio.shield`.

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- All 30 existing unit tests pass (events buffer tests updated for new tuple return type + background execution tests)
- Formatter also cleaned up minor whitespace in files that were on the base branch