### PR TITLE
fix typo in 05_agent_os readme

### DIFF
--- a/cookbook/05_agent_os/README.md
+++ b/cookbook/05_agent_os/README.md
@@ -3,11 +3,13 @@
 Top-level AgentOS quickstart and entrypoint examples.
 
 ## Files
-- `agno_agent.py` — Agno Agent.
+
+- `agno_assist.py` — Agno Agent.
 - `basic.py` — Minimal example for AgentOS.
 - `demo.py` — AgentOS Demo.
 
 ## Prerequisites
+
 - Load environment variables with `direnv allow` (requires `.envrc`).
 - Run examples with `.venvs/demo/bin/python <path-to-file>.py`.
 - Some examples require local services (for example Postgres, Redis, Slack, or MCP servers).


### PR DESCRIPTION
## Summary

Fixed a typo in the README under cookbook/05_agent_os/readme: it incorrectly referenced agno_agent.py, which is not present in the directory. Updated it to agno_assist.py, which is the correct file.

Issue: #7664 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
