### PR TITLE
feat: multi-block prompt caching for Claude

### DIFF
--- a/cookbook/02_agents/02_input_output/output_schema.py
+++ b/cookbook/02_agents/02_input_output/output_schema.py
@@ -15,7 +15,9 @@ from rich.pretty import pprint  # noqa
 
 class BreakingNewsSummary(BaseModel):
     topic: str = Field(..., description="The topic or region being summarized")
-    summary: str = Field(..., description="A concise summary of the latest developments")
+    summary: str = Field(
+        ..., description="A concise summary of the latest developments"
+    )
     key_updates: List[str] = Field(
         ..., description="Important updates or headlines related to the topic"
     )

--- a/cookbook/90_models/anthropic/prompt_caching_multi_block.py
+++ b/cookbook/90_models/anthropic/prompt_caching_multi_block.py
@@ -14,6 +14,13 @@ which itself becomes the first cached block when cache_system_prompt=True. This
 preserves your agent's description, instructions, and tool hints while letting
 you add per-request static or dynamic blocks with their own cache settings.
 
+Note on mixed TTLs: Anthropic requires any 1h cached block to appear before any
+5m cached block in the request. Because the agent-built block comes first and
+inherits the model-level TTL, you must set extended_cache_time=True whenever
+any SystemPromptBlock uses ttl="1h". Otherwise the request would be
+5m (agent) -> 1h (block), which the API rejects. Agno validates this at
+assembly time with a clear error.
+
 Docs: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
 """
 
@@ -46,6 +53,10 @@ agent = Agent(
     model=Claude(
         id="claude-sonnet-4-5-20250929",
         cache_system_prompt=True,
+        # Required when any SystemPromptBlock uses ttl="1h": the agent-built
+        # block would otherwise be cached at 5m and precede a 1h block, which
+        # violates Anthropic's mixed-TTL ordering rule.
+        extended_cache_time=True,
         cache_tools=True,
         system_prompt_blocks=blocks,
     ),

--- a/cookbook/90_models/anthropic/prompt_caching_multi_block.py
+++ b/cookbook/90_models/anthropic/prompt_caching_multi_block.py
@@ -1,0 +1,66 @@
+"""
+Multi-block prompt caching with per-block TTL and tool caching.
+
+Demonstrates two Anthropic caching features:
+1. Per-block TTL: Split system prompts into static (cached) and dynamic (uncached)
+   blocks with independent TTLs. The static block uses a 1h extended TTL so it
+   survives across longer conversations, while the dynamic block is never cached.
+2. Tool caching: Opt in to caching tool definitions by setting cache_tools=True.
+   Anthropic caches all tools as a prefix when cache_control is on the last tool.
+
+Blocks live on the Claude model (not on Agent.system_message) because this is a
+Claude-specific feature. When set, the blocks replace the agent-built system
+string entirely, so include any static instructions you want cached yourself.
+
+Docs: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
+"""
+
+from datetime import datetime
+
+from agno.agent import Agent
+from agno.models.anthropic import Claude, SystemPromptBlock
+from agno.tools.duckduckgo import DuckDuckGoTools
+
+blocks = [
+    # Static instructions, cached for 1 hour (2x cost but survives much longer)
+    SystemPromptBlock(
+        text=(
+            "You are a senior software architect. You give concise, opinionated "
+            "advice grounded in real-world experience. Prefer battle-tested "
+            "patterns over trendy abstractions. When recommending tools or "
+            "libraries, explain the trade-offs honestly."
+        ),
+        cache=True,
+        ttl="1h",
+    ),
+    # Dynamic per-user context, never cached (changes every request)
+    SystemPromptBlock(
+        text=f"The user is on the Enterprise plan and prefers Python examples. Current time: {datetime.now().isoformat()}",
+        cache=False,
+    ),
+]
+
+agent = Agent(
+    model=Claude(
+        id="claude-sonnet-4-5-20250929",
+        cache_system_prompt=True,
+        cache_tools=True,
+        system_prompt_blocks=blocks,
+    ),
+    tools=[DuckDuckGoTools()],
+    markdown=True,
+)
+
+# First run creates the cache
+response = agent.run("What's the best way to structure a large FastAPI project?")
+if response and response.metrics:
+    print(
+        f"Run 1 - cache write: {response.metrics.cache_write_tokens}, cache read: {response.metrics.cache_read_tokens}"
+    )
+
+# Second run reads from cache
+response = agent.run("How should I handle database migrations in that setup?")
+if response and response.metrics:
+    print(
+        f"Run 2 - cache write: {response.metrics.cache_write_tokens}, cache read: {response.metrics.cache_read_tokens}"
+    )

--- a/cookbook/90_models/anthropic/prompt_caching_multi_block.py
+++ b/cookbook/90_models/anthropic/prompt_caching_multi_block.py
@@ -9,8 +9,10 @@ Demonstrates two Anthropic caching features:
    Anthropic caches all tools as a prefix when cache_control is on the last tool.
 
 Blocks live on the Claude model (not on Agent.system_message) because this is a
-Claude-specific feature. When set, the blocks replace the agent-built system
-string entirely, so include any static instructions you want cached yourself.
+Claude-specific feature. They are appended after the agent-built system prompt,
+which itself becomes the first cached block when cache_system_prompt=True. This
+preserves your agent's description, instructions, and tool hints while letting
+you add per-request static or dynamic blocks with their own cache settings.
 
 Docs: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
 """

--- a/cookbook/90_models/anthropic/prompt_caching_with_dynamic_block.py
+++ b/cookbook/90_models/anthropic/prompt_caching_with_dynamic_block.py
@@ -2,13 +2,16 @@
 Augment the agent-built system prompt with a dynamic per-request block.
 
 The Agent's description + instructions are assembled into the first system
-block and cached automatically when cache_system_prompt=True. Any
-SystemPromptBlock on the Claude model is appended as an additional block,
-with its own cache setting.
+block and cached automatically when cache_system_prompt=True. A
+SystemPromptBlock appended after can carry dynamic content without
+invalidating the cached prefix, as long as cache=False on the dynamic
+block.
 
