### PR TITLE
feat: expose agno framework version on /info route

### DIFF
--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -8,6 +8,7 @@ from fastapi import (
     WebSocket,
 )
 
+from agno import __version__ as agno_version
 from agno.exceptions import RemoteServerUnavailableError
 from agno.os.auth import get_authentication_dependency, validate_websocket_token
 from agno.os.managers import websocket_manager
@@ -251,6 +252,7 @@ def get_info_router(os: "AgentOS") -> APIRouter:
     )
     async def get_info() -> InfoResponse:
         return InfoResponse(
+            agno_version=agno_version,
             agent_count=len(os.agents or []),
             team_count=len(os.teams or []),
             workflow_count=len(os.workflows or []),

--- a/libs/agno/agno/os/schema.py
+++ b/libs/agno/agno/os/schema.py
@@ -151,6 +151,7 @@ class WorkflowSummaryResponse(BaseModel):
 class InfoResponse(BaseModel):
     """Response schema for the /info endpoint returning lightweight OS metadata."""
 
+    agno_version: str = Field(..., description="Version of the agno framework")
     agent_count: int = Field(0, description="Number of agents registered in the OS")
     team_count: int = Field(0, description="Number of teams registered in the OS")
     workflow_count: int = Field(0, description="Number of workflows registered in the OS")


### PR DESCRIPTION
## Summary

Adds an `agno_version` field to the `InfoResponse` returned by `GET /info`, sourced from `agno.__version__`. This lets clients and monitoring tools read the installed framework version without authentication, alongside the existing `agent_count` / `team_count` / `workflow_count`.

Example response:

```json
{
  "agno_version": "2.5.17",
  "agent_count": 1,
  "team_count": 0,
  "workflow_count": 0
}
```

**Fallback behavior:** If the package metadata cannot be resolved (e.g., running from source without install), `agno.__version__` falls back to `"0.0.0"` via the existing `PackageNotFoundError` handler in `libs/agno/agno/__init__.py`. No new failure modes are introduced at the router layer.

**Why `/info`:** It is already the lightweight, unauthenticated metadata endpoint — framework version fits its contract. Putting it on `/` would have collided with the existing `version` key there (which refers to the user's AgentOS instance version, not the framework).

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Smoke-tested locally via `TestClient`:

```
GET /info -> 200
{"agno_version": "2.5.13", "agent_count": 1, "team_count": 0, "workflow_count": 0}
```

No existing tests or cookbooks reference `/info`, so nothing needed updating.