### PR TITLE
fix: include column default in describe_table

### DIFF
--- a/libs/agno/agno/tools/sql.py
+++ b/libs/agno/agno/tools/sql.py
@@ -101,7 +101,12 @@ class SQLTools(Toolkit):
             table_schema = inspector.get_columns(table_name, schema=self.schema)
             return json.dumps(
                 [
-                    {"name": column["name"], "type": str(column["type"]), "nullable": column["nullable"]}
+                    {
+                        "name": column["name"],
+                        "type": str(column["type"]),
+                        "nullable": column["nullable"],
+                        "default": column.get("default"),
+                    }
                     for column in table_schema
                 ]
             )


### PR DESCRIPTION
## Summary

- Add `default` field to column metadata in `describe_table()` output

## Problem

When `describe_table` returns `nullable: false` without indicating there's a server default, LLMs incorrectly insert `NULL` instead of omitting the column entirely. This causes silent data corruption for `NOT NULL DEFAULT` columns.

**Example:** A `tags ARRAY NOT NULL DEFAULT '{}'` column would show:
```json
{"name": "tags", "type": "ARRAY", "nullable": false}
```

The LLM thinks "I must provide a value" and picks `NULL` → SQL error or silent corruption.

## Solution

SQLAlchemy's `get_columns()` already returns the `default` expression — we just weren't exposing it. Now it shows:
```json
{"name": "tags", "type": "ARRAY", "nullable": false, "default": "'{}'"}
```

The LLM can now correctly reason: "nullable=false but has default → I can omit this column."

## Will This Break Existing Code?

**No.** This is a safe, additive change:

| Concern | Why it's safe |
|---------|---------------|
| **JSON consumers** | Adding a new field is non-breaking. Code that doesn't expect `default` will ignore it |
| **LLM prompts** | More information = better decisions. The LLM won't suddenly do something wrong |
| **Null handling** | Uses `.get("default")` which returns `None` if SQLAlchemy doesn't provide it |
| **Output size** | Adds ~15-20 chars per column — negligible |
| **Existing data** | This is purely read-only metadata display — it doesn't touch any tables, columns, or rows |

```
┌─────────────────────────────────────────────────────────┐
│                    What the fix does                    │
├─────────────────────────────────────────────────────────┤
│  SQLAlchemy Inspector  ──reads──▶  Your DB Schema       │
│         │                              (unchanged)      │
│         ▼                                               │
│  describe_table()  ──returns──▶  JSON string            │
│         │                         (now includes         │
│         │                          "default" field)     │
│         ▼                                               │
│       LLM  ──makes smarter──▶  INSERT decisions         │
│                                 (going forward)         │
└─────────────────────────────────────────────────────────┘
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Formatted and validated code (`./scripts/format.sh` + `./scripts/validate.sh`)