### PR TITLE
fix: use insert-before-delete in optimize_memories to prevent data loss

### DIFF
--- a/libs/agno/agno/memory/manager.py
+++ b/libs/agno/agno/memory/manager.py
@@ -843,18 +843,19 @@ class MemoryManager:
                 log_warning("Memory DB not provided. Cannot apply optimized memories.")
                 return optimized_memories
 
-            # Clear all existing memories for the user
-            self.clear_user_memories(user_id=user_id)
+            # Collect old memory IDs before making any changes
+            old_memory_ids = [mem.memory_id for mem in memories if mem.memory_id]
 
-            # Add all optimized memories
+            # Insert optimized memories first (with fresh IDs to avoid collisions)
             for opt_mem in optimized_memories:
-                # Ensure memory has an ID (generate if needed for new memories)
-                if not opt_mem.memory_id:
-                    from uuid import uuid4
+                from uuid import uuid4
 
-                    opt_mem.memory_id = str(uuid4())
-
+                opt_mem.memory_id = str(uuid4())
                 self.db.upsert_user_memory(memory=opt_mem)
+
+            # Delete old memories only after all inserts succeed
+            if old_memory_ids:
+                self.db.delete_user_memories(memory_ids=old_memory_ids, user_id=user_id)
 
         optimized_tokens = strategy_instance.count_tokens(optimized_memories)
         log_debug(f"Optimization complete. New token count: {optimized_tokens}")
@@ -913,21 +914,26 @@ class MemoryManager:
                 log_warning("Memory DB not provided. Cannot apply optimized memories.")
                 return optimized_memories
 
-            # Clear all existing memories for the user
-            await self.aclear_user_memories(user_id=user_id)
+            # Collect old memory IDs before making any changes
+            old_memory_ids = [mem.memory_id for mem in memories if mem.memory_id]
 
-            # Add all optimized memories
+            # Insert optimized memories first (with fresh IDs to avoid collisions)
             for opt_mem in optimized_memories:
-                # Ensure memory has an ID (generate if needed for new memories)
-                if not opt_mem.memory_id:
-                    from uuid import uuid4
+                from uuid import uuid4
 
-                    opt_mem.memory_id = str(uuid4())
+                opt_mem.memory_id = str(uuid4())
 
                 if isinstance(self.db, AsyncBaseDb):
                     await self.db.upsert_user_memory(memory=opt_mem)
                 elif isinstance(self.db, BaseDb):
                     self.db.upsert_user_memory(memory=opt_mem)
+
+            # Delete old memories only after all inserts succeed
+            if old_memory_ids:
+                if isinstance(self.db, AsyncBaseDb):
+                    await self.db.delete_user_memories(memory_ids=old_memory_ids, user_id=user_id)
+                elif isinstance(self.db, BaseDb):
+                    self.db.delete_user_memories(memory_ids=old_memory_ids, user_id=user_id)
 
         optimized_tokens = strategy_instance.count_tokens(optimized_memories)
         log_debug(f"Memory optimization complete. New token count: {optimized_tokens}")


### PR DESCRIPTION
Fixes #7051

### Root Cause

`optimize_memories` and `aoptimize_memories` use a **delete-all → insert-each** pattern with no transactional guarantee. If a failure occurs between the delete and the final insert (network error, process crash, DB constraint violation), all user memories are permanently lost.

### Fix

Reverse the order to **insert-first → delete-old**:

1. Collect old `memory_id`s from the existing memories
2. Upsert all optimized memories with fresh UUIDs (avoids ID collisions with not-yet-deleted records)
3. Delete old memories by their original IDs only after all inserts succeed

**Failure modes become benign:**
- Crash after inserts but before delete → duplicate memories (easily recoverable, no data loss)
- Crash before any insert → original memories remain intact

### Changes

- `optimize_memories` (sync): replace `clear_user_memories()` + insert loop with insert loop + `delete_user_memories()`
- `aoptimize_memories` (async): same pattern, preserving async/sync DB dispatch