### PR TITLE
feat: add ParallelMCPBackend for web search via Parallel MCP

### DIFF
--- a/cookbook/12_context/11_web_parallel_mcp.py
+++ b/cookbook/12_context/11_web_parallel_mcp.py
@@ -18,7 +18,7 @@ would normally be wired into the framework's lifespan hook.
 
 Requires:
     OPENAI_API_KEY
-    (optional) PARALLEL_API_KEY   raises the rate ceiling
+    (optional) PARALLEL_API_KEY raises the rate ceiling
 """
 
 from __future__ import annotations

--- a/cookbook/12_context/11_web_parallel_mcp.py
+++ b/cookbook/12_context/11_web_parallel_mcp.py
@@ -36,7 +36,7 @@ async def main() -> None:
     # ------------------------------------------------------------------
     web = WebContextProvider(
         backend=ParallelMCPBackend(),  # reads PARALLEL_API_KEY if present; works keyless otherwise
-        model=OpenAIResponses(id="gpt-5.4-mini"),
+        model=OpenAIResponses(id="gpt-5.4"),
     )
 
     # ------------------------------------------------------------------

--- a/cookbook/12_context/11_web_parallel_mcp.py
+++ b/cookbook/12_context/11_web_parallel_mcp.py
@@ -1,0 +1,64 @@
+"""
+Web Context Provider with Parallel's MCP endpoint
+=================================================
+
+`ParallelMCPBackend` speaks to Parallel's public MCP server at
+https://search.parallel.ai/mcp — keyless by default (rate-limited),
+Bearer-authenticated if `PARALLEL_API_KEY` is set.
+
+Pairs with `ParallelBackend` (direct SDK) but is NOT equivalent: the
+SDK exposes `web_search` + `web_extract`, whereas the MCP server
+exposes `web_search` + `web_fetch` (token-efficient markdown). Pick
+MCP when you want the compressed markdown output, SDK when you need
+the raw extraction payload.
+
+Because the backend holds an MCP session, the cookbook explicitly
+brackets usage with `asetup()` / `aclose()`. In a real app those
+would normally be wired into the framework's lifespan hook.
+
+Requires:
+    OPENAI_API_KEY
+    (optional) PARALLEL_API_KEY   raises the rate ceiling
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from agno.agent import Agent
+from agno.context.web import ParallelMCPBackend, WebContextProvider
+from agno.models.openai import OpenAIResponses
+
+
+async def main() -> None:
+    # ------------------------------------------------------------------
+    # Create the provider (unconnected)
+    # ------------------------------------------------------------------
+    web = WebContextProvider(
+        backend=ParallelMCPBackend(),  # reads PARALLEL_API_KEY if present; works keyless otherwise
+        model=OpenAIResponses(id="gpt-5.4-mini"),
+    )
+
+    # ------------------------------------------------------------------
+    # Bracket with asetup / aclose so the MCP session lives on this task
+    # ------------------------------------------------------------------
+    await web.asetup()
+    try:
+        print(f"\nweb.status() = {web.status()}\n")
+
+        agent = Agent(
+            model=OpenAIResponses(id="gpt-5.4"),
+            tools=web.get_tools(),
+            instructions=web.instructions() + "\nAlways cite URLs inline.",
+            markdown=True,
+        )
+
+        prompt = "What is the latest stable release of CPython? Cite the source."
+        print(f"> {prompt}\n")
+        await agent.aprint_response(prompt)
+    finally:
+        await web.aclose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cookbook/12_context/11_web_parallel_mcp.py
+++ b/cookbook/12_context/11_web_parallel_mcp.py
@@ -53,7 +53,7 @@ async def main() -> None:
             markdown=True,
         )
 
-        prompt = "What is the latest stable release of CPython? Cite the source."
+        prompt = "What is the latest stable release of Agno? Cite the source."
         await agent.aprint_response(prompt)
     finally:
         await web.aclose()

--- a/cookbook/12_context/11_web_parallel_mcp.py
+++ b/cookbook/12_context/11_web_parallel_mcp.py
@@ -54,7 +54,6 @@ async def main() -> None:
         )
 
         prompt = "What is the latest stable release of CPython? Cite the source."
-        print(f"> {prompt}\n")
         await agent.aprint_response(prompt)
     finally:
         await web.aclose()

--- a/cookbook/12_context/11_web_parallel_mcp.py
+++ b/cookbook/12_context/11_web_parallel_mcp.py
@@ -49,7 +49,7 @@ async def main() -> None:
         agent = Agent(
             model=OpenAIResponses(id="gpt-5.4"),
             tools=web.get_tools(),
-            instructions=web.instructions() + "\nAlways cite URLs inline.",
+            instructions=web.instructions(),
             markdown=True,
         )
 

--- a/cookbook/12_context/README.md
+++ b/cookbook/12_context/README.md
@@ -23,6 +23,7 @@ Providers ship in this package:
 | `WebContextProvider` + `ExaMCPBackend` | Web via Exa's public MCP server (keyless / keyed) | `query_<id>` (search + fetch sub-agent) |
 | `WebContextProvider` + `ExaBackend` | Web via Exa's direct SDK | `query_<id>` (search + fetch sub-agent) |
 | `WebContextProvider` + `ParallelBackend` | Web via Parallel's beta API | `query_<id>` (search + fetch sub-agent) |