-This is the common case: keep your normal agent description/instructions
-(which are static and cache well), and add a small dynamic block for
-per-request context that would otherwise invalidate the cached prefix.
+Pass system_prompt_blocks as a callable to have it evaluated on every
+request — the right pattern when the dynamic text (timestamp, user
+identity, session state) must be fresh per call. The callable runs inside
+Claude._build_system with no arguments, so close over whatever state you
+need.
 
 Docs: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
 """
@@ -19,38 +22,38 @@ from agno.agent import Agent
 from agno.models.anthropic import Claude, SystemPromptBlock
 
 
-def make_agent() -> Agent:
-    # Dynamic block rebuilt on every process start. cache=False so Anthropic
-    # does not try to cache text that will be different next request.
-    dynamic_context = SystemPromptBlock(
-        text=(
-            f"Current server time: {datetime.now().isoformat()}. "
-            "The user is on the Enterprise plan and prefers Python examples."
-        ),
-        cache=False,
-    )
-
-    return Agent(
-        model=Claude(
-            id="claude-sonnet-4-5-20250929",
-            cache_system_prompt=True,
-            system_prompt_blocks=[dynamic_context],
-        ),
-        description=(
-            "You are an expert software architect who gives concise, opinionated "
-            "advice grounded in real-world experience. You prefer battle-tested "
-            "patterns over trendy abstractions."
-        ),
-        instructions=[
-            "Answer in two to four paragraphs.",
-            "When comparing options, list the trade-offs honestly.",
-            "If you do not know the answer, say so plainly.",
-        ],
-        markdown=True,
-    )
+def build_request_blocks() -> list[SystemPromptBlock]:
+    # Evaluated per request: the timestamp (and any other per-request context)
+    # stays fresh without mutating the model or reinstantiating the agent.
+    return [
+        SystemPromptBlock(
+            text=(
+                f"Current server time: {datetime.now().isoformat()}. "
+                "The user is on the Enterprise plan and prefers Python examples."
+            ),
+            cache=False,
+        )
+    ]
 
 
-agent = make_agent()
+agent = Agent(
+    model=Claude(
+        id="claude-sonnet-4-5-20250929",
+        cache_system_prompt=True,
+        system_prompt_blocks=build_request_blocks,
+    ),
+    description=(
+        "You are an expert software architect who gives concise, opinionated "
+        "advice grounded in real-world experience. You prefer battle-tested "
+        "patterns over trendy abstractions."
+    ),
+    instructions=[
+        "Answer in two to four paragraphs.",
+        "When comparing options, list the trade-offs honestly.",
+        "If you do not know the answer, say so plainly.",
+    ],
+    markdown=True,
+)
 
 # First run writes the cache on the agent-built system block
 response = agent.run("How should I structure a large FastAPI application?")
@@ -60,7 +63,9 @@ if response and response.metrics:
         f"cache read: {response.metrics.cache_read_tokens}"
     )
 
-# Second run reads the cached prefix, even though the dynamic block is not cached
+# Second run reads the cached prefix. build_request_blocks runs again so the
+# dynamic timestamp refreshes, but because that block is cache=False the
+# prefix before it stays stable and cache-hot.
 response = agent.run("How should I handle background jobs in that setup?")
 if response and response.metrics:
     print(

--- a/cookbook/90_models/anthropic/prompt_caching_with_dynamic_block.py
+++ b/cookbook/90_models/anthropic/prompt_caching_with_dynamic_block.py
@@ -1,0 +1,69 @@
+"""
+Augment the agent-built system prompt with a dynamic per-request block.
+
+The Agent's description + instructions are assembled into the first system
+block and cached automatically when cache_system_prompt=True. Any
+SystemPromptBlock on the Claude model is appended as an additional block,
+with its own cache setting.
+
+This is the common case: keep your normal agent description/instructions
+(which are static and cache well), and add a small dynamic block for
+per-request context that would otherwise invalidate the cached prefix.
+
+Docs: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
+"""
+
+from datetime import datetime
+
+from agno.agent import Agent
+from agno.models.anthropic import Claude, SystemPromptBlock
+
+
+def make_agent() -> Agent:
+    # Dynamic block rebuilt on every process start. cache=False so Anthropic
+    # does not try to cache text that will be different next request.
+    dynamic_context = SystemPromptBlock(
+        text=(
+            f"Current server time: {datetime.now().isoformat()}. "
+            "The user is on the Enterprise plan and prefers Python examples."
+        ),
+        cache=False,
+    )
+
+    return Agent(
+        model=Claude(
+            id="claude-sonnet-4-5-20250929",
+            cache_system_prompt=True,
+            system_prompt_blocks=[dynamic_context],
+        ),
+        description=(
+            "You are an expert software architect who gives concise, opinionated "
+            "advice grounded in real-world experience. You prefer battle-tested "
+            "patterns over trendy abstractions."
+        ),
+        instructions=[
+            "Answer in two to four paragraphs.",
+            "When comparing options, list the trade-offs honestly.",
+            "If you do not know the answer, say so plainly.",
+        ],
+        markdown=True,
+    )
+
+
+agent = make_agent()
+
+# First run writes the cache on the agent-built system block
+response = agent.run("How should I structure a large FastAPI application?")
+if response and response.metrics:
+    print(
+        f"Run 1 - cache write: {response.metrics.cache_write_tokens}, "
+        f"cache read: {response.metrics.cache_read_tokens}"
+    )
+
+# Second run reads the cached prefix, even though the dynamic block is not cached
+response = agent.run("How should I handle background jobs in that setup?")
+if response and response.metrics:
+    print(
+        f"Run 2 - cache write: {response.metrics.cache_write_tokens}, "
+        f"cache read: {response.metrics.cache_read_tokens}"
+    )

--- a/libs/agno/agno/models/anthropic/__init__.py
+++ b/libs/agno/agno/models/anthropic/__init__.py
@@ -1,5 +1,6 @@
-from agno.models.anthropic.claude import Claude
+from agno.models.anthropic.claude import Claude, SystemPromptBlock
 
 __all__ = [
     "Claude",
+    "SystemPromptBlock",
 ]

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -2,7 +2,7 @@ import json
 from collections.abc import AsyncIterator
 from dataclasses import asdict, dataclass
 from os import getenv
-from typing import Any, Dict, List, Literal, NoReturn, Optional, Type, Union
+from typing import Any, Callable, Dict, List, Literal, NoReturn, Optional, Type, Union
 
 import httpx
 from pydantic import BaseModel, ValidationError
@@ -133,9 +133,12 @@ class Claude(Model):
     extended_cache_time: Optional[bool] = False
     cache_tools: bool = False
     # Optional multi-block system prompt with per-block cache control.
-    # When set, replaces the agent-built system string and is sent to Anthropic
-    # as the ``system`` array. See SystemPromptBlock for cache/ttl semantics.
-    system_prompt_blocks: Optional[List[SystemPromptBlock]] = None
+    # Appended after the agent-built system message in the Anthropic ``system``
+    # array. See SystemPromptBlock for cache/ttl semantics. May be a list, or a
+    # zero-arg callable returning a list — the callable is evaluated on every
+    # request, which is how you inject dynamic per-request content into a
+    # cached system prompt without reinstantiating the model or agent.
+    system_prompt_blocks: Optional[Union[List[SystemPromptBlock], Callable[[], List[SystemPromptBlock]]]] = None
     request_params: Optional[Dict[str, Any]] = None
 
     # Anthropic beta and experimental features
@@ -616,10 +619,11 @@ class Claude(Model):
                     extended_cache_time=bool(self.extended_cache_time),
                 )
             )
-        if self.system_prompt_blocks:
+        user_blocks = self.system_prompt_blocks() if callable(self.system_prompt_blocks) else self.system_prompt_blocks
+        if user_blocks:
             blocks.extend(
                 build_system_blocks(
-                    self.system_prompt_blocks,
+                    user_blocks,
                     cache_system_prompt=bool(self.cache_system_prompt),
                     extended_cache_time=bool(self.extended_cache_time),
                 )

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -17,6 +17,7 @@ from agno.tools.function import Function
 from agno.utils.log import log_debug, log_error, log_warning
 from agno.utils.models.claude import (
     MCPServerConfiguration,
+    _validate_cache_ttl_order,
     build_system_blocks,
     format_messages,
     format_tools_for_model,
@@ -602,6 +603,9 @@ class Claude(Model):
 
         Used by both ``_prepare_request_kwargs`` and ``count_tokens`` so the
         two paths cannot diverge.
+
+        Raises ``ValueError`` if the assembled order would violate Anthropic's
+        mixed-TTL rule (a 1h cache_control block cannot appear after a 5m one).
         """
         blocks: List[Dict[str, Any]] = []
         if system_message:
@@ -620,6 +624,7 @@ class Claude(Model):
                     extended_cache_time=bool(self.extended_cache_time),
                 )
             )
