### PR TITLE
fix: allow tool_hooks to access Function object via tool_definition param

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -966,6 +966,8 @@ class FunctionCall(BaseModel):
             hook_args["args"] = args
         if "arguments" in signature(hook).parameters:
             hook_args["arguments"] = args
+        if "tool_definition" in signature(hook).parameters:
+            hook_args["tool_definition"] = self.function
         return hook_args
 
     def _build_nested_execution_chain(self, entrypoint_args: Dict[str, Any]):


### PR DESCRIPTION
Fixes #7687

### Root Cause

`_build_hook_args` injects context into hook callables based on their declared parameter names (`agent`, `team`, `run_context`, `function_call`, `arguments`, etc.), but never injects the `Function` object itself. Hooks therefore have no way to access or mutate `Function` attributes like `stop_after_tool_call` at runtime.

### Fix

Add support for a `tool_definition` parameter in `_build_hook_args` that injects `self.function` (the `Function` object). This follows the exact same opt-in pattern used for all other injectable parameters — hooks declare `tool_definition` in their signature to receive it.

```python
# Example usage
def my_hook(tool_definition, arguments):
    if some_condition:
        tool_definition.stop_after_tool_call = True
```