+| `WebContextProvider` + `ParallelMCPBackend` | Web via Parallel's public MCP server (keyless / keyed) | `query_<id>` (search + fetch sub-agent) |
 | `DatabaseContextProvider` | Any SQL database (SQLAlchemy) | `query_<id>`, `update_<id>` (separate read/write sub-agents) |
 | `SlackContextProvider` | A Slack workspace | `query_<id>`, `update_<id>` (separate read/write sub-agents; writer only gets `send_message` + the lookup tools it needs) |
 | `MCPContextProvider` | One MCP server | `query_<id>` (sub-agent over the server's tools) or flat tools in `mode=tools` |
@@ -43,6 +44,7 @@ Providers ship in this package:
 | `08_multi_provider.py` | Three providers on one agent; names compose cleanly |
 | `09_web_plus_slack.py` | Compositional: Slack topics feed per-topic web searches |
 | `10_custom_provider.py` | Subclass `ContextProvider` for your own source |
+| `11_web_parallel_mcp.py` | Web research via Parallel's public MCP endpoint (keyless; `PARALLEL_API_KEY` raises the ceiling) |
 
 ## Run
 
@@ -57,6 +59,9 @@ OPENAI_API_KEY=... EXA_API_KEY=... .venvs/demo/bin/python cookbook/12_context/01
 
 # Keyless Exa MCP — no signup required
 OPENAI_API_KEY=... .venvs/demo/bin/python cookbook/12_context/02_web_exa_mcp.py
+
+# Keyless Parallel MCP — no signup required; set PARALLEL_API_KEY for higher limits
+OPENAI_API_KEY=... .venvs/demo/bin/python cookbook/12_context/11_web_parallel_mcp.py
 
 # Parallel SDK
 OPENAI_API_KEY=... PARALLEL_API_KEY=... .venvs/demo/bin/python cookbook/12_context/03_web_parallel.py

--- a/libs/agno/agno/context/web/__init__.py
+++ b/libs/agno/agno/context/web/__init__.py
@@ -1,6 +1,7 @@
 from agno.context.web.exa import ExaBackend
 from agno.context.web.exa_mcp import ExaMCPBackend
 from agno.context.web.parallel import ParallelBackend
+from agno.context.web.parallel_mcp import ParallelMCPBackend
 from agno.context.web.provider import DEFAULT_WEB_INSTRUCTIONS, WebContextProvider
 
 __all__ = [
@@ -8,5 +9,6 @@ __all__ = [
     "ExaBackend",
     "ExaMCPBackend",
     "ParallelBackend",
+    "ParallelMCPBackend",
     "WebContextProvider",
 ]

--- a/libs/agno/agno/context/web/exa_mcp.py
+++ b/libs/agno/agno/context/web/exa_mcp.py
@@ -11,6 +11,7 @@ the SDK path is available.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from os import getenv
 from typing import Any
 
@@ -19,18 +20,30 @@ from agno.context.provider import Status
 from agno.utils.log import log_warning
 
 _BASE_URL = "https://mcp.exa.ai/mcp"
-_TOOLS = "web_search_exa,web_fetch_exa"
+_DEFAULT_TOOLS: Sequence[str] = ("web_search_exa", "web_fetch_exa")
 
 
 class ExaMCPBackend(ContextBackend):
     """Backend for `WebContextProvider` that speaks to Exa's MCP server."""
 
-    def __init__(self, *, api_key: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        include_tools: Sequence[str] | None = _DEFAULT_TOOLS,
+        exclude_tools: Sequence[str] | None = None,
+        tool_name_prefix: str | None = None,
+    ) -> None:
         self.api_key = api_key if api_key is not None else (getenv("EXA_API_KEY", "") or None)
+        self.include_tools = list(include_tools) if include_tools is not None else None
+        self.exclude_tools = list(exclude_tools) if exclude_tools is not None else None
+        self.tool_name_prefix = tool_name_prefix
+        # Build URL with tool filter query param
+        tools_param = ",".join(self.include_tools) if self.include_tools else ""
         if self.api_key:
-            self.url = f"{_BASE_URL}?exaApiKey={self.api_key}&tools={_TOOLS}"
+            self.url = f"{_BASE_URL}?exaApiKey={self.api_key}&tools={tools_param}"
         else:
-            self.url = f"{_BASE_URL}?tools={_TOOLS}"
+            self.url = f"{_BASE_URL}?tools={tools_param}"
         self._mcp_tools: Any = None
 
     def status(self) -> Status:
@@ -47,7 +60,12 @@ class ExaMCPBackend(ContextBackend):
     def _build_tools(self) -> Any:
         from agno.tools.mcp import MCPTools
 
-        return MCPTools(url=self.url, transport="streamable-http")
+        return MCPTools(
+            url=self.url,
+            transport="streamable-http",
+            exclude_tools=self.exclude_tools,
+            tool_name_prefix=self.tool_name_prefix,
+        )
 
     async def asetup(self) -> None:
         """Connect to the Exa MCP server.

--- a/libs/agno/agno/context/web/exa_mcp.py
+++ b/libs/agno/agno/context/web/exa_mcp.py
@@ -30,11 +30,13 @@ class ExaMCPBackend(ContextBackend):
         self,
         *,
         api_key: str | None = None,
+        timeout_seconds: int = 60,
         include_tools: Sequence[str] | None = _DEFAULT_TOOLS,
         exclude_tools: Sequence[str] | None = None,
         tool_name_prefix: str | None = None,
     ) -> None:
         self.api_key = api_key if api_key is not None else (getenv("EXA_API_KEY", "") or None)
+        self.timeout_seconds = timeout_seconds
         self.include_tools = list(include_tools) if include_tools is not None else None
         self.exclude_tools = list(exclude_tools) if exclude_tools is not None else None
         self.tool_name_prefix = tool_name_prefix
@@ -58,13 +60,21 @@ class ExaMCPBackend(ContextBackend):
         return [self._mcp_tools]
 
     def _build_tools(self) -> Any:
-        from agno.tools.mcp import MCPTools
+        from datetime import timedelta
 
-        return MCPTools(
+        from agno.tools.mcp import MCPTools
+        from agno.tools.mcp.params import StreamableHTTPClientParams
+
+        server_params = StreamableHTTPClientParams(
             url=self.url,
+            timeout=timedelta(seconds=self.timeout_seconds),
+        )
+        return MCPTools(
+            server_params=server_params,
             transport="streamable-http",
             exclude_tools=self.exclude_tools,
             tool_name_prefix=self.tool_name_prefix,
+            timeout_seconds=self.timeout_seconds,
         )
 
     async def asetup(self) -> None:

--- a/libs/agno/agno/context/web/parallel_mcp.py
+++ b/libs/agno/agno/context/web/parallel_mcp.py
@@ -1,0 +1,104 @@
+"""ParallelMCPBackend — keyless (or keyed) web search via Parallel's MCP server.
+
+Exposes Parallel's `web_search` + `web_fetch` tools to the calling
+agent. The default endpoint is keyless; passing `api_key` (or setting
+`PARALLEL_API_KEY`) authenticates via Bearer token and raises the
+rate ceiling.
+
+Pairs with `ParallelBackend` (direct SDK) — the two are not equivalent:
+the SDK exposes `web_search` + `web_extract`, whereas the MCP server
+exposes `web_search` + `web_fetch` (token-efficient markdown). Pick
+MCP when you want the compressed markdown output, SDK when you need
+the raw extraction payload.
+"""
+
+from __future__ import annotations
+
+from os import getenv
+from typing import Any
+
+from agno.context.backend import ContextBackend
+from agno.context.provider import Status
+from agno.utils.log import log_warning
+
+_BASE_URL = "https://search.parallel.ai/mcp"
+_OAUTH_BASE_URL = "https://search.parallel.ai/mcp-oauth"
+_TOOLS = ("web_search", "web_fetch")
+
+
+class ParallelMCPBackend(ContextBackend):
+    """Backend for `WebContextProvider` that speaks to Parallel's MCP server."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        use_oauth: bool = False,
+        timeout_seconds: int = 30,
+    ) -> None:
+        self.api_key = api_key if api_key is not None else (getenv("PARALLEL_API_KEY", "") or None)
+        # OAuth endpoint still accepts Bearer tokens but requires one — reject
+        # the nonsensical "oauth + keyless" combination up front.
+        if use_oauth and not self.api_key:
+            raise ValueError("use_oauth=True requires api_key (or PARALLEL_API_KEY env var).")
+        self.use_oauth = use_oauth
+        self.url = _OAUTH_BASE_URL if self.use_oauth else _BASE_URL
+        # Bumped from MCPTools' 10s default — Parallel's web_fetch returns
+        # server-compressed markdown for long pages and regularly exceeds 10s.
+        self.timeout_seconds = timeout_seconds
+        self._mcp_tools: Any = None
+
+    def status(self) -> Status:
+        endpoint = "mcp-oauth" if self.use_oauth else "mcp"
+        return Status(ok=True, detail=f"search.parallel.ai/{endpoint} ({'keyed' if self.api_key else 'keyless'})")
+
+    async def astatus(self) -> Status:
+        return self.status()
+
+    def get_tools(self) -> list:
+        if self._mcp_tools is None:
+            self._mcp_tools = self._build_tools()
+        return [self._mcp_tools]
+
+    def _build_tools(self) -> Any:
+        from agno.tools.mcp import MCPTools
+        from agno.tools.mcp.params import StreamableHTTPClientParams
+
+        headers: dict[str, Any] | None = None
+        if self.api_key:
+            headers = {"Authorization": f"Bearer {self.api_key}"}
+
+        server_params = StreamableHTTPClientParams(url=self.url, headers=headers)
+        return MCPTools(
+            server_params=server_params,
+            transport="streamable-http",
+            include_tools=list(_TOOLS),
+            timeout_seconds=self.timeout_seconds,
+        )
+
+    async def asetup(self) -> None:
+        """Connect to the Parallel MCP server.
+
+        On failure, logs a warning; the web backend will be
+        unavailable until the next restart.
+        """
+        if self._mcp_tools is None:
+            self._mcp_tools = self._build_tools()
+        if getattr(self._mcp_tools, "initialized", False):
+            return
+        try:
+            await self._mcp_tools._connect()
+        except Exception as exc:
+            log_warning(f"ParallelMCPBackend setup failed — {type(exc).__name__}: {exc}.")
+            self._mcp_tools = None
+
+    async def aclose(self) -> None:
+        """Close the MCP session and drop cached state."""
+        tools = self._mcp_tools
+        self._mcp_tools = None
+        if tools is None:
+            return
+        try:
+            await tools.close()
+        except Exception as exc:
+            log_warning(f"ParallelMCPBackend close raised {type(exc).__name__}: {exc}")

--- a/libs/agno/agno/context/web/parallel_mcp.py
+++ b/libs/agno/agno/context/web/parallel_mcp.py
@@ -21,6 +21,7 @@ the raw extraction payload.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from os import getenv
 from typing import Any, Optional
 
@@ -30,7 +31,7 @@ from agno.utils.log import log_info, log_warning
 
 _BASE_URL = "https://search.parallel.ai/mcp"
 _OAUTH_BASE_URL = "https://search.parallel.ai/mcp-oauth"
-_TOOLS = ("web_search", "web_fetch")
+_DEFAULT_TOOLS: Sequence[str] = ("web_search", "web_fetch")
 
 
 class ParallelMCPBackend(ContextBackend):
@@ -42,9 +43,15 @@ class ParallelMCPBackend(ContextBackend):
         api_key: Optional[str] = None,
         authenticated: bool = False,
         timeout_seconds: int = 60,
+        include_tools: Sequence[str] | None = _DEFAULT_TOOLS,
+        exclude_tools: Sequence[str] | None = None,
+        tool_name_prefix: str | None = None,
     ) -> None:
         self.api_key = api_key if api_key is not None else (getenv("PARALLEL_API_KEY", "") or None)
         self.url = _OAUTH_BASE_URL if authenticated else _BASE_URL
