### PR TITLE
fix: accumulate parser, output, and member metrics in team run_response

### DIFF
--- a/libs/agno/agno/team/_response.py
+++ b/libs/agno/agno/team/_response.py
@@ -146,7 +146,11 @@ def process_parser_response(
 
 
 def parse_response_with_parser_model(
-    team: "Team", model_response: ModelResponse, run_messages: RunMessages, run_context: Optional[RunContext] = None
+    team: "Team",
+    model_response: ModelResponse,
+    run_messages: RunMessages,
+    run_context: Optional[RunContext] = None,
+    run_response: Optional[TeamRunOutput] = None,
 ) -> None:
     """Parse the model response using the parser model."""
     from agno.team._messages import _get_messages_for_parser_model
@@ -166,13 +170,29 @@ def parse_response_with_parser_model(
             messages=messages_for_parser_model,
             response_format=parser_response_format,
         )
+
+        # Accumulate parser model metrics
+        if run_response is not None:
+            from agno.metrics import ModelType, accumulate_model_metrics
+
+            accumulate_model_metrics(
+                parser_model_response,
+                team.parser_model,
+                ModelType.PARSER_MODEL,
+                run_response.metrics,
+            )
+
         process_parser_response(team, model_response, run_messages, parser_model_response, messages_for_parser_model)
     else:
         log_warning("A response model is required to parse the response with a parser model")
 
 
 async def aparse_response_with_parser_model(
-    team: "Team", model_response: ModelResponse, run_messages: RunMessages, run_context: Optional[RunContext] = None
+    team: "Team",
+    model_response: ModelResponse,
+    run_messages: RunMessages,
+    run_context: Optional[RunContext] = None,
+    run_response: Optional[TeamRunOutput] = None,
 ) -> None:
     """Parse the model response using the parser model."""
     from agno.team._messages import _get_messages_for_parser_model
@@ -192,6 +212,18 @@ async def aparse_response_with_parser_model(
             messages=messages_for_parser_model,
             response_format=parser_response_format,
         )
+
+        # Accumulate parser model metrics
+        if run_response is not None:
+            from agno.metrics import ModelType, accumulate_model_metrics
+
+            accumulate_model_metrics(
+                parser_model_response,
+                team.parser_model,
+                ModelType.PARSER_MODEL,
+                run_response.metrics,
+            )
+
         process_parser_response(team, model_response, run_messages, parser_model_response, messages_for_parser_model)
     else:
         log_warning("A response model is required to parse the response with a parser model")
@@ -230,6 +262,7 @@ def parse_response_with_parser_model_stream(
                 messages=messages_for_parser_model,
                 response_format=parser_response_format,
                 stream_model_response=False,
+                run_response=run_response,
             ):
                 yield from _handle_model_response_chunk(
                     team,
@@ -300,6 +333,7 @@ async def aparse_response_with_parser_model_stream(
                 messages=messages_for_parser_model,
                 response_format=parser_response_format,
                 stream_model_response=False,
+                run_response=run_response,
             )
             async for model_response_event in model_response_stream:  # type: ignore
                 for event in _handle_model_response_chunk(
@@ -343,7 +377,12 @@ async def aparse_response_with_parser_model_stream(
 # ---------------------------------------------------------------------------
 
 
-def parse_response_with_output_model(team: "Team", model_response: ModelResponse, run_messages: RunMessages) -> None:
+def parse_response_with_output_model(
+    team: "Team",
+    model_response: ModelResponse,
+    run_messages: RunMessages,
+    run_response: Optional[TeamRunOutput] = None,
+) -> None:
     """Parse the model response using the output model."""
     from agno.team._messages import _get_messages_for_output_model
 
@@ -352,6 +391,18 @@ def parse_response_with_output_model(team: "Team", model_response: ModelResponse
 
     messages_for_output_model = _get_messages_for_output_model(team, run_messages.messages)
     output_model_response: ModelResponse = team.output_model.response(messages=messages_for_output_model)
+
+    # Accumulate output model metrics
+    if run_response is not None:
+        from agno.metrics import ModelType, accumulate_model_metrics
+
+        accumulate_model_metrics(
+            output_model_response,
+            team.output_model,
+            ModelType.OUTPUT_MODEL,
+            run_response.metrics,
+        )
+
     model_response.content = output_model_response.content
 
 
@@ -383,7 +434,9 @@ def generate_response_with_output_model_stream(
     messages_for_output_model = _get_messages_for_output_model(team, run_messages.messages)
     model_response = ModelResponse(content="")
 
-    for model_response_event in team.output_model.response_stream(messages=messages_for_output_model):
+    for model_response_event in team.output_model.response_stream(
+        messages=messages_for_output_model, run_response=run_response
+    ):
         yield from _handle_model_response_chunk(
             team,
             session=session,
@@ -410,7 +463,10 @@ def generate_response_with_output_model_stream(
 
 
 async def agenerate_response_with_output_model(
-    team: "Team", model_response: ModelResponse, run_messages: RunMessages
+    team: "Team",
+    model_response: ModelResponse,
+    run_messages: RunMessages,
+    run_response: Optional[TeamRunOutput] = None,
 ) -> None:
     """Parse the model response using the output model stream."""
     from agno.team._messages import _get_messages_for_output_model
@@ -420,6 +476,18 @@ async def agenerate_response_with_output_model(
 
     messages_for_output_model = _get_messages_for_output_model(team, run_messages.messages)
     output_model_response: ModelResponse = await team.output_model.aresponse(messages=messages_for_output_model)
+
+    # Accumulate output model metrics
+    if run_response is not None:
+        from agno.metrics import ModelType, accumulate_model_metrics
+
+        accumulate_model_metrics(
+            output_model_response,
+            team.output_model,
+            ModelType.OUTPUT_MODEL,
+            run_response.metrics,
+        )
+
     model_response.content = output_model_response.content
 
 
@@ -451,7 +519,9 @@ async def agenerate_response_with_output_model_stream(
     messages_for_output_model = _get_messages_for_output_model(team, run_messages.messages)
     model_response = ModelResponse(content="")
 
-    async for model_response_event in team.output_model.aresponse_stream(messages=messages_for_output_model):
+    async for model_response_event in team.output_model.aresponse_stream(
+        messages=messages_for_output_model, run_response=run_response
+    ):
         for event in _handle_model_response_chunk(
             team,
             session=session,

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -4117,48 +4117,6 @@ def _update_team_media(team: "Team", run_response: Union[TeamRunOutput, RunOutpu
 
 
 # ---------------------------------------------------------------------------
-# Member metrics rollup
-# ---------------------------------------------------------------------------
-
-
-def _accumulate_member_run_metrics(run_response: TeamRunOutput) -> None:
-    """Accumulate metrics from member agent/team responses into the team run_response.metrics.
-
-    This ensures that run_response.metrics reflects the total token usage across all LLM calls
-    in a team run, including those made by member agents and nested teams.
-    """
-    if run_response.metrics is None:
-        return
-
-    for member_response in run_response.member_responses:
-        if member_response.metrics is None:
-            continue
-        m = member_response.metrics
-        run_response.metrics.input_tokens += m.input_tokens
-        run_response.metrics.output_tokens += m.output_tokens
-        run_response.metrics.total_tokens += m.total_tokens
-        run_response.metrics.audio_input_tokens += m.audio_input_tokens
-        run_response.metrics.audio_output_tokens += m.audio_output_tokens
-        run_response.metrics.audio_total_tokens += m.audio_total_tokens
-        run_response.metrics.cache_read_tokens += m.cache_read_tokens
-        run_response.metrics.cache_write_tokens += m.cache_write_tokens
-        run_response.metrics.reasoning_tokens += m.reasoning_tokens
-        if m.cost is not None:
-            run_response.metrics.cost = (run_response.metrics.cost or 0) + m.cost
-
-        # Merge per-model details
-        if m.details:
-            if run_response.metrics.details is None:
-                run_response.metrics.details = {}
-            for model_type_key, model_metrics_list in m.details.items():
-                # Prefix with "member:" to distinguish member model usage from leader usage
-                prefixed_key = f"member:{model_type_key}"
-                if prefixed_key not in run_response.metrics.details:
-                    run_response.metrics.details[prefixed_key] = []
-                run_response.metrics.details[prefixed_key].extend(model_metrics_list)
-
-
-# ---------------------------------------------------------------------------
 # Post-run cleanup (moved from _storage.py)
 # ---------------------------------------------------------------------------
 
@@ -4173,9 +4131,6 @@ def _cleanup_and_store(
 
     from agno.run.approval import update_approval_run_status
     from agno.team._session import update_session_metrics
-
-    # Accumulate member agent/team metrics into the team run_response.metrics
-    _accumulate_member_run_metrics(run_response)
 
     # Scrub a shallow copy for storage — the original run_response is never
     # mutated so the caller always sees generated media regardless of store_media.
@@ -4222,9 +4177,6 @@ async def _acleanup_and_store(
 
     from agno.run.approval import aupdate_approval_run_status
     from agno.team._session import update_session_metrics
-
-    # Accumulate member agent/team metrics into the team run_response.metrics
-    _accumulate_member_run_metrics(run_response)
 
     # Scrub a shallow copy for storage — the original run_response is never
     # mutated so the caller always sees generated media regardless of store_media.

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -1146,10 +1146,12 @@ def _run(
                 raise_if_cancelled(run_response.run_id)  # type: ignore
 
                 # If an output model is provided, generate output using the output model
-                parse_response_with_output_model(team, model_response, run_messages)
+                parse_response_with_output_model(team, model_response, run_messages, run_response=run_response)
 
                 # If a parser model is provided, structure the response separately
-                parse_response_with_parser_model(team, model_response, run_messages, run_context=run_context)
+                parse_response_with_parser_model(
+                    team, model_response, run_messages, run_context=run_context, run_response=run_response
+                )
 
                 # 7. Update TeamRunOutput with the model response
                 _update_run_response(
@@ -3003,12 +3005,16 @@ async def _arun(
 
                 # If an output model is provided, generate output using the output model
                 await agenerate_response_with_output_model(
-                    team, model_response=model_response, run_messages=run_messages
+                    team, model_response=model_response, run_messages=run_messages, run_response=run_response
                 )
 
                 # If a parser model is provided, structure the response separately
                 await aparse_response_with_parser_model(
-                    team, model_response=model_response, run_messages=run_messages, run_context=run_context
+                    team,
+                    model_response=model_response,
+                    run_messages=run_messages,
+                    run_context=run_context,
+                    run_response=run_response,
                 )
 
                 # 7. Update TeamRunOutput with the model response
@@ -4111,6 +4117,48 @@ def _update_team_media(team: "Team", run_response: Union[TeamRunOutput, RunOutpu
 
 
 # ---------------------------------------------------------------------------
+# Member metrics rollup
+# ---------------------------------------------------------------------------
+
+
+def _accumulate_member_run_metrics(run_response: TeamRunOutput) -> None:
+    """Accumulate metrics from member agent/team responses into the team run_response.metrics.
+
+    This ensures that run_response.metrics reflects the total token usage across all LLM calls
+    in a team run, including those made by member agents and nested teams.
+    """
+    if run_response.metrics is None:
+        return
+
+    for member_response in run_response.member_responses:
+        if member_response.metrics is None:
+            continue
+        m = member_response.metrics
+        run_response.metrics.input_tokens += m.input_tokens
+        run_response.metrics.output_tokens += m.output_tokens
+        run_response.metrics.total_tokens += m.total_tokens
+        run_response.metrics.audio_input_tokens += m.audio_input_tokens
+        run_response.metrics.audio_output_tokens += m.audio_output_tokens
+        run_response.metrics.audio_total_tokens += m.audio_total_tokens
+        run_response.metrics.cache_read_tokens += m.cache_read_tokens
+        run_response.metrics.cache_write_tokens += m.cache_write_tokens
+        run_response.metrics.reasoning_tokens += m.reasoning_tokens
+        if m.cost is not None:
+            run_response.metrics.cost = (run_response.metrics.cost or 0) + m.cost
+
+        # Merge per-model details
+        if m.details:
+            if run_response.metrics.details is None:
+                run_response.metrics.details = {}
+            for model_type_key, model_metrics_list in m.details.items():
+                # Prefix with "member:" to distinguish member model usage from leader usage
+                prefixed_key = f"member:{model_type_key}"
+                if prefixed_key not in run_response.metrics.details:
+                    run_response.metrics.details[prefixed_key] = []
+                run_response.metrics.details[prefixed_key].extend(model_metrics_list)
+
+
+# ---------------------------------------------------------------------------
 # Post-run cleanup (moved from _storage.py)
 # ---------------------------------------------------------------------------
 
@@ -4125,6 +4173,9 @@ def _cleanup_and_store(
 
     from agno.run.approval import update_approval_run_status
     from agno.team._session import update_session_metrics
+
+    # Accumulate member agent/team metrics into the team run_response.metrics
+    _accumulate_member_run_metrics(run_response)
 
     # Scrub a shallow copy for storage — the original run_response is never
     # mutated so the caller always sees generated media regardless of store_media.
@@ -4171,6 +4222,9 @@ async def _acleanup_and_store(
 
     from agno.run.approval import aupdate_approval_run_status
     from agno.team._session import update_session_metrics
+
+    # Accumulate member agent/team metrics into the team run_response.metrics
+    _accumulate_member_run_metrics(run_response)
 
     # Scrub a shallow copy for storage — the original run_response is never
     # mutated so the caller always sees generated media regardless of store_media.
@@ -5304,8 +5358,10 @@ async def _ahandle_model_response_for_continue(
 
     await araise_if_cancelled(run_response.run_id)  # type: ignore
 
-    await agenerate_response_with_output_model(team, model_response, run_messages)
-    await aparse_response_with_parser_model(team, model_response, run_messages, run_context=run_context)
+    await agenerate_response_with_output_model(team, model_response, run_messages, run_response=run_response)
+    await aparse_response_with_parser_model(
+        team, model_response, run_messages, run_context=run_context, run_response=run_response
+    )
 
     _update_run_response(
         team,
@@ -5933,8 +5989,10 @@ def _continue_run(
                 raise_if_cancelled(run_response.run_id)  # type: ignore
 
                 # Parse with output/parser models if needed
-                parse_response_with_output_model(team, model_response, run_messages)
-                parse_response_with_parser_model(team, model_response, run_messages, run_context=run_context)
+                parse_response_with_output_model(team, model_response, run_messages, run_response=run_response)
+                parse_response_with_parser_model(
+                    team, model_response, run_messages, run_context=run_context, run_response=run_response
+                )
 
                 # Update run response
                 _update_run_response(

--- a/libs/agno/agno/team/_session.py
+++ b/libs/agno/agno/team/_session.py
@@ -507,8 +507,8 @@ def update_session_metrics(team: "Team", session: TeamSession, run_response: Tea
     session-level SessionMetrics (details: List[ModelMetrics]) using
     SessionMetrics.accumulate_from_run().
 
-    run_response.metrics already includes member agent/team metrics (rolled up
-    in _accumulate_member_run_metrics), so we only need to accumulate once.
+    Accumulates metrics from the team leader's own model calls as well as
+    all member agent/team responses (recursively for nested teams).
     """
     from agno.team._storage import get_session_metrics_internal
 
@@ -518,8 +518,24 @@ def update_session_metrics(team: "Team", session: TeamSession, run_response: Tea
     if run_response.metrics is not None:
         session_metrics.accumulate_from_run(run_response.metrics)
 
+    # Accumulate metrics from member responses (agent and nested team runs)
+    _accumulate_member_metrics(session_metrics, run_response.member_responses)
+
     if session.session_data is not None:
         session.session_data["session_metrics"] = session_metrics.to_dict()
+
+
+def _accumulate_member_metrics(
+    session_metrics: SessionMetrics,
+    member_responses: "List",
+) -> None:
+    """Recursively accumulate metrics from member responses into session metrics."""
+    for member_response in member_responses:
+        if member_response.metrics is not None:
+            session_metrics.accumulate_from_run(member_response.metrics)
+        # Recurse into nested team member responses
+        if isinstance(member_response, TeamRunOutput) and member_response.member_responses:
+            _accumulate_member_metrics(session_metrics, member_response.member_responses)
 
 
 # ---------------------------------------------------------------------------

--- a/libs/agno/agno/team/_session.py
+++ b/libs/agno/agno/team/_session.py
@@ -507,8 +507,8 @@ def update_session_metrics(team: "Team", session: TeamSession, run_response: Tea
     session-level SessionMetrics (details: List[ModelMetrics]) using
     SessionMetrics.accumulate_from_run().
 
-    Accumulates metrics from the team leader's own model calls as well as
-    all member agent/team responses (recursively for nested teams).
+    run_response.metrics already includes member agent/team metrics (rolled up
+    in _accumulate_member_run_metrics), so we only need to accumulate once.
     """
     from agno.team._storage import get_session_metrics_internal
 
@@ -518,24 +518,8 @@ def update_session_metrics(team: "Team", session: TeamSession, run_response: Tea
     if run_response.metrics is not None:
         session_metrics.accumulate_from_run(run_response.metrics)
 
-    # Accumulate metrics from member responses (agent and nested team runs)
-    _accumulate_member_metrics(session_metrics, run_response.member_responses)
-
     if session.session_data is not None:
         session.session_data["session_metrics"] = session_metrics.to_dict()
-
-
-def _accumulate_member_metrics(
-    session_metrics: SessionMetrics,
-    member_responses: "List",
-) -> None:
-    """Recursively accumulate metrics from member responses into session metrics."""
-    for member_response in member_responses:
-        if member_response.metrics is not None:
-            session_metrics.accumulate_from_run(member_response.metrics)
-        # Recurse into nested team member responses
-        if isinstance(member_response, TeamRunOutput) and member_response.member_responses:
-            _accumulate_member_metrics(session_metrics, member_response.member_responses)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Team runs were not tracking token metrics from parser model and output model LLM calls in `run_response.metrics`. These calls were silently dropped, causing under-reporting of token usage at the run level.

Member agent metrics were already correctly accumulated at the session level via `_accumulate_member_metrics`, and are accessible per-member via `run_response.member_responses[i].metrics`.

### Changes

**Parser model metrics (`_response.py`)**
- Added `run_response` parameter to `parse_response_with_parser_model` and `aparse_response_with_parser_model`
- Pass `run_response` to streaming parser model calls (`response_stream` / `aresponse_stream`)
- Accumulate parser model metrics using `ModelType.PARSER_MODEL`, matching the agent-side pattern

**Output model metrics (`_response.py`)**
- Added `run_response` parameter to `parse_response_with_output_model` and `agenerate_response_with_output_model`
- Pass `run_response` to streaming output model calls
- Accumulate output model metrics using `ModelType.OUTPUT_MODEL`, matching the agent-side pattern

**Call sites (`_run.py`)**
- Updated all 4 call sites for parser/output model functions to pass `run_response`

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

The fix mirrors the existing pattern already used on the agent side (`libs/agno/agno/agent/_response.py`), where parser and output model metrics are properly accumulated. The team side was missing this accumulation.