+        _validate_cache_ttl_order(blocks)
         return blocks
 
     def _prepare_request_kwargs(

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -2,7 +2,7 @@ import json
 from collections.abc import AsyncIterator
 from dataclasses import asdict, dataclass
 from os import getenv
-from typing import Any, Dict, List, NoReturn, Optional, Type, Union
+from typing import Any, Dict, List, Literal, NoReturn, Optional, Type, Union
 
 import httpx
 from pydantic import BaseModel, ValidationError
@@ -17,6 +17,7 @@ from agno.tools.function import Function
 from agno.utils.log import log_debug, log_error, log_warning
 from agno.utils.models.claude import (
     MCPServerConfiguration,
+    build_system_blocks,
     format_messages,
     format_tools_for_model,
     supports_prefill,
@@ -67,6 +68,20 @@ except ImportError as e:
     ) from e
 
 
+class SystemPromptBlock(BaseModel):
+    """A block of system prompt content with Anthropic cache control metadata.
+
+    Used with ``Claude.system_prompt_blocks`` to split the system prompt into
+    independently-cacheable segments. ``cache=True`` adds ``cache_control`` to
+    the block when the model has ``cache_system_prompt=True``. ``ttl`` overrides
+    the model-level ``extended_cache_time`` flag for that block only.
+    """
+
+    text: str
+    cache: bool = True
+    ttl: Optional[Literal["5m", "1h"]] = None
+
+
 @dataclass
 class Claude(Model):
     """
@@ -115,6 +130,11 @@ class Claude(Model):
     top_k: Optional[int] = None
     cache_system_prompt: Optional[bool] = False
     extended_cache_time: Optional[bool] = False
+    cache_tools: bool = False
+    # Optional multi-block system prompt with per-block cache control.
+    # When set, replaces the agent-built system string and is sent to Anthropic
+    # as the ``system`` array. See SystemPromptBlock for cache/ttl semantics.
+    system_prompt_blocks: Optional[List[SystemPromptBlock]] = None
     request_params: Optional[Dict[str, Any]] = None
 
     # Anthropic beta and experimental features
@@ -564,6 +584,11 @@ class Claude(Model):
                 return container_id
         return None
 
+    def _apply_cache_tools(self, request_kwargs: Dict[str, Any]) -> None:
+        """Tag the last tool with cache_control when cache_tools is enabled."""
+        if self.cache_tools and "tools" in request_kwargs and request_kwargs["tools"]:
+            request_kwargs["tools"][-1]["cache_control"] = {"type": "ephemeral"}
+
     def _prepare_request_kwargs(
         self,
         system_message: str,
@@ -596,16 +621,21 @@ class Claude(Model):
             container_id = self._extract_container_id_from_messages(messages)
             if container_id:
                 request_kwargs["container"] = {**request_kwargs["container"], "id": container_id}
-        if system_message:
-            if self.cache_system_prompt:
-                cache_control = (
-                    {"type": "ephemeral", "ttl": "1h"}
-                    if self.extended_cache_time is not None and self.extended_cache_time is True
-                    else {"type": "ephemeral"}
-                )
-                request_kwargs["system"] = [{"text": system_message, "type": "text", "cache_control": cache_control}]
-            else:
-                request_kwargs["system"] = [{"text": system_message, "type": "text"}]
+        # system_prompt_blocks takes precedence over the agent-built string. Users
+        # who need per-block cache control pass blocks on the model; the agent-built
+        # system_message is ignored in that case.
+        if self.system_prompt_blocks:
+            request_kwargs["system"] = build_system_blocks(
+                self.system_prompt_blocks,
+                cache_system_prompt=bool(self.cache_system_prompt),
+                extended_cache_time=bool(self.extended_cache_time),
+            )
+        elif system_message:
+            request_kwargs["system"] = build_system_blocks(
+                system_message,
+                cache_system_prompt=bool(self.cache_system_prompt),
+                extended_cache_time=bool(self.extended_cache_time),
+            )
 
         # Add code execution tool if skills are enabled
         if self.skills:
@@ -619,6 +649,8 @@ class Claude(Model):
         # Format tools (this will handle strict mode)
         if tools:
             request_kwargs["tools"] = format_tools_for_model(tools)
+
+        self._apply_cache_tools(request_kwargs)
 
         # Build output_format if response_format is provided
         output_format = self._build_output_format(response_format)

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -467,6 +467,7 @@ class Claude(Model):
                 "top_k": self.top_k,
                 "cache_system_prompt": self.cache_system_prompt,
                 "extended_cache_time": self.extended_cache_time,
+                "cache_tools": self.cache_tools,
                 "betas": self.betas,
             }
         )

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -482,8 +482,9 @@ class Claude(Model):
             anthropic_tools = format_tools_for_model(formatted_tools)
 
         kwargs: Dict[str, Any] = {"messages": anthropic_messages, "model": self.id}
-        if system_prompt:
-            kwargs["system"] = system_prompt
+        system = self._build_system(system_prompt)
+        if system:
+            kwargs["system"] = system
         if anthropic_tools:
             kwargs["tools"] = anthropic_tools
 
@@ -509,8 +510,9 @@ class Claude(Model):
             anthropic_tools = format_tools_for_model(formatted_tools)
 
         kwargs: Dict[str, Any] = {"messages": anthropic_messages, "model": self.id}
-        if system_prompt:
-            kwargs["system"] = system_prompt
+        system = self._build_system(system_prompt)
+        if system:
+            kwargs["system"] = system
         if anthropic_tools:
             kwargs["tools"] = anthropic_tools
 
@@ -589,6 +591,37 @@ class Claude(Model):
         if self.cache_tools and "tools" in request_kwargs and request_kwargs["tools"]:
             request_kwargs["tools"][-1]["cache_control"] = {"type": "ephemeral"}
 
+    def _build_system(self, system_message: str) -> List[Dict[str, Any]]:
+        """Assemble the Anthropic ``system`` array.
+
+        Agent-built ``system_message`` becomes the first block (cached per
+        ``cache_system_prompt``). Model-level ``system_prompt_blocks`` are
+        appended after, each with its own cache/ttl. This ordering matches
+        Anthropic's prefix-cache semantics: stable content first, dynamic
+        per-request content later.
+
+        Used by both ``_prepare_request_kwargs`` and ``count_tokens`` so the
+        two paths cannot diverge.
+        """
+        blocks: List[Dict[str, Any]] = []
+        if system_message:
+            blocks.extend(
+                build_system_blocks(
+                    system_message,
+                    cache_system_prompt=bool(self.cache_system_prompt),
+                    extended_cache_time=bool(self.extended_cache_time),
+                )
+            )
+        if self.system_prompt_blocks:
+            blocks.extend(
+                build_system_blocks(
+                    self.system_prompt_blocks,
+                    cache_system_prompt=bool(self.cache_system_prompt),
+                    extended_cache_time=bool(self.extended_cache_time),
+                )
+            )
+        return blocks
+
     def _prepare_request_kwargs(
         self,
         system_message: str,
@@ -621,21 +654,9 @@ class Claude(Model):
             container_id = self._extract_container_id_from_messages(messages)
             if container_id:
                 request_kwargs["container"] = {**request_kwargs["container"], "id": container_id}
-        # system_prompt_blocks takes precedence over the agent-built string. Users
-        # who need per-block cache control pass blocks on the model; the agent-built
-        # system_message is ignored in that case.
-        if self.system_prompt_blocks:
-            request_kwargs["system"] = build_system_blocks(
-                self.system_prompt_blocks,
-                cache_system_prompt=bool(self.cache_system_prompt),
-                extended_cache_time=bool(self.extended_cache_time),
-            )
-        elif system_message:
-            request_kwargs["system"] = build_system_blocks(
-                system_message,
-                cache_system_prompt=bool(self.cache_system_prompt),
-                extended_cache_time=bool(self.extended_cache_time),
-            )
+        system = self._build_system(system_message)
+        if system:
+            request_kwargs["system"] = system
 
         # Add code execution tool if skills are enabled
         if self.skills:

--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -74,8 +74,14 @@ class SystemPromptBlock(BaseModel):
 
     Used with ``Claude.system_prompt_blocks`` to split the system prompt into
     independently-cacheable segments. ``cache=True`` adds ``cache_control`` to
-    the block when the model has ``cache_system_prompt=True``. ``ttl`` overrides
-    the model-level ``extended_cache_time`` flag for that block only.
+    this block; ``cache=False`` leaves it uncached. This decision is made per
+    block and is independent of the model-level ``cache_system_prompt`` flag,
+    which only controls whether the agent-built system message gets cached.
+    That separation lets you leave the agent-built block uncached while still
+    caching selected custom blocks (or vice versa).
+
+    ``ttl`` overrides the model-level ``extended_cache_time`` flag for that
+    block only.
     """
 
     text: str

--- a/libs/agno/agno/models/aws/claude.py
+++ b/libs/agno/agno/models/aws/claude.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from agno.models.anthropic import Claude as AnthropicClaude
 from agno.utils.log import log_debug, log_warning
-from agno.utils.models.claude import format_tools_for_model
+from agno.utils.models.claude import build_system_blocks, format_tools_for_model
 
 try:
     from anthropic import AnthropicBedrock, AsyncAnthropicBedrock
@@ -244,20 +244,25 @@ class Claude(AnthropicClaude):
         """
         # Pass response_format and tools to get_request_params for beta header handling
         request_kwargs = self.get_request_params(response_format=response_format, tools=tools).copy()
-        if system_message:
-            if self.cache_system_prompt:
-                cache_control = (
-                    {"type": "ephemeral", "ttl": "1h"}
-                    if self.extended_cache_time is not None and self.extended_cache_time is True
-                    else {"type": "ephemeral"}
-                )
-                request_kwargs["system"] = [{"text": system_message, "type": "text", "cache_control": cache_control}]
-            else:
-                request_kwargs["system"] = [{"text": system_message, "type": "text"}]
+        # system_prompt_blocks takes precedence over the agent-built string.
+        if self.system_prompt_blocks:
+            request_kwargs["system"] = build_system_blocks(
+                self.system_prompt_blocks,
+                cache_system_prompt=bool(self.cache_system_prompt),
+                extended_cache_time=bool(self.extended_cache_time),
+            )
+        elif system_message:
+            request_kwargs["system"] = build_system_blocks(
+                system_message,
+                cache_system_prompt=bool(self.cache_system_prompt),
+                extended_cache_time=bool(self.extended_cache_time),
+            )
 
         # Format tools (this will handle strict mode)
         if tools:
             request_kwargs["tools"] = format_tools_for_model(tools)
+
+        self._apply_cache_tools(request_kwargs)
 
         if request_kwargs:
             log_debug(f"Calling {self.provider} with request parameters: {request_kwargs}", log_level=2)

--- a/libs/agno/agno/models/aws/claude.py
+++ b/libs/agno/agno/models/aws/claude.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from agno.models.anthropic import Claude as AnthropicClaude
 from agno.utils.log import log_debug, log_warning
-from agno.utils.models.claude import build_system_blocks, format_tools_for_model
+from agno.utils.models.claude import format_tools_for_model
 
 try:
     from anthropic import AnthropicBedrock, AsyncAnthropicBedrock
@@ -244,19 +244,9 @@ class Claude(AnthropicClaude):
         """
         # Pass response_format and tools to get_request_params for beta header handling
         request_kwargs = self.get_request_params(response_format=response_format, tools=tools).copy()
-        # system_prompt_blocks takes precedence over the agent-built string.
-        if self.system_prompt_blocks:
-            request_kwargs["system"] = build_system_blocks(
-                self.system_prompt_blocks,
-                cache_system_prompt=bool(self.cache_system_prompt),
-                extended_cache_time=bool(self.extended_cache_time),
-            )
-        elif system_message:
-            request_kwargs["system"] = build_system_blocks(
-                system_message,
-                cache_system_prompt=bool(self.cache_system_prompt),
-                extended_cache_time=bool(self.extended_cache_time),
-            )
+        system = self._build_system(system_message)
+        if system:
+            request_kwargs["system"] = system
 
         # Format tools (this will handle strict mode)
         if tools:

--- a/libs/agno/agno/models/azure/claude.py
+++ b/libs/agno/agno/models/azure/claude.py
@@ -162,19 +162,14 @@ class Claude(AnthropicClaude):
     ) -> Dict[str, Any]:
         """Prepare the request keyword arguments for the API call."""
         request_kwargs = self.get_request_params(response_format=response_format, tools=tools).copy()
-        if system_message:
-            if self.cache_system_prompt:
-                cache_control = (
-                    {"type": "ephemeral", "ttl": "1h"}
-                    if self.extended_cache_time is not None and self.extended_cache_time is True
-                    else {"type": "ephemeral"}
-                )
-                request_kwargs["system"] = [{"text": system_message, "type": "text", "cache_control": cache_control}]
-            else:
-                request_kwargs["system"] = [{"text": system_message, "type": "text"}]
+        system = self._build_system(system_message)
+        if system:
+            request_kwargs["system"] = system
 
         if tools:
             request_kwargs["tools"] = format_tools_for_model(tools)