+        self.include_tools = list(include_tools) if include_tools is not None else None
+        self.exclude_tools = list(exclude_tools) if exclude_tools is not None else None
+        self.tool_name_prefix = tool_name_prefix
         # /mcp-oauth rejects anonymous requests with 401 (unlike /mcp), so
         # the endpoint is unusable without a key — fail fast instead of
         # surfacing a runtime 401 during asetup().
@@ -79,7 +86,9 @@ class ParallelMCPBackend(ContextBackend):
         return MCPTools(
             server_params=server_params,
             transport="streamable-http",
-            include_tools=list(_TOOLS),
+            include_tools=self.include_tools,
+            exclude_tools=self.exclude_tools,
+            tool_name_prefix=self.tool_name_prefix,
             timeout_seconds=self.timeout_seconds,
         )
 

--- a/libs/agno/agno/context/web/parallel_mcp.py
+++ b/libs/agno/agno/context/web/parallel_mcp.py
@@ -5,6 +5,13 @@ agent. The default endpoint is keyless; passing `api_key` (or setting
 `PARALLEL_API_KEY`) authenticates via Bearer token and raises the
 rate ceiling.
 
+Two endpoints are supported:
+- `search.parallel.ai/mcp` (default): allows anonymous use, Bearer token
+  optional. Good for prototyping and single-user dev.
+- `search.parallel.ai/mcp-oauth` (`use_oauth_endpoint=True`): authenticated-only,
+  rejects anonymous requests with 401. Use for org-wide deployments, ZDR
+  contexts, or MCP clients that negotiate auth via OAuth2.
+
 Pairs with `ParallelBackend` (direct SDK) — the two are not equivalent:
 the SDK exposes `web_search` + `web_extract`, whereas the MCP server
 exposes `web_search` + `web_fetch` (token-efficient markdown). Pick
