### PR TITLE
fix: preserve HITL review config in deep_copy for Step, Router, and Loop

### DIFF
--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -9714,6 +9714,9 @@ class Workflow:
                 "user_input_message",
                 "user_input_schema",
                 "on_error",
+                "requires_output_review",
+                "output_review_message",
+                "human_review",
             ]:
                 if hasattr(step, attr):
                     value = getattr(step, attr)
@@ -9742,7 +9745,7 @@ class Workflow:
         # Handle Loop steps
         if isinstance(step, Loop):
             copied_loop_steps = [self._deep_copy_single_step(s) for s in step.steps] if step.steps else []
-            return Loop(
+            loop_kwargs: Dict[str, Any] = dict(
                 steps=copied_loop_steps,
                 name=step.name,
                 description=step.description,
@@ -9752,6 +9755,9 @@ class Workflow:
                 confirmation_message=step.confirmation_message,
                 on_reject=step.on_reject,
             )
+            if getattr(step, "human_review", None) is not None:
+                loop_kwargs["human_review"] = step.human_review
+            return Loop(**loop_kwargs)
 
         # Handle Condition steps
         if isinstance(step, Condition):
@@ -9782,6 +9788,9 @@ class Workflow:
                 requires_user_input=step.requires_user_input,
                 user_input_message=step.user_input_message,
                 allow_multiple_selections=step.allow_multiple_selections,
+                requires_output_review=step.requires_output_review,
+                output_review_message=step.output_review_message,
+                hitl_max_retries=step.hitl_max_retries,
             )
 
         # Handle Steps container


### PR DESCRIPTION
## Summary

- `_deep_copy_single_step()` was not copying `requires_output_review`, `output_review_message`, and `human_review` fields when creating fresh workflow instances
- This caused all output review / iteration review HITL to silently stop working when served through AgentOS, because `resolve_workflow()` calls `deep_copy(create_fresh=True)` for every request
- Adds the missing fields to the Step attribute copy list, the Router constructor call, and the Loop kwargs

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
