### PR TITLE
fix: preserve original run when regenerate fails on retry, cancel, or validation

### DIFF
--- a/cookbook/02_agents/05_state_and_session/branch_session.py
+++ b/cookbook/02_agents/05_state_and_session/branch_session.py
@@ -28,30 +28,30 @@ agent = Agent(
 # Run Demo
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":
-    original_session = "branch-demo-original"
+    original_session_id = "branch-demo-original"
     user_id = "demo-user"
 
     # 1. Build up a conversation
     print("\n--- Building original conversation ---\n")
     agent.print_response(
         "I'm planning a trip to Japan. What are the top 3 cities to visit?",
-        session_id=original_session,
+        session_id=original_session_id,
         user_id=user_id,
         stream=True,
     )
     agent.print_response(
         "Tell me more about Kyoto. What should I see there?",
-        session_id=original_session,
+        session_id=original_session_id,
         user_id=user_id,
         stream=True,
     )
 
     # 2. Branch the session
     new_session_id = agent.branch_session(
-        source_session_id=original_session,
+        source_session_id=original_session_id,
         user_id=user_id,
     )
-    print(f"\nBranched session: {original_session} -> {new_session_id}\n")
+    print(f"\nBranched session: {original_session_id} -> {new_session_id}\n")
 
     # 3. Continue the branched session in a different direction
     print("\n--- Continuing branched session (different direction) ---\n")
@@ -66,7 +66,7 @@ if __name__ == "__main__":
     print("\n--- Continuing original session (unaffected) ---\n")
     agent.print_response(
         "What about the temples in Kyoto? Which ones are must-see?",
-        session_id=original_session,
+        session_id=original_session_id,
         user_id=user_id,
         stream=True,
     )

--- a/cookbook/03_teams/22_metrics/06_loop_team_and_member_metrics.py
+++ b/cookbook/03_teams/22_metrics/06_loop_team_and_member_metrics.py
@@ -24,7 +24,6 @@ from agno.run.team import TeamRunOutput
 from agno.team import Team
 from rich.pretty import pprint
 
-
 endpoint = getenv("AZURE_OPENAI_ENDPOINT")
 api_key = getenv("AZURE_OPENAI_API_KEY")
 

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -5029,6 +5029,10 @@ def regenerate_dispatch(
 
     # Read existing session from storage
     agent_session = read_or_create_session(agent, session_id=session_id, user_id=user_id)
+    # Detach from cache: regenerate mutates this session in-memory before delegating, so a
+    # failure would leak the popped state into the cache and destroy the original on next save.
+    if agent.cache_session and agent._cached_session is agent_session:
+        agent._cached_session = None
     update_metadata(agent, session=agent_session)
 
     # Find the last run
@@ -5333,6 +5337,10 @@ async def _aregenerate_prepare(
     from agno.utils.merge_dict import merge_dictionaries
 
     agent_session = await aread_or_create_session(agent, session_id=session_id, user_id=user_id)
+    # Detach from cache: regenerate mutates this session in-memory before delegating, so a
+    # failure would leak the popped state into the cache and destroy the original on next save.
+    if agent.cache_session and agent._cached_session is agent_session:
+        agent._cached_session = None
     update_metadata(agent, session=agent_session)
 
     # Re-merge agent.metadata into run_context.metadata now that update_metadata has run.

--- a/libs/agno/agno/agent/_run.py
+++ b/libs/agno/agno/agent/_run.py
@@ -15,6 +15,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Tuple,
     Type,
     Union,
     cast,
@@ -3069,6 +3070,7 @@ def _continue_run(
     response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
     debug_mode: Optional[bool] = None,
     background_tasks: Optional[Any] = None,
+    pre_session: Optional[AgentSession] = None,
     **kwargs,
 ) -> RunOutput:
     """Continue a previous run.
@@ -3208,10 +3210,12 @@ def _continue_run(
                 run_response.status = RunStatus.cancelled
                 run_response.content = str(e)
 
-                # Cleanup and store the run response and session
-                cleanup_and_store(
-                    agent, run_response=run_response, session=session, run_context=run_context, user_id=user_id
-                )
+                # Cleanup and store. Skip when caller pre-mutated the session (regenerate path):
+                # persisting a cancelled stub onto the popped session would destroy the original.
+                if pre_session is None:
+                    cleanup_and_store(
+                        agent, run_response=run_response, session=session, run_context=run_context, user_id=user_id
+                    )
 
                 return run_response
             except (InputCheckError, OutputCheckError) as e:
@@ -3224,9 +3228,12 @@ def _continue_run(
 
                 log_error(f"Validation failed: {str(e)} | Check trigger: {e.check_trigger}")
 
-                cleanup_and_store(
-                    agent, run_response=run_response, session=session, run_context=run_context, user_id=user_id
-                )
+                # Cleanup and store. Skip when caller pre-mutated the session (regenerate path):
+                # persisting a validation-error stub onto the popped session would destroy the original.
+                if pre_session is None:
+                    cleanup_and_store(
+                        agent, run_response=run_response, session=session, run_context=run_context, user_id=user_id
+                    )
 
                 return run_response
             except KeyboardInterrupt:
@@ -3256,10 +3263,12 @@ def _continue_run(
 
                 log_error(f"Error in Agent run: {str(e)}")
 
-                # Cleanup and store the run response and session
-                cleanup_and_store(
-                    agent, run_response=run_response, session=session, run_context=run_context, user_id=user_id
-                )
+                # Cleanup and store. Skip when caller pre-mutated the session (regenerate path):
+                # persisting an error stub onto the popped session would destroy the original.
+                if pre_session is None:
+                    cleanup_and_store(
+                        agent, run_response=run_response, session=session, run_context=run_context, user_id=user_id
+                    )
 
                 return run_response
     finally:
@@ -3283,6 +3292,7 @@ def _continue_run_stream(
     debug_mode: Optional[bool] = None,
     yield_run_output: bool = False,
     background_tasks: Optional[Any] = None,
+    pre_session: Optional[AgentSession] = None,
     **kwargs,
 ) -> Iterator[Union[RunOutputEvent, RunOutput]]:
     """Continue a previous run.
@@ -3313,8 +3323,8 @@ def _continue_run_stream(
     try:
         for attempt in range(num_attempts):
             try:
-                # 1. Resolve dependencies
-                if run_context.dependencies is not None:
+                # 1. Resolve dependencies. Skip when caller pre-resolved (regenerate path).
+                if run_context.dependencies is not None and pre_session is None:
                     resolve_run_dependencies(agent, run_context=run_context)
 
                 # Start the Run by yielding a RunContinued event
@@ -3481,10 +3491,12 @@ def _continue_run_stream(
                     store_events=agent.store_events,
                 )
 
-                # Cleanup and store the run response and session
-                cleanup_and_store(
-                    agent, run_response=run_response, session=session, run_context=run_context, user_id=user_id
-                )
+                # Cleanup and store. Skip when caller pre-mutated the session (regenerate path):
+                # persisting a cancelled stub onto the popped session would destroy the original.
+                if pre_session is None:
+                    cleanup_and_store(
+                        agent, run_response=run_response, session=session, run_context=run_context, user_id=user_id
+                    )
                 break
             except (InputCheckError, OutputCheckError) as e:
                 run_response = cast(RunOutput, run_response)
@@ -3506,9 +3518,12 @@ def _continue_run_stream(
 
                 log_error(f"Validation failed: {str(e)} | Check trigger: {e.check_trigger}")
 
-                cleanup_and_store(
-                    agent, run_response=run_response, session=session, run_context=run_context, user_id=user_id
-                )
+                # Cleanup and store. Skip when caller pre-mutated the session (regenerate path):
+                # persisting a validation-error stub onto the popped session would destroy the original.
+                if pre_session is None:
+                    cleanup_and_store(
+                        agent, run_response=run_response, session=session, run_context=run_context, user_id=user_id
+                    )
                 yield run_error
                 break
             except KeyboardInterrupt:
@@ -3545,10 +3560,12 @@ def _continue_run_stream(
 
                 log_error(f"Error in Agent run: {str(e)}")
 
-                # Cleanup and store the run response and session
-                cleanup_and_store(
-                    agent, run_response=run_response, session=session, run_context=run_context, user_id=user_id
-                )
+                # Cleanup and store. Skip when caller pre-mutated the session (regenerate path):
+                # persisting an error stub onto the popped session would destroy the original.
+                if pre_session is None:
+                    cleanup_and_store(
+                        agent, run_response=run_response, session=session, run_context=run_context, user_id=user_id
+                    )
 
                 yield run_error
     finally:
@@ -3885,6 +3902,7 @@ async def _acontinue_run(
     response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
     debug_mode: Optional[bool] = None,
     background_tasks: Optional[Any] = None,
+    pre_session: Optional[AgentSession] = None,
     **kwargs,
 ) -> RunOutput:
     """Continue a previous run.
@@ -3930,11 +3948,16 @@ async def _acontinue_run(
                 if attempt > 0:
                     log_debug(f"Retrying Agent acontinue_run {run_id}. Attempt {attempt + 1} of {num_attempts}...")
 
-                # 1. Read existing session from db
-                agent_session = await aread_or_create_session(agent, session_id=session_id, user_id=user_id)
+                # 1. Read or create session. When the caller pre-mutated a session
+                # (regenerate path), keep using it across retries — re-reading from DB
+                # would lose the pop/mark and produce duplicate runs on success.
+                if pre_session is not None:
+                    agent_session = pre_session
+                else:
+                    agent_session = await aread_or_create_session(agent, session_id=session_id, user_id=user_id)
 
-                # 2. Resolve dependencies
-                if run_context.dependencies is not None:
+                # 2. Resolve dependencies. Skip when caller pre-resolved (regenerate path).
+                if run_context.dependencies is not None and pre_session is None:
                     await aresolve_run_dependencies(agent, run_context=run_context)
 
                 # 3. Update metadata and session state
@@ -4162,8 +4185,9 @@ async def _acontinue_run(
                 run_response.status = RunStatus.cancelled
                 run_response.content = str(e)
 
-                # Cleanup and store the run response and session
-                if agent_session is not None:
+                # Cleanup and store. Skip when caller pre-mutated the session (regenerate path):
+                # persisting a cancelled stub onto the popped session would destroy the original.
+                if agent_session is not None and pre_session is None:
                     await acleanup_and_store(
                         agent,
                         run_response=run_response,
@@ -4183,7 +4207,9 @@ async def _acontinue_run(
 
                 log_error(f"Validation failed: {str(e)} | Check trigger: {e.check_trigger}")
 
-                if agent_session is not None:
+                # Cleanup and store. Skip when caller pre-mutated the session (regenerate path):
+                # persisting a validation-error stub onto the popped session would destroy the original.
+                if agent_session is not None and pre_session is None:
                     await acleanup_and_store(
                         agent,
                         run_response=run_response,
@@ -4227,8 +4253,9 @@ async def _acontinue_run(
 
                 log_error(f"Error in Agent run: {str(e)}")
 
-                # Cleanup and store the run response and session
-                if agent_session is not None:
+                # Cleanup and store. Skip when caller pre-mutated the session (regenerate path):
+                # persisting an error stub onto the popped session would destroy the original.
+                if agent_session is not None and pre_session is None:
                     await acleanup_and_store(
                         agent,
                         run_response=run_response,  # type: ignore
@@ -4264,6 +4291,7 @@ async def _acontinue_run_stream(
     yield_run_output: bool = False,
     debug_mode: Optional[bool] = None,
     background_tasks: Optional[Any] = None,
+    pre_session: Optional[AgentSession] = None,
     **kwargs,
 ) -> AsyncIterator[Union[RunOutputEvent, RunOutput]]:
     """Continue a previous run.
@@ -4303,8 +4331,13 @@ async def _acontinue_run_stream(
         num_attempts = agent.retries + 1
         for attempt in range(num_attempts):
             try:
-                # 1. Read existing session from db
-                agent_session = await aread_or_create_session(agent, session_id=session_id, user_id=user_id)
+                # 1. Read or create session. When the caller pre-mutated a session
+                # (regenerate path), keep using it across retries — re-reading from DB
+                # would lose the pop/mark and produce duplicate runs on success.
+                if pre_session is not None:
+                    agent_session = pre_session
+                else:
+                    agent_session = await aread_or_create_session(agent, session_id=session_id, user_id=user_id)
 
                 # 2. Update session state and metadata
                 update_metadata(agent, session=agent_session)
@@ -4322,8 +4355,8 @@ async def _acontinue_run_stream(
                     run_id=run_context.run_id,
                 )
 
-                # 3. Resolve dependencies
-                if run_context.dependencies is not None:
+                # 3. Resolve dependencies (skipped when caller already resolved them in regenerate prep)
+                if run_context.dependencies is not None and pre_session is None:
                     await aresolve_run_dependencies(agent, run_context=run_context)
 
                 # 4. Prepare run response
@@ -4627,8 +4660,9 @@ async def _acontinue_run_stream(
                     store_events=agent.store_events,
                 )
 
-                # Cleanup and store the run response and session
-                if agent_session is not None:
+                # Cleanup and store. Skip when caller pre-mutated the session (regenerate path):
+                # persisting a cancelled stub onto the popped session would destroy the original.
+                if agent_session is not None and pre_session is None:
                     await acleanup_and_store(
                         agent,
                         run_response=run_response,
@@ -4660,8 +4694,9 @@ async def _acontinue_run_stream(
 
                 log_error(f"Validation failed: {str(e)} | Check trigger: {e.check_trigger}")
 
-                # Cleanup and store the run response and session
-                if agent_session is not None:
+                # Cleanup and store. Skip when caller pre-mutated the session (regenerate path):
+                # persisting a validation-error stub onto the popped session would destroy the original.
+                if agent_session is not None and pre_session is None:
                     await acleanup_and_store(
                         agent,
                         run_response=run_response,
@@ -4713,8 +4748,9 @@ async def _acontinue_run_stream(
 
                 log_error(f"Error in Agent run: {str(e)}")
 
-                # Cleanup and store the run response and session
-                if agent_session is not None:
+                # Cleanup and store. Skip when caller pre-mutated the session (regenerate path):
+                # persisting an error stub onto the popped session would destroy the original.
+                if agent_session is not None and pre_session is None:
                     await acleanup_and_store(
                         agent,
                         run_response=run_response,
@@ -5008,6 +5044,10 @@ def regenerate_dispatch(
 
     # Build message context: everything except the final assistant response
     trimmed_messages = _strip_final_assistant_messages(last_run.messages)
+    # If the surviving tail is an unresolved tool_call, drop it too so we don't
+    # append a user message after a tool_call (providers reject that ordering).
+    while trimmed_messages and trimmed_messages[-1].role == "assistant" and trimmed_messages[-1].tool_calls:
+        trimmed_messages.pop()
     if not trimmed_messages:
         raise ValueError("Cannot regenerate: no user messages found in the last run.")
 
@@ -5115,6 +5155,9 @@ def regenerate_dispatch(
     run_response.status = RunStatus.running
 
     if opts.stream:
+        # Pass pre_session so _continue_run_stream skips duplicate dep resolution and
+        # gates cleanup_and_store on error — without it, a mid-stream failure persists
+        # the popped session and destroys the original.
         response_iterator = _continue_run_stream(
             agent,
             run_response=run_response,
@@ -5128,10 +5171,13 @@ def regenerate_dispatch(
             yield_run_output=opts.yield_run_output,
             debug_mode=debug_mode,
             background_tasks=background_tasks,
+            pre_session=agent_session,
             **kwargs,
         )
         return response_iterator
     else:
+        # Pass pre_session so _continue_run gates cleanup_and_store on error branches —
+        # without it, a model failure persists the popped session and destroys the original.
         response = _continue_run(
             agent,
             run_response=run_response,
@@ -5143,6 +5189,7 @@ def regenerate_dispatch(
             response_format=response_format,
             debug_mode=debug_mode,
             background_tasks=background_tasks,
+            pre_session=agent_session,
             **kwargs,
         )
         return response
@@ -5279,20 +5326,25 @@ async def _aregenerate_prepare(
     user_id: Optional[str],
     additional_instructions: Optional[str],
     preserve_original: bool,
-) -> RunOutput:
-    """Shared prep for async regeneration.
-
-    Reads the session, strips the trailing assistant response, marks or pops the
-    old run, persists the mutation, resolves dependencies against the refreshed
-    session_state, and returns a fully-initialized new RunOutput ready to hand off
-    to _acontinue_run / _acontinue_run_stream. Works against both sync and async
-    DBs because aread_or_create_session / asave_session dispatch internally.
-    """
-    from agno.agent._session import asave_session
+) -> Tuple[RunOutput, AgentSession]:
+    """Shared prep for async regeneration. Returns the new RunOutput and the in-memory
+    session for the caller to hand to _acontinue_run via pre_session."""
     from agno.agent._storage import aread_or_create_session, load_session_state, update_metadata
+    from agno.utils.merge_dict import merge_dictionaries
 
     agent_session = await aread_or_create_session(agent, session_id=session_id, user_id=user_id)
     update_metadata(agent, session=agent_session)
+
+    # Re-merge agent.metadata into run_context.metadata now that update_metadata has run.
+    # Sync regenerate orders read → update_metadata → resolve_run_options; async resolves options
+    # before the awaitable read, so we mirror the merge here for parity with the sync path.
+    if agent.metadata is not None:
+        if run_context.metadata is None:
+            run_context.metadata = agent.metadata.copy()
+        else:
+            merged = dict(run_context.metadata)
+            merge_dictionaries(merged, agent.metadata)
+            run_context.metadata = merged
 
     if not agent_session.runs:
         raise ValueError("No runs found in session to regenerate.")
@@ -5304,6 +5356,10 @@ async def _aregenerate_prepare(
     predecessor_run_id = last_run.run_id
 
     trimmed_messages = _strip_final_assistant_messages(last_run.messages)
+    # If the surviving tail is an unresolved tool_call, drop it too so we don't
+    # append a user message after a tool_call (providers reject that ordering).
+    while trimmed_messages and trimmed_messages[-1].role == "assistant" and trimmed_messages[-1].tool_calls:
+        trimmed_messages.pop()
     if not trimmed_messages:
         raise ValueError("Cannot regenerate: no user messages found in the last run.")
 
@@ -5312,14 +5368,12 @@ async def _aregenerate_prepare(
     else:
         agent_session.runs.pop()  # type: ignore[union-attr]
 
-    # Persist mutation before delegating to _acontinue_run, which re-reads from DB.
-    await asave_session(agent, session=agent_session)
-
     if additional_instructions is not None:
         trimmed_messages.append(Message(role=agent.user_message_role, content=additional_instructions))
 
     # Populate session_state from the refreshed session, then resolve dependencies
-    # so callables see the real state (this fixes a prior sync/async divergence).
+    # so callables see the real state. _acontinue_run is told to skip its own
+    # dependency resolution to avoid double-firing side-effecting callables.
     run_context.session_state = load_session_state(
         agent,
         session=agent_session,
@@ -5345,7 +5399,7 @@ async def _aregenerate_prepare(
     new_run_response.metrics.start_timer()
     new_run_response.messages = trimmed_messages
 
-    return new_run_response
+    return new_run_response, agent_session
 
 
 async def _aregenerate_run(
@@ -5361,7 +5415,7 @@ async def _aregenerate_run(
     **kwargs: Any,
 ) -> RunOutput:
     """Async non-streaming regeneration: prep then delegate to _acontinue_run."""
-    new_run_response = await _aregenerate_prepare(
+    new_run_response, agent_session = await _aregenerate_prepare(
         agent,
         run_context=run_context,
         session_id=session_id,
@@ -5381,6 +5435,7 @@ async def _aregenerate_run(
         response_format=response_format,
         debug_mode=debug_mode,
         background_tasks=background_tasks,
+        pre_session=agent_session,
         **kwargs,
     )
 
@@ -5400,7 +5455,7 @@ async def _aregenerate_run_stream(
     **kwargs: Any,
 ) -> AsyncIterator[Union[RunOutputEvent, RunOutput]]:
     """Async streaming regeneration: prep then delegate to _acontinue_run_stream."""
-    new_run_response = await _aregenerate_prepare(
+    new_run_response, agent_session = await _aregenerate_prepare(
         agent,
         run_context=run_context,
         session_id=session_id,
@@ -5422,6 +5477,7 @@ async def _aregenerate_run_stream(
         yield_run_output=yield_run_output,
         debug_mode=debug_mode,
         background_tasks=background_tasks,
+        pre_session=agent_session,
         **kwargs,
     ):
         yield event
@@ -5494,8 +5550,9 @@ def branch_session_dispatch(
         if not run.branched_from:
             run.branched_from = source_session_id
 
-    # Carry over session_data and record the source session at the session level
-    # for accountability (even if all runs are later deleted/regenerated).
+    # session.branched_from records the **immediate** parent (overwritten on each branch),
+    # while run.branched_from records each run's **original** session (set only-if-empty).
+    # For root → mid → leaf: leaf.session.branched_from == mid; leaf.runs[*].branched_from == root.
     new_session_data = copy.deepcopy(source_session.session_data) or {}
     new_session_data["branched_from"] = source_session_id
 
@@ -5581,8 +5638,9 @@ async def abranch_session_dispatch(
         if not run.branched_from:
             run.branched_from = source_session_id
 
-    # Carry over session_data and record the source session at the session level
-    # for accountability (even if all runs are later deleted/regenerated).
+    # session.branched_from records the **immediate** parent (overwritten on each branch),
+    # while run.branched_from records each run's **original** session (set only-if-empty).
+    # For root → mid → leaf: leaf.session.branched_from == mid; leaf.runs[*].branched_from == root.
     new_session_data = copy.deepcopy(source_session.session_data) or {}
     new_session_data["branched_from"] = source_session_id
 

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -1743,7 +1743,7 @@ class Agent:
         dependencies: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
         debug_mode: Optional[bool] = None,
-    ) -> RunOutput: ...
+    ) -> Coroutine[Any, Any, RunOutput]: ...
 
     @overload
     def aregenerate(

--- a/libs/agno/tests/integration/workflows/test_workflow_cancellation.py
+++ b/libs/agno/tests/integration/workflows/test_workflow_cancellation.py
@@ -13,7 +13,6 @@ from agno.run.workflow import WorkflowCancelledEvent
 from agno.workflow import Step, Workflow
 from agno.workflow.types import StepInput, StepOutput
 
-
 # ============================================================================
 # FIXTURES
 # ============================================================================

--- a/libs/agno/tests/unit/agent/test_regenerate_fork.py
+++ b/libs/agno/tests/unit/agent/test_regenerate_fork.py
@@ -437,8 +437,9 @@ class TestRegenerateSessionPersistence:
         assert len(captured_sessions[0]) == 1
         assert captured_sessions[0][0][1] == RunStatus.regenerated
 
-    def test_async_regenerate_saves_session_before_continue(self, monkeypatch: pytest.MonkeyPatch):
-        """aregenerate_dispatch must persist session before _acontinue_run re-reads."""
+    def test_async_regenerate_passes_pre_session_with_old_run_removed(self, monkeypatch: pytest.MonkeyPatch):
+        """aregenerate_dispatch must NOT save before _acontinue_run; instead it hands the
+        mutated session in via pre_session so a model crash leaves the DB untouched."""
         agent = Agent(name="test")
         old_run = _make_run(
             messages=[
@@ -449,7 +450,6 @@ class TestRegenerateSessionPersistence:
         )
         session = _make_session(runs=[old_run])
 
-        # Patch deps for aregenerate_dispatch
         monkeypatch.setattr(_init, "set_default_model", lambda a: None)
         monkeypatch.setattr(_storage, "update_metadata", lambda a, session=None: None)
         monkeypatch.setattr(
@@ -480,39 +480,43 @@ class TestRegenerateSessionPersistence:
         mock_model.provider = "test"
         agent.model = mock_model
 
-        # Track the order of operations: save_session then _acontinue_run
-        call_order: list = []
-        saved_run_counts: list = []
+        # Track that asave_session is NOT called by the prep code path
+        save_call_count = 0
 
         async def tracking_save(agent_arg, session=None):
-            call_order.append("save_session")
-            saved_run_counts.append(len(session.runs) if session and session.runs else 0)
+            nonlocal save_call_count
+            save_call_count += 1
 
         monkeypatch.setattr(_session, "asave_session", tracking_save)
 
-        # Mock _acontinue_run as an async function
+        captured_kwargs: list = []
         result_run = RunOutput(run_id="new-run", session_id="sess-1")
         result_run.content = "regenerated"
         result_run.status = RunStatus.completed
 
         async def mock_acontinue_run(*args, **kwargs):
-            call_order.append("_acontinue_run")
+            captured_kwargs.append(kwargs)
             return result_run
 
         monkeypatch.setattr(_run, "_acontinue_run", mock_acontinue_run)
 
-        # Run the async dispatch
         result = _run.aregenerate_dispatch(agent, session_id="sess-1", preserve_original=False, stream=False)
-        # aregenerate_dispatch returns a coroutine for non-streaming
         asyncio.new_event_loop().run_until_complete(result)  # type: ignore[arg-type]
 
-        # save_session must come before _acontinue_run
-        assert call_order == ["save_session", "_acontinue_run"]
-        # At save time, old run should be gone
-        assert saved_run_counts[0] == 0
+        # Critical safety property: no save before model
+        assert save_call_count == 0
+        # _acontinue_run was handed the mutated in-memory session. Its presence is the
+        # single signal that the regenerate-mode contract applies (skip DB re-read,
+        # skip duplicate dep resolution, skip persist on error).
+        assert len(captured_kwargs) == 1
+        prepared = captured_kwargs[0].get("pre_session")
+        assert prepared is session
+        assert len(prepared.runs) == 0  # old run popped in-memory
 
-    def test_async_regenerate_stream_saves_session_before_continue(self, monkeypatch: pytest.MonkeyPatch):
-        """aregenerate_dispatch (stream=True) must persist session before _acontinue_run_stream re-reads."""
+    def test_async_regenerate_stream_passes_pre_session_with_old_run_removed(self, monkeypatch: pytest.MonkeyPatch):
+        """aregenerate_dispatch (stream=True) must hand the mutated session via
+        pre_session and skip the early DB save, so a crash mid-stream leaves
+        the original run intact in the DB."""
         agent = Agent(name="test")
         old_run = _make_run(
             messages=[
@@ -553,26 +557,24 @@ class TestRegenerateSessionPersistence:
         mock_model.provider = "test"
         agent.model = mock_model
 
-        call_order: list = []
-        saved_run_counts: list = []
+        save_call_count = 0
 
         async def tracking_save(agent_arg, session=None):
-            call_order.append("save_session")
-            saved_run_counts.append(len(session.runs) if session and session.runs else 0)
+            nonlocal save_call_count
+            save_call_count += 1
 
         monkeypatch.setattr(_session, "asave_session", tracking_save)
 
-        # Mock _acontinue_run_stream as an async generator
+        captured_kwargs: list = []
+
         async def mock_acontinue_run_stream(*args, **kwargs):
-            call_order.append("_acontinue_run_stream")
+            captured_kwargs.append(kwargs)
             yield RunOutput(run_id="new-run", session_id="sess-1")
 
         monkeypatch.setattr(_run, "_acontinue_run_stream", mock_acontinue_run_stream)
 
-        # aregenerate_dispatch with stream=True returns an async iterator directly
         async_iter = _run.aregenerate_dispatch(agent, session_id="sess-1", preserve_original=False, stream=True)
 
-        # Consume the async iterator
         async def consume():
             results = []
             async for item in async_iter:  # type: ignore[union-attr]
@@ -581,12 +583,15 @@ class TestRegenerateSessionPersistence:
 
         asyncio.new_event_loop().run_until_complete(consume())
 
-        # save_session must come before _acontinue_run_stream
-        assert call_order == ["save_session", "_acontinue_run_stream"]
-        assert saved_run_counts[0] == 0
+        assert save_call_count == 0
+        assert len(captured_kwargs) == 1
+        prepared = captured_kwargs[0].get("pre_session")
+        assert prepared is session
+        assert len(prepared.runs) == 0
 
-    def test_async_regenerate_preserve_original_saves_both_statuses(self, monkeypatch: pytest.MonkeyPatch):
-        """aregenerate_dispatch with preserve_original=True saves the old run as regenerated before continue."""
+    def test_async_regenerate_preserve_original_marks_status_in_pre_session(self, monkeypatch: pytest.MonkeyPatch):
+        """aregenerate_dispatch with preserve_original=True marks the old run as regenerated
+        in the in-memory session and hands it to _acontinue_run via pre_session."""
         agent = Agent(name="test")
         old_run = _make_run(
             messages=[
@@ -627,19 +632,21 @@ class TestRegenerateSessionPersistence:
         mock_model.provider = "test"
         agent.model = mock_model
 
-        saved_statuses: list = []
+        save_call_count = 0
 
         async def tracking_save(agent_arg, session=None):
-            if session and session.runs:
-                saved_statuses.append([(r.run_id, r.status) for r in session.runs])
+            nonlocal save_call_count
+            save_call_count += 1
 
         monkeypatch.setattr(_session, "asave_session", tracking_save)
 
+        captured_kwargs: list = []
         result_run = RunOutput(run_id="new-run", session_id="sess-1")
         result_run.content = "regenerated"
         result_run.status = RunStatus.completed
 
         async def mock_acontinue_run(*args, **kwargs):
+            captured_kwargs.append(kwargs)
             return result_run
 
         monkeypatch.setattr(_run, "_acontinue_run", mock_acontinue_run)
@@ -647,10 +654,14 @@ class TestRegenerateSessionPersistence:
         result = _run.aregenerate_dispatch(agent, session_id="sess-1", preserve_original=True, stream=False)
         asyncio.new_event_loop().run_until_complete(result)  # type: ignore[arg-type]
 
-        # First save should have the old run with regenerated status
-        assert len(saved_statuses) >= 1
-        assert len(saved_statuses[0]) == 1
-        assert saved_statuses[0][0][1] == RunStatus.regenerated
+        # No early save happens any more
+        assert save_call_count == 0
+        # The prepared session has the old run marked as regenerated
+        assert len(captured_kwargs) == 1
+        prepared = captured_kwargs[0].get("pre_session")
+        assert prepared is session
+        assert len(prepared.runs) == 1
+        assert prepared.runs[0].status == RunStatus.regenerated
 
 
 # ---------------------------------------------------------------------------
@@ -818,3 +829,268 @@ class TestBranchSessionDispatch:
 
         restored = RunOutput.from_dict(d)
         assert restored.branched_from == "source-sess"
+
+
+# ---------------------------------------------------------------------------
+# pre_session forwarding tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegeneratePreSessionForwarding:
+    def test_sync_regenerate_forwards_pre_session_to_continue_run(self, monkeypatch: pytest.MonkeyPatch):
+        """Sync regenerate must pass pre_session=session to _continue_run."""
+        agent = Agent(name="test")
+        old_run = _make_run(
+            messages=[
+                Message(role="user", content="hi"),
+                Message(role="assistant", content="hello"),
+            ],
+            input="hi",
+        )
+        session = _make_session(runs=[old_run])
+        mock_continue = _patch_regenerate_deps(agent, monkeypatch, session)
+
+        _run.regenerate_dispatch(agent, session_id="sess-1", stream=False)
+
+        kwargs = mock_continue.call_args.kwargs
+        assert kwargs.get("pre_session") is session
+
+    def test_sync_regenerate_stream_forwards_pre_session_to_continue_run_stream(self, monkeypatch: pytest.MonkeyPatch):
+        """Sync streaming regenerate must pass pre_session=session to _continue_run_stream."""
+        agent = Agent(name="test")
+        old_run = _make_run(
+            messages=[
+                Message(role="user", content="hi"),
+                Message(role="assistant", content="hello"),
+            ],
+            input="hi",
+        )
+        session = _make_session(runs=[old_run])
+        _patch_regenerate_deps(agent, monkeypatch, session)
+
+        # Switch resolved options to streaming and capture the streaming continue call.
+        monkeypatch.setattr(
+            _run,
+            "resolve_run_options",
+            lambda a, **kw: MagicMock(
+                stream=True,
+                stream_events=False,
+                yield_run_output=False,
+                dependencies=None,
+                knowledge_filters=None,
+                metadata=None,
+                apply_to_context=MagicMock(),
+            ),
+        )
+        captured_kwargs: list = []
+
+        def mock_continue_stream(*args, **kwargs):
+            captured_kwargs.append(kwargs)
+            yield RunOutput(run_id="new-run", session_id="sess-1")
+
+        monkeypatch.setattr(_run, "_continue_run_stream", mock_continue_stream)
+
+        list(_run.regenerate_dispatch(agent, session_id="sess-1", stream=True))  # type: ignore[arg-type]
+
+        assert len(captured_kwargs) == 1
+        assert captured_kwargs[0].get("pre_session") is session
+
+    def test_async_regenerate_forwards_pre_session_to_acontinue_run(self, monkeypatch: pytest.MonkeyPatch):
+        """Async regenerate must pass pre_session=session to _acontinue_run."""
+        agent = Agent(name="test")
+        old_run = _make_run(
+            messages=[
+                Message(role="user", content="hi"),
+                Message(role="assistant", content="hello"),
+            ],
+            input="hi",
+        )
+        session = _make_session(runs=[old_run])
+
+        monkeypatch.setattr(_init, "set_default_model", lambda a: None)
+        monkeypatch.setattr(_storage, "update_metadata", lambda a, session=None: None)
+        monkeypatch.setattr(
+            _storage, "load_session_state", lambda a, session=None, session_state=None: session_state or {}
+        )
+
+        async def mock_aread(agent_arg, session_id=None, user_id=None):
+            return session
+
+        monkeypatch.setattr(_storage, "aread_or_create_session", mock_aread)
+        monkeypatch.setattr(_run, "aresolve_run_dependencies", lambda a, run_context: None)
+        monkeypatch.setattr(_response, "get_response_format", lambda a, run_context=None: None)
+        monkeypatch.setattr(
+            _run,
+            "resolve_run_options",
+            lambda a, **kw: MagicMock(
+                stream=False,
+                stream_events=False,
+                yield_run_output=False,
+                dependencies=None,
+                knowledge_filters=None,
+                metadata=None,
+                apply_to_context=MagicMock(),
+            ),
+        )
+
+        mock_model = MagicMock()
+        mock_model.id = "test-model"
+        mock_model.provider = "test"
+        agent.model = mock_model
+
+        captured_kwargs: list = []
+        result_run = RunOutput(run_id="new-run", session_id="sess-1")
+        result_run.content = "regenerated"
+        result_run.status = RunStatus.completed
+
+        async def mock_acontinue_run(*args, **kwargs):
+            captured_kwargs.append(kwargs)
+            return result_run
+
+        monkeypatch.setattr(_run, "_acontinue_run", mock_acontinue_run)
+
+        result = _run.aregenerate_dispatch(agent, session_id="sess-1", preserve_original=False, stream=False)
+        asyncio.new_event_loop().run_until_complete(result)  # type: ignore[arg-type]
+
+        assert len(captured_kwargs) == 1
+        prepared = captured_kwargs[0].get("pre_session")
+        assert prepared is session
+        assert len(prepared.runs) == 0  # popped in-memory
+
+    def test_async_regenerate_stream_forwards_pre_session_to_acontinue_run_stream(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Async streaming regenerate must pass pre_session=session to _acontinue_run_stream."""
+        agent = Agent(name="test")
+        old_run = _make_run(
+            messages=[
+                Message(role="user", content="hi"),
+                Message(role="assistant", content="hello"),
+            ],
+            input="hi",
+        )
+        session = _make_session(runs=[old_run])
+
+        monkeypatch.setattr(_init, "set_default_model", lambda a: None)
+        monkeypatch.setattr(_storage, "update_metadata", lambda a, session=None: None)
+        monkeypatch.setattr(
+            _storage, "load_session_state", lambda a, session=None, session_state=None: session_state or {}
+        )
+
+        async def mock_aread(agent_arg, session_id=None, user_id=None):
+            return session
+
+        monkeypatch.setattr(_storage, "aread_or_create_session", mock_aread)
+        monkeypatch.setattr(_run, "aresolve_run_dependencies", lambda a, run_context: None)
+        monkeypatch.setattr(_response, "get_response_format", lambda a, run_context=None: None)
+        monkeypatch.setattr(
+            _run,
+            "resolve_run_options",
+            lambda a, **kw: MagicMock(
+                stream=True,
+                stream_events=False,
+                yield_run_output=False,
+                dependencies=None,
+                knowledge_filters=None,
+                metadata=None,
+                apply_to_context=MagicMock(),
+            ),
+        )
+
+        mock_model = MagicMock()
+        mock_model.id = "test-model"
+        mock_model.provider = "test"
+        agent.model = mock_model
+
+        captured_kwargs: list = []
+
+        async def mock_acontinue_run_stream(*args, **kwargs):
+            captured_kwargs.append(kwargs)
+            yield RunOutput(run_id="new-run", session_id="sess-1")
+
+        monkeypatch.setattr(_run, "_acontinue_run_stream", mock_acontinue_run_stream)
+
+        async_iter = _run.aregenerate_dispatch(agent, session_id="sess-1", preserve_original=False, stream=True)
+
+        async def consume():
+            async for _ in async_iter:  # type: ignore[union-attr]
+                pass
+
+        asyncio.new_event_loop().run_until_complete(consume())
+
+        assert len(captured_kwargs) == 1
+        prepared = captured_kwargs[0].get("pre_session")
+        assert prepared is session
+        assert len(prepared.runs) == 0
+
+
+class TestAcontinueRunRetryReusesPreSession:
+    def test_acontinue_run_skips_db_reread_on_retry_when_pre_session_set(self, monkeypatch: pytest.MonkeyPatch):
+        """On retry, _acontinue_run must reuse pre_session instead of re-reading from DB."""
+        from agno.run import RunContext
+
+        agent = Agent(name="test")
+        agent.retries = 1
+        agent.delay_between_retries = 0
+        agent.exponential_backoff = False
+        mock_model = MagicMock()
+        mock_model.id = "test-model"
+        mock_model.provider = "test"
+        agent.model = mock_model
+
+        prepared = _make_session(runs=[])  # popped already by prep
+
+        aread_calls = {"n": 0}
+
+        async def mock_aread(agent_arg, session_id=None, user_id=None):
+            aread_calls["n"] += 1
+            return _make_session(runs=[_make_run(run_id="db-run")])
+
+        monkeypatch.setattr(_storage, "aread_or_create_session", mock_aread)
+        monkeypatch.setattr(_storage, "update_metadata", lambda a, session=None: None)
+        monkeypatch.setattr(
+            _storage, "load_session_state", lambda a, session=None, session_state=None: session_state or {}
+        )
+
+        # Stub everything past the read so the loop body throws on the first attempt
+        # and succeeds on the second. We only care that aread is never called.
+        attempts = {"n": 0}
+
+        async def fake_call_model(*a, **k):
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise RuntimeError("transient")
+            # On second attempt return early — model_response object isn't critical;
+            # we'll short-circuit further by patching downstream helpers to no-ops.
+            return MagicMock()
+
+        # Patch out internals so _acontinue_run progresses without doing real work.
+        monkeypatch.setattr(_run, "acall_model_with_fallback", fake_call_model, raising=False)
+        monkeypatch.setattr(_run, "araise_if_cancelled", lambda *a, **k: asyncio.sleep(0), raising=False)
+
+        # Run _acontinue_run with pre_session=prepared. The first attempt raises,
+        # the second succeeds — and aread_or_create_session must be called zero times.
+        run_response = RunOutput(run_id="new-run", session_id="sess-1")
+        run_context = RunContext(run_id="new-run", session_id="sess-1", user_id=None, session_state={})
+
+        # Drive the retry loop directly; we don't need the full success path,
+        # only that no DB read happens for either attempt.
+        try:
+            asyncio.new_event_loop().run_until_complete(
+                _run._acontinue_run(
+                    agent,
+                    run_response=run_response,
+                    run_context=run_context,
+                    session_id="sess-1",
+                    pre_session=prepared,
+                )
+            )
+        except Exception:
+            # The stubs are intentionally minimal — we let _acontinue_run bail out
+            # however it likes, as long as it never reads from DB.
+            pass
+
+        assert aread_calls["n"] == 0, (
+            f"_acontinue_run re-read DB {aread_calls['n']} times across retries; "
+            "pre_session must be sticky across all attempts."
+        )


### PR DESCRIPTION
## Summary

Follow-up bug fixes for #7157. Three independent code paths could destroy the original run during regenerate when the new run was not successfully produced:

1. **Async retry-after-error.** `_acontinue_run` / `_acontinue_run_stream` re-read the DB on attempt 1+, losing the in-memory pop/mark from `_aregenerate_prepare`. A successful retry then persisted `[old, new]` instead of `[new]` for `preserve_original=False`, and left the old run's status untouched for `preserve_original=True`. Now `pre_session` is sticky across all retry attempts.

2. **Async cancel / validation.** `RunCancelledException` and `InputCheckError` / `OutputCheckError` handlers unconditionally called `acleanup_and_store`, persisting the popped session plus a cancelled/error stub. Gated on `pre_session is None` to match the generic-`Exception` branch.

3. **Sync paths.** `_continue_run` had no `pre_session` at all and `_continue_run_stream` only used it to skip dependency resolution. Their cancel / validation / error branches all called `cleanup_and_store` on the popped session. Threaded `pre_session` through `_continue_run` and gated every error-path `cleanup_and_store` on `pre_session is None` in both sync continue helpers; `regenerate_dispatch` now passes `pre_session=agent_session` to both.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