@@ -33,23 +40,24 @@ class ParallelMCPBackend(ContextBackend):
         self,
         *,
         api_key: str | None = None,
-        use_oauth: bool = False,
+        use_oauth_endpoint: bool = False,
         timeout_seconds: int = 30,
     ) -> None:
         self.api_key = api_key if api_key is not None else (getenv("PARALLEL_API_KEY", "") or None)
-        # OAuth endpoint still accepts Bearer tokens but requires one — reject
-        # the nonsensical "oauth + keyless" combination up front.
-        if use_oauth and not self.api_key:
-            raise ValueError("use_oauth=True requires api_key (or PARALLEL_API_KEY env var).")
-        self.use_oauth = use_oauth
-        self.url = _OAUTH_BASE_URL if self.use_oauth else _BASE_URL
+        # /mcp-oauth rejects anonymous requests with 401 (unlike /mcp), so
+        # the endpoint is unusable without a key — fail fast instead of
+        # surfacing a runtime 401 during asetup().
+        if use_oauth_endpoint and not self.api_key:
+            raise ValueError("use_oauth_endpoint=True requires api_key (or PARALLEL_API_KEY env var).")
+        self.use_oauth_endpoint = use_oauth_endpoint
+        self.url = _OAUTH_BASE_URL if self.use_oauth_endpoint else _BASE_URL
         # Bumped from MCPTools' 10s default — Parallel's web_fetch returns
         # server-compressed markdown for long pages and regularly exceeds 10s.
         self.timeout_seconds = timeout_seconds
         self._mcp_tools: Any = None
 
     def status(self) -> Status:
-        endpoint = "mcp-oauth" if self.use_oauth else "mcp"
+        endpoint = "mcp-oauth" if self.use_oauth_endpoint else "mcp"
         return Status(ok=True, detail=f"search.parallel.ai/{endpoint} ({'keyed' if self.api_key else 'keyless'})")
 
     async def astatus(self) -> Status:

--- a/libs/agno/agno/context/web/parallel_mcp.py
+++ b/libs/agno/agno/context/web/parallel_mcp.py
@@ -75,6 +75,8 @@ class ParallelMCPBackend(ContextBackend):
         return [self._mcp_tools]
 
     def _build_tools(self) -> Any:
+        from datetime import timedelta
+
         from agno.tools.mcp import MCPTools
         from agno.tools.mcp.params import StreamableHTTPClientParams
 
@@ -82,7 +84,11 @@ class ParallelMCPBackend(ContextBackend):
         if self.api_key:
             headers = {"Authorization": f"Bearer {self.api_key}"}
 
