### PR TITLE
fix: preserve MCP tool result metadata

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -1335,3 +1335,4 @@ class ToolResult(BaseModel):
     videos: Optional[List[Video]] = None
     audios: Optional[List[Audio]] = None
     files: Optional[List[File]] = None
+    meta: Optional[Dict[str, Any]] = None

--- a/libs/agno/agno/utils/mcp.py
+++ b/libs/agno/agno/utils/mcp.py
@@ -78,10 +78,11 @@ def get_entrypoint_for_tool(
 
             log_debug(f"Calling MCP Tool '{tool_name}' with args: {kwargs}")
             result: CallToolResult = await active_session.call_tool(tool_name, kwargs)  # type: ignore
+            result_meta = getattr(result, "meta", None)
 
             # Return an error if the tool call failed
             if result.isError:
-                return ToolResult(content=f"Error from MCP tool '{tool_name}': {result.content}")
+                return ToolResult(content=f"Error from MCP tool '{tool_name}': {result.content}", meta=result_meta)
 
             # Process the result content
             response_str = ""
@@ -161,6 +162,7 @@ def get_entrypoint_for_tool(
             return ToolResult(
                 content=response_str.strip(),
                 images=images if images else None,
+                meta=result_meta,
             )
         except Exception as e:
             log_exception(f"Failed to call MCP tool '{tool_name}': {e}")

--- a/libs/agno/tests/unit/tools/test_mcp.py
+++ b/libs/agno/tests/unit/tools/test_mcp.py
@@ -1,9 +1,11 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from mcp.types import TextContent
 
 from agno.tools.mcp import MCPTools, MultiMCPTools
 from agno.tools.mcp.params import SSEClientParams, StreamableHTTPClientParams
+from agno.utils.mcp import get_entrypoint_for_tool
 
 
 class _AsyncContextManager:
@@ -111,6 +113,50 @@ async def test_mcp_include_exclude_tools_bad_values(kwargs):
     with pytest.raises(ValueError, match="not present in the toolkit"):
         tools.session = session_mock
         await tools.build_tools()
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_result_preserves_meta():
+    """Test that MCP CallToolResult metadata is preserved on ToolResult."""
+    tool = MagicMock()
+    tool.name = "lookup"
+
+    session_mock = AsyncMock()
+    session_mock.send_ping = AsyncMock()
+    session_mock.call_tool = AsyncMock(
+        return_value=MagicMock(
+            isError=False,
+            content=[TextContent(type="text", text="done")],
+            meta={"trace_id": "abc-123", "cursor": "next-page"},
+        )
+    )
+
+    entrypoint = get_entrypoint_for_tool(tool=tool, session=session_mock)
+
+    result = await entrypoint(query="agno")
+
+    assert result.content == "done"
+    assert result.meta == {"trace_id": "abc-123", "cursor": "next-page"}
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_error_result_preserves_meta():
+    """Test that MCP error results keep metadata for hooks and callers."""
+    tool = MagicMock()
+    tool.name = "lookup"
+
+    session_mock = AsyncMock()
+    session_mock.send_ping = AsyncMock()
+    session_mock.call_tool = AsyncMock(
+        return_value=MagicMock(isError=True, content="rate limited", meta={"retry_after": 30})
+    )
+
+    entrypoint = get_entrypoint_for_tool(tool=tool, session=session_mock)
+
+    result = await entrypoint(query="agno")
+
+    assert result.content == "Error from MCP tool 'lookup': rate limited"
+    assert result.meta == {"retry_after": 30}
 
 
 # =============================================================================

--- a/libs/agno/tests/unit/tools/test_tool_result.py
+++ b/libs/agno/tests/unit/tools/test_tool_result.py
@@ -1,0 +1,11 @@
+from agno.tools.function import ToolResult
+
+
+def test_tool_result_preserves_meta_in_model_dump_round_trip():
+    result = ToolResult(content="done", meta={"trace_id": "abc-123", "score": 0.98})
+
+    dumped = result.model_dump()
+    restored = ToolResult.model_validate(dumped)
+
+    assert dumped["meta"] == {"trace_id": "abc-123", "score": 0.98}
+    assert restored.meta == {"trace_id": "abc-123", "score": 0.98}


### PR DESCRIPTION
## Summary
- Add optional `meta` to `ToolResult` so structured out-of-band metadata can survive Agno tool execution paths.
- Preserve `CallToolResult.meta` when the MCP wrapper returns both successful and error `ToolResult` values.
- Add unit coverage for MCP success/error propagation plus `ToolResult` model_dump/model_validate round trips.

Fixes #7658

## Tests
- `uv run --no-sync pytest tests/unit/tools/test_mcp.py tests/unit/tools/test_tool_result.py`
- `uv run --no-sync ruff check agno/tools/function.py agno/utils/mcp.py tests/unit/tools/test_mcp.py tests/unit/tools/test_tool_result.py`
- `uv run --no-sync ruff format --check agno/tools/function.py agno/utils/mcp.py tests/unit/tools/test_mcp.py tests/unit/tools/test_tool_result.py`
- `git diff --check`