+
+        self._apply_cache_tools(request_kwargs)
 
         if request_kwargs:
             log_debug(f"Calling {self.provider} with request parameters: {request_kwargs}", log_level=2)

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -587,6 +587,14 @@ class Model(ABC):
         """
         pass
 
+    @staticmethod
+    def _tool_name(t: Dict[str, Any]) -> str:
+        """Extract a tool's name for deterministic sorting."""
+        fn = t.get("function")
+        if isinstance(fn, dict):
+            return str(fn.get("name", ""))
+        return str(t.get("name", ""))
+
     def _format_tools(self, tools: Optional[List[Union[Function, dict]]]) -> List[Dict[str, Any]]:
         _tool_dicts = []
         for tool in tools or []:
@@ -595,6 +603,10 @@ class Model(ABC):
             else:
                 # If a dict is passed, it is a builtin tool
                 _tool_dicts.append(tool)
+        # Deterministic ordering so prompt caching gets consistent cache hits.
+        # Applies across providers — Anthropic, OpenAI, and Gemini prompt/context
+        # caching all require stable request prefixes.
+        _tool_dicts.sort(key=self._tool_name)
         return _tool_dicts
 
     def _ensure_message_metrics_initialized(self, assistant_message: Message) -> None:

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -587,6 +587,14 @@ class Model(ABC):
         """
         pass
 
+    @staticmethod
+    def _tool_name(t: Dict[str, Any]) -> str:
+        """Extract a tool's name for deterministic sorting."""
+        fn = t.get("function")
+        if isinstance(fn, dict):
+            return str(fn.get("name", ""))
+        return str(t.get("name", ""))
+
     def _format_tools(self, tools: Optional[List[Union[Function, dict]]]) -> List[Dict[str, Any]]:
         _tool_dicts = []
         for tool in tools or []:
@@ -595,6 +603,8 @@ class Model(ABC):
             else:
                 # If a dict is passed, it is a builtin tool
                 _tool_dicts.append(tool)
+        # Deterministic ordering so prompt caching gets consistent cache hits.
+        _tool_dicts.sort(key=self._tool_name)
         return _tool_dicts
 
     def _ensure_message_metrics_initialized(self, assistant_message: Message) -> None:

--- a/libs/agno/agno/models/base.py
+++ b/libs/agno/agno/models/base.py
@@ -587,14 +587,6 @@ class Model(ABC):
         """
         pass
 
-    @staticmethod
-    def _tool_name(t: Dict[str, Any]) -> str:
-        """Extract a tool's name for deterministic sorting."""
-        fn = t.get("function")
-        if isinstance(fn, dict):
-            return str(fn.get("name", ""))
-        return str(t.get("name", ""))
-
     def _format_tools(self, tools: Optional[List[Union[Function, dict]]]) -> List[Dict[str, Any]]:
         _tool_dicts = []
         for tool in tools or []:
@@ -603,8 +595,6 @@ class Model(ABC):
             else:
                 # If a dict is passed, it is a builtin tool
                 _tool_dicts.append(tool)
-        # Deterministic ordering so prompt caching gets consistent cache hits.
-        _tool_dicts.sort(key=self._tool_name)
         return _tool_dicts
 
     def _ensure_message_metrics_initialized(self, assistant_message: Message) -> None:

--- a/libs/agno/agno/models/vertexai/claude.py
+++ b/libs/agno/agno/models/vertexai/claude.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from agno.models.anthropic import Claude as AnthropicClaude
 from agno.utils.log import log_debug, log_warning
-from agno.utils.models.claude import build_system_blocks, format_tools_for_model
+from agno.utils.models.claude import format_tools_for_model
 
 try:
     from anthropic import AnthropicVertex, AsyncAnthropicVertex
@@ -167,19 +167,9 @@ class Claude(AnthropicClaude):
         """
         # Pass response_format and tools to get_request_params for beta header handling
         request_kwargs = self.get_request_params(response_format=response_format, tools=tools).copy()
-        # system_prompt_blocks takes precedence over the agent-built string.
-        if self.system_prompt_blocks:
-            request_kwargs["system"] = build_system_blocks(
-                self.system_prompt_blocks,
-                cache_system_prompt=bool(self.cache_system_prompt),
-                extended_cache_time=bool(self.extended_cache_time),
-            )
-        elif system_message:
-            request_kwargs["system"] = build_system_blocks(
-                system_message,
-                cache_system_prompt=bool(self.cache_system_prompt),
-                extended_cache_time=bool(self.extended_cache_time),
-            )
+        system = self._build_system(system_message)
+        if system:
+            request_kwargs["system"] = system
 
         # Format tools (this will handle strict mode)
         if tools:

--- a/libs/agno/agno/models/vertexai/claude.py
+++ b/libs/agno/agno/models/vertexai/claude.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 from agno.models.anthropic import Claude as AnthropicClaude
 from agno.utils.log import log_debug, log_warning
-from agno.utils.models.claude import format_tools_for_model
+from agno.utils.models.claude import build_system_blocks, format_tools_for_model
 
 try:
     from anthropic import AnthropicVertex, AsyncAnthropicVertex
@@ -167,20 +167,25 @@ class Claude(AnthropicClaude):
         """
         # Pass response_format and tools to get_request_params for beta header handling
         request_kwargs = self.get_request_params(response_format=response_format, tools=tools).copy()
-        if system_message:
-            if self.cache_system_prompt:
-                cache_control = (
-                    {"type": "ephemeral", "ttl": "1h"}
-                    if self.extended_cache_time is not None and self.extended_cache_time is True
-                    else {"type": "ephemeral"}
-                )
-                request_kwargs["system"] = [{"text": system_message, "type": "text", "cache_control": cache_control}]
-            else:
-                request_kwargs["system"] = [{"text": system_message, "type": "text"}]
+        # system_prompt_blocks takes precedence over the agent-built string.
+        if self.system_prompt_blocks:
+            request_kwargs["system"] = build_system_blocks(
+                self.system_prompt_blocks,
+                cache_system_prompt=bool(self.cache_system_prompt),
+                extended_cache_time=bool(self.extended_cache_time),
+            )
+        elif system_message:
+            request_kwargs["system"] = build_system_blocks(
+                system_message,
+                cache_system_prompt=bool(self.cache_system_prompt),
+                extended_cache_time=bool(self.extended_cache_time),
+            )
 
         # Format tools (this will handle strict mode)
         if tools:
             request_kwargs["tools"] = format_tools_for_model(tools)
+
+        self._apply_cache_tools(request_kwargs)
 
         if request_kwargs:
             log_debug(f"Calling {self.provider} with request parameters: {request_kwargs}", log_level=2)

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -1,10 +1,13 @@
 import json
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from agno.media import File, Image
 from agno.models.message import Message
 from agno.utils.log import log_error, log_info, log_warning
+
+if TYPE_CHECKING:
+    from agno.models.anthropic.claude import SystemPromptBlock
 
 # Models that support assistant message prefill. This is a closed set —
 # prefill was deprecated starting with Claude 4.6 and all future models
@@ -326,6 +329,45 @@ def _format_file_for_message(file: File, enable_citations: bool = True) -> Optio
     return document
 
 
