### PR TITLE
fix: create E2B sandbox lazily

### DIFF
--- a/libs/agno/agno/tools/e2b.py
+++ b/libs/agno/agno/tools/e2b.py
@@ -41,15 +41,10 @@ class E2BTools(Toolkit):
         if not self.api_key:
             raise ValueError("E2B_API_KEY not set. Please set the E2B_API_KEY environment variable.")
 
-        # Create the sandbox once and reuse it
+        # Create the sandbox lazily on first use and reuse it.
+        self.timeout = timeout
         self.sandbox_options = sandbox_options or {}
-
-        # According to official docs, the parameter is 'timeout' (in seconds), not 'timeout_ms'
-        try:
-            self.sandbox = Sandbox.create(api_key=self.api_key, timeout=timeout, **self.sandbox_options)
-        except Exception as e:
-            logger.exception("Warning: Could not create sandbox")
-            raise e
+        self._sandbox = None
 
         # Last execution result for reference
         self.last_execution = None
@@ -84,6 +79,21 @@ class E2BTools(Toolkit):
         ]
 
         super().__init__(name="e2b_tools", tools=tools, **kwargs)
+
+    @property
+    def sandbox(self):
+        if self._sandbox is None:
+            # According to official docs, the parameter is 'timeout' (in seconds), not 'timeout_ms'
+            try:
+                self._sandbox = Sandbox.create(api_key=self.api_key, timeout=self.timeout, **self.sandbox_options)
+            except Exception as e:
+                logger.exception("Warning: Could not create sandbox")
+                raise e
+        return self._sandbox
+
+    @sandbox.setter
+    def sandbox(self, value):
+        self._sandbox = value
 
     # Code Execution Functions
     def run_python_code(self, code: str) -> str:
@@ -662,7 +672,10 @@ class E2BTools(Toolkit):
             str: Success message or error message
         """
         try:
+            if self._sandbox is None:
+                return json.dumps({"status": "success", "message": "No sandbox has been created yet"})
             cont = self.sandbox.kill()
+            self._sandbox = None
             return json.dumps({"status": "success", "message": "Sandbox shut down successfully", "content": cont})
         except Exception as e:
             return json.dumps({"status": "error", "message": f"Error shutting down sandbox: {str(e)}"})

--- a/libs/agno/tests/unit/tools/test_e2b.py
+++ b/libs/agno/tests/unit/tools/test_e2b.py
@@ -1,5 +1,6 @@
 """Unit tests for E2BTools class."""
 
+import json
 import os
 import sys
 from unittest.mock import Mock, patch
@@ -105,6 +106,51 @@ def test_init_with_env_var():
         with patch.dict("os.environ", {"E2B_API_KEY": TEST_API_KEY}):
             tools = E2BTools()
             assert tools.api_key == TEST_API_KEY
+
+
+def test_init_does_not_create_sandbox():
+    """Test that initialization does not eagerly allocate a sandbox."""
+    with patch("agno.tools.e2b.Sandbox") as mock_sandbox_class:
+        tools = E2BTools(api_key=TEST_API_KEY)
+
+        assert tools._sandbox is None
+        mock_sandbox_class.create.assert_not_called()
+
+
+def test_run_python_code_creates_sandbox_once():
+    """Test that the sandbox is created lazily and then reused."""
+    with patch("agno.tools.e2b.Sandbox") as mock_sandbox_class:
+        mock_sandbox = Mock()
+        mock_sandbox.run_code.return_value = Mock(error=None, logs=[], results=[])
+        mock_sandbox_class.create.return_value = mock_sandbox
+        tools = E2BTools(
+            api_key=TEST_API_KEY,
+            timeout=123,
+            sandbox_options={"template": "python"},
+        )
+
+        result = tools.run_python_code("print('hello')")
+        assert result == "Code executed successfully with no output."
+        mock_sandbox_class.create.assert_called_once_with(
+            api_key=TEST_API_KEY,
+            timeout=123,
+            template="python",
+        )
+
+        tools.run_python_code("print('again')")
+        mock_sandbox_class.create.assert_called_once()
+
+
+def test_shutdown_before_use_does_not_create_sandbox():
+    """Test that shutdown is a no-op when no sandbox has been created yet."""
+    with patch("agno.tools.e2b.Sandbox") as mock_sandbox_class:
+        tools = E2BTools(api_key=TEST_API_KEY)
+
+        result = json.loads(tools.shutdown_sandbox())
+
+        assert result["status"] == "success"
+        assert result["message"] == "No sandbox has been created yet"
+        mock_sandbox_class.create.assert_not_called()
 
 
 def test_init_without_api_key():


### PR DESCRIPTION
## Summary

- make `E2BTools` create its sandbox lazily on first use instead of during toolkit construction
- keep the existing `sandbox` access point backed by a reusable lazy property
- make `shutdown_sandbox()` a no-op when no sandbox has been created yet so shutdown does not allocate one
- add unit coverage for lazy initialization, sandbox reuse, and shutdown-before-use

Fixes #7215.

## Validation

- `libs/agno/.venv/bin/python -m pytest libs/agno/tests/unit/tools/test_e2b.py -q`
- `libs/agno/.venv/bin/ruff check libs/agno/agno/tools/e2b.py libs/agno/tests/unit/tools/test_e2b.py`
