### PR TITLE
chore: map "openai:" model string to OpenAIResponses

### DIFF
--- a/libs/agno/agno/models/utils.py
+++ b/libs/agno/agno/models/utils.py
@@ -175,6 +175,11 @@ def _get_model_class(model_id: str, model_provider: str) -> Model:
         return Ollama(id=model_id)
 
     elif model_provider == "openai":
+        from agno.models.openai import OpenAIResponses
+
+        return OpenAIResponses(id=model_id)
+
+    elif model_provider == "openai-chat":
         from agno.models.openai import OpenAIChat
 
         return OpenAIChat(id=model_id)

--- a/libs/agno/tests/unit/agent/test_agent_config.py
+++ b/libs/agno/tests/unit/agent/test_agent_config.py
@@ -243,7 +243,7 @@ class TestAgentFromDict:
 
     def test_from_dict_with_model(self):
         """Test from_dict reconstructs model from config."""
-        from agno.models.openai import OpenAIChat
+        from agno.models.openai import OpenAIResponses
 
         config = {
             "id": "model-agent",
@@ -256,7 +256,7 @@ class TestAgentFromDict:
 
         # Model should be reconstructed
         assert agent.model is not None
-        assert isinstance(agent.model, OpenAIChat)
+        assert isinstance(agent.model, OpenAIResponses)
         assert agent.model.id == "gpt-4o-mini"
 
     def test_from_dict_preserves_settings(self):

--- a/libs/agno/tests/unit/team/test_team_config.py
+++ b/libs/agno/tests/unit/team/test_team_config.py
@@ -311,7 +311,7 @@ class TestTeamFromDict:
 
     def test_from_dict_with_model(self):
         """Test from_dict reconstructs model from config."""
-        from agno.models.openai import OpenAIChat
+        from agno.models.openai import OpenAIResponses
 
         config = {
             "id": "model-team",
@@ -322,7 +322,7 @@ class TestTeamFromDict:
         team = Team.from_dict(config)
 
         assert team.model is not None
-        assert isinstance(team.model, OpenAIChat)
+        assert isinstance(team.model, OpenAIResponses)
         assert team.model.id == "gpt-4o-mini"
 
     def test_from_dict_preserves_settings(self):

--- a/libs/agno/tests/unit/utils/test_model_string.py
+++ b/libs/agno/tests/unit/utils/test_model_string.py
@@ -7,7 +7,7 @@ from agno.memory.manager import MemoryManager
 from agno.models.anthropic import Claude
 from agno.models.google import Gemini
 from agno.models.groq import Groq
-from agno.models.openai import OpenAIChat
+from agno.models.openai import OpenAIChat, OpenAIResponses
 from agno.models.utils import get_model
 from agno.team import Team
 
@@ -15,7 +15,7 @@ from agno.team import Team
 def test_get_model_with_string():
     """Test get_model() with a model string."""
     model = get_model("openai:gpt-4o")
-    assert isinstance(model, OpenAIChat)
+    assert isinstance(model, OpenAIResponses)
     assert model.id == "gpt-4o"
 
 
@@ -35,7 +35,7 @@ def test_get_model_with_none():
 def test_get_model_parses_openai_string():
     """Test get_model() parses OpenAI model string."""
     model = get_model("openai:gpt-4o")
-    assert isinstance(model, OpenAIChat)
+    assert isinstance(model, OpenAIResponses)
     assert model.id == "gpt-4o"
 
 
@@ -49,7 +49,7 @@ def test_get_model_parses_anthropic_string():
 def test_get_model_strips_whitespace():
     """Test that get_model() strips spaces from model string."""
     model = get_model(" openai : gpt-4o ")
-    assert isinstance(model, OpenAIChat)
+    assert isinstance(model, OpenAIResponses)
     assert model.id == "gpt-4o"
 
 
@@ -80,7 +80,7 @@ def test_get_model_unknown_provider():
 def test_agent_with_model_string():
     """Test creating Agent with model string."""
     agent = Agent(model="openai:gpt-4o")
-    assert isinstance(agent.model, OpenAIChat)
+    assert isinstance(agent.model, OpenAIResponses)
     assert agent.model.id == "gpt-4o"
 
 
@@ -93,7 +93,7 @@ def test_agent_with_all_model_params_as_strings():
         parser_model="google:gemini-2.0-flash-exp",
         output_model="groq:llama-3.1-70b-versatile",
     )
-    assert isinstance(agent.model, OpenAIChat)
+    assert isinstance(agent.model, OpenAIResponses)
     assert isinstance(agent.reasoning_model, Claude)
     assert isinstance(agent.parser_model, Gemini)
     assert isinstance(agent.output_model, Groq)
@@ -125,7 +125,7 @@ def test_team_with_all_model_params_as_strings():
         output_model="groq:llama-3.1-70b-versatile",
     )
     assert isinstance(team.model, Claude)
-    assert isinstance(team.reasoning_model, OpenAIChat)
+    assert isinstance(team.reasoning_model, OpenAIResponses)
     assert isinstance(team.parser_model, Gemini)
     assert isinstance(team.output_model, Groq)
 
@@ -133,7 +133,7 @@ def test_team_with_all_model_params_as_strings():
 def test_memory_manager_with_model_string():
     """Test MemoryManager accepts model string."""
     manager = MemoryManager(model="openai:gpt-4o")
-    assert isinstance(manager.model, OpenAIChat)
+    assert isinstance(manager.model, OpenAIResponses)
 
 
 def test_memory_manager_with_model_instance():
@@ -145,7 +145,7 @@ def test_memory_manager_with_model_instance():
 def test_culture_manager_with_model_string():
     """Test CultureManager accepts model string."""
     manager = CultureManager(model="openai:gpt-4o")
-    assert isinstance(manager.model, OpenAIChat)
+    assert isinstance(manager.model, OpenAIResponses)
 
 
 def test_culture_manager_with_model_instance():
@@ -157,7 +157,7 @@ def test_culture_manager_with_model_instance():
 def test_agentic_chunking_with_model_string():
     """Test AgenticChunking accepts model string."""
     chunking = AgenticChunking(model="openai:gpt-4o")
-    assert isinstance(chunking.model, OpenAIChat)
+    assert isinstance(chunking.model, OpenAIResponses)
 
 
 def test_agentic_chunking_with_model_instance():


### PR DESCRIPTION
## Summary

Map the `"openai:"` model string prefix to `OpenAIResponses` instead of `OpenAIChat`, 
so that `Agent(model="openai:gpt-5.4")` resolves to `OpenAIResponses(id="gpt-5.4")`.

Added `"openai-chat:"` as a fallback prefix for users who still need `OpenAIChat`.

Combined with the default model change in 48624cfc, this means:
- No model passed → `OpenAIResponses(id="gpt-5.4")`
- `"openai:gpt-5.4"` → `OpenAIResponses(id="gpt-5.4")`
- `"openai-chat:gpt-4o"` → `OpenAIChat(id="gpt-4o")`
- `"openai-responses:gpt-5.4"` → `OpenAIResponses(id="gpt-5.4")` (unchanged)


## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
