### PR TITLE
fix: preserve Gemini unknown error context

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -63,6 +63,14 @@ except ImportError:
     ToolParallelAiSearch = None
 
 
+def _format_unknown_gemini_error(error: Exception) -> str:
+    error_message = str(error).strip()
+    error_type = type(error).__name__
+    if error_message:
+        return f"{error_type}: {error_message}"
+    return error_type
+
+
 @dataclass
 class Gemini(Model):
     """
@@ -567,8 +575,9 @@ class Gemini(Model):
         except RetryableModelProviderError:
             raise
         except Exception as e:
-            log_error(f"Unknown error from Gemini API: {str(e)}")
-            raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
+            error_message = _format_unknown_gemini_error(e)
+            log_error(f"Unknown error from Gemini API: {error_message}")
+            raise ModelProviderError(message=error_message, model_name=self.name, model_id=self.id) from e
 
     def invoke_stream(
         self,
@@ -621,8 +630,9 @@ class Gemini(Model):
         except RetryableModelProviderError:
             raise
         except Exception as e:
-            log_error(f"Unknown error from Gemini API: {str(e)}")
-            raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
+            error_message = _format_unknown_gemini_error(e)
+            log_error(f"Unknown error from Gemini API: {error_message}")
+            raise ModelProviderError(message=error_message, model_name=self.name, model_id=self.id) from e
 
     async def ainvoke(
         self,
@@ -680,8 +690,9 @@ class Gemini(Model):
         except RetryableModelProviderError:
             raise
         except Exception as e:
-            log_error(f"Unknown error from Gemini API: {str(e)}")
-            raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
+            error_message = _format_unknown_gemini_error(e)
+            log_error(f"Unknown error from Gemini API: {error_message}")
+            raise ModelProviderError(message=error_message, model_name=self.name, model_id=self.id) from e
 
     async def ainvoke_stream(
         self,
@@ -737,8 +748,9 @@ class Gemini(Model):
         except RetryableModelProviderError:
             raise
         except Exception as e:
-            log_error(f"Unknown error from Gemini API: {str(e)}")
-            raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
+            error_message = _format_unknown_gemini_error(e)
+            log_error(f"Unknown error from Gemini API: {error_message}")
+            raise ModelProviderError(message=error_message, model_name=self.name, model_id=self.id) from e
 
     def _format_messages(self, messages: List[Message], compress_tool_results: bool = False):
         """

--- a/libs/agno/tests/unit/models/google/test_gemini.py
+++ b/libs/agno/tests/unit/models/google/test_gemini.py
@@ -1,9 +1,10 @@
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from agno.exceptions import ModelProviderError
 from agno.media import File
 from agno.models.google.gemini import Gemini
 from agno.models.message import Message
@@ -52,6 +53,76 @@ def test_gemini_get_client_ai_studio_mode():
         assert "credentials" not in kwargs
         assert "api_key" in kwargs
         assert kwargs.get("vertexai") is not True
+
+
+def test_gemini_unknown_error_includes_type_when_message_is_empty():
+    model = Gemini(api_key="test-key")
+    client = MagicMock()
+    client.models.generate_content.side_effect = TimeoutError()
+
+    with patch.object(model, "get_client", return_value=client):
+        with pytest.raises(ModelProviderError) as exc_info:
+            model.invoke([Message(role="user", content="Hello")], Message(role="assistant"))
+
+    assert exc_info.value.message == "TimeoutError"
+    assert isinstance(exc_info.value.__cause__, TimeoutError)
+
+
+def test_gemini_unknown_error_includes_type_and_message():
+    model = Gemini(api_key="test-key")
+    client = MagicMock()
+    client.models.generate_content.side_effect = RuntimeError("connection reset")
+
+    with patch.object(model, "get_client", return_value=client):
+        with pytest.raises(ModelProviderError) as exc_info:
+            model.invoke([Message(role="user", content="Hello")], Message(role="assistant"))
+
+    assert exc_info.value.message == "RuntimeError: connection reset"
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+def test_gemini_stream_unknown_error_includes_type_when_message_is_empty():
+    model = Gemini(api_key="test-key")
+    client = MagicMock()
+    client.models.generate_content_stream.side_effect = TimeoutError()
+
+    with patch.object(model, "get_client", return_value=client):
+        with pytest.raises(ModelProviderError) as exc_info:
+            list(model.invoke_stream([Message(role="user", content="Hello")], Message(role="assistant")))
+
+    assert exc_info.value.message == "TimeoutError"
+    assert isinstance(exc_info.value.__cause__, TimeoutError)
+
+
+@pytest.mark.asyncio
+async def test_gemini_async_unknown_error_includes_type_when_message_is_empty():
+    model = Gemini(api_key="test-key")
+    client = MagicMock()
+    client.aio.models.generate_content = AsyncMock(side_effect=TimeoutError())
+
+    with patch.object(model, "get_client", return_value=client):
+        with pytest.raises(ModelProviderError) as exc_info:
+            await model.ainvoke([Message(role="user", content="Hello")], Message(role="assistant"))
+
+    assert exc_info.value.message == "TimeoutError"
+    assert isinstance(exc_info.value.__cause__, TimeoutError)
+
+
+@pytest.mark.asyncio
+async def test_gemini_async_stream_unknown_error_includes_type_when_message_is_empty():
+    model = Gemini(api_key="test-key")
+    client = MagicMock()
+    client.aio.models.generate_content_stream = AsyncMock(side_effect=TimeoutError())
+
+    with patch.object(model, "get_client", return_value=client):
+        with pytest.raises(ModelProviderError) as exc_info:
+            async for _ in model.ainvoke_stream(
+                [Message(role="user", content="Hello")], Message(role="assistant")
+            ):
+                pass
+
+    assert exc_info.value.message == "TimeoutError"
+    assert isinstance(exc_info.value.__cause__, TimeoutError)
 
 
 class TestFormatFileForMessage:


### PR DESCRIPTION
## Summary

- preserve the exception type when Gemini's generic error handler wraps exceptions whose `str(error)` is empty
- apply the same formatting in sync, streaming, async, and async-streaming Gemini invoke paths
- add regression tests for silent `TimeoutError` wrapping and non-empty generic errors

Fixes #7600.

## Validation

- `libs/agno/.venv/bin/python -m pytest libs/agno/tests/unit/models/google/test_gemini.py -q`
- `libs/agno/.venv/bin/ruff check libs/agno/agno/models/google/gemini.py libs/agno/tests/unit/models/google/test_gemini.py`