-        server_params = StreamableHTTPClientParams(url=self.url, headers=headers)
+        server_params = StreamableHTTPClientParams(
+            url=self.url,
+            headers=headers,
+            timeout=timedelta(seconds=self.timeout_seconds),
+        )
         return MCPTools(
             server_params=server_params,
             transport="streamable-http",

--- a/libs/agno/agno/context/web/parallel_mcp.py
+++ b/libs/agno/agno/context/web/parallel_mcp.py
@@ -8,7 +8,7 @@ rate ceiling.
 Two endpoints are supported:
 - `search.parallel.ai/mcp` (default): allows anonymous use, Bearer token
   optional. Good for prototyping and single-user dev.
-- `search.parallel.ai/mcp-oauth` (`use_oauth_endpoint=True`): authenticated-only,
+- `search.parallel.ai/mcp-oauth` (`authenticated=True`): authenticated-only,
   rejects anonymous requests with 401. Use for org-wide deployments, ZDR
   contexts, or MCP clients that negotiate auth via OAuth2.
 
@@ -22,11 +22,11 @@ the raw extraction payload.
 from __future__ import annotations
 
 from os import getenv
-from typing import Any
+from typing import Any, Optional
 
 from agno.context.backend import ContextBackend
 from agno.context.provider import Status
-from agno.utils.log import log_warning
+from agno.utils.log import log_info, log_warning
 
 _BASE_URL = "https://search.parallel.ai/mcp"
 _OAUTH_BASE_URL = "https://search.parallel.ai/mcp-oauth"
@@ -39,18 +39,17 @@ class ParallelMCPBackend(ContextBackend):
     def __init__(
         self,
         *,
-        api_key: str | None = None,
-        use_oauth_endpoint: bool = False,
+        api_key: Optional[str] = None,
+        authenticated: bool = False,
         timeout_seconds: int = 60,
     ) -> None:
         self.api_key = api_key if api_key is not None else (getenv("PARALLEL_API_KEY", "") or None)
+        self.url = _OAUTH_BASE_URL if authenticated else _BASE_URL
         # /mcp-oauth rejects anonymous requests with 401 (unlike /mcp), so
         # the endpoint is unusable without a key — fail fast instead of
         # surfacing a runtime 401 during asetup().
-        if use_oauth_endpoint and not self.api_key:
-            raise ValueError("use_oauth_endpoint=True requires api_key (or PARALLEL_API_KEY env var).")
-        self.use_oauth_endpoint = use_oauth_endpoint
-        self.url = _OAUTH_BASE_URL if self.use_oauth_endpoint else _BASE_URL
+        if self.url == _OAUTH_BASE_URL and not self.api_key:
+            raise ValueError("authenticated=True requires api_key (or PARALLEL_API_KEY env var).")
         # web_fetch returns server-compressed markdown for long pages and
         # regularly exceeds MCPTools' 10s default.
         self.timeout_seconds = timeout_seconds
@@ -94,6 +93,7 @@ class ParallelMCPBackend(ContextBackend):
             self._mcp_tools = self._build_tools()
         if getattr(self._mcp_tools, "initialized", False):
             return
+        log_info(f"ParallelMCPBackend: connecting to {self.url} ({'keyed' if self.api_key else 'keyless'})")
         try:
             await self._mcp_tools._connect()
         except Exception as exc:

--- a/libs/agno/agno/context/web/parallel_mcp.py
+++ b/libs/agno/agno/context/web/parallel_mcp.py
@@ -51,13 +51,13 @@ class ParallelMCPBackend(ContextBackend):
             raise ValueError("use_oauth_endpoint=True requires api_key (or PARALLEL_API_KEY env var).")
         self.use_oauth_endpoint = use_oauth_endpoint
         self.url = _OAUTH_BASE_URL if self.use_oauth_endpoint else _BASE_URL
-        # Bumped from MCPTools' 10s default — Parallel's web_fetch returns
-        # server-compressed markdown for long pages and regularly exceeds 10s.
+        # web_fetch returns server-compressed markdown for long pages and
+        # regularly exceeds MCPTools' 10s default.
         self.timeout_seconds = timeout_seconds
         self._mcp_tools: Any = None
 
     def status(self) -> Status:
-        endpoint = "mcp-oauth" if self.use_oauth_endpoint else "mcp"
+        endpoint = self.url.rsplit("/", 1)[-1]
         return Status(ok=True, detail=f"search.parallel.ai/{endpoint} ({'keyed' if self.api_key else 'keyless'})")
 
     async def astatus(self) -> Status:
@@ -101,7 +101,7 @@ class ParallelMCPBackend(ContextBackend):
             self._mcp_tools = None
 
     async def aclose(self) -> None:
-        """Close the MCP session and drop cached state."""
+        """Close the MCP session and clear the cached tool handle."""
         tools = self._mcp_tools
         self._mcp_tools = None
         if tools is None:

--- a/libs/agno/agno/context/web/parallel_mcp.py
+++ b/libs/agno/agno/context/web/parallel_mcp.py
@@ -41,7 +41,7 @@ class ParallelMCPBackend(ContextBackend):
         *,
         api_key: str | None = None,
         use_oauth_endpoint: bool = False,
-        timeout_seconds: int = 30,
+        timeout_seconds: int = 60,
     ) -> None:
         self.api_key = api_key if api_key is not None else (getenv("PARALLEL_API_KEY", "") or None)
         # /mcp-oauth rejects anonymous requests with 401 (unlike /mcp), so

--- a/libs/agno/tests/unit/context/test_providers.py
+++ b/libs/agno/tests/unit/context/test_providers.py
@@ -83,34 +83,33 @@ def test_parallel_mcp_backend_keyless_status_ok(monkeypatch):
     b = ParallelMCPBackend()
     status = b.status()
     assert status.ok is True
