### PR TITLE
fix: return True from Qdrant.upsert_available

### DIFF
--- a/libs/agno/agno/vectordb/qdrant/qdrant.py
+++ b/libs/agno/agno/vectordb/qdrant/qdrant.py
@@ -493,6 +493,9 @@ class Qdrant(VectorDb):
             await self.async_client.upsert(collection_name=self.collection, wait=False, points=points)
         log_debug(f"Upserted {len(points)} documents asynchronously")
 
+    def upsert_available(self) -> bool:
+        return True
+
     def upsert(self, content_hash: str, documents: List[Document], filters: Optional[Dict[str, Any]] = None) -> None:
         """
         Upsert documents into the database.


### PR DESCRIPTION
## Summary

Fixes #7728.

The `Qdrant` vector DB class has both `upsert` and `async_upsert` fully implemented, but `upsert_available()` was never overridden and therefore inherited the base class default of `False`. This means callers that check `upsert_available()` before deciding whether to call `upsert` would always skip the upsert path, even though Qdrant supports it.

**Change:** add a one-line override in `Qdrant` that returns `True`:

```python
def upsert_available(self) -> bool:
    return True
```

## Test plan
- [ ] Instantiate a `Qdrant` vector DB and verify `qdrant_db.upsert_available()` returns `True`
- [ ] Confirm that knowledge-base workflows that rely on `upsert_available()` now correctly route through `upsert`/`async_upsert` for Qdrant

🤖 Generated with [Claude Code](https://claude.com/claude-code)