### PR TITLE
fix: preserve Gemini generic exception context

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -63,6 +63,13 @@ except ImportError:
     ToolParallelAiSearch = None
 
 
+def _format_exception_message(exc: Exception) -> str:
+    """Return a useful message even for exceptions with empty string values."""
+    message = str(exc).strip()
+    exc_name = exc.__class__.__name__
+    return f"{exc_name}: {message}" if message else exc_name
+
+
 @dataclass
 class Gemini(Model):
     """
@@ -567,8 +574,9 @@ class Gemini(Model):
         except RetryableModelProviderError:
             raise
         except Exception as e:
-            log_error(f"Unknown error from Gemini API: {str(e)}")
-            raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
+            error_message = _format_exception_message(e)
+            log_error(f"Unknown error from Gemini API: {error_message}")
+            raise ModelProviderError(message=error_message, model_name=self.name, model_id=self.id) from e
 
     def invoke_stream(
         self,
@@ -621,8 +629,9 @@ class Gemini(Model):
         except RetryableModelProviderError:
             raise
         except Exception as e:
-            log_error(f"Unknown error from Gemini API: {str(e)}")
-            raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
+            error_message = _format_exception_message(e)
+            log_error(f"Unknown error from Gemini API: {error_message}")
+            raise ModelProviderError(message=error_message, model_name=self.name, model_id=self.id) from e
 
     async def ainvoke(
         self,
@@ -680,8 +689,9 @@ class Gemini(Model):
         except RetryableModelProviderError:
             raise
         except Exception as e:
-            log_error(f"Unknown error from Gemini API: {str(e)}")
-            raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
+            error_message = _format_exception_message(e)
+            log_error(f"Unknown error from Gemini API: {error_message}")
+            raise ModelProviderError(message=error_message, model_name=self.name, model_id=self.id) from e
 
     async def ainvoke_stream(
         self,
@@ -737,8 +747,9 @@ class Gemini(Model):
         except RetryableModelProviderError:
             raise
         except Exception as e:
-            log_error(f"Unknown error from Gemini API: {str(e)}")
-            raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
+            error_message = _format_exception_message(e)
+            log_error(f"Unknown error from Gemini API: {error_message}")
+            raise ModelProviderError(message=error_message, model_name=self.name, model_id=self.id) from e
 
     def _format_messages(self, messages: List[Message], compress_tool_results: bool = False):
         """

--- a/libs/agno/tests/unit/models/google/test_gemini.py
+++ b/libs/agno/tests/unit/models/google/test_gemini.py
@@ -1,9 +1,11 @@
+import asyncio
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from agno.exceptions import ModelProviderError
 from agno.media import File
 from agno.models.google.gemini import Gemini
 from agno.models.message import Message
@@ -52,6 +54,63 @@ def test_gemini_get_client_ai_studio_mode():
         assert "credentials" not in kwargs
         assert "api_key" in kwargs
         assert kwargs.get("vertexai") is not True
+
+
+def _gemini_with_timeout_client():
+    model = Gemini(api_key="test-key")
+    model._format_messages = MagicMock(return_value=([], None))  # type: ignore[method-assign]
+    model.get_request_params = MagicMock(return_value={})  # type: ignore[method-assign]
+
+    client = MagicMock()
+    model.client = client
+    return model, client
+
+
+def test_invoke_preserves_empty_exception_type_in_provider_error():
+    model, client = _gemini_with_timeout_client()
+    client.models.generate_content.side_effect = asyncio.TimeoutError()
+
+    with pytest.raises(ModelProviderError) as exc_info:
+        model.invoke(messages=[], assistant_message=Message(role="assistant"))
+
+    assert exc_info.value.message == "TimeoutError"
+    assert isinstance(exc_info.value.__cause__, asyncio.TimeoutError)
+
+
+def test_invoke_stream_preserves_empty_exception_type_in_provider_error():
+    model, client = _gemini_with_timeout_client()
+    client.models.generate_content_stream.side_effect = asyncio.TimeoutError()
+
+    with pytest.raises(ModelProviderError) as exc_info:
+        list(model.invoke_stream(messages=[], assistant_message=Message(role="assistant")))
+
+    assert exc_info.value.message == "TimeoutError"
+    assert isinstance(exc_info.value.__cause__, asyncio.TimeoutError)
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_preserves_empty_exception_type_in_provider_error():
+    model, client = _gemini_with_timeout_client()
+    client.aio.models.generate_content = AsyncMock(side_effect=asyncio.TimeoutError())
+
+    with pytest.raises(ModelProviderError) as exc_info:
+        await model.ainvoke(messages=[], assistant_message=Message(role="assistant"))
+
+    assert exc_info.value.message == "TimeoutError"
+    assert isinstance(exc_info.value.__cause__, asyncio.TimeoutError)
+
+
+@pytest.mark.asyncio
+async def test_ainvoke_stream_preserves_empty_exception_type_in_provider_error():
+    model, client = _gemini_with_timeout_client()
+    client.aio.models.generate_content_stream = AsyncMock(side_effect=asyncio.TimeoutError())
+
+    with pytest.raises(ModelProviderError) as exc_info:
+        async for _ in model.ainvoke_stream(messages=[], assistant_message=Message(role="assistant")):
+            pass
+
+    assert exc_info.value.message == "TimeoutError"
+    assert isinstance(exc_info.value.__cause__, asyncio.TimeoutError)
 
 
 class TestFormatFileForMessage:


### PR DESCRIPTION
Summary
- Format unknown Gemini exceptions with their exception class, so empty-message errors like TimeoutError still produce useful logs and ModelProviderError messages.
- Apply the same handling to sync, async, streaming, and non-streaming Gemini calls.
- Add unit coverage for empty-message timeout failures across all four paths.

Fixes #7600

Tests
- uv run --no-sync pytest tests/unit/models/google/test_gemini.py
- uv run --no-sync ruff check agno/models/google/gemini.py tests/unit/models/google/test_gemini.py
- uv run --no-sync ruff format --check agno/models/google/gemini.py tests/unit/models/google/test_gemini.py