-    assert "keyless" in status.detail
-    assert "/mcp" in status.detail
+    assert status.detail == "search.parallel.ai/mcp (keyless)"
 
 
 def test_parallel_mcp_backend_keyed_status_reports_keyed():
     b = ParallelMCPBackend(api_key="secret")
     status = b.status()
     assert status.ok is True
-    assert "keyed" in status.detail
+    assert status.detail == "search.parallel.ai/mcp (keyed)"
 
 
 def test_parallel_mcp_backend_picks_up_env_var(monkeypatch):
     monkeypatch.setenv("PARALLEL_API_KEY", "env-secret")
     b = ParallelMCPBackend()
     assert b.api_key == "env-secret"
-    assert "keyed" in b.status().detail
+    assert b.status().detail == "search.parallel.ai/mcp (keyed)"
 
 
-def test_parallel_mcp_backend_oauth_requires_api_key(monkeypatch):
+def test_parallel_mcp_backend_oauth_endpoint_requires_api_key(monkeypatch):
     monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
-    with pytest.raises(ValueError, match="use_oauth=True requires api_key"):
-        ParallelMCPBackend(use_oauth=True)
+    with pytest.raises(ValueError, match="use_oauth_endpoint=True requires api_key"):
+        ParallelMCPBackend(use_oauth_endpoint=True)
 
 
-def test_parallel_mcp_backend_oauth_points_at_oauth_endpoint():
-    b = ParallelMCPBackend(api_key="secret", use_oauth=True)
+def test_parallel_mcp_backend_oauth_endpoint_points_at_oauth_url():
+    b = ParallelMCPBackend(api_key="secret", use_oauth_endpoint=True)
     assert b.url == "https://search.parallel.ai/mcp-oauth"
-    assert "/mcp-oauth" in b.status().detail
+    assert b.status().detail == "search.parallel.ai/mcp-oauth (keyed)"
 
 
 def test_parallel_mcp_backend_builds_mcp_tools_with_bearer_header():
@@ -143,6 +142,50 @@ def test_web_provider_accepts_parallel_mcp_backend(monkeypatch):
     p = WebContextProvider(backend=ParallelMCPBackend())
     assert [t.name for t in p.get_tools()] == ["query_web"]
     assert p.status().ok is True
+
+
+@pytest.mark.asyncio
+async def test_parallel_mcp_backend_asetup_swallows_errors_and_retries(monkeypatch):
+    from agno.tools.mcp import MCPTools
+
+    b = ParallelMCPBackend(api_key="test-key", timeout_seconds=1)
+
+    calls = {"n": 0}
+
+    async def _fail(self_):
+        calls["n"] += 1
+        raise RuntimeError("connect failed")
+
+    monkeypatch.setattr(MCPTools, "_connect", _fail)
+
+    await b.asetup()
+    assert b._mcp_tools is None
+
+    await b.asetup()
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_parallel_mcp_backend_aclose_noop_when_never_connected():
+    b = ParallelMCPBackend(api_key="test-key")
+    await b.aclose()
+    assert b._mcp_tools is None
+
+
+@pytest.mark.asyncio
+async def test_parallel_mcp_backend_aclose_swallows_close_errors(monkeypatch):
+    from agno.tools.mcp import MCPTools
+
+    b = ParallelMCPBackend(api_key="test-key")
+    b._mcp_tools = b._build_tools()
+
+    async def _close_fails(self_):
+        raise RuntimeError("close failed")
+
+    monkeypatch.setattr(MCPTools, "close", _close_fails)
+
+    await b.aclose()
+    assert b._mcp_tools is None
 
 
 # ---------------------------------------------------------------------------

--- a/libs/agno/tests/unit/context/test_providers.py
+++ b/libs/agno/tests/unit/context/test_providers.py
@@ -121,7 +121,7 @@ def test_parallel_mcp_backend_builds_mcp_tools_with_bearer_header():
     assert params.url == "https://search.parallel.ai/mcp"
     assert params.headers == {"Authorization": "Bearer secret"}
     assert mcp_tools.include_tools == ["web_search", "web_fetch"]
-    assert mcp_tools.timeout_seconds == 30
+    assert mcp_tools.timeout_seconds == 60
 
 
 def test_parallel_mcp_backend_keyless_has_no_auth_header(monkeypatch):

--- a/libs/agno/tests/unit/context/test_providers.py
+++ b/libs/agno/tests/unit/context/test_providers.py
@@ -17,7 +17,7 @@ from agno.context.fs import FilesystemContextProvider
 from agno.context.gdrive import GDriveContextProvider
 from agno.context.mcp import MCPContextProvider
 from agno.context.slack import SlackContextProvider
-from agno.context.web import ExaBackend, WebContextProvider
+from agno.context.web import ExaBackend, ParallelMCPBackend, WebContextProvider
 
 # ---------------------------------------------------------------------------
 # Filesystem
@@ -75,6 +75,73 @@ def test_web_provider_exposes_query_tool():
 
 def test_web_provider_forwards_status_from_backend():
     p = WebContextProvider(backend=ExaBackend(api_key="x"))
