### PR TITLE
chore: Release v2.6.1

### DIFF
--- a/.github/workflows/test_on_release.yml
+++ b/.github/workflows/test_on_release.yml
@@ -1035,14 +1035,16 @@ jobs:
           VIRTUAL_ENV=.venv uv venv --python 3.12
           VIRTUAL_ENV=.venv uv pip install -r ./libs/agno/requirements.txt
           VIRTUAL_ENV=.venv uv pip install -e ./libs/agno[dev,os,integration-tests,openai]
-          VIRTUAL_ENV=.venv uv pip install a2a-sdk
+          # TODO: a2a-sdk v1.0+ has breaking changes, update agno for it
+          VIRTUAL_ENV=.venv uv pip install "a2a-sdk>=0.3.0,<1.0"
       - name: Run A2A integration tests
         working-directory: .
         env:
           AGNO_TELEMETRY: false
         run: |
           source .venv/bin/activate
-          pip install a2a-sdk
+          # TODO: a2a-sdk v1.0+ has breaking changes, update agno for it
+          pip install "a2a-sdk>=0.3.0,<1.0"
           python -m pytest ./libs/agno/tests/integration/os/interfaces/test_a2a.py
 
   test-clean:

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "2.6.0"
+version = "2.6.1"
 description = "The programming language for agentic software."
 requires-python = ">=3.7,<4"
 readme = "README.md"

--- a/libs/agno/tests/integration/agent/test_shared_model.py
+++ b/libs/agno/tests/integration/agent/test_shared_model.py
@@ -45,15 +45,15 @@ def test_tools_available_to_agents(web_agent, finance_agent):
         tools = mock_invoke.call_args[1].get("tools", [])
         tool_names = [tool["function"]["name"] for tool in tools]
         assert tool_names == [
-            "get_current_stock_price",
+            "get_analyst_recommendations",
             "get_company_info",
-            "get_stock_fundamentals",
+            "get_company_news",
+            "get_current_stock_price",
+            "get_historical_stock_prices",
             "get_income_statements",
             "get_key_financial_ratios",
-            "get_analyst_recommendations",
-            "get_company_news",
+            "get_stock_fundamentals",
             "get_technical_indicators",
-            "get_historical_stock_prices",
         ]
 
     with patch.object(web_agent.model, "invoke", wraps=web_agent.model.invoke) as mock_invoke:
@@ -62,4 +62,4 @@ def test_tools_available_to_agents(web_agent, finance_agent):
         # Get the tools passed to invoke
         tools = mock_invoke.call_args[1].get("tools", [])
         tool_names = [tool["function"]["name"] for tool in tools]
-        assert tool_names == ["web_search", "search_news"]
+        assert tool_names == ["search_news", "web_search"]

--- a/libs/agno/tests/integration/agent/test_tool_hooks.py
+++ b/libs/agno/tests/integration/agent/test_tool_hooks.py
@@ -59,7 +59,7 @@ def mul(a: int, b: int) -> int:
 
 
 def test_logger_hook_invocation_sub_tool():
-    agent = Agent(tools=[sub])
+    agent = Agent(tools=[sub], instructions="Always use the sub tool to compute differences.")
 
     with patch.object(type(logger), "info", wraps=logger.info) as mock_info:
         response: RunOutput = agent.run("Compute 6 - 5")

--- a/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
+++ b/libs/agno/tests/integration/models/anthropic/test_prompt_caching.py
@@ -149,7 +149,7 @@ async def test_async_prompt_caching():
     large_system_prompt = _get_large_system_prompt()
 
     agent = Agent(
-        model=Claude(id="claude-3-5-haiku-20241022", cache_system_prompt=True),
+        model=Claude(id="claude-sonnet-4-5-20250929", cache_system_prompt=True),
         system_message=large_system_prompt,
         telemetry=False,
     )


### PR DESCRIPTION
# Changelog

## New Features:

- **Claude Prompt Caching (Multi-Block):** Three Anthropic prompt caching enhancements, scoped to the Claude model (#7662):
    - New `system_prompt_blocks: List[SystemPromptBlock]` on `Claude` — each block has `text`, `cache`, and optional `ttl` (`"5m"` or `"1h"`) that overrides the model-level `extended_cache_time` flag per block.
    - New `cache_tools: bool` on Claude (Anthropic, AWS Bedrock, VertexAI). Adds `cache_control` to the last tool so the tool prefix is cached.
    - Deterministic tool ordering in `Model._format_tools` (sort by name), so request prefixes stay stable across runs and prompt caches actually hit. Applies across Anthropic, OpenAI, Gemini, and Bedrock.
- **Parallel MCP Backend:** Added `ParallelMCPBackend` as a new web backend for `WebContextProvider` (#7667). Talks to Parallel's public MCP server at `search.parallel.ai/mcp`, exposing `web_search` + `web_fetch` (compressed markdown output). Keyless by default; Bearer-auth via `PARALLEL_API_KEY` for higher rate limits; optional OAuth endpoint via `use_oauth=True`. Defaults to a 30s timeout (up from `MCPTools`' 10s) because `web_fetch` frequently runs longer on large pages.

## Improvements:

- **OpenAI Model String:** Mapped `"openai:"` model string prefix to `OpenAIResponses` (previously `OpenAIChat`). Added `"openai-chat:"` as a fallback for users who still need `OpenAIChat`. `Agent(model="openai:gpt-5.4")` now resolves to `OpenAIResponses(id="gpt-5.4")`.

## Bug Fixes:

- **A2A:** Pinned `a2a-sdk>=0.3.0,<1.0` in the release workflow. `a2a-sdk` v1.0 has breaking changes that need to be adopted in a follow-up.
- **Cookbook:**
    - Fixed outdated Redis cookbook docs - removed dependency install and setup commands that are no longer needed (#7615).
    - Fixed `output_schema` example to demonstrate `output_schema` with a Pydantic model (it was incorrectly using `output_model` with web search).
    - Fixed typo in `cookbook/05_agent_os/README.md` that referenced a non-existent `agno_agent.py` (corrected to `agno_assist.py`) (#7663).