### PR TITLE
fix(team): add learnings-to-context injection in Team system message builder

### DIFF
--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -535,6 +535,16 @@ def get_system_message(
             "You should ALWAYS prefer information from this conversation over the past summary.\n\n"
         )
 
+    # 2.5 Learnings: add personalized context from LearningMachine
+    if team._learning is not None and team.add_learnings_to_context:
+        learning_context = team._learning.build_context(
+            user_id=user_id,
+            session_id=session.session_id if session else None,
+            agent_id=team.team_id,
+        )
+        if learning_context:
+            system_message_content += learning_context + "\n"
+
     # 2.6 Trailing sections: media, additional info, tools, expected output, etc.
     system_message_content += _build_trailing_sections(
         team,
@@ -755,6 +765,16 @@ async def aget_system_message(
             "Note: this information is from previous interactions and may be outdated. "
             "You should ALWAYS prefer information from this conversation over the past summary.\n\n"
         )
+
+    # 2.5 Learnings: add personalized context from LearningMachine
+    if team._learning is not None and team.add_learnings_to_context:
+        learning_context = await team._learning.abuild_context(
+            user_id=user_id,
+            session_id=session.session_id if session else None,
+            agent_id=team.team_id,
+        )
+        if learning_context:
+            system_message_content += learning_context + "\n"
 
     # 2.6 Trailing sections: media, additional info, tools, expected output, etc.
     system_message_content += _build_trailing_sections(

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -540,7 +540,7 @@ def get_system_message(
         learning_context = team._learning.build_context(
             user_id=user_id,
             session_id=session.session_id if session else None,
-            agent_id=team.team_id,
+            agent_id=team.id,
         )
         if learning_context:
             system_message_content += learning_context + "\n"
@@ -771,7 +771,7 @@ async def aget_system_message(
         learning_context = await team._learning.abuild_context(
             user_id=user_id,
             session_id=session.session_id if session else None,
-            agent_id=team.team_id,
+            agent_id=team.id,
         )
         if learning_context:
             system_message_content += learning_context + "\n"


### PR DESCRIPTION
## Summary

`Team` exposes `learning: Optional[Union[bool, LearningMachine]]` and `add_learnings_to_context: bool = True`, and initializes `_learning` through the same lazy property pattern as `Agent`. However `team/_messages.py` — which builds the team's system prompt — never reads `add_learnings_to_context` and never calls `team._learning.build_context()` / `abuild_context()`. The result is that the write path works (the `update_profile` agentic tool saves to DB), but the read path is silently absent: stored profiles and session learnings have no effect on subsequent Team runs.

## Root cause

`agent/_messages.py` has section `3.3.12` that injects learning context in both `get_system_message` (sync) and `aget_system_message` (async). The equivalent section was simply never added to `team/_messages.py`.

## Fix

Add section `2.5` in `get_system_message` and the matching `await` call in `aget_system_message` in `team/_messages.py`, immediately before the trailing sections block, mirroring the agent implementation:

```python
if team._learning is not None and team.add_learnings_to_context:
    learning_context = team._learning.build_context(
        user_id=user_id,
        session_id=session.session_id if session else None,
        agent_id=team.id,
    )
    if learning_context:
        system_message_content += learning_context + "\n"
```

The async path uses `await team._learning.abuild_context(...)` identically.

No changes to `team.py`, `_init.py`, or any other file — the lazy initialization and field definitions were already correct.

Fixes #7595