+    assert p.status().ok is True
+
+
+def test_parallel_mcp_backend_keyless_status_ok(monkeypatch):
+    monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+    b = ParallelMCPBackend()
+    status = b.status()
+    assert status.ok is True
+    assert "keyless" in status.detail
+    assert "/mcp" in status.detail
+
+
+def test_parallel_mcp_backend_keyed_status_reports_keyed():
+    b = ParallelMCPBackend(api_key="secret")
+    status = b.status()
+    assert status.ok is True
+    assert "keyed" in status.detail
+
+
+def test_parallel_mcp_backend_picks_up_env_var(monkeypatch):
+    monkeypatch.setenv("PARALLEL_API_KEY", "env-secret")
+    b = ParallelMCPBackend()
+    assert b.api_key == "env-secret"
+    assert "keyed" in b.status().detail
+
+
+def test_parallel_mcp_backend_oauth_requires_api_key(monkeypatch):
+    monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="use_oauth=True requires api_key"):
+        ParallelMCPBackend(use_oauth=True)
+
+
+def test_parallel_mcp_backend_oauth_points_at_oauth_endpoint():
+    b = ParallelMCPBackend(api_key="secret", use_oauth=True)
+    assert b.url == "https://search.parallel.ai/mcp-oauth"
+    assert "/mcp-oauth" in b.status().detail
+
+
+def test_parallel_mcp_backend_builds_mcp_tools_with_bearer_header():
+    b = ParallelMCPBackend(api_key="secret")
+    tools = b.get_tools()
+    assert len(tools) == 1
+    mcp_tools = tools[0]
+    params = mcp_tools.server_params
+    assert params.url == "https://search.parallel.ai/mcp"
+    assert params.headers == {"Authorization": "Bearer secret"}
+    assert mcp_tools.include_tools == ["web_search", "web_fetch"]
+    assert mcp_tools.timeout_seconds == 30
+
+
+def test_parallel_mcp_backend_keyless_has_no_auth_header(monkeypatch):
+    monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+    b = ParallelMCPBackend()
+    tools = b.get_tools()
+    assert tools[0].server_params.headers is None
+
+
+def test_parallel_mcp_backend_custom_timeout_propagates():
+    b = ParallelMCPBackend(api_key="x", timeout_seconds=120)
+    tools = b.get_tools()
+    assert tools[0].timeout_seconds == 120
+
+
+def test_web_provider_accepts_parallel_mcp_backend(monkeypatch):
+    monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+    p = WebContextProvider(backend=ParallelMCPBackend())
+    assert [t.name for t in p.get_tools()] == ["query_web"]
     assert p.status().ok is True
 
 

--- a/libs/agno/tests/unit/context/test_providers.py
+++ b/libs/agno/tests/unit/context/test_providers.py
@@ -17,7 +17,7 @@ from agno.context.fs import FilesystemContextProvider
 from agno.context.gdrive import GDriveContextProvider
 from agno.context.mcp import MCPContextProvider
 from agno.context.slack import SlackContextProvider
-from agno.context.web import ExaBackend, ParallelMCPBackend, WebContextProvider
+from agno.context.web import ExaBackend, ExaMCPBackend, ParallelMCPBackend, WebContextProvider
 
 # ---------------------------------------------------------------------------
 # Filesystem
@@ -78,6 +78,51 @@ def test_web_provider_forwards_status_from_backend():
     assert p.status().ok is True
 
 
+def test_exa_mcp_backend_keyless_status_ok(monkeypatch):
+    monkeypatch.delenv("EXA_API_KEY", raising=False)
+    b = ExaMCPBackend()
+    status = b.status()
+    assert status.ok is True
+    assert status.detail == "mcp.exa.ai (keyless)"
+
+
+def test_exa_mcp_backend_keyed_status_reports_keyed():
+    b = ExaMCPBackend(api_key="secret")
+    assert b.status().detail == "mcp.exa.ai (keyed)"
+
+
+def test_exa_mcp_backend_default_include_tools():
+    b = ExaMCPBackend(api_key="x")
+    assert b.include_tools == ["web_search_exa", "web_fetch_exa"]
+    assert "tools=web_search_exa,web_fetch_exa" in b.url
+
+
+def test_exa_mcp_backend_custom_include_tools():
+    b = ExaMCPBackend(api_key="x", include_tools=["web_search_exa"])
+    assert b.include_tools == ["web_search_exa"]
+    assert "tools=web_search_exa" in b.url
+
+
+def test_exa_mcp_backend_include_tools_none_passes_empty():
+    b = ExaMCPBackend(api_key="x", include_tools=None)
+    assert b.include_tools is None
+    assert "tools=" in b.url
+
+
+def test_exa_mcp_backend_exclude_tools_propagates():
+    b = ExaMCPBackend(api_key="x", exclude_tools=["web_fetch_exa"])
+    assert b.exclude_tools == ["web_fetch_exa"]
+    tools = b.get_tools()
+    assert tools[0].exclude_tools == ["web_fetch_exa"]
+
+
+def test_exa_mcp_backend_tool_name_prefix_propagates():
+    b = ExaMCPBackend(api_key="x", tool_name_prefix="exa")
+    assert b.tool_name_prefix == "exa"
+    tools = b.get_tools()
+    assert tools[0].tool_name_prefix == "exa"
+
+
 def test_parallel_mcp_backend_keyless_status_ok(monkeypatch):
     monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
     b = ParallelMCPBackend()
@@ -135,6 +180,32 @@ def test_parallel_mcp_backend_custom_timeout_propagates():
     b = ParallelMCPBackend(api_key="x", timeout_seconds=120)
     tools = b.get_tools()
     assert tools[0].timeout_seconds == 120
