### PR TITLE
fix: factory secondary endpoints (get/list/resume/continue)

### DIFF
--- a/cookbook/05_agent_os/factories/agent/05_hitl_factory.py
+++ b/cookbook/05_agent_os/factories/agent/05_hitl_factory.py
@@ -20,18 +20,19 @@ Test flow:
     #                "requires_confirmation": true, ...}]
     # Note the run_id, session_id, and the full tools array from the response.
 
-    # 2. Confirm: echo the full tools array back with `confirmed: true` set on each entry.
-    # (The /continue endpoint replaces stored tool state with what you send, so the
-    # payload must include tool_name and tool_args — not just tool_call_id.)
+    # 2. Confirm the tool call (replace TOOL_CALL_ID with the id from step 1).
+    # The /continue endpoint overwrites stored tool state with what you send, so
+    # the payload must include tool_name, tool_args, and requires_confirmation —
+    # not just tool_call_id + confirmed.
     curl -X POST http://localhost:7777/agents/hitl-agent/runs/RUN_ID/continue \
         -F 'session_id=SESSION_ID' \
-        -F 'tools=<TOOLS_ARRAY_FROM_STEP_1_WITH_CONFIRMED_TRUE>' \
+        -F 'tools=[{"tool_call_id": "TOOL_CALL_ID", "tool_name": "get_top_hackernews_stories", "tool_args": {"num_stories": 3}, "requires_confirmation": true, "confirmed": true}]' \
         -F 'stream=false'
 
-    # 3. Or reject: same pattern, set `confirmed: false` (and optional confirmation_note).
+    # 3. Or reject it (same payload with confirmed: false).
     curl -X POST http://localhost:7777/agents/hitl-agent/runs/RUN_ID/continue \
         -F 'session_id=SESSION_ID' \
-        -F 'tools=<TOOLS_ARRAY_FROM_STEP_1_WITH_CONFIRMED_FALSE>' \
+        -F 'tools=[{"tool_call_id": "TOOL_CALL_ID", "tool_name": "get_top_hackernews_stories", "tool_args": {"num_stories": 3}, "requires_confirmation": true, "confirmed": false, "confirmation_note": "User rejected"}]' \
         -F 'stream=false'
 
     # 4. Check run status

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -895,6 +895,10 @@ def get_agent_router(
             False,
             description="Run continue in background (survives client disconnect). Requires database. Use /resume to reconnect.",
         ),
+        factory_input: Optional[str] = Form(
+            None,
+            description="JSON object with factory-specific parameters for dynamic agent reconstruction",
+        ),
     ):
         if hasattr(request.state, "user_id") and request.state.user_id is not None:
             user_id = request.state.user_id
