### PR TITLE
feat: add workspace context provider

### DIFF
--- a/cookbook/12_context/12_workspace.py
+++ b/cookbook/12_context/12_workspace.py
@@ -1,0 +1,58 @@
+"""
+Workspace Context Provider
+==========================
+
+WorkspaceContextProvider wraps a project directory and gives the agent
+a single `query_<id>` tool. The tool routes through a read-only sub-agent
+that has the `Workspace` toolkit scoped to the root: list files, search
+content, and read files with line numbers.
+
+Use this for repository roots and active project workspaces. It skips
+common dependency directories, build outputs, caches, virtualenvs, and
+agent scratch folders by default.
+
+Requires: OPENAI_API_KEY
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from agno.agent import Agent
+from agno.context.workspace import WorkspaceContextProvider
+from agno.models.openai import OpenAIResponses
+
+# ---------------------------------------------------------------------------
+# Create the provider
+# ---------------------------------------------------------------------------
+project = WorkspaceContextProvider(
+    id="project",
+    name="Agno Project",
+    root=Path(__file__).resolve().parents[2],
+    model=OpenAIResponses(id="gpt-5.4-mini"),
+)
+
+# ---------------------------------------------------------------------------
+# Create the Agent
+# ---------------------------------------------------------------------------
+agent = Agent(
+    model=OpenAIResponses(id="gpt-5.4"),
+    tools=project.get_tools(),
+    instructions=project.instructions(),
+    markdown=True,
+)
+
+
+# ---------------------------------------------------------------------------
+# Run the Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    print(f"\nproject.status() = {project.status()}\n")
+    prompt = (
+        "Find where the workspace context provider and Workspace toolkit are "
+        "implemented. Explain why this provider is better than a generic "
+        "filesystem provider for repository roots. Cite the files you read."
+    )
+    print(f"> {prompt}\n")
+    asyncio.run(agent.aprint_response(prompt))

--- a/cookbook/12_context/README.md
+++ b/cookbook/12_context/README.md
@@ -20,6 +20,7 @@ Providers ship in this package:
 | Provider | Source | Tools |
 |----------|--------|-------|
 | `FilesystemContextProvider` | Local directory tree | `query_<id>` (read-only `FileTools` sub-agent) |
+| `WorkspaceContextProvider` | Local project workspace | `query_<id>` (read-only `Workspace` sub-agent with project-aware excludes) |
 | `WebContextProvider` + `ExaMCPBackend` | Web via Exa's public MCP server (keyless / keyed) | `query_<id>` (search + fetch sub-agent) |
 | `WebContextProvider` + `ExaBackend` | Web via Exa's direct SDK | `query_<id>` (search + fetch sub-agent) |
 | `WebContextProvider` + `ParallelBackend` | Web via Parallel's beta API | `query_<id>` (search + fetch sub-agent) |
@@ -45,6 +46,7 @@ Providers ship in this package:
 | `09_web_plus_slack.py` | Compositional: Slack topics feed per-topic web searches |
 | `10_custom_provider.py` | Subclass `ContextProvider` for your own source |
 | `11_web_parallel_mcp.py` | Web research via Parallel's public MCP endpoint (keyless; `PARALLEL_API_KEY` raises the ceiling) |
+| `12_workspace.py` | Browse a repository root via `WorkspaceContextProvider` without virtualenv / scratch noise |
 
 ## Run
 
@@ -53,6 +55,7 @@ Providers ship in this package:
 OPENAI_API_KEY=... .venvs/demo/bin/python cookbook/12_context/00_filesystem.py
 OPENAI_API_KEY=... .venvs/demo/bin/python cookbook/12_context/04_database_read_write.py
 OPENAI_API_KEY=... .venvs/demo/bin/python cookbook/12_context/10_custom_provider.py
+OPENAI_API_KEY=... .venvs/demo/bin/python cookbook/12_context/12_workspace.py
 
 # Exa SDK (keyed) — higher throughput
 OPENAI_API_KEY=... EXA_API_KEY=... .venvs/demo/bin/python cookbook/12_context/01_web_exa.py

--- a/cookbook/12_context/TEST_LOG.md
+++ b/cookbook/12_context/TEST_LOG.md
@@ -145,3 +145,19 @@ dict).
 and answered the user's question.
 
 ---
+
+### 12_workspace.py
+
+**Status:** Smoke-only (no OPENAI_API_KEY available locally)
+
+**Description:** `WorkspaceContextProvider` rooted at the repository.
+It wraps the read-only `Workspace` toolkit so project searches skip
+virtualenvs, dependency folders, build outputs, caches, and agent
+scratch directories by default.
+
+**Result:** Imported the cookbook with
+`PYTHONPATH=libs/agno .venvs/demo/bin/python` to verify construction.
+Unit tests cover the provider surface and exclude behavior for
+`.context` and `.venvs`.
+
+---

--- a/libs/agno/agno/context/fs/provider.py
+++ b/libs/agno/agno/context/fs/provider.py
@@ -34,10 +34,12 @@ class FilesystemContextProvider(ContextProvider):
         instructions: str | None = None,
         mode: ContextMode = ContextMode.default,
         model: Model | None = None,
+        exclude_patterns: list[str] | None = None,
     ) -> None:
         super().__init__(id=id, name=name, mode=mode, model=model)
         self.root = Path(root).expanduser().resolve()
         self.instructions_text = instructions if instructions is not None else DEFAULT_FS_INSTRUCTIONS
+        self.exclude_patterns = exclude_patterns
         self._agent: Agent | None = None
 
     def status(self) -> Status:
@@ -80,7 +82,7 @@ class FilesystemContextProvider(ContextProvider):
         return [self._query_tool()]
 
     def _all_tools(self) -> list:
-        return [_build_file_tools(self.root)]
+        return [_build_file_tools(self.root, exclude_patterns=self.exclude_patterns)]
 
     # ------------------------------------------------------------------
     # Sub-agent — built lazily for agent mode and programmatic query()
@@ -97,12 +99,12 @@ class FilesystemContextProvider(ContextProvider):
             name=self.name,
             model=self.model,
             instructions=self.instructions_text.replace("{root}", str(self.root)),
-            tools=[_build_file_tools(self.root)],
+            tools=[_build_file_tools(self.root, exclude_patterns=self.exclude_patterns)],
             markdown=True,
         )
 
 
-def _build_file_tools(root: Path) -> FileTools:
+def _build_file_tools(root: Path, *, exclude_patterns: list[str] | None = None) -> FileTools:
     return FileTools(
         base_dir=root,
         enable_save_file=False,
@@ -113,6 +115,7 @@ def _build_file_tools(root: Path) -> FileTools:
         enable_search_content=True,
         enable_read_file=True,
         enable_read_file_chunk=True,
+        exclude_patterns=exclude_patterns,
     )
 
 
@@ -128,6 +131,8 @@ Workflow:
 4. **Cite the paths.** Every claim points to a file path relative to the
    root. When quoting, use the exact text from the file — don't paraphrase.
    If the path you cite is a file you didn't actually read, note that.
+5. **Ignore generated noise.** Virtualenvs, dependency directories, build
+   outputs, caches, and agent scratch folders are excluded by default.
 
 You are read-only. No save, no delete. If a query doesn't match any
 file, say so plainly — don't guess at filenames.

--- a/libs/agno/agno/context/workspace/__init__.py
+++ b/libs/agno/agno/context/workspace/__init__.py
@@ -1,0 +1,3 @@
+from agno.context.workspace.provider import DEFAULT_WORKSPACE_INSTRUCTIONS, WorkspaceContextProvider
+
+__all__ = ["DEFAULT_WORKSPACE_INSTRUCTIONS", "WorkspaceContextProvider"]

--- a/libs/agno/agno/context/workspace/provider.py
+++ b/libs/agno/agno/context/workspace/provider.py
@@ -1,0 +1,138 @@
+"""
+Workspace Context Provider
+==========================
+
+Exposes a local project workspace via a read-only `Workspace` toolkit.
+The provider is intended for repository roots and other working trees
+where dependency directories, build outputs, and agent scratch folders
+should be ignored by default.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from agno.agent import Agent
+from agno.context._utils import answer_from_run
+from agno.context.mode import ContextMode
+from agno.context.provider import Answer, ContextProvider, Status
+from agno.run import RunContext
+from agno.tools.workspace import DEFAULT_EXCLUDE_PATTERNS, Workspace
+
+if TYPE_CHECKING:
+    from agno.models.base import Model
+
+
+class WorkspaceContextProvider(ContextProvider):
+    """Project-aware local workspace rooted at a single directory."""
+
+    def __init__(
+        self,
+        root: str | Path | None = None,
+        *,
+        id: str = "workspace",
+        name: str = "Workspace",
+        instructions: str | None = None,
+        mode: ContextMode = ContextMode.default,
+        model: Model | None = None,
+        exclude_patterns: list[str] | None = None,
+        max_file_lines: int = 100_000,
+        max_file_length: int = 10_000_000,
+    ) -> None:
+        super().__init__(id=id, name=name, mode=mode, model=model)
+        self.root = Path(root).expanduser().resolve() if root is not None else Path.cwd().resolve()
+        self.instructions_text = instructions if instructions is not None else DEFAULT_WORKSPACE_INSTRUCTIONS
+        self.exclude_patterns = exclude_patterns if exclude_patterns is not None else list(DEFAULT_EXCLUDE_PATTERNS)
+        self.max_file_lines = max_file_lines
+        self.max_file_length = max_file_length
+        self._agent: Agent | None = None
+
+    def status(self) -> Status:
+        if not self.root.exists():
+            return Status(ok=False, detail=f"root does not exist: {self.root}")
+        if not self.root.is_dir():
+            return Status(ok=False, detail=f"root is not a directory: {self.root}")
+        return Status(ok=True, detail=str(self.root))
+
+    async def astatus(self) -> Status:
+        return self.status()
+
+    def query(self, question: str, *, run_context: RunContext | None = None) -> Answer:
+        kwargs = self._run_kwargs_for_sub_agent(run_context)
+        return answer_from_run(self._ensure_agent().run(question, **kwargs))
+
+    async def aquery(self, question: str, *, run_context: RunContext | None = None) -> Answer:
+        kwargs = self._run_kwargs_for_sub_agent(run_context)
+        return answer_from_run(await self._ensure_agent().arun(question, **kwargs))
+
+    def instructions(self) -> str:
+        if self.mode == ContextMode.tools:
+            return (
+                f"`{self.name}`: inspect project files under {self.root}. Use read-only "
+                "`list_files`, `search_content`, and `read_file`. Paths are relative to "
+                "the workspace root; common dependency, build, and agent scratch folders "
+                "are excluded."
+            )
+        return (
+            f"`{self.name}`: call `{self.query_tool_name}(question)` to inspect project "
+            f"files under {self.root}. Common dependency, build, and agent scratch folders "
+            "are excluded."
+        )
+
+    # ------------------------------------------------------------------
+    # Mode resolution
+    # ------------------------------------------------------------------
+
+    def _default_tools(self) -> list:
+        return [self._query_tool()]
+
+    def _all_tools(self) -> list:
+        return [self._build_workspace_tools()]
+
+    # ------------------------------------------------------------------
+    # Sub-agent
+    # ------------------------------------------------------------------
+
+    def _ensure_agent(self) -> Agent:
+        if self._agent is None:
+            self._agent = self._build_agent()
+        return self._agent
+
+    def _build_agent(self) -> Agent:
+        return Agent(
+            id=self.id,
+            name=self.name,
+            model=self.model,
+            instructions=self.instructions_text.replace("{root}", str(self.root)),
+            tools=[self._build_workspace_tools()],
+            markdown=True,
+        )
+
+    def _build_workspace_tools(self) -> Workspace:
+        return Workspace(
+            root=self.root,
+            allowed=Workspace.READ_TOOLS,
+            exclude_patterns=list(self.exclude_patterns),
+            max_file_lines=self.max_file_lines,
+            max_file_length=self.max_file_length,
+        )
+
+
+DEFAULT_WORKSPACE_INSTRUCTIONS = """\
+You answer questions by inspecting project files under {root}.
+
+Workflow:
+1. **Map the workspace first.** Use `list_files(recursive=True)` with a
+   modest `max_depth` to identify likely source, docs, and cookbook paths.
+2. **Search narrowly.** Use `search_content(query, directory=...)` once you
+   know the relevant subtree. Avoid whole-workspace searches unless the user
+   asks for a broad audit.
+3. **Read before citing.** Use `read_file(path)` or a line range for the
+   files you rely on. Cite paths relative to the workspace root.
+4. **Ignore generated noise.** Dependency directories, virtualenvs, build
+   outputs, caches, and agent scratch folders are excluded by default.
+
+You are read-only. No save, edit, delete, move, or shell tools are available.
+If a query does not match any project file, say so plainly.
+"""