+
+
+def test_parallel_mcp_backend_custom_include_tools():
+    b = ParallelMCPBackend(api_key="x", include_tools=["web_search"])
+    tools = b.get_tools()
+    assert tools[0].include_tools == ["web_search"]
+
+
+def test_parallel_mcp_backend_include_tools_none_passes_none():
+    b = ParallelMCPBackend(api_key="x", include_tools=None)
+    tools = b.get_tools()
+    assert tools[0].include_tools is None
+
+
+def test_parallel_mcp_backend_exclude_tools_propagates():
+    b = ParallelMCPBackend(api_key="x", exclude_tools=["web_fetch"])
+    assert b.exclude_tools == ["web_fetch"]
+    tools = b.get_tools()
+    assert tools[0].exclude_tools == ["web_fetch"]
+
+
+def test_parallel_mcp_backend_tool_name_prefix_propagates():
+    b = ParallelMCPBackend(api_key="x", tool_name_prefix="parallel")
+    assert b.tool_name_prefix == "parallel"
+    tools = b.get_tools()
+    assert tools[0].tool_name_prefix == "parallel"
 
 
 def test_web_provider_accepts_parallel_mcp_backend(monkeypatch):

--- a/libs/agno/tests/unit/context/test_providers.py
+++ b/libs/agno/tests/unit/context/test_providers.py
@@ -100,14 +100,14 @@ def test_parallel_mcp_backend_picks_up_env_var(monkeypatch):
     assert b.status().detail == "search.parallel.ai/mcp (keyed)"
 
 
-def test_parallel_mcp_backend_oauth_endpoint_requires_api_key(monkeypatch):
+def test_parallel_mcp_backend_authenticated_requires_api_key(monkeypatch):
     monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
-    with pytest.raises(ValueError, match="use_oauth_endpoint=True requires api_key"):
-        ParallelMCPBackend(use_oauth_endpoint=True)
+    with pytest.raises(ValueError, match="authenticated=True requires api_key"):
+        ParallelMCPBackend(authenticated=True)
 
 
-def test_parallel_mcp_backend_oauth_endpoint_points_at_oauth_url():
-    b = ParallelMCPBackend(api_key="secret", use_oauth_endpoint=True)
+def test_parallel_mcp_backend_authenticated_uses_oauth_endpoint():
+    b = ParallelMCPBackend(api_key="secret", authenticated=True)
     assert b.url == "https://search.parallel.ai/mcp-oauth"
     assert b.status().detail == "search.parallel.ai/mcp-oauth (keyed)"
 


### PR DESCRIPTION
## Summary

Adds `ParallelMCPBackend` — a third web backend for `WebContextProvider` that talks to Parallel's public MCP server at `search.parallel.ai/mcp`. Sits alongside the existing `ExaBackend` (SDK), `ExaMCPBackend`, and `ParallelBackend` (SDK).

**Why:** Parallel's MCP server is free/keyless at lower rate limits (no account needed to prototype) and exposes `web_search` + `web_fetch` (token-efficient markdown output), giving `WebContextProvider` users a new search source with no API-key setup required.

**Not equivalent to `ParallelBackend`:** the SDK exposes `web_search` + `web_extract` (raw extraction payload); the MCP server exposes `web_search` + `web_fetch` (compressed markdown). Pick MCP for agent-friendly output, SDK for the raw bytes.

### Auth model

- Keyless by default — works out of the box, no env vars
- Bearer-authenticated when `PARALLEL_API_KEY` is set → higher rate limits
- Optional `/mcp-oauth` endpoint via `use_oauth=True` (requires an API key; validated against live endpoint)

### Configurable timeout

`timeout_seconds` kwarg (default **30s**, up from `MCPTools`' 10s). Parallel's `web_fetch` regularly exceeds 10s because it returns server-compressed markdown for long pages — the default blocked document-fetch workflows in live testing. Users needing longer fetches (large PDFs, slow origins) can bump further.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` — clean; `ruff check` clean on touched files)
- [x] Self-review completed
- [x] Documentation updated (docstrings, WHY comments on non-obvious defaults)
- [x] Examples and guides: follows the ExaMCPBackend pattern; existing `WebContextProvider` cookbooks (`cookbook/12_context/02_web_exa_mcp.py`, `03_web_parallel.py`) already demonstrate the pattern — a new cookbook can follow if desired
- [x] Tested in clean environment (full E2E against live Parallel MCP server; see below)
- [x] Tests added — 9 unit tests covering status/auth/URL/headers/timeout/env-var/OAuth-guard/provider integration

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach — N/A, no overlap
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.) — authored with Claude Code assistance; every change reviewed and live-tested

## Additional Notes

### E2E verification

Ran against the live Parallel MCP server with an API key. All five phases green:

| Phase | Result |
|---|---|
| 1. Plumbing (URL, headers, include_tools, OAuth URL) | ✅ |
| 2. Keyless lifecycle (`asetup` → `web_search` → `aclose`) | ✅ |
| 3. Keyed lifecycle (Bearer auth; `web_search` + `web_fetch`) | ✅ |
| 4. OAuth endpoint (`/mcp-oauth` with Bearer) | ✅ — confirmed accepts Bearer |
| 5. Full `WebContextProvider` + LLM agent | ✅ — agent answers from `web_search` results |

### Files

- `libs/agno/agno/context/web/parallel_mcp.py` — new, ~90 lines
- `libs/agno/agno/context/web/__init__.py` — exports `ParallelMCPBackend`
- `libs/agno/tests/unit/context/test_providers.py` — 9 new unit tests

### Discovered during testing (FYI, not bugs in this PR)

- Parallel's MCP `web_search` requires `objective` + `search_queries` (not `query`); `web_fetch` requires `urls` (list). The LLM discovers these from the MCP `list_tools` schema automatically, so no special wiring needed in the backend.