### PR TITLE
fix: run ChromaDb sync operations in thread for async methods

### DIFF
--- a/libs/agno/agno/vectordb/chroma/chromadb.py
+++ b/libs/agno/agno/vectordb/chroma/chromadb.py
@@ -465,7 +465,8 @@ class ChromaDb(VectorDb):
         if self._collection is None:
             logger.warning("Collection does not exist")
         else:
-            self._batch_operation(
+            await asyncio.to_thread(
+                self._batch_operation,
                 ids=ids,
                 embeddings=docs_embeddings,
                 documents=docs,
@@ -656,7 +657,8 @@ class ChromaDb(VectorDb):
         if self._collection is None:
             logger.warning("Collection does not exist")
         else:
-            self._batch_operation(
+            await asyncio.to_thread(
+                self._batch_operation,
                 ids=ids,
                 embeddings=docs_embeddings,
                 documents=docs,
@@ -670,8 +672,8 @@ class ChromaDb(VectorDb):
     ) -> None:
         """Upsert documents asynchronously by running in a thread."""
         try:
-            if self.content_hash_exists(content_hash):
-                self._delete_by_content_hash(content_hash)
+            if await asyncio.to_thread(self.content_hash_exists, content_hash):
+                await asyncio.to_thread(self._delete_by_content_hash, content_hash)
             await self._async_upsert(content_hash, documents, filters)
         except Exception:
             logger.exception("Error upserting documents by content hash")


### PR DESCRIPTION
Fixes #7712

### Root Cause

`async_insert` and `_async_upsert` call the synchronous `_batch_operation` (which invokes ChromaDB's Rust bindings) directly on the asyncio event loop, blocking all concurrent coroutines. Additionally, `async_upsert` calls `content_hash_exists` and `_delete_by_content_hash` synchronously.

Other async methods in the same file (`async_create`, `async_search`, `async_drop`, `async_exists`) correctly use `asyncio.to_thread()` — these three were the only ones missing.

### Fix

Wrap all blocking calls with `asyncio.to_thread()`:
- `async_insert`: `_batch_operation` → `await asyncio.to_thread(self._batch_operation, ...)`
- `_async_upsert`: `_batch_operation` → `await asyncio.to_thread(self._batch_operation, ...)`
- `async_upsert`: `content_hash_exists` and `_delete_by_content_hash` → `await asyncio.to_thread(...)`