+def build_system_blocks(
+    system_message: Union[str, List["SystemPromptBlock"]],
+    cache_system_prompt: bool,
+    extended_cache_time: bool = False,
+) -> List[Dict[str, Any]]:
+    """Build the system parameter blocks for the Anthropic API.
+
+    Converts either a plain string or a list of SystemPromptBlock into the
+    list-of-dicts format the Anthropic API expects for the ``system`` field,
+    applying ``cache_control`` only to blocks marked as cacheable.
+
+    TTL resolution for each cached block:
+    - Explicit block.ttl wins: "5m" => plain ephemeral (5m is the default),
+      "1h" => ephemeral with ttl key.
+    - block.ttl is None => falls back to model-level extended_cache_time.
+    """
+    if isinstance(system_message, str):
+        entry: Dict[str, Any] = {"text": system_message, "type": "text"}
+        if cache_system_prompt:
+            cc: Dict[str, str] = {"type": "ephemeral"}
+            if extended_cache_time:
+                cc["ttl"] = "1h"
+            entry["cache_control"] = cc
+        return [entry]
+
+    result: List[Dict[str, Any]] = []
+    for block in system_message:
+        b: Dict[str, Any] = {"text": block.text, "type": "text"}
+        if cache_system_prompt and block.cache:
+            # Explicit block-level ttl wins; None falls back to model-level extended_cache_time
+            effective_ttl = block.ttl if block.ttl is not None else ("1h" if extended_cache_time else "5m")
+            cc = {"type": "ephemeral"}
+            if effective_ttl == "1h":
+                cc["ttl"] = "1h"
+            b["cache_control"] = cc
+        result.append(b)
+    return result
+
+
 def format_messages(
     messages: List[Message],
     compress_tool_results: bool = False,
@@ -453,7 +495,7 @@ def format_messages(
     merged_messages: List[Dict[str, Union[str, list]]] = []
     for msg in chat_messages:
         if merged_messages and merged_messages[-1]["role"] == msg["role"]:
-            # Same role as previous → merge contents
+            # Same role as previous, merge contents
             prev_content = merged_messages[-1]["content"]
             curr_content = msg["content"]
 
@@ -466,7 +508,7 @@ def format_messages(
                 curr_content.insert(0, {"type": "text", "text": str(prev_content)})
                 merged_messages[-1]["content"] = curr_content
             else:
-                # Both strings → convert in list
+                # Both strings, convert to list
                 merged_messages[-1]["content"] = [
                     {"type": "text", "text": str(prev_content)},
                     {"type": "text", "text": str(curr_content)},

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -368,6 +368,33 @@ def build_system_blocks(
     return result
 
 
+def _validate_cache_ttl_order(blocks: List[Dict[str, Any]]) -> None:
+    """Validate that no 5m-cached block appears before a 1h-cached block.
+
+    Anthropic's prompt caching rejects requests where a longer-TTL cache entry
+    follows a shorter-TTL one in the cached prefix. Catch this at assembly
+    time with an actionable error rather than letting the API reject it.
+    """
+    seen_5m = False
+    for block in blocks:
+        cc = block.get("cache_control")
+        if cc is None:
+            continue
+        if cc.get("ttl") == "1h":
+            if seen_5m:
+                raise ValueError(
+                    "Invalid Anthropic cache TTL ordering: a 1h cached block cannot "
+                    "follow a 5m cached block. This usually means cache_system_prompt=True "
+                    "(so the agent-built block is cached at 5m by default) together with "
+                    "a SystemPromptBlock(ttl='1h'). Fix with one of:\n"
+                    "  - Claude(extended_cache_time=True) so the agent-built block is 1h too\n"
+                    "  - Change your block ttl to '5m' or None\n"
+                    "  - Set cache_system_prompt=False so the agent-built block is uncached"
+                )
+        else:
+            seen_5m = True
+
+
 def format_messages(
     messages: List[Message],
     compress_tool_results: bool = False,
@@ -606,4 +633,9 @@ def format_tools_for_model(tools: Optional[List[Dict[str, Any]]] = None) -> Opti
             tool["strict"] = True
 
         parsed_tools.append(tool)
+    # Deterministic ordering for Anthropic prompt caching: tool order contributes
+    # to the cached prefix, so dict-iteration / MCP / registration-order noise
+    # would otherwise invalidate cache hits. Non-function tools (built-ins) keep
+    # their declared position relative to other non-function tools.
+    parsed_tools.sort(key=lambda t: t.get("name", ""))
     return parsed_tools

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -337,13 +337,21 @@ def build_system_blocks(
     """Build the system parameter blocks for the Anthropic API.
 
     Converts either a plain string or a list of SystemPromptBlock into the
-    list-of-dicts format the Anthropic API expects for the ``system`` field,
-    applying ``cache_control`` only to blocks marked as cacheable.
+    list-of-dicts format the Anthropic API expects for the ``system`` field.
+
+    Caching semantics are asymmetric by design:
+    - For a string (the agent-built system message), ``cache_system_prompt``
+      decides whether it gets ``cache_control``. That flag is the single
+      switch for the agent-built block.
+    - For a list of ``SystemPromptBlock`` (user-supplied), each block's own
+      ``block.cache`` field decides. This is independent of
+      ``cache_system_prompt`` so that you can leave the agent-built block
+      uncached while still caching selected user blocks (or vice versa).
 
     TTL resolution for each cached block:
-    - Explicit block.ttl wins: "5m" => plain ephemeral (5m is the default),
-      "1h" => ephemeral with ttl key.
-    - block.ttl is None => falls back to model-level extended_cache_time.
+    - Explicit ``block.ttl`` wins: ``"5m"`` => plain ephemeral (5m is the
+      default), ``"1h"`` => ephemeral with ttl key.
+    - ``block.ttl is None`` => falls back to model-level ``extended_cache_time``.
     """
     if isinstance(system_message, str):
         entry: Dict[str, Any] = {"text": system_message, "type": "text"}
@@ -357,8 +365,11 @@ def build_system_blocks(
     result: List[Dict[str, Any]] = []
     for block in system_message:
         b: Dict[str, Any] = {"text": block.text, "type": "text"}
-        if cache_system_prompt and block.cache:
-            # Explicit block-level ttl wins; None falls back to model-level extended_cache_time
+        if block.cache:
+            # Explicit block-level ttl wins; None falls back to model-level extended_cache_time.
+            # Deliberately independent of cache_system_prompt — that flag only gates the
+            # agent-built block, so users can cache custom blocks without also caching
+            # the agent-built one (and vice versa).
             effective_ttl = block.ttl if block.ttl is not None else ("1h" if extended_cache_time else "5m")
             cc = {"type": "ephemeral"}
             if effective_ttl == "1h":
@@ -389,7 +400,8 @@ def _validate_cache_ttl_order(blocks: List[Dict[str, Any]]) -> None:
                     "a SystemPromptBlock(ttl='1h'). Fix with one of:\n"
                     "  - Claude(extended_cache_time=True) so the agent-built block is 1h too\n"
                     "  - Change your block ttl to '5m' or None\n"
-                    "  - Set cache_system_prompt=False so the agent-built block is uncached"
+                    "  - Set cache_system_prompt=False to leave the agent-built block "
+                    "uncached (custom blocks still cache per their own block.cache field)"
                 )
         else:
             seen_5m = True

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -633,9 +633,4 @@ def format_tools_for_model(tools: Optional[List[Dict[str, Any]]] = None) -> Opti
             tool["strict"] = True
 
         parsed_tools.append(tool)
-    # Deterministic ordering for Anthropic prompt caching: tool order contributes
-    # to the cached prefix, so dict-iteration / MCP / registration-order noise
-    # would otherwise invalidate cache hits. Non-function tools (built-ins) keep
-    # their declared position relative to other non-function tools.
-    parsed_tools.sort(key=lambda t: t.get("name", ""))
     return parsed_tools

--- a/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
+++ b/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
@@ -186,18 +186,22 @@ def test_multi_block_system_message_caching():
     }
 
 
-def test_multi_block_no_caching():
-    """Blocks sent without cache_control when cache_system_prompt=False."""
+def test_block_cache_field_independent_of_cache_system_prompt():
+    """block.cache decides per-block caching on its own — cache_system_prompt
+    only controls the agent-built string block. This lets users cache custom
+    blocks while leaving the agent-built block uncached."""
     blocks = [
-        SystemPromptBlock(text="Static.", cache=True),
-        SystemPromptBlock(text="Dynamic.", cache=False),
+        SystemPromptBlock(text="Custom cached.", cache=True),
+        SystemPromptBlock(text="Custom uncached.", cache=False),
     ]
     claude = Claude(cache_system_prompt=False, system_prompt_blocks=blocks)
     kwargs = claude._prepare_request_kwargs("")
 
     assert len(kwargs["system"]) == 2
-    for block in kwargs["system"]:
-        assert "cache_control" not in block
+    # block.cache=True still gets cache_control even when cache_system_prompt=False
+    assert kwargs["system"][0]["cache_control"] == {"type": "ephemeral"}
+    # block.cache=False stays uncached
+    assert "cache_control" not in kwargs["system"][1]
 
 
 def test_multi_block_extended_cache_time():
@@ -318,14 +322,16 @@ def test_build_system_valid_when_extended_cache_time_matches():
 
 
 def test_build_system_valid_when_agent_block_uncached():
-    """cache_system_prompt=False disables caching on every block, so TTL
-    ordering is vacuously satisfied (no cache_control anywhere)."""
+    """cache_system_prompt=False leaves the agent-built block uncached while
+    user blocks still cache per their own block.cache field. The resulting
+    [uncached agent, 1h cached user] ordering satisfies Anthropic's rule
+    (no 5m cached block precedes the 1h one)."""
     blocks = [SystemPromptBlock(text="User 1h.", cache=True, ttl="1h")]
     claude = Claude(cache_system_prompt=False, system_prompt_blocks=blocks)
 
     result = claude._build_system("Agent content.")
     assert "cache_control" not in result[0]
-    assert "cache_control" not in result[1]
+    assert result[1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
 
 
 def test_tools_sorted_by_name_for_cache_stability():

--- a/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
+++ b/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
@@ -555,3 +555,47 @@ def test_aws_cache_tools():
 
     assert "cache_control" not in kwargs["tools"][0]
     assert kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_azure_cache_tools_and_blocks():
+    """Azure Foundry Claude routes through the shared _build_system and
+    _apply_cache_tools helpers, so it gets system_prompt_blocks and cache_tools
+    support for free."""
+    from agno.models.azure.claude import Claude as AzureClaude
+
+    blocks = [SystemPromptBlock(text="User static.", cache=True, ttl="1h")]
+    claude = AzureClaude(
+        cache_system_prompt=True,
+        extended_cache_time=True,
+        cache_tools=True,
+        system_prompt_blocks=blocks,
+    )
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "tool_a",
+                "description": "A",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "tool_b",
+                "description": "B",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+    ]
+    kwargs = claude._prepare_request_kwargs("Agent content.", tools=tools)
+
+    # Augmented system: agent block first (1h), then user block (1h)
+    assert len(kwargs["system"]) == 2
+    assert kwargs["system"][0]["text"] == "Agent content."
+    assert kwargs["system"][0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+    assert kwargs["system"][1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+    # cache_tools marks the last tool
+    assert "cache_control" not in kwargs["tools"][0]
+    assert kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral"}

--- a/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
+++ b/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
@@ -252,6 +252,49 @@ def test_system_prompt_blocks_augment_agent_system_message():
     }
 
 
+def test_system_prompt_blocks_callable_evaluated_per_request():
+    """A callable system_prompt_blocks is resolved on every _build_system call,
+    so users can inject dynamic per-request content without reinstantiating
+    the model or agent.
+    """
+    call_count = {"n": 0}
+
+    def build_blocks():
+        call_count["n"] += 1
+        return [
+            SystemPromptBlock(text="Static role.", cache=True, ttl="1h"),
+            SystemPromptBlock(text=f"Request #{call_count['n']}.", cache=False),
+        ]
+
+    claude = Claude(cache_system_prompt=True, extended_cache_time=True, system_prompt_blocks=build_blocks)
+
+    # First call: callable runs once, block text reflects the invocation
+    first = claude._build_system("Agent content.")
+    assert call_count["n"] == 1
+    assert first[2]["text"] == "Request #1."
+    assert "cache_control" not in first[2]  # dynamic block stays uncached
+
+    # Second call: callable runs again, text differs → dynamic content refreshed
+    second = claude._build_system("Agent content.")
+    assert call_count["n"] == 2
+    assert second[2]["text"] == "Request #2."
+
+    # Static parts are identical across calls → cache prefix is stable
+    assert first[0] == second[0]
+    assert first[1] == second[1]
+
+
+def test_system_prompt_blocks_callable_propagates_validation():
+    """TTL ordering validation still fires when blocks come from a callable."""
+    claude = Claude(
+        cache_system_prompt=True,
+        extended_cache_time=False,
+        system_prompt_blocks=lambda: [SystemPromptBlock(text="User 1h.", cache=True, ttl="1h")],
+    )
+    with pytest.raises(ValueError, match="Invalid Anthropic cache TTL ordering"):
+        claude._build_system("Agent content.")
+
+
 def test_build_system_raises_on_invalid_ttl_ordering():
     """Anthropic rejects 5m-cached-block before 1h-cached-block. _build_system
     must catch this at assembly time with an actionable ValueError."""

--- a/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
+++ b/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
@@ -5,6 +5,7 @@ Tests the basic caching features including:
 - System message caching with real API calls
 - Cache performance tracking
 - Usage metrics with standard field names
+- Multi-block system prompt caching (static/dynamic split)
 """
 
 from pathlib import Path
@@ -13,7 +14,8 @@ from unittest.mock import Mock
 import pytest
 
 from agno.agent import Agent, RunOutput
-from agno.models.anthropic import Claude
+from agno.models.anthropic import Claude, SystemPromptBlock
+from agno.session.agent import AgentSession
 from agno.utils.media import download_file
 
 
@@ -138,7 +140,7 @@ def test_prompt_caching_with_agent():
         cache_read_tokens = response2.metrics.cache_read_tokens
         assert cache_read_tokens > 0, f"Expected cache read tokens but found {cache_read_tokens}"
     else:
-        print(f"✅ Cache was used with {cache_hit_tokens} tokens from previous run")
+        print(f"Cache was used with {cache_hit_tokens} tokens from previous run")
 
 
 @pytest.mark.asyncio
@@ -147,7 +149,7 @@ async def test_async_prompt_caching():
     large_system_prompt = _get_large_system_prompt()
 
     agent = Agent(
-        model=Claude(id="claude-sonnet-4-20250514", cache_system_prompt=True),
+        model=Claude(id="claude-3-5-haiku-20241022", cache_system_prompt=True),
         system_message=large_system_prompt,
         telemetry=False,
     )
@@ -158,3 +160,301 @@ async def test_async_prompt_caching():
     assert response.messages is not None
     assert len(response.messages) == 3
     assert [m.role for m in response.messages] == ["system", "user", "assistant"]
+
+
+# --- Multi-block system prompt caching tests ---
+
+
+def test_multi_block_system_message_caching():
+    """system_prompt_blocks on the model produces a multi-block system array."""
+    blocks = [
+        SystemPromptBlock(text="Static instructions here.", cache=True),
+        SystemPromptBlock(text="Dynamic per-user context.", cache=False),
+    ]
+    claude = Claude(cache_system_prompt=True, system_prompt_blocks=blocks)
+    kwargs = claude._prepare_request_kwargs("")
+
+    assert len(kwargs["system"]) == 2
+    assert kwargs["system"][0] == {
+        "text": "Static instructions here.",
+        "type": "text",
+        "cache_control": {"type": "ephemeral"},
+    }
+    assert kwargs["system"][1] == {
+        "text": "Dynamic per-user context.",
+        "type": "text",
+    }
+
+
+def test_multi_block_no_caching():
+    """Blocks sent without cache_control when cache_system_prompt=False."""
+    blocks = [
+        SystemPromptBlock(text="Static.", cache=True),
+        SystemPromptBlock(text="Dynamic.", cache=False),
+    ]
+    claude = Claude(cache_system_prompt=False, system_prompt_blocks=blocks)
+    kwargs = claude._prepare_request_kwargs("")
+
+    assert len(kwargs["system"]) == 2
+    for block in kwargs["system"]:
+        assert "cache_control" not in block
+
+
+def test_multi_block_extended_cache_time():
+    """extended_cache_time applies only to cached blocks."""
+    blocks = [
+        SystemPromptBlock(text="Static.", cache=True),
+        SystemPromptBlock(text="Dynamic.", cache=False),
+    ]
+    claude = Claude(cache_system_prompt=True, extended_cache_time=True, system_prompt_blocks=blocks)
+    kwargs = claude._prepare_request_kwargs("")
+
+    assert kwargs["system"][0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+    assert "cache_control" not in kwargs["system"][1]
+
+
+def test_string_system_message_backward_compat():
+    """Plain string still produces a single cached block."""
+    claude = Claude(cache_system_prompt=True)
+    kwargs = claude._prepare_request_kwargs("You are helpful.")
+
+    assert len(kwargs["system"]) == 1
+    assert kwargs["system"][0]["cache_control"] == {"type": "ephemeral"}
+    assert kwargs["system"][0]["text"] == "You are helpful."
+
+
+def test_system_prompt_blocks_override_agent_system_message():
+    """When system_prompt_blocks is set, the agent-built string is ignored."""
+    blocks = [
+        SystemPromptBlock(text="Block-controlled content.", cache=True),
+    ]
+    claude = Claude(cache_system_prompt=True, system_prompt_blocks=blocks)
+    # Simulate the agent-built string arriving as system_message
+    kwargs = claude._prepare_request_kwargs("Agent-built fallback that should not be sent.")
+
+    assert len(kwargs["system"]) == 1
+    assert kwargs["system"][0]["text"] == "Block-controlled content."
+
+
+def test_agent_system_message_stays_string():
+    """Agent system message is a plain string; Claude-level blocks live on the model."""
+    agent = Agent(
+        model=Claude(id="claude-sonnet-4-5-20250929", cache_system_prompt=True),
+        description="Test agent",
+        instructions=["Be helpful"],
+        add_datetime_to_context=True,
+        telemetry=False,
+    )
+    session = AgentSession(session_id="test")
+    msg = agent.get_system_message(session=session)
+
+    assert msg is not None
+    assert isinstance(msg.content, str)
+    assert "Test agent" in msg.content
+    assert "The current time is" in msg.content
+
+
+# --- Per-block TTL tests ---
+
+
+def test_per_block_ttl():
+    """A block with ttl='1h' produces extended cache_control."""
+    blocks = [
+        SystemPromptBlock(text="Static instructions.", cache=True, ttl="1h"),
+    ]
+    claude = Claude(cache_system_prompt=True, system_prompt_blocks=blocks)
+    kwargs = claude._prepare_request_kwargs("")
+
+    assert len(kwargs["system"]) == 1
+    assert kwargs["system"][0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+def test_mixed_ttl_blocks():
+    """Blocks with different TTLs produce independent cache_control."""
+    blocks = [
+        SystemPromptBlock(text="Long-lived.", cache=True, ttl="1h"),
+        SystemPromptBlock(text="Short-lived.", cache=True, ttl="5m"),
+        SystemPromptBlock(text="Dynamic.", cache=False),
+    ]
+    claude = Claude(cache_system_prompt=True, system_prompt_blocks=blocks)
+    kwargs = claude._prepare_request_kwargs("")
+
+    assert len(kwargs["system"]) == 3
+    assert kwargs["system"][0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+    assert kwargs["system"][1]["cache_control"] == {"type": "ephemeral"}
+    assert "cache_control" not in kwargs["system"][2]
+
+
+def test_explicit_block_ttl_overrides_model_extended_cache_time():
+    """Explicit block-level ttl='5m' stays 5m even with extended_cache_time=True."""
+    blocks = [
+        SystemPromptBlock(text="Explicit 5m.", cache=True, ttl="5m"),
+        SystemPromptBlock(text="Default (inherits model).", cache=True),
+    ]
+    claude = Claude(cache_system_prompt=True, extended_cache_time=True, system_prompt_blocks=blocks)
+    kwargs = claude._prepare_request_kwargs("")
+
+    assert kwargs["system"][0]["cache_control"] == {"type": "ephemeral"}
+    assert kwargs["system"][1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+def test_cache_false_ignores_ttl():
+    """cache=False produces no cache_control even when ttl is set."""
+    blocks = [
+        SystemPromptBlock(text="Not cached.", cache=False, ttl="1h"),
+    ]
+    claude = Claude(cache_system_prompt=True, system_prompt_blocks=blocks)
+    kwargs = claude._prepare_request_kwargs("")
+
+    assert len(kwargs["system"]) == 1
+    assert "cache_control" not in kwargs["system"][0]
+
+
+def test_explicit_5m_with_no_extended_cache():
+    """Explicit ttl='5m' with extended_cache_time=False produces ephemeral without ttl key."""
+    blocks = [
+        SystemPromptBlock(text="Explicit 5m.", cache=True, ttl="5m"),
+        SystemPromptBlock(text="Default None.", cache=True),
+    ]
+    claude = Claude(cache_system_prompt=True, extended_cache_time=False, system_prompt_blocks=blocks)
+    kwargs = claude._prepare_request_kwargs("")
+
+    assert kwargs["system"][0]["cache_control"] == {"type": "ephemeral"}
+    assert kwargs["system"][1]["cache_control"] == {"type": "ephemeral"}
+
+
+# --- Tool caching tests ---
+
+
+def test_cache_tools_flag():
+    """cache_tools=True adds cache_control to the last tool."""
+    claude = Claude(cache_system_prompt=True, cache_tools=True)
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "tool_a",
+                "description": "A",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "tool_b",
+                "description": "B",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+    ]
+    kwargs = claude._prepare_request_kwargs("System.", tools=tools)
+
+    assert "tools" in kwargs
+    assert len(kwargs["tools"]) == 2
+    assert "cache_control" not in kwargs["tools"][0]
+    assert kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_cache_tools_disabled():
+    """cache_tools=False leaves tools untouched."""
+    claude = Claude(cache_system_prompt=True, cache_tools=False)
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "tool_a",
+                "description": "A",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+    ]
+    kwargs = claude._prepare_request_kwargs("System.", tools=tools)
+
+    assert "tools" in kwargs
+    for tool in kwargs["tools"]:
+        assert "cache_control" not in tool
+
+
+def test_cache_tools_single_tool():
+    """cache_tools=True with a single tool adds cache_control to that tool."""
+    claude = Claude(cache_system_prompt=True, cache_tools=True)
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "only_tool",
+                "description": "Solo",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+    ]
+    kwargs = claude._prepare_request_kwargs("System.", tools=tools)
+
+    assert len(kwargs["tools"]) == 1
+    assert kwargs["tools"][0]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_cache_tools_no_tools():
+    """cache_tools=True with no tools does not error."""
+    claude = Claude(cache_system_prompt=True, cache_tools=True)
+    kwargs = claude._prepare_request_kwargs("System.", tools=None)
+
+    assert "tools" not in kwargs
+
+
+def test_vertexai_cache_tools():
+    """VertexAI Claude also adds cache_control to the last tool."""
+    from agno.models.vertexai.claude import Claude as VertexClaude
+
+    claude = VertexClaude(cache_system_prompt=True, cache_tools=True)
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "tool_a",
+                "description": "A",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "tool_b",
+                "description": "B",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+    ]
+    kwargs = claude._prepare_request_kwargs("System.", tools=tools)
+
+    assert "cache_control" not in kwargs["tools"][0]
+    assert kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_aws_cache_tools():
+    """AWS Bedrock Claude also adds cache_control to the last tool."""
+    from agno.models.aws.claude import Claude as AwsClaude
+
+    claude = AwsClaude(cache_system_prompt=True, cache_tools=True)
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "tool_a",
+                "description": "A",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "tool_b",
+                "description": "B",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        },
+    ]
+    kwargs = claude._prepare_request_kwargs("System.", tools=tools)
+
+    assert "cache_control" not in kwargs["tools"][0]
+    assert kwargs["tools"][-1]["cache_control"] == {"type": "ephemeral"}

--- a/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
+++ b/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
@@ -334,6 +334,25 @@ def test_build_system_valid_when_agent_block_uncached():
     assert result[1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
 
 
+def test_to_dict_serializes_cache_flags_but_not_blocks():
+    """Scalar cache flags round-trip via to_dict. system_prompt_blocks does not —
+    the callable form cannot serialize and the list form would round-trip only
+    partially, so we deliberately leave it out of the dict."""
+    blocks = [SystemPromptBlock(text="X.", cache=True, ttl="1h")]
+    claude = Claude(
+        cache_system_prompt=True,
+        extended_cache_time=True,
+        cache_tools=True,
+        system_prompt_blocks=blocks,
+    )
+    d = claude.to_dict()
+
+    assert d["cache_system_prompt"] is True
+    assert d["extended_cache_time"] is True
+    assert d["cache_tools"] is True
+    assert "system_prompt_blocks" not in d
+
+
 def test_tools_sorted_by_name_for_cache_stability():
     """Model._format_tools returns tools sorted by name across all providers.
 

--- a/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
+++ b/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
@@ -285,27 +285,23 @@ def test_build_system_valid_when_agent_block_uncached():
     assert "cache_control" not in result[1]
 
 
-def test_tools_sorted_in_claude_formatter():
-    """format_tools_for_model returns tools sorted by name for cache stability.
-    Scoped to Claude (not base.Model) so other providers are unaffected."""
-    from agno.utils.models.claude import format_tools_for_model
+def test_tools_sorted_by_name_for_cache_stability():
+    """Model._format_tools returns tools sorted by name across all providers.
 
+    Anthropic, OpenAI, and Gemini caching all depend on a stable request
+    prefix; the deterministic tool order removes dict-iteration / MCP /
+    registration-order noise.
+    """
+    from agno.tools.function import Function
+
+    claude = Claude()
     tools = [
-        {
-            "type": "function",
-            "function": {"name": "zeta", "description": "Z", "parameters": {"type": "object", "properties": {}}},
-        },
-        {
-            "type": "function",
-            "function": {"name": "alpha", "description": "A", "parameters": {"type": "object", "properties": {}}},
-        },
-        {
-            "type": "function",
-            "function": {"name": "mu", "description": "M", "parameters": {"type": "object", "properties": {}}},
-        },
+        Function(name="zeta", description="Z"),
+        Function(name="alpha", description="A"),
+        Function(name="mu", description="M"),
     ]
-    result = format_tools_for_model(tools)
-    assert [t["name"] for t in result] == ["alpha", "mu", "zeta"]
+    result = claude._format_tools(tools)
+    assert [t["function"]["name"] for t in result] == ["alpha", "mu", "zeta"]
 
 
 def test_build_system_shared_between_request_and_count_tokens():

--- a/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
+++ b/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
@@ -229,7 +229,9 @@ def test_system_prompt_blocks_augment_agent_system_message():
         SystemPromptBlock(text="User-added static.", cache=True, ttl="1h"),
         SystemPromptBlock(text="User-added dynamic.", cache=False),
     ]
-    claude = Claude(cache_system_prompt=True, system_prompt_blocks=blocks)
+    # extended_cache_time=True so the agent block matches the 1h user block's TTL
+    # (Anthropic requires 1h cache_control to not follow a 5m one).
+    claude = Claude(cache_system_prompt=True, extended_cache_time=True, system_prompt_blocks=blocks)
     kwargs = claude._prepare_request_kwargs("You are a helpful assistant.")
 
     # Agent content is the first block (cached per cache_system_prompt), then user blocks
@@ -237,7 +239,7 @@ def test_system_prompt_blocks_augment_agent_system_message():
     assert kwargs["system"][0] == {
         "text": "You are a helpful assistant.",
         "type": "text",
-        "cache_control": {"type": "ephemeral"},
+        "cache_control": {"type": "ephemeral", "ttl": "1h"},
     }
     assert kwargs["system"][1] == {
         "text": "User-added static.",
@@ -248,6 +250,62 @@ def test_system_prompt_blocks_augment_agent_system_message():
         "text": "User-added dynamic.",
         "type": "text",
     }
+
+
+def test_build_system_raises_on_invalid_ttl_ordering():
+    """Anthropic rejects 5m-cached-block before 1h-cached-block. _build_system
+    must catch this at assembly time with an actionable ValueError."""
+    blocks = [SystemPromptBlock(text="User 1h.", cache=True, ttl="1h")]
+    # cache_system_prompt=True with extended_cache_time=False → agent block is 5m,
+    # then a 1h user block follows. Invalid per Anthropic's mixed-TTL rule.
+    claude = Claude(cache_system_prompt=True, extended_cache_time=False, system_prompt_blocks=blocks)
+
+    with pytest.raises(ValueError, match="Invalid Anthropic cache TTL ordering"):
+        claude._build_system("Agent content.")
+
+
+def test_build_system_valid_when_extended_cache_time_matches():
+    """Setting extended_cache_time=True aligns the agent block to 1h, fixing the order."""
+    blocks = [SystemPromptBlock(text="User 1h.", cache=True, ttl="1h")]
+    claude = Claude(cache_system_prompt=True, extended_cache_time=True, system_prompt_blocks=blocks)
+
+    result = claude._build_system("Agent content.")
+    assert result[0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+    assert result[1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+
+
+def test_build_system_valid_when_agent_block_uncached():
+    """cache_system_prompt=False disables caching on every block, so TTL
+    ordering is vacuously satisfied (no cache_control anywhere)."""
+    blocks = [SystemPromptBlock(text="User 1h.", cache=True, ttl="1h")]
+    claude = Claude(cache_system_prompt=False, system_prompt_blocks=blocks)
+
+    result = claude._build_system("Agent content.")
+    assert "cache_control" not in result[0]
+    assert "cache_control" not in result[1]
+
+
+def test_tools_sorted_in_claude_formatter():
+    """format_tools_for_model returns tools sorted by name for cache stability.
+    Scoped to Claude (not base.Model) so other providers are unaffected."""
+    from agno.utils.models.claude import format_tools_for_model
+
+    tools = [
+        {
+            "type": "function",
+            "function": {"name": "zeta", "description": "Z", "parameters": {"type": "object", "properties": {}}},
+        },
+        {
+            "type": "function",
+            "function": {"name": "alpha", "description": "A", "parameters": {"type": "object", "properties": {}}},
+        },
+        {
+            "type": "function",
+            "function": {"name": "mu", "description": "M", "parameters": {"type": "object", "properties": {}}},
+        },
+    ]
+    result = format_tools_for_model(tools)
+    assert [t["name"] for t in result] == ["alpha", "mu", "zeta"]
 
 
 def test_build_system_shared_between_request_and_count_tokens():
@@ -261,7 +319,7 @@ def test_build_system_shared_between_request_and_count_tokens():
         SystemPromptBlock(text="User static.", cache=True, ttl="1h"),
         SystemPromptBlock(text="User dynamic.", cache=False),
     ]
-    claude = Claude(cache_system_prompt=True, system_prompt_blocks=blocks)
+    claude = Claude(cache_system_prompt=True, extended_cache_time=True, system_prompt_blocks=blocks)
 
     request_system = claude._prepare_request_kwargs("Agent content.")["system"]
     # _build_system is what count_tokens calls; assert same output shape
@@ -323,16 +381,22 @@ def test_mixed_ttl_blocks():
 
 
 def test_explicit_block_ttl_overrides_model_extended_cache_time():
-    """Explicit block-level ttl='5m' stays 5m even with extended_cache_time=True."""
+    """Explicit block-level ttl='5m' stays 5m even with extended_cache_time=True.
+
+    Ordered 1h-first-then-5m to respect Anthropic's mixed-TTL rule: the block
+    inheriting 1h must precede the explicit-5m block.
+    """
     blocks = [
-        SystemPromptBlock(text="Explicit 5m.", cache=True, ttl="5m"),
         SystemPromptBlock(text="Default (inherits model).", cache=True),
+        SystemPromptBlock(text="Explicit 5m.", cache=True, ttl="5m"),
     ]
     claude = Claude(cache_system_prompt=True, extended_cache_time=True, system_prompt_blocks=blocks)
     kwargs = claude._prepare_request_kwargs("")
 
-    assert kwargs["system"][0]["cache_control"] == {"type": "ephemeral"}
-    assert kwargs["system"][1]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+    # ttl=None falls back to model-level extended_cache_time=True => 1h
+    assert kwargs["system"][0]["cache_control"] == {"type": "ephemeral", "ttl": "1h"}
+    # Explicit ttl="5m" overrides model-level extended_cache_time
+    assert kwargs["system"][1]["cache_control"] == {"type": "ephemeral"}
 
 
 def test_cache_false_ignores_ttl():

--- a/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
+++ b/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
@@ -223,17 +223,54 @@ def test_string_system_message_backward_compat():
     assert kwargs["system"][0]["text"] == "You are helpful."
 
 
-def test_system_prompt_blocks_override_agent_system_message():
-    """When system_prompt_blocks is set, the agent-built string is ignored."""
+def test_system_prompt_blocks_augment_agent_system_message():
+    """Agent-built string comes first as a cached block, user blocks are appended."""
     blocks = [
-        SystemPromptBlock(text="Block-controlled content.", cache=True),
+        SystemPromptBlock(text="User-added static.", cache=True, ttl="1h"),
+        SystemPromptBlock(text="User-added dynamic.", cache=False),
     ]
     claude = Claude(cache_system_prompt=True, system_prompt_blocks=blocks)
-    # Simulate the agent-built string arriving as system_message
-    kwargs = claude._prepare_request_kwargs("Agent-built fallback that should not be sent.")
+    kwargs = claude._prepare_request_kwargs("You are a helpful assistant.")
 
-    assert len(kwargs["system"]) == 1
-    assert kwargs["system"][0]["text"] == "Block-controlled content."
+    # Agent content is the first block (cached per cache_system_prompt), then user blocks
+    assert len(kwargs["system"]) == 3
+    assert kwargs["system"][0] == {
+        "text": "You are a helpful assistant.",
+        "type": "text",
+        "cache_control": {"type": "ephemeral"},
+    }
+    assert kwargs["system"][1] == {
+        "text": "User-added static.",
+        "type": "text",
+        "cache_control": {"type": "ephemeral", "ttl": "1h"},
+    }
+    assert kwargs["system"][2] == {
+        "text": "User-added dynamic.",
+        "type": "text",
+    }
+
+
+def test_build_system_shared_between_request_and_count_tokens():
+    """count_tokens must assemble the same system array as _prepare_request_kwargs.
+
+    Both paths delegate to _build_system so system_prompt_blocks flow through
+    token counting. Regression guard: without the shared helper, count_tokens
+    would miss user blocks and under-report tokens.
+    """
+    blocks = [
+        SystemPromptBlock(text="User static.", cache=True, ttl="1h"),
+        SystemPromptBlock(text="User dynamic.", cache=False),
+    ]
+    claude = Claude(cache_system_prompt=True, system_prompt_blocks=blocks)
+
+    request_system = claude._prepare_request_kwargs("Agent content.")["system"]
+    # _build_system is what count_tokens calls; assert same output shape
+    count_system = claude._build_system("Agent content.")
+
+    assert request_system == count_system
+    # And blocks actually show up (not dropped like before the fix)
+    texts = [b["text"] for b in count_system]
+    assert texts == ["Agent content.", "User static.", "User dynamic."]
 
 
 def test_agent_system_message_stays_string():


### PR DESCRIPTION
## Summary

Three Anthropic prompt caching enhancements. All scoped to the Claude model so the API surface never leaks into non-Claude paths.

Issue: #6280

Overlaps with (and supersedes) #6820 — the design here differs in scoping the feature to the Claude model rather than routing it through `Agent.system_message`, which avoids a silent-drop path for non-Claude models.

**1. Per-block system prompt caching**

`Claude` gains `system_prompt_blocks: Optional[List[SystemPromptBlock]]`. When set, it replaces the agent-built system string and is sent as the multi-block `system` array. `SystemPromptBlock` has `text`, `cache`, and optional `ttl` (`"5m"` | `"1h"`). The block-level `ttl` overrides the model-level `extended_cache_time` flag for that block only — lets users pin specific blocks to 5-minute or 1-hour cache lifetimes independently.

```python
from agno.models.anthropic import Claude, SystemPromptBlock

agent = Agent(
    model=Claude(
        cache_system_prompt=True,
        system_prompt_blocks=[
            SystemPromptBlock(text="Static system prompt...", cache=True, ttl="1h"),
            SystemPromptBlock(text=f"Dynamic context: {time_now}", cache=False),
        ],
    ),
)
```

The import path (`agno.models.anthropic`) signals this is Claude-specific. Users of other providers never see the type on `Agent`, so there is no silent-drop DX hazard.

**2. Tool caching**

New `cache_tools: bool` on Claude (Anthropic, AWS Bedrock, VertexAI). When True, `cache_control` is added to the last tool so Anthropic caches the tool prefix. AWS and VertexAI inherit a shared `_apply_cache_tools` helper from the base Claude class — no copy-paste.

**3. Deterministic tool ordering**

`Model._format_tools` now sorts tools by name. Prompt caching on Anthropic, OpenAI, Gemini, and Bedrock all require stable request prefixes; this removes dict-iteration / MCP / registration-order noise so caches actually hit.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [x] Model update

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`) — clean on the diff; pre-existing mypy errors (12 in 5 files) unchanged from `main`
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: `cookbook/90_models/anthropic/prompt_caching_multi_block.py` added
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] Searched existing open pull requests
- [x] #6820 by @JasonLovesDoggo addresses the same issue with a different design. This PR scopes the API to the Claude model namespace instead of threading it through `Agent.system_message`, resolving the DX concern raised in review (non-Claude users could pass blocks and have cache metadata silently dropped). Credit to @JasonLovesDoggo for the original implementation — the `build_system_blocks` helper, AWS/VertexAI wiring, and cookbook structure all came from that PR.
- [x] This PR was partially AI-generated (Claude Code) following design discussion between Yash and Claude

## Test plan

- [x] `pytest libs/agno/tests/integration/models/anthropic/test_prompt_caching.py -k "not _with_agent and not async_prompt"` — 20/20 pass
- [x] `pytest libs/agno/tests/unit/agent/` — 326/326 pass (no regressions from `Model._format_tools` sort change)
- [x] `pytest libs/agno/tests/unit/models/anthropic/` — 91/91 pass
- [ ] Live integration run of `cookbook/90_models/anthropic/prompt_caching_multi_block.py` against the Anthropic API
- [ ] Confirm cache hit behavior end-to-end on a long-running session with `extended_cache_time=True`

## Additional Notes

If #6820 lands first, this PR needs a trivial rebase (removing `SystemPromptBlock` from `agno.models.message` and the related `Agent`/`Message`/`format_messages` plumbing that #6820 adds).