@@ -908,7 +912,6 @@ def get_agent_router(
             raise HTTPException(status_code=400, detail="Invalid JSON in tools field")
 
         # Factory agents: re-invoke factory to get a real agent for continue
-        # (needs model/tools to resume the paused run, factory_input not available)
         factory = find_factory_by_id(agent_id, os.agents)
         if factory:
             agent = await resolve_agent(  # type: ignore[assignment]
@@ -918,6 +921,7 @@ def get_agent_router(
                 request=request,
                 user_id=user_id,
                 session_id=session_id,
+                factory_input=factory_input,
             )
         else:
             try:
@@ -1213,7 +1217,12 @@ def get_agent_router(
     async def get_agent_run(
         agent_id: str,
         run_id: str,
+        request: Request,
         session_id: str = Query(..., description="Session ID for the run"),
+        factory_input: Optional[str] = Query(
+            None,
+            description="JSON object with factory-specific parameters for dynamic agent reconstruction",
+        ),
     ):
         # Factory agents: resolve to get a real agent for session lookup
         factory = find_factory_by_id(agent_id, os.agents)
@@ -1222,7 +1231,9 @@ def get_agent_router(
                 agent_id,
                 os.agents,
                 factory.db,
+                request=request,
                 session_id=session_id,
+                factory_input=factory_input,
             )
         else:
             try:
@@ -1273,12 +1284,31 @@ def get_agent_router(
     async def resume_agent_run_stream(
         agent_id: str,
         run_id: str,
+        request: Request,
         last_event_index: Optional[int] = Form(None, description="Index of last event received by client (0-based)"),
         session_id: Optional[str] = Form(None, description="Session ID for database fallback"),
+        factory_input: Optional[str] = Form(
+            None,
+            description="JSON object with factory-specific parameters for dynamic agent reconstruction",
+        ),
     ):
-        agent = get_agent_by_id(agent_id=agent_id, agents=os.agents, db=os.db, registry=os.registry, create_fresh=True)
-        if agent is None:
-            raise HTTPException(status_code=404, detail="Agent not found")
+        # Factory agents: resolve through the factory (needs request context); plain agents: direct lookup.
+        factory = find_factory_by_id(agent_id, os.agents)
+        if factory:
+            agent = await resolve_agent(  # type: ignore[assignment]
+                agent_id,
+                os.agents,
+                factory.db,
+                request=request,
+                session_id=session_id,
+                factory_input=factory_input,
+            )
+        else:
+            agent = get_agent_by_id(  # type: ignore[assignment]
+                agent_id=agent_id, agents=os.agents, db=os.db, registry=os.registry, create_fresh=True
+            )
+            if agent is None:
+                raise HTTPException(status_code=404, detail="Agent not found")
         if isinstance(agent, RemoteAgent):
             raise HTTPException(status_code=400, detail="Stream resumption is not supported for remote agents")
 
@@ -1304,8 +1334,13 @@ def get_agent_router(
     )
     async def list_agent_runs(
         agent_id: str,
+        request: Request,
         session_id: str = Query(..., description="Session ID to list runs for"),
         status: Optional[str] = Query(None, description="Filter by run status (PENDING, RUNNING, COMPLETED, ERROR)"),
+        factory_input: Optional[str] = Query(
+            None,
+            description="JSON object with factory-specific parameters for dynamic agent reconstruction",
+        ),
     ):
         from agno.os.schema import RunSchema
 
@@ -1316,7 +1351,9 @@ def get_agent_router(
                 agent_id,
                 os.agents,
                 factory.db,
+                request=request,
                 session_id=session_id,
+                factory_input=factory_input,
             )
         else:
             try:

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -329,7 +329,9 @@ async def _resume_stream_generator(
                 meta: dict = {
                     "event": "replay",
                     "run_id": run_id,
-                    "status": run_output.status.value if run_output.status else "unknown",
+                    "status": getattr(run_output.status, "value", run_output.status)
+                    if run_output.status
+                    else "unknown",
                     "total_events": len(run_output.events),
                     "message": "Run completed. Replaying all events from database.",
                 }
@@ -347,7 +349,9 @@ async def _resume_stream_generator(
                 meta = {
                     "event": "replay",
                     "run_id": run_id,
-                    "status": run_output.status.value if run_output.status else "unknown",
+                    "status": getattr(run_output.status, "value", run_output.status)
+                    if run_output.status
+                    else "unknown",
                     "total_events": 0,
                     "message": "Run completed but no events stored.",
                 }
@@ -1224,6 +1228,12 @@ def get_agent_router(
             description="JSON object with factory-specific parameters for dynamic agent reconstruction",
         ),
     ):
+        user_id = getattr(request.state, "user_id", None)
+        if hasattr(request.state, "session_id") and request.state.session_id is not None:
+            if session_id and session_id != request.state.session_id:
+                log_warning("Session ID parameter passed in both request state and query params, using request state")
+            session_id = request.state.session_id
+
         # Factory agents: resolve to get a real agent for session lookup
         factory = find_factory_by_id(agent_id, os.agents)
         if factory:
@@ -1232,6 +1242,7 @@ def get_agent_router(
                 os.agents,
                 factory.db,
                 request=request,
+                user_id=user_id,
                 session_id=session_id,
                 factory_input=factory_input,
             )
@@ -1292,6 +1303,12 @@ def get_agent_router(
             description="JSON object with factory-specific parameters for dynamic agent reconstruction",
         ),
     ):
+        user_id = getattr(request.state, "user_id", None)
+        if hasattr(request.state, "session_id") and request.state.session_id is not None:
+            if session_id and session_id != request.state.session_id:
+                log_warning("Session ID parameter passed in both request state and form, using request state")
+            session_id = request.state.session_id
+
         # Factory agents: resolve through the factory (needs request context); plain agents: direct lookup.
         factory = find_factory_by_id(agent_id, os.agents)
         if factory:
@@ -1300,13 +1317,18 @@ def get_agent_router(
                 os.agents,
                 factory.db,
                 request=request,
+                user_id=user_id,
                 session_id=session_id,
                 factory_input=factory_input,
             )
         else:
-            agent = get_agent_by_id(  # type: ignore[assignment]
-                agent_id=agent_id, agents=os.agents, db=os.db, registry=os.registry, create_fresh=True
-            )
+            try:
+                agent = get_agent_by_id(  # type: ignore[assignment]
+                    agent_id=agent_id, agents=os.agents, db=os.db, registry=os.registry, create_fresh=True
+                )
+            except Exception as e:
+                log_error(f"Error resolving agent '{agent_id}': {e}")
+                raise HTTPException(status_code=500, detail=f"Error resolving agent: {e}")
             if agent is None:
                 raise HTTPException(status_code=404, detail="Agent not found")
         if isinstance(agent, RemoteAgent):
@@ -1344,6 +1366,12 @@ def get_agent_router(
     ):
         from agno.os.schema import RunSchema
 
+        user_id = getattr(request.state, "user_id", None)
+        if hasattr(request.state, "session_id") and request.state.session_id is not None:
+            if session_id and session_id != request.state.session_id:
+                log_warning("Session ID parameter passed in both request state and query params, using request state")
+            session_id = request.state.session_id
+
         # Factory agents: resolve to get a real agent for session lookup
         factory = find_factory_by_id(agent_id, os.agents)
         if factory:
@@ -1352,6 +1380,7 @@ def get_agent_router(
                 os.agents,
                 factory.db,
                 request=request,
+                user_id=user_id,
                 session_id=session_id,
                 factory_input=factory_input,
             )

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -224,7 +224,9 @@ async def _resume_stream_generator(
                 meta: dict = {
                     "event": "replay",
                     "run_id": run_id,
-                    "status": run_output.status.value if run_output.status else "unknown",
+                    "status": getattr(run_output.status, "value", run_output.status)
+                    if run_output.status
+                    else "unknown",
                     "total_events": len(run_output.events),
                     "message": "Run completed. Replaying all events from database.",
                 }
@@ -242,7 +244,9 @@ async def _resume_stream_generator(
                 meta = {
                     "event": "replay",
                     "run_id": run_id,
-                    "status": run_output.status.value if run_output.status else "unknown",
+                    "status": getattr(run_output.status, "value", run_output.status)
+                    if run_output.status
+                    else "unknown",
                     "total_events": 0,
                     "message": "Run completed but no events stored.",
                 }
@@ -846,6 +850,12 @@ def get_team_router(
             description="JSON object with factory-specific parameters for dynamic team reconstruction",
         ),
     ):
+        user_id = getattr(request.state, "user_id", None)
+        if hasattr(request.state, "session_id") and request.state.session_id is not None:
+            if session_id and session_id != request.state.session_id:
+                log_warning("Session ID parameter passed in both request state and form, using request state")
+            session_id = request.state.session_id
+
         # Factory teams: resolve through the factory (needs request context); plain teams: direct lookup.
         factory = find_factory_by_id(team_id, os.teams)
         if factory:
@@ -854,13 +864,18 @@ def get_team_router(
                 os.teams,
                 factory.db,
                 request=request,
+                user_id=user_id,
                 session_id=session_id,
                 factory_input=factory_input,
             )
         else:
-            team = get_team_by_id(  # type: ignore[assignment]
-                team_id=team_id, teams=os.teams, db=os.db, registry=registry, create_fresh=True
-            )
+            try:
+                team = get_team_by_id(  # type: ignore[assignment]
+                    team_id=team_id, teams=os.teams, db=os.db, registry=registry, create_fresh=True
+                )
+            except Exception as e:
+                logger.error(f"Error resolving team '{team_id}': {e}")
+                raise HTTPException(status_code=500, detail=f"Error resolving team: {e}")
             if team is None:
                 raise HTTPException(status_code=404, detail="Team not found")
         if isinstance(team, RemoteTeam):
@@ -1302,6 +1317,12 @@ def get_team_router(
             description="JSON object with factory-specific parameters for dynamic team reconstruction",
         ),
     ):
+        user_id = getattr(request.state, "user_id", None)
+        if hasattr(request.state, "session_id") and request.state.session_id is not None:
+            if session_id and session_id != request.state.session_id:
+                log_warning("Session ID parameter passed in both request state and query params, using request state")
+            session_id = request.state.session_id
+
         # Factory teams
         factory = find_factory_by_id(team_id, os.teams)
         if factory:
@@ -1310,6 +1331,7 @@ def get_team_router(
                 os.teams,
                 factory.db,
                 request=request,
+                user_id=user_id,
                 session_id=session_id,
                 factory_input=factory_input,
             )
@@ -1358,6 +1380,12 @@ def get_team_router(
         from agno.os.schema import TeamRunSchema
         from agno.team._storage import _aread_or_create_session
 
+        user_id = getattr(request.state, "user_id", None)
+        if hasattr(request.state, "session_id") and request.state.session_id is not None:
+            if session_id and session_id != request.state.session_id:
+                log_warning("Session ID parameter passed in both request state and query params, using request state")
+            session_id = request.state.session_id
+
         # Factory teams
         factory = find_factory_by_id(team_id, os.teams)
         if factory:
@@ -1366,6 +1394,7 @@ def get_team_router(
                 os.teams,
                 factory.db,
                 request=request,
+                user_id=user_id,
                 session_id=session_id,
                 factory_input=factory_input,
             )

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -838,12 +838,31 @@ def get_team_router(
     async def resume_team_run_stream(
         team_id: str,
         run_id: str,
+        request: Request,
         last_event_index: Optional[int] = Form(None, description="Index of last event received by client (0-based)"),
         session_id: Optional[str] = Form(None, description="Session ID for database fallback"),
+        factory_input: Optional[str] = Form(
+            None,
+            description="JSON object with factory-specific parameters for dynamic team reconstruction",
+        ),
     ):
-        team = get_team_by_id(team_id=team_id, teams=os.teams, db=os.db, registry=registry, create_fresh=True)
-        if team is None:
-            raise HTTPException(status_code=404, detail="Team not found")
+        # Factory teams: resolve through the factory (needs request context); plain teams: direct lookup.
+        factory = find_factory_by_id(team_id, os.teams)
+        if factory:
+            team = await resolve_team(  # type: ignore[assignment]
+                team_id,
+                os.teams,
+                factory.db,
+                request=request,
+                session_id=session_id,
+                factory_input=factory_input,
+            )
+        else:
+            team = get_team_by_id(  # type: ignore[assignment]
+                team_id=team_id, teams=os.teams, db=os.db, registry=registry, create_fresh=True
+            )
+            if team is None:
+                raise HTTPException(status_code=404, detail="Team not found")
         if isinstance(team, RemoteTeam):
             raise HTTPException(status_code=400, detail="Stream resumption is not supported for remote teams")
 
@@ -902,6 +921,10 @@ def get_team_router(
         user_id: Optional[str] = Form(None),
         stream: bool = Form(True),
         background: bool = Form(False),
+        factory_input: Optional[str] = Form(
+            None,
+            description="JSON object with factory-specific parameters for dynamic team reconstruction",
+        ),
     ):
         if hasattr(request.state, "user_id") and request.state.user_id is not None:
             user_id = request.state.user_id
@@ -924,6 +947,7 @@ def get_team_router(
                 request=request,
                 user_id=user_id,
                 session_id=session_id,
+                factory_input=factory_input,
             )
         else:
             try:
@@ -1271,7 +1295,12 @@ def get_team_router(
     async def get_team_run(
         team_id: str,
         run_id: str,
+        request: Request,
         session_id: str = Query(..., description="Session ID for the run"),
+        factory_input: Optional[str] = Query(
+            None,
+            description="JSON object with factory-specific parameters for dynamic team reconstruction",
+        ),
     ):
         # Factory teams
         factory = find_factory_by_id(team_id, os.teams)
@@ -1280,7 +1309,9 @@ def get_team_router(
                 team_id,
                 os.teams,
                 factory.db,
+                request=request,
                 session_id=session_id,
+                factory_input=factory_input,
             )
         else:
             try:
@@ -1316,8 +1347,13 @@ def get_team_router(
     )
     async def list_team_runs(
         team_id: str,
+        request: Request,
         session_id: str = Query(..., description="Session ID to list runs for"),
         status: Optional[str] = Query(None, description="Filter by run status (PENDING, RUNNING, COMPLETED, ERROR)"),
+        factory_input: Optional[str] = Query(
+            None,
+            description="JSON object with factory-specific parameters for dynamic team reconstruction",
+        ),
     ):
         from agno.os.schema import TeamRunSchema
         from agno.team._storage import _aread_or_create_session
@@ -1329,7 +1365,9 @@ def get_team_router(
                 team_id,
                 os.teams,
                 factory.db,
+                request=request,
                 session_id=session_id,
+                factory_input=factory_input,
             )
         else:
             try:

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -675,7 +675,9 @@ async def _resume_stream_generator(
                 meta: dict = {
                     "event": "replay",
                     "run_id": run_id,
-                    "status": run_output.status.value if run_output.status else "unknown",
+                    "status": getattr(run_output.status, "value", run_output.status)
+                    if run_output.status
+                    else "unknown",
                     "total_events": len(run_output.events),
                     "message": "Run completed. Replaying all events from database.",
                 }
@@ -693,7 +695,9 @@ async def _resume_stream_generator(
                 meta = {
                     "event": "replay",
                     "run_id": run_id,
-                    "status": run_output.status.value if run_output.status else "unknown",
+                    "status": getattr(run_output.status, "value", run_output.status)
+                    if run_output.status
+                    else "unknown",
                     "total_events": 0,
                     "message": "Run completed but no events stored.",
                 }
@@ -1487,6 +1491,12 @@ def get_workflow_router(
             description="JSON object with factory-specific parameters for dynamic workflow reconstruction",
         ),
     ):
+        user_id = getattr(request.state, "user_id", None)
+        if hasattr(request.state, "session_id") and request.state.session_id is not None:
+            if session_id and session_id != request.state.session_id:
+                log_warning("Session ID parameter passed in both request state and form, using request state")
+            session_id = request.state.session_id
+
         # Factory workflows: resolve through the factory; plain workflows: direct lookup.
         factory = find_factory_by_id(workflow_id, os.workflows)
         if factory:
@@ -1495,13 +1505,18 @@ def get_workflow_router(
                 os.workflows,
                 factory.db,
                 request=request,
+                user_id=user_id,
                 session_id=session_id,
                 factory_input=factory_input,
             )
         else:
-            workflow = get_workflow_by_id(  # type: ignore[assignment]
-                workflow_id=workflow_id, workflows=os.workflows, db=os.db, registry=os.registry, create_fresh=True
-            )
+            try:
+                workflow = get_workflow_by_id(  # type: ignore[assignment]
+                    workflow_id=workflow_id, workflows=os.workflows, db=os.db, registry=os.registry, create_fresh=True
+                )
+            except Exception as e:
+                logger.error(f"Error resolving workflow '{workflow_id}': {e}")
+                raise HTTPException(status_code=500, detail=f"Error resolving workflow: {e}")
             if workflow is None:
                 raise HTTPException(status_code=404, detail="Workflow not found")
         if isinstance(workflow, RemoteWorkflow):

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -1479,14 +1479,31 @@ def get_workflow_router(
     async def resume_workflow_run_stream(
         workflow_id: str,
         run_id: str,
+        request: Request,
         last_event_index: Optional[int] = Form(None, description="Index of last event received by client (0-based)"),
         session_id: Optional[str] = Form(None, description="Session ID for database fallback"),
+        factory_input: Optional[str] = Form(
+            None,
+            description="JSON object with factory-specific parameters for dynamic workflow reconstruction",
+        ),
     ):
-        workflow = get_workflow_by_id(
-            workflow_id=workflow_id, workflows=os.workflows, db=os.db, registry=os.registry, create_fresh=True
-        )
-        if workflow is None:
-            raise HTTPException(status_code=404, detail="Workflow not found")
+        # Factory workflows: resolve through the factory; plain workflows: direct lookup.
+        factory = find_factory_by_id(workflow_id, os.workflows)
+        if factory:
+            workflow = await resolve_workflow(  # type: ignore[assignment]
+                workflow_id,
+                os.workflows,
+                factory.db,
+                request=request,
+                session_id=session_id,
+                factory_input=factory_input,
+            )
+        else:
+            workflow = get_workflow_by_id(  # type: ignore[assignment]
+                workflow_id=workflow_id, workflows=os.workflows, db=os.db, registry=os.registry, create_fresh=True
+            )
+            if workflow is None:
+                raise HTTPException(status_code=404, detail="Workflow not found")
         if isinstance(workflow, RemoteWorkflow):
             raise HTTPException(status_code=400, detail="Stream resumption is not supported for remote workflows")
 


### PR DESCRIPTION
## Summary

Factory agents/teams/workflows were broken on four secondary endpoints because the router branches for factories didn't plumb `request` (required to build the factory's `RequestContext`) and `factory_input` (required when the factory has a pydantic `input_schema` with required fields). Workflows had partial coverage already; this PR brings agents + teams to parity and adds the missing pieces on workflow `/resume`.

### What this PR changes

- `libs/agno/agno/os/routers/agents/router.py` — add `request` + `factory_input` to `get_agent_run`, `list_agent_runs`, `resume_agent_run_stream`; add `factory_input` to `continue_agent_run`. `resume_agent_run_stream` now routes factory agents through `resolve_agent` instead of the sync `get_agent_by_id` (which raised uncaught).
- `libs/agno/agno/os/routers/teams/router.py` — same four changes.
- `libs/agno/agno/os/routers/workflows/router.py` — `resume_workflow_run_stream` now routes factory workflows through `resolve_workflow`.
- `cookbook/05_agent_os/factories/agent/05_hitl_factory.py` — docstring example for `/continue` was showing a partial payload `[{tool_call_id, confirmed}]`. The engine does `run_response.tools = updated_tools` wholesale, so a partial payload wipes stored `tool_name`/`tool_args` and the continued run loops back to the model with `status: ERROR`. Updated to the minimum 5-field payload (`tool_call_id`, `tool_name`, `tool_args`, `requires_confirmation`, `confirmed`).


## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (HITL cookbook docstring)
- [x] Tested in clean environment
- [x] Tests added/updated 