--- a/libs/agno/agno/tools/_local_file_utils.py
+++ b/libs/agno/agno/tools/_local_file_utils.py
@@ -1,0 +1,87 @@
+"""Shared helpers for local filesystem-oriented tools."""
+
+from __future__ import annotations
+
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Sequence
+
+DEFAULT_EXCLUDE_PATTERNS = [
+    # Agent and local scratch state
+    ".context",
+    ".conductor",
+    ".claude",
+    ".codex",
+    ".cursor",
+    # Environments and secrets
+    ".venv",
+    ".venvs",
+    "venv",
+    ".env*",
+    "*.env",
+    # Version control
+    ".git",
+    ".hg",
+    ".svn",
+    # Python caches and build artifacts
+    "__pycache__",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".pytest_cache",
+    ".tox",
+    ".nox",
+    ".ipynb_checkpoints",
+    "dist",
+    "build",
+    "*.egg-info",
+    # JavaScript and TypeScript
+    "node_modules",
+    ".next",
+    ".turbo",
+    ".nuxt",
+    ".svelte-kit",
+    ".docusaurus",
+    ".parcel-cache",
+    ".nyc_output",
+    "*.tsbuildinfo",
+    ".serverless",
+    # JVM (Java, Kotlin, Android, Gradle)
+    ".gradle",
+    ".kotlin",
+    "*.class",
+    # Dart and Flutter
+    ".dart_tool",
+    ".flutter-plugins",
+    ".flutter-plugins-dependencies",
+    # Swift and Xcode
+    ".build",
+    "xcuserdata",
+    "*.xcuserstate",
+    # Ruby
+    ".bundle",
+    "*.gem",
+    ".yardoc",
+    # Elixir
+    "_build",
+    ".elixir_ls",
+    # .NET / Visual Studio
+    ".vs",
+    # Infrastructure as Code
+    ".terraform",
+    "*.tfstate",
+    "*.tfstate.*",
+    ".terragrunt-cache",
+    # OS artifacts
+    ".DS_Store",
+]
+
+
+def path_matches_exclude(path: Path, root: Path, exclude_patterns: Sequence[str]) -> bool:
+    """Return True when any path component matches an exclude pattern."""
+    if not exclude_patterns:
+        return False
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        return False
+    return any(fnmatch(part, pattern) for part in rel.parts for pattern in exclude_patterns)

--- a/libs/agno/agno/tools/file.py
+++ b/libs/agno/agno/tools/file.py
@@ -1,10 +1,10 @@
 import json
 import os
-from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
 
 from agno.tools import Toolkit
+from agno.tools._local_file_utils import DEFAULT_EXCLUDE_PATTERNS, path_matches_exclude
 from agno.utils.log import log_debug, log_error
 
 TEXT_EXTENSIONS = {
@@ -28,68 +28,6 @@ TEXT_EXTENSIONS = {
     ".log",
     ".rst",
 }
-
-DEFAULT_EXCLUDE_PATTERNS = [
-    # Environments and secrets
-    ".venv",
-    "venv",
-    ".env*",
-    "*.env",
-    # Version control
-    ".git",
-    ".hg",
-    ".svn",
-    # Python caches and build artifacts
-    "__pycache__",
-    ".mypy_cache",
-    ".ruff_cache",
-    ".pytest_cache",
-    ".tox",
-    ".nox",
-    ".ipynb_checkpoints",
-    "dist",
-    "build",
-    "*.egg-info",
-    # JavaScript and TypeScript
-    "node_modules",
-    ".next",
-    ".turbo",
-    ".nuxt",
-    ".svelte-kit",
-    ".docusaurus",
-    ".parcel-cache",
-    ".nyc_output",
-    "*.tsbuildinfo",
-    ".serverless",
-    # JVM (Java, Kotlin, Android, Gradle)
-    ".gradle",
-    ".kotlin",
-    "*.class",
-    # Dart and Flutter
-    ".dart_tool",
-    ".flutter-plugins",
-    ".flutter-plugins-dependencies",
-    # Swift and Xcode
-    ".build",
-    "xcuserdata",
-    "*.xcuserstate",
-    # Ruby
-    ".bundle",
-    "*.gem",
-    ".yardoc",
-    # Elixir
-    "_build",
-    ".elixir_ls",
-    # .NET / Visual Studio
-    ".vs",
-    # Infrastructure as Code (state files hidden by default for security)
-    ".terraform",
-    "*.tfstate",
-    "*.tfstate.*",
-    ".terragrunt-cache",
-    # OS artifacts
-    ".DS_Store",
-]
 
 
 def _format_size(size: int) -> str:
@@ -122,8 +60,9 @@ class FileTools(Toolkit):
     """Toolkit for read/write access to a local directory tree.
 
     By default, results from ``list_files``, ``search_files``, and ``search_content``
-    skip common noise directories (``.venv``, ``.git``, ``__pycache__``,
-    ``node_modules``, etc.). See ``DEFAULT_EXCLUDE_PATTERNS`` for the full list.
+    skip common noise directories (``.venv``, ``.venvs``, ``.context``,
+    ``.git``, ``__pycache__``, ``node_modules``, etc.). See
+    ``DEFAULT_EXCLUDE_PATTERNS`` for the full list.
 
     To customize:
     - Pass ``exclude_patterns=[...]`` with your own list of fnmatch-style patterns.
@@ -188,13 +127,7 @@ class FileTools(Toolkit):
 
     def _is_excluded(self, path: Path) -> bool:
         """Return True if any component of ``path`` (relative to ``base_dir``) matches an exclude pattern."""
-        if not self.exclude_patterns:
-            return False
-        try:
-            rel = path.relative_to(self.base_dir)
-        except ValueError:
-            return False
-        return any(fnmatch(part, pattern) for part in rel.parts for pattern in self.exclude_patterns)
+        return path_matches_exclude(path, self.base_dir, self.exclude_patterns)
 
     def check_escape(self, relative_path: str) -> Tuple[bool, Path]:
         """Check if the file path is within the base directory.

--- a/libs/agno/agno/tools/workspace.py
+++ b/libs/agno/agno/tools/workspace.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 from agno.tools import Toolkit
+from agno.tools._local_file_utils import DEFAULT_EXCLUDE_PATTERNS, path_matches_exclude
 from agno.utils.log import log_debug, log_error, log_info, log_warning
 
 TEXT_EXTENSIONS = {
@@ -133,68 +134,6 @@ TEXT_EXTENSIONS = {
     ".bzl",
 }
 
-DEFAULT_EXCLUDE_PATTERNS = [
-    # Environments and secrets
-    ".venv",
-    "venv",
-    ".env*",
-    "*.env",
-    # Version control
-    ".git",
-    ".hg",
-    ".svn",
-    # Python caches and build artifacts
-    "__pycache__",
-    ".mypy_cache",
-    ".ruff_cache",
-    ".pytest_cache",
-    ".tox",
-    ".nox",
-    ".ipynb_checkpoints",
-    "dist",
-    "build",
-    "*.egg-info",
-    # JavaScript and TypeScript
-    "node_modules",
-    ".next",
-    ".turbo",
-    ".nuxt",
-    ".svelte-kit",
-    ".docusaurus",
-    ".parcel-cache",
-    ".nyc_output",
-    "*.tsbuildinfo",
-    ".serverless",
-    # JVM (Java, Kotlin, Android, Gradle)
-    ".gradle",
-    ".kotlin",
-    "*.class",
-    # Dart and Flutter
-    ".dart_tool",
-    ".flutter-plugins",
-    ".flutter-plugins-dependencies",
-    # Swift and Xcode
-    ".build",
-    "xcuserdata",
-    "*.xcuserstate",
-    # Ruby
-    ".bundle",
-    "*.gem",
-    ".yardoc",
-    # Elixir
-    "_build",
-    ".elixir_ls",
-    # .NET / Visual Studio
-    ".vs",
-    # Infrastructure as Code
-    ".terraform",
-    "*.tfstate",
-    "*.tfstate.*",
-    ".terragrunt-cache",
-    # OS artifacts
-    ".DS_Store",
-]
-
 # Strips ANSI CSI sequences (color codes, cursor moves) from terminal output.
 _ANSI_RE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
@@ -284,8 +223,9 @@ class Workspace(Toolkit):
       and the surface is exactly what you specified.
 
     Listing results from ``list_files`` and ``search_content`` skip common noise directories
-    (``.venv``, ``.git``, ``__pycache__``, ``node_modules``, etc.) by default. Pass
-    ``exclude_patterns=[]`` to disable, or ``exclude_patterns=[...]`` to override.
+    (``.venv``, ``.venvs``, ``.context``, ``.git``, ``__pycache__``,
+    ``node_modules``, etc.) by default. Pass ``exclude_patterns=[]`` to disable,
+    or ``exclude_patterns=[...]`` to override.
 
     Optional ``require_read_before_write=True`` blocks ``write_file`` / ``edit_file`` /
     ``move_file`` / ``delete_file`` on existing files until the agent has read them in
@@ -423,13 +363,7 @@ class Workspace(Toolkit):
 
     def _is_excluded(self, path: Path) -> bool:
         """Return True if any component of ``path`` (relative to ``root``) matches an exclude pattern."""
-        if not self.exclude_patterns:
-            return False
-        try:
-            rel = path.relative_to(self.root)
-        except ValueError:
-            return False
-        return any(fnmatch(part, pattern) for part in rel.parts for pattern in self.exclude_patterns)
+        return path_matches_exclude(path, self.root, self.exclude_patterns)
 
     def _check_read_before_write(self, file_path: Path, op: str) -> Optional[str]:
         """If require_read_before_write is on, verify the file was read this session.
@@ -526,8 +460,8 @@ class Workspace(Toolkit):
         ``size`` is a human-readable string for files and ``null`` for directories.
 
         For tree-style exploration of a project use ``recursive=True`` (defaults to
-        depth 3). Default-excluded directories (``.venv``, ``.git``, ``node_modules``,
-        etc.) are always pruned.
+        depth 3). Default-excluded directories (``.venv``, ``.venvs``,
+        ``.context``, ``.git``, ``node_modules``, etc.) are always pruned.
 
         :param directory: Subdirectory relative to the workspace root (default ".").
         :param pattern: Optional glob pattern to filter by (e.g. ``"*.py"``). When

--- a/libs/agno/tests/unit/context/test_providers.py
+++ b/libs/agno/tests/unit/context/test_providers.py
@@ -7,6 +7,7 @@ The full end-to-end behaviour is covered by the cookbooks.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -16,8 +17,10 @@ from agno.context.database import DatabaseContextProvider
 from agno.context.fs import FilesystemContextProvider
 from agno.context.gdrive import GDriveContextProvider
 from agno.context.mcp import MCPContextProvider
+from agno.context.mode import ContextMode
 from agno.context.slack import SlackContextProvider
 from agno.context.web import ExaBackend, ExaMCPBackend, ParallelMCPBackend, WebContextProvider
+from agno.context.workspace import WorkspaceContextProvider
 
 # ---------------------------------------------------------------------------
 # Filesystem
@@ -52,6 +55,75 @@ def test_fs_default_surface_is_single_query_tool(tmp_path: Path):
     p = FilesystemContextProvider(root=tmp_path, id="docs")
     tools = p.get_tools()
     assert [t.name for t in tools] == ["query_docs"]
+
+
+def test_fs_provider_can_opt_out_of_default_excludes(tmp_path: Path):
+    hidden = tmp_path / ".context"
+    hidden.mkdir()
+    (hidden / "note.py").write_text("# marker")
+
+    p = FilesystemContextProvider(root=tmp_path, mode=ContextMode.tools, exclude_patterns=[])
+    file_tools = p.get_tools()[0]
+    result = json.loads(file_tools.search_content("marker"))
+    assert result["matches_found"] == 1
+    assert result["files"][0]["file"] == ".context/note.py"
+
+
+# ---------------------------------------------------------------------------
+# Workspace
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_status_ok_for_existing_dir(tmp_path: Path):
+    p = WorkspaceContextProvider(root=tmp_path)
+    status = p.status()
+    assert status.ok is True
+    assert str(tmp_path) in status.detail
+
+
+def test_workspace_status_reports_missing_root(tmp_path: Path):
+    missing = tmp_path / "does-not-exist"
+    p = WorkspaceContextProvider(root=missing)
+    status = p.status()
+    assert status.ok is False
+    assert "does not exist" in status.detail
+
+
+def test_workspace_status_reports_non_directory(tmp_path: Path):
+    file_ = tmp_path / "a.txt"
+    file_.write_text("hi")
+    p = WorkspaceContextProvider(root=file_)
+    status = p.status()
+    assert status.ok is False
+    assert "not a directory" in status.detail
+
+
+def test_workspace_default_surface_is_single_query_tool(tmp_path: Path):
+    p = WorkspaceContextProvider(root=tmp_path, id="project")
+    tools = p.get_tools()
+    assert [t.name for t in tools] == ["query_project"]
+
+
+def test_workspace_tools_mode_is_read_only(tmp_path: Path):
+    p = WorkspaceContextProvider(root=tmp_path, mode=ContextMode.tools)
+    workspace = p.get_tools()[0]
+    assert sorted(workspace.functions.keys()) == ["list_files", "read_file", "search_content"]
+
+
+def test_workspace_context_excludes_agent_scratch_and_plural_venvs(tmp_path: Path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("# marker")
+    (tmp_path / ".context").mkdir()
+    (tmp_path / ".context" / "notes.py").write_text("# marker")
+    venvs_pkg = tmp_path / ".venvs" / "demo" / "lib"
+    venvs_pkg.mkdir(parents=True)
+    (venvs_pkg / "installed.py").write_text("# marker")
+
+    p = WorkspaceContextProvider(root=tmp_path, mode=ContextMode.tools)
+    workspace = p.get_tools()[0]
+    result = json.loads(workspace.search_content("marker", limit=10))
+    assert result["matches_found"] == 1
+    assert result["files"][0]["file"] == "src/app.py"
 
 
 # ---------------------------------------------------------------------------

--- a/libs/agno/tests/unit/tools/test_filetools.py
+++ b/libs/agno/tests/unit/tools/test_filetools.py
@@ -327,6 +327,25 @@ def test_default_excludes_env_family():
         assert listed == ["env.yaml", "environment.py", "keep.txt"]
 
 
+def test_default_excludes_agent_scratch_and_plural_venvs():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        base_dir = Path(tmp_dir)
+        file_tools = FileTools(base_dir=base_dir)
+
+        (base_dir / "real.py").write_text("# TODO: real work")
+        scratch = base_dir / ".context"
+        scratch.mkdir()
+        (scratch / "notes.py").write_text("# TODO: scratch")
+        venvs_pkg = base_dir / ".venvs" / "demo" / "lib"
+        venvs_pkg.mkdir(parents=True)
+        (venvs_pkg / "installed.py").write_text("# TODO: dependency")
+
+        result = json.loads(file_tools.search_content(query="TODO", limit=10))
+        file_names = [m["file"] for m in result["files"]]
+        assert result["matches_found"] == 1
+        assert file_names == ["real.py"]
+
+
 def test_search_content_honors_exclusions():
     """search_content should not return matches inside excluded directories."""
     with tempfile.TemporaryDirectory() as tmp_dir:

--- a/libs/agno/tests/unit/tools/test_workspace.py
+++ b/libs/agno/tests/unit/tools/test_workspace.py
@@ -394,6 +394,23 @@ def test_search_content_skips_excluded_dirs():
         assert not any(".venv" in f for f in names)
 
 
+def test_search_content_skips_agent_scratch_and_plural_venvs():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        ws = Workspace(tmp_dir)
+        base = Path(tmp_dir)
+        (base / "real.py").write_text("# TODO: real work")
+        (base / ".context").mkdir()
+        (base / ".context" / "notes.py").write_text("# TODO: scratch")
+        venvs_pkg = base / ".venvs" / "demo" / "lib"
+        venvs_pkg.mkdir(parents=True)
+        (venvs_pkg / "installed.py").write_text("# TODO: dependency")
+
+        result = json.loads(ws.search_content(query="TODO", limit=10))
+        names = [m["file"] for m in result["files"]]
+        assert result["matches_found"] == 1
+        assert names == ["real.py"]
+
+
 def test_search_content_empty_query():
     with tempfile.TemporaryDirectory() as tmp_dir:
         ws = Workspace(tmp_dir)


### PR DESCRIPTION
## Summary

Adds a project-aware `WorkspaceContextProvider` for repository roots, backed by the read-only `Workspace` toolkit instead of generic `FileTools`.

Also centralizes local filesystem exclude patterns so both `FileTools` and `Workspace` skip `.context`, `.venvs`, and other agent/dependency/build noise by default. `FilesystemContextProvider` now accepts `exclude_patterns` for explicit opt-out/customization.

(If applicable, issue number: #____)

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Verification run:

- `./scripts/format.sh` passed
- `pytest libs/agno/tests/unit/tools/test_filetools.py libs/agno/tests/unit/tools/test_workspace.py libs/agno/tests/unit/context/test_providers.py -q` passed: 145 tests
- `PYTHONPATH=libs/agno .venvs/demo/bin/python -c "import runpy; runpy.run_path('cookbook/12_context/12_workspace.py', run_name='cookbook_12_workspace')"` passed
- Targeted mypy on changed modules passed
- `./scripts/validate.sh` was run; ruff passed, but repo-level mypy still reports pre-existing failures in `libs/agno/agno/tools/sql.py`, `libs/agno/agno/tools/slack.py`, and `libs/agno/agno/tools/google/drive.py`

This is separate from #7706 (`codex/slack-context-briefing-design`). Once this provider lands, the engineering briefing cookbook can use `WorkspaceContextProvider` instead of `FilesystemContextProvider` for repository-root context.
