### PR TITLE
chore: auto generate id from name in base ext agents

### DIFF
--- a/cookbook/frameworks/claude-agent-sdk/claude_agentos.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_agentos.py
@@ -37,8 +37,7 @@ from agno.os.app import AgentOS
 # Create the Claude Agent SDK agent
 # ---------------------------------------------------------------------------
 claude_agent = ClaudeAgent(
-    agent_id="claude-assistant",
-    agent_name="Claude Assistant",
+    name="Claude Assistant",
     description="A Claude-powered assistant served through AgentOS",
     model="claude-sonnet-4-20250514",
     allowed_tools=["Read", "Bash"],

--- a/cookbook/frameworks/claude-agent-sdk/claude_basic.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_basic.py
@@ -12,8 +12,7 @@ from agno.agents.claude import ClaudeAgent
 
 # ----- Wrap Claude Agent SDK for Agno -----
 agent = ClaudeAgent(
-    agent_id="claude-assistant",
-    agent_name="Claude Assistant",
+    name="Claude Assistant",
     model="claude-sonnet-4-20250514",
     max_turns=3,
 )

--- a/cookbook/frameworks/claude-agent-sdk/claude_mcp_tools.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_mcp_tools.py
@@ -50,8 +50,7 @@ try:
 
     # ----- Agent with custom MCP tools -----
     agent = ClaudeAgent(
-        agent_id="claude-city-agent",
-        agent_name="Claude City Agent",
+        name="Claude City Agent",
         model="claude-sonnet-4-20250514",
         mcp_servers={"city-tools": server},
         allowed_tools=[

--- a/cookbook/frameworks/claude-agent-sdk/claude_session.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_session.py
@@ -19,8 +19,7 @@ db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
 pg_db = PostgresDb(db_url=db_url)
 
 agent = ClaudeAgent(
-    agent_id="claude-chat",
-    agent_name="Claude Chat",
+    name="Claude Chat",
     model="claude-sonnet-4-20250514",
     allowed_tools=["WebSearch"],
     permission_mode="acceptEdits",

--- a/cookbook/frameworks/claude-agent-sdk/claude_session_agentos.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_session_agentos.py
@@ -20,8 +20,7 @@ db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
 pg_db = PostgresDb(db_url=db_url)
 
 agent = ClaudeAgent(
-    agent_id="claude-chat",
-    agent_name="Claude Chat",
+    name="Claude Chat",
     model="claude-sonnet-4-20250514",
     allowed_tools=["WebSearch"],
     permission_mode="acceptEdits",

--- a/cookbook/frameworks/claude-agent-sdk/claude_tools.py
+++ b/cookbook/frameworks/claude-agent-sdk/claude_tools.py
@@ -15,8 +15,7 @@ from agno.agents.claude import ClaudeAgent
 
 # ----- Agent with built-in tools -----
 agent = ClaudeAgent(
-    agent_id="claude-coder",
-    agent_name="Claude Coder",
+    name="Claude Coder",
     model="claude-sonnet-4-20250514",
     allowed_tools=["Read", "Bash", "Glob"],
     permission_mode="acceptEdits",

--- a/cookbook/frameworks/dspy/dspy_agentos.py
+++ b/cookbook/frameworks/dspy/dspy_agentos.py
@@ -42,8 +42,7 @@ dspy.configure(lm=dspy.LM("openai/gpt-5.4"))
 # Create the DSPy agent
 # ---------------------------------------------------------------------------
 dspy_agent = DSPyAgent(
-    agent_id="dspy-assistant",
-    agent_name="DSPy Assistant",
+    name="DSPy Assistant",
     description="A DSPy-powered assistant served through AgentOS",
     program=dspy.ChainOfThought("question -> answer"),
 )

--- a/cookbook/frameworks/dspy/dspy_basic.py
+++ b/cookbook/frameworks/dspy/dspy_basic.py
@@ -17,8 +17,7 @@ dspy.configure(lm=lm)
 
 # ----- Basic Q&A with ChainOfThought -----
 agent = DSPyAgent(
-    agent_id="dspy-qa",
-    agent_name="DSPy Q&A",
+    name="DSPy Q&A",
     program=dspy.ChainOfThought("question -> answer"),
 )
 

--- a/cookbook/frameworks/dspy/dspy_session.py
+++ b/cookbook/frameworks/dspy/dspy_session.py
@@ -24,8 +24,7 @@ dspy.configure(lm=lm)
 db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
 
 agent = DSPyAgent(
-    agent_id="dspy-chat",
-    agent_name="DSPy Chat",
+    name="DSPy Chat",
     program=dspy.ChainOfThought("question -> answer"),
     db=db,
 )

--- a/cookbook/frameworks/dspy/dspy_session_agentos.py
+++ b/cookbook/frameworks/dspy/dspy_session_agentos.py
@@ -56,8 +56,7 @@ react_program = dspy.ReAct(
 )
 
 agent = DSPyAgent(
-    agent_id="dspy-search",
-    agent_name="DSPy Search Agent",
+    name="DSPy Search Agent",
     description="A DSPy ReAct agent with live web search, served through AgentOS",
     program=react_program,
     db=db,

--- a/cookbook/frameworks/dspy/dspy_tools.py
+++ b/cookbook/frameworks/dspy/dspy_tools.py
@@ -44,8 +44,7 @@ react_program = dspy.ReAct(
 )
 
 agent = DSPyAgent(
-    agent_id="dspy-react",
-    agent_name="DSPy ReAct Agent",
+    name="DSPy ReAct Agent",
     program=react_program,
 )
 

--- a/cookbook/frameworks/langgraph/langgraph_agentos.py
+++ b/cookbook/frameworks/langgraph/langgraph_agentos.py
@@ -45,8 +45,7 @@ compiled = graph.compile()
 
 # ----- Wrap for AgentOS -----
 langgraph_agent = LangGraphAgent(
-    agent_id="langgraph-chatbot",
-    agent_name="LangGraph Chatbot",
+    name="LangGraph Chatbot",
     description="A simple chatbot built with LangGraph, served through AgentOS",
     graph=compiled,
 )

--- a/cookbook/frameworks/langgraph/langgraph_basic.py
+++ b/cookbook/frameworks/langgraph/langgraph_basic.py
@@ -26,8 +26,7 @@ compiled = graph.compile()
 
 # ----- Wrap it for Agno -----
 agent = LangGraphAgent(
-    agent_id="langgraph-chatbot",
-    agent_name="LangGraph Chatbot",
+    name="LangGraph Chatbot",
     graph=compiled,
 )
 

--- a/cookbook/frameworks/langgraph/langgraph_session.py
+++ b/cookbook/frameworks/langgraph/langgraph_session.py
@@ -34,8 +34,7 @@ compiled = graph.compile()
 db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
 
 agent = LangGraphAgent(
-    agent_id="langgraph-chat",
-    agent_name="LangGraph Chat",
+    name="LangGraph Chat",
     graph=compiled,
     db=db,
 )

--- a/cookbook/frameworks/langgraph/langgraph_session_agentos.py
+++ b/cookbook/frameworks/langgraph/langgraph_session_agentos.py
@@ -67,8 +67,7 @@ compiled = graph.compile()
 db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
 
 agent = LangGraphAgent(
-    agent_id="langgraph-search",
-    agent_name="LangGraph Search Agent",
+    name="LangGraph Search Agent",
     description="A LangGraph agent with web search, served through AgentOS",
     graph=compiled,
     db=db,

--- a/cookbook/frameworks/langgraph/langgraph_time_travel.py
+++ b/cookbook/frameworks/langgraph/langgraph_time_travel.py
@@ -37,8 +37,7 @@ compiled = graph.compile(checkpointer=checkpointer)
 
 # ----- Wrap for Agno -----
 agent = LangGraphAgent(
-    agent_id="time-travel-agent",
-    agent_name="Time Travel Agent",
+    name="Time Travel Agent",
     graph=compiled,
 )
 

--- a/cookbook/frameworks/langgraph/langgraph_tools.py
+++ b/cookbook/frameworks/langgraph/langgraph_tools.py
@@ -69,8 +69,7 @@ compiled = graph.compile()
 
 # ----- Wrap for Agno -----
 agent = LangGraphAgent(
-    agent_id="langgraph-tool-agent",
-    agent_name="LangGraph Tool Agent",
+    name="LangGraph Tool Agent",
     graph=compiled,
 )
 

--- a/cookbook/frameworks/langgraph/langgraph_tools_session.py
+++ b/cookbook/frameworks/langgraph/langgraph_tools_session.py
@@ -76,8 +76,7 @@ compiled = graph.compile()
 db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
 
 agent = LangGraphAgent(
-    agent_id="langgraph-tools",
-    agent_name="LangGraph Tools Agent",
+    name="LangGraph Tools Agent",
     graph=compiled,
     db=db,
 )

--- a/cookbook/frameworks/multi_framework_agentos.py
+++ b/cookbook/frameworks/multi_framework_agentos.py
@@ -66,8 +66,7 @@ agno_agent = Agent(
 # 2. Claude Agent SDK
 # ---------------------------------------------------------------------------
 claude_agent = ClaudeAgent(
-    agent_id="claude-assistant",
-    agent_name="Claude Assistant",
+    name="Claude Assistant",
     description="A Claude-powered assistant with web search",
     model="claude-sonnet-4-20250514",
     allowed_tools=["WebSearch"],
@@ -92,8 +91,7 @@ graph.set_entry_point("chatbot")
 compiled = graph.compile()
 
 langgraph_agent = LangGraphAgent(
-    agent_id="langgraph-assistant",
-    agent_name="LangGraph Assistant",
+    name="LangGraph Assistant",
     description="A LangGraph chatbot",
     graph=compiled,
     db=db,
@@ -105,8 +103,7 @@ langgraph_agent = LangGraphAgent(
 dspy.configure(lm=dspy.LM("openai/gpt-5.4"))
 
 dspy_agent = DSPyAgent(
-    agent_id="dspy-assistant",
-    agent_name="DSPy Assistant",
+    name="DSPy Assistant",
     description="A DSPy chain-of-thought agent",
     program=dspy.ChainOfThought("question -> answer"),
     db=db,

--- a/libs/agno/agno/agents/base.py
+++ b/libs/agno/agno/agents/base.py
@@ -46,20 +46,18 @@ class BaseExternalAgent:
     - _arun_adapter_stream(input, **kwargs) -> AsyncIterator[RunOutputEvent]  (streaming)
     """
 
-    agent_id: str
-    agent_name: Optional[str] = None
+    name: Optional[str] = None
+    id: Optional[str] = None
     description: Optional[str] = None
     framework: str = "external"
     markdown: bool = True
     db: Optional[Union[BaseDb, AsyncBaseDb]] = None
 
-    @property
-    def id(self) -> str:
-        return self.agent_id
+    def __post_init__(self) -> None:
+        from agno.utils.string import generate_id_from_name
 
-    @property
-    def name(self) -> Optional[str]:
-        return self.agent_name or self.agent_id
+        if self.id is None:
+            self.id = generate_id_from_name(self.name)
 
     # ---------------------------------------------------------------------------
     # Public async API (satisfies AgentProtocol protocol)

--- a/libs/agno/agno/agents/base.py
+++ b/libs/agno/agno/agents/base.py
@@ -59,6 +59,10 @@ class BaseExternalAgent:
         if self.id is None:
             self.id = generate_id_from_name(self.name)
 
+    def get_id(self) -> str:
+        """Return the agent ID, guaranteed non-None after __post_init__."""
+        return self.id or ""
+
     # ---------------------------------------------------------------------------
     # Public async API (satisfies AgentProtocol protocol)
     # ---------------------------------------------------------------------------
@@ -374,7 +378,7 @@ class BaseExternalAgent:
         """Create a new AgentSession."""
         return AgentSession(
             session_id=session_id,
-            agent_id=self.id,
+            agent_id=self.get_id(),
             user_id=user_id,
             session_data={},
             agent_data={"agent_id": self.id, "agent_name": self.name, "framework": self.framework},
@@ -508,7 +512,7 @@ class BaseExternalAgent:
 
         return RunOutput(
             run_id=run_id,
-            agent_id=self.id,
+            agent_id=self.get_id(),
             agent_name=self.name,
             session_id=session_id,
             user_id=user_id,
@@ -628,7 +632,7 @@ class BaseExternalAgent:
 
         yield RunStartedEvent(
             run_id=run_id,
-            agent_id=self.id,
+            agent_id=self.get_id(),
             agent_name=self.name or "",
             session_id=session_id,
         )
@@ -687,7 +691,7 @@ class BaseExternalAgent:
         if run_error is not None:
             yield RunErrorEvent(
                 run_id=run_id,
-                agent_id=self.id,
+                agent_id=self.get_id(),
                 agent_name=self.name or "",
                 session_id=session_id,
                 content=str(run_error),
@@ -695,7 +699,7 @@ class BaseExternalAgent:
         else:
             yield RunCompletedEvent(
                 run_id=run_id,
-                agent_id=self.id,
+                agent_id=self.get_id(),
                 agent_name=self.name or "",
                 session_id=session_id,
                 content=accumulated_content,

--- a/libs/agno/agno/agents/claude/agent.py
+++ b/libs/agno/agno/agents/claude/agent.py
@@ -208,7 +208,7 @@ class ClaudeAgent(BaseExternalAgent):
                         if text:
                             yield RunContentEvent(
                                 run_id=run_id,
-                                agent_id=self.id,
+                                agent_id=self.get_id(),
                                 agent_name=self.name or "",
                                 content=text,
                             )
@@ -228,7 +228,7 @@ class ClaudeAgent(BaseExternalAgent):
                         if not got_stream_events and block.text:
                             yield RunContentEvent(
                                 run_id=run_id,
-                                agent_id=self.id,
+                                agent_id=self.get_id(),
                                 agent_name=self.name or "",
                                 content=block.text,
                             )
@@ -242,7 +242,7 @@ class ClaudeAgent(BaseExternalAgent):
                             tool_info_map[tool_id] = {"name": tool_name, "args": tool_args}
                             yield ToolCallStartedEvent(
                                 run_id=run_id,
-                                agent_id=self.id,
+                                agent_id=self.get_id(),
                                 agent_name=self.name or "",
                                 tool=ToolExecution(
                                     tool_call_id=tool_id,
@@ -267,7 +267,7 @@ class ClaudeAgent(BaseExternalAgent):
                             info = tool_info_map.get(tool_use_id, {})
                             yield ToolCallCompletedEvent(
                                 run_id=run_id,
-                                agent_id=self.id,
+                                agent_id=self.get_id(),
                                 agent_name=self.name or "",
                                 tool=ToolExecution(
                                     tool_call_id=tool_use_id,

--- a/libs/agno/agno/agents/claude/agent.py
+++ b/libs/agno/agno/agents/claude/agent.py
@@ -33,8 +33,8 @@ class ClaudeAgent(BaseExternalAgent):
     internally by the SDK — you configure tools via allowed_tools and MCP servers.
 
     Args:
-        agent_id: Unique identifier for this agent.
-        agent_name: Display name for this agent.
+        name: Display name for this agent.
+        id: Unique identifier (auto-generated from name if not set).
         system_prompt: Optional system prompt for the agent.
         model: Model to use (e.g. "claude-sonnet-4-20250514"). Defaults to SDK default.
         allowed_tools: List of tools the agent can use (e.g. ["Read", "Bash", "WebSearch"]).
@@ -50,8 +50,7 @@ class ClaudeAgent(BaseExternalAgent):
         from agno.agents.claude import ClaudeAgent
 
         agent = ClaudeAgent(
-            agent_id="claude-coder",
-            agent_name="Claude Coder",
+            name="Claude Coder",
             allowed_tools=["Read", "Edit", "Bash"],
             permission_mode="acceptEdits",
             max_turns=10,

--- a/libs/agno/agno/agents/dspy/agent.py
+++ b/libs/agno/agno/agents/dspy/agent.py
@@ -155,7 +155,7 @@ class DSPyAgent(BaseExternalAgent):
                     if chunk.chunk:
                         yield RunContentEvent(
                             run_id=run_id,
-                            agent_id=self.id,
+                            agent_id=self.get_id(),
                             agent_name=self.name or "",
                             content=chunk.chunk,
                         )
@@ -171,7 +171,7 @@ class DSPyAgent(BaseExternalAgent):
                             t_id = str(uuid4())
                             yield ToolCallStartedEvent(
                                 run_id=run_id,
-                                agent_id=self.id,
+                                agent_id=self.get_id(),
                                 agent_name=self.name or "",
                                 tool=ToolExecution(
                                     tool_call_id=t_id,
@@ -181,7 +181,7 @@ class DSPyAgent(BaseExternalAgent):
                             )
                             yield ToolCallCompletedEvent(
                                 run_id=run_id,
-                                agent_id=self.id,
+                                agent_id=self.get_id(),
                                 agent_name=self.name or "",
                                 tool=ToolExecution(
                                     tool_call_id=t_id,

--- a/libs/agno/agno/agents/dspy/agent.py
+++ b/libs/agno/agno/agents/dspy/agent.py
@@ -21,8 +21,8 @@ class DSPyAgent(BaseExternalAgent):
     be used with AgentOS endpoints or standalone via .run() / .print_response().
 
     Args:
-        agent_id: Unique identifier for this agent.
-        agent_name: Display name for this agent.
+        name: Display name for this agent.
+        id: Unique identifier (auto-generated from name if not set).
         program: A DSPy Module instance (e.g. dspy.Predict, dspy.ChainOfThought, dspy.ReAct, or custom).
         input_field: Name of the input field in the DSPy signature. Defaults to "question".
         output_field: Name of the output field to extract from the Prediction. Defaults to "answer".
@@ -33,11 +33,10 @@ class DSPyAgent(BaseExternalAgent):
         import dspy
         from agno.agents.dspy import DSPyAgent
 
-        dspy.configure(lm=dspy.LM("openai/gpt-4o-mini"))
+        dspy.configure(lm=dspy.LM("openai/gpt-5.4"))
 
         agent = DSPyAgent(
-            agent_id="dspy-qa",
-            agent_name="DSPy Q&A",
+            name="DSPy Q&A",
             program=dspy.ChainOfThought("question -> answer"),
         )
 

--- a/libs/agno/agno/agents/langgraph/agent.py
+++ b/libs/agno/agno/agents/langgraph/agent.py
@@ -119,7 +119,7 @@ class LangGraphAgent(BaseExternalAgent):
                     if isinstance(chunk.content, str):
                         yield RunContentEvent(
                             run_id=run_id,
-                            agent_id=self.id,
+                            agent_id=self.get_id(),
                             agent_name=self.name or "",
                             content=chunk.content,
                         )
@@ -130,7 +130,7 @@ class LangGraphAgent(BaseExternalAgent):
                 tool_run_id = event.get("run_id", str(uuid4()))
                 yield ToolCallStartedEvent(
                     run_id=run_id,
-                    agent_id=self.id,
+                    agent_id=self.get_id(),
                     agent_name=self.name or "",
                     tool=ToolExecution(
                         tool_call_id=tool_run_id,
@@ -146,7 +146,7 @@ class LangGraphAgent(BaseExternalAgent):
                 result_str = str(output.content) if hasattr(output, "content") else str(output)
                 yield ToolCallCompletedEvent(
                     run_id=run_id,
-                    agent_id=self.id,
+                    agent_id=self.get_id(),
                     agent_name=self.name or "",
                     tool=ToolExecution(
                         tool_call_id=tool_run_id,

--- a/libs/agno/agno/agents/langgraph/agent.py
+++ b/libs/agno/agno/agents/langgraph/agent.py
@@ -21,8 +21,8 @@ class LangGraphAgent(BaseExternalAgent):
     or standalone via .run() / .print_response().
 
     Args:
-        agent_id: Unique identifier for this agent.
-        agent_name: Display name for this agent.
+        name: Display name for this agent.
+        id: Unique identifier (auto-generated from name if not set).
         graph: A LangGraph compiled graph (from graph.compile()).
         input_key: Key in the graph state used for input messages. Defaults to "messages".
         output_key: Key in the graph state used for output messages. Defaults to "messages".
@@ -34,7 +34,7 @@ class LangGraphAgent(BaseExternalAgent):
         from agno.agents.langgraph import LangGraphAgent
 
         def chatbot(state: MessagesState):
-            return {"messages": [ChatOpenAI(model="gpt-4o").invoke(state["messages"])]}
+            return {"messages": [ChatOpenAI(model="gpt-5.4").invoke(state["messages"])]}
 
         graph = StateGraph(MessagesState)
         graph.add_node("chatbot", chatbot)
@@ -42,8 +42,7 @@ class LangGraphAgent(BaseExternalAgent):
         compiled = graph.compile()
 
         agent = LangGraphAgent(
-            agent_id="my-agent",
-            agent_name="My LangGraph Agent",
+            name="My LangGraph Agent",
             graph=compiled,
         )
 


### PR DESCRIPTION
## Summary

auto generate id from name in multi framework agents, and use id, name instead of agent_id, agent_name

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
