### PR TITLE
fix: replace Slack bot @mention with display name instead of stripping

### DIFF
--- a/libs/agno/agno/os/interfaces/slack/helpers.py
+++ b/libs/agno/agno/os/interfaces/slack/helpers.py
@@ -66,22 +66,24 @@ def extract_event_context(event: dict) -> Dict[str, Any]:
     }
 
 
-def strip_bot_mention(text: str, bot_user_id: Optional[str]) -> str:
-    """Remove the bot's own @mention from message text.
+def strip_bot_mention(text: str, bot_user_id: Optional[str], bot_name: Optional[str] = None) -> str:
+    """Replace the bot's own @mention with its display name (or remove if no name).
 
     Slack encodes mentions as ``<@U123>``. When a user @-mentions the bot,
     the agent shouldn't see its own ID in the text — it just adds noise and
     causes the model to echo back the raw mention tag.
 
-    Only strips the *bot's* mention; other users' mentions are preserved.
+    If bot_name is provided, the mention is replaced with that name so the
+    agent sees "hi Scout" instead of "hi " when the user types "hi @Scout".
+
+    Only processes the *bot's* mention; other users' mentions are preserved.
     """
     if not bot_user_id or not text:
         return text
     import re
 
-    # Replace the mention and any surrounding whitespace with a single space,
-    # then strip leading/trailing whitespace left at the edges.
-    return re.sub(rf"\s*<@{re.escape(bot_user_id)}>\s*", " ", text).strip()
+    replacement = f" {bot_name} " if bot_name else " "
+    return re.sub(rf"\s*<@{re.escape(bot_user_id)}>\s*", replacement, text).strip()
 
 
 async def resolve_slack_user(async_client: Any, slack_user_id: str) -> Tuple[str, Optional[str]]:
@@ -106,6 +108,35 @@ async def resolve_slack_user(async_client: Any, slack_user_id: str) -> Tuple[str
     except Exception as e:
         log_warning(f"Failed to resolve Slack user {slack_user_id}: {str(e)}")
         return (slack_user_id, None)
+
+
+_bot_name_cache: Dict[str, Optional[str]] = {}
+
+
+async def resolve_bot_name(async_client: Any, bot_user_id: str) -> Optional[str]:
+    """Resolve a Slack bot user ID to its display name.
+
+    Results are cached since bot names don't change during a session.
+    Returns None if the lookup fails.
+    """
+    if bot_user_id in _bot_name_cache:
+        return _bot_name_cache[bot_user_id]
+
+    try:
+        resp = await async_client.users_info(user=bot_user_id)
+        user = resp.get("user", {}) if resp else {}
+        profile = user.get("profile", {})
+
+        name = profile.get("display_name") or profile.get("real_name") or user.get("name") or None
+        if name is not None and not name.strip():
+            name = None
+
+        _bot_name_cache[bot_user_id] = name
+        return name
+    except Exception as e:
+        log_warning(f"Failed to resolve bot name for {bot_user_id}: {str(e)}")
+        _bot_name_cache[bot_user_id] = None
+        return None
 
 
 async def resolve_channel_name(async_client: Any, channel_id: str) -> Optional[str]:

--- a/libs/agno/agno/os/interfaces/slack/helpers.py
+++ b/libs/agno/agno/os/interfaces/slack/helpers.py
@@ -110,33 +110,37 @@ async def resolve_slack_user(async_client: Any, slack_user_id: str) -> Tuple[str
         return (slack_user_id, None)
 
 
-_bot_name_cache: Dict[str, Optional[str]] = {}
+class BotNameResolver:
+    """Resolves a Slack bot user ID to its display name with per-instance caching.
 
-
-async def resolve_bot_name(async_client: Any, bot_user_id: str) -> Optional[str]:
-    """Resolve a Slack bot user ID to its display name.
-
-    Results are cached since bot names don't change during a session.
-    Returns None if the lookup fails.
+    Instantiated once per mounted Slack interface inside ``attach_routes`` so
+    each interface keeps its own cache without polluting module-level state.
+    Only successful lookups are cached — transient API failures are retried on
+    the next message.
     """
-    if bot_user_id in _bot_name_cache:
-        return _bot_name_cache[bot_user_id]
 
-    try:
-        resp = await async_client.users_info(user=bot_user_id)
-        user = resp.get("user", {}) if resp else {}
-        profile = user.get("profile", {})
+    def __init__(self) -> None:
+        self._cache: Dict[str, str] = {}
 
-        name = profile.get("display_name") or profile.get("real_name") or user.get("name") or None
-        if name is not None and not name.strip():
-            name = None
+    async def resolve(self, async_client: Any, bot_user_id: str) -> Optional[str]:
+        if bot_user_id in self._cache:
+            return self._cache[bot_user_id]
 
-        _bot_name_cache[bot_user_id] = name
-        return name
-    except Exception as e:
-        log_warning(f"Failed to resolve bot name for {bot_user_id}: {str(e)}")
-        _bot_name_cache[bot_user_id] = None
-        return None
+        try:
+            resp = await async_client.users_info(user=bot_user_id)
+            user = resp.get("user", {}) if resp else {}
+            profile = user.get("profile", {})
+
+            name = profile.get("display_name") or profile.get("real_name") or user.get("name") or None
+            if name is not None and not name.strip():
+                name = None
+
+            if name is not None:
+                self._cache[bot_user_id] = name
+            return name
+        except Exception as e:
+            log_warning(f"Failed to resolve bot name for {bot_user_id}: {str(e)}")
+            return None
 
 
 async def resolve_channel_name(async_client: Any, channel_id: str) -> Optional[str]:

--- a/libs/agno/agno/os/interfaces/slack/router.py
+++ b/libs/agno/agno/os/interfaces/slack/router.py
@@ -12,6 +12,7 @@ from agno.os.interfaces.slack.helpers import (
     build_run_metadata,
     download_event_files_async,
     extract_event_context,
+    resolve_bot_name,
     resolve_channel_name,
     resolve_slack_user,
     send_slack_message_async,
@@ -156,14 +157,16 @@ def attach_routes(
         from slack_sdk.web.async_client import AsyncWebClient
 
         ctx = extract_event_context(event)
+        async_client = AsyncWebClient(token=slack_tools.token, ssl=ssl)
 
-        # Strip the bot's own @mention from the message text
+        # Replace the bot's @mention with its Slack display name so the agent sees
+        # "hi Scout" instead of "hi " when the user types "hi @Scout"
         bot_user_id = (data.get("authorizations") or [{}])[0].get("user_id")
-        ctx["message_text"] = strip_bot_mention(ctx["message_text"], bot_user_id)
+        bot_name = await resolve_bot_name(async_client, bot_user_id) if bot_user_id else None
+        ctx["message_text"] = strip_bot_mention(ctx["message_text"], bot_user_id, bot_name)
 
         # Namespace with entity_id so threads don't collide across mounted interfaces
         session_id = f"{entity_id}:{ctx['thread_id']}"
-        async_client = AsyncWebClient(token=slack_tools.token, ssl=ssl)
 
         try:
             await async_client.assistant_threads_setStatus(
@@ -265,9 +268,13 @@ def attach_routes(
 
         ctx = extract_event_context(event)
 
-        # Strip the bot's own @mention from the message text
+        async_client = AsyncWebClient(token=slack_tools.token, ssl=ssl)
+
+        # Replace the bot's @mention with its Slack display name so the agent sees
+        # "hi Scout" instead of "hi " when the user types "hi @Scout"
         bot_user_id = (data.get("authorizations") or [{}])[0].get("user_id")
-        ctx["message_text"] = strip_bot_mention(ctx["message_text"], bot_user_id)
+        bot_name = await resolve_bot_name(async_client, bot_user_id) if bot_user_id else None
+        ctx["message_text"] = strip_bot_mention(ctx["message_text"], bot_user_id, bot_name)
 
         session_id = f"{entity_id}:{ctx['thread_id']}"
 
@@ -278,8 +285,6 @@ def attach_routes(
         # = the bot's own user ID. Using the bot ID causes Slack to stream content
         # to an invisible recipient, resulting in a blank bubble until stopStream.
         user_id = ctx["user"]
-
-        async_client = AsyncWebClient(token=slack_tools.token, ssl=ssl)
         state = StreamState(entity_type=entity_type, entity_name=entity_name)
         stream = None
 

--- a/libs/agno/agno/os/interfaces/slack/router.py
+++ b/libs/agno/agno/os/interfaces/slack/router.py
@@ -12,7 +12,7 @@ from agno.os.interfaces.slack.helpers import (
     build_run_metadata,
     download_event_files_async,
     extract_event_context,
-    resolve_bot_name,
+    BotNameResolver,
     resolve_channel_name,
     resolve_slack_user,
     send_slack_message_async,
@@ -88,6 +88,7 @@ def attach_routes(
     entity_id = getattr(entity, "id", None) or entity_name
 
     slack_tools = SlackTools(token=token, ssl=ssl, max_file_size=max_file_size)
+    bot_name_resolver = BotNameResolver()
 
     @router.post(
         "/events",
@@ -162,7 +163,7 @@ def attach_routes(
         # Replace the bot's @mention with its Slack display name so the agent sees
         # "hi Scout" instead of "hi " when the user types "hi @Scout"
         bot_user_id = (data.get("authorizations") or [{}])[0].get("user_id")
-        bot_name = await resolve_bot_name(async_client, bot_user_id) if bot_user_id else None
+        bot_name = await bot_name_resolver.resolve(async_client, bot_user_id) if bot_user_id else None
         ctx["message_text"] = strip_bot_mention(ctx["message_text"], bot_user_id, bot_name)
 
         # Namespace with entity_id so threads don't collide across mounted interfaces
@@ -273,7 +274,7 @@ def attach_routes(
         # Replace the bot's @mention with its Slack display name so the agent sees
         # "hi Scout" instead of "hi " when the user types "hi @Scout"
         bot_user_id = (data.get("authorizations") or [{}])[0].get("user_id")
-        bot_name = await resolve_bot_name(async_client, bot_user_id) if bot_user_id else None
+        bot_name = await bot_name_resolver.resolve(async_client, bot_user_id) if bot_user_id else None
         ctx["message_text"] = strip_bot_mention(ctx["message_text"], bot_user_id, bot_name)
 
         session_id = f"{entity_id}:{ctx['thread_id']}"

--- a/libs/agno/tests/unit/os/routers/test_slack_helpers.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_helpers.py
@@ -3,9 +3,11 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from agno.os.interfaces.slack.helpers import (
+    _bot_name_cache,
     download_event_files_async,
     extract_event_context,
     member_name,
+    resolve_bot_name,
     resolve_slack_user,
     send_slack_message_async,
     should_respond,
@@ -276,6 +278,54 @@ class TestResolveSlackUser:
         assert display_name is None
 
 
+# -- resolve_bot_name --
+
+
+class TestResolveBotName:
+    def setup_method(self):
+        _bot_name_cache.clear()
+
+    @pytest.mark.asyncio
+    async def test_resolves_bot_display_name(self):
+        client = AsyncMock()
+        client.users_info = AsyncMock(
+            return_value={"user": {"name": "scout_bot", "profile": {"display_name": "Scout", "real_name": "Scout Bot"}}}
+        )
+        name = await resolve_bot_name(client, "UBOT123")
+        assert name == "Scout"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_real_name(self):
+        client = AsyncMock()
+        client.users_info = AsyncMock(
+            return_value={"user": {"name": "scout_bot", "profile": {"display_name": "", "real_name": "Scout Bot"}}}
+        )
+        name = await resolve_bot_name(client, "UBOT456")
+        assert name == "Scout Bot"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_username(self):
+        client = AsyncMock()
+        client.users_info = AsyncMock(return_value={"user": {"name": "scout_bot", "profile": {}}})
+        name = await resolve_bot_name(client, "UBOT789")
+        assert name == "scout_bot"
+
+    @pytest.mark.asyncio
+    async def test_caches_result(self):
+        client = AsyncMock()
+        client.users_info = AsyncMock(return_value={"user": {"profile": {"display_name": "Scout"}}})
+        await resolve_bot_name(client, "UCACHED")
+        await resolve_bot_name(client, "UCACHED")
+        assert client.users_info.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_api_error_returns_none(self):
+        client = AsyncMock()
+        client.users_info = AsyncMock(side_effect=RuntimeError("API error"))
+        name = await resolve_bot_name(client, "UFAIL")
+        assert name is None
+
+
 # -- strip_bot_mention --
 
 
@@ -307,3 +357,19 @@ class TestStripBotMention:
     def test_mention_in_middle(self):
         result = strip_bot_mention("hey <@U0APCSS3MDH> what's up", "U0APCSS3MDH")
         assert result == "hey what's up"
+
+    def test_replaces_with_bot_name(self):
+        result = strip_bot_mention("<@U0APCSS3MDH> hello world", "U0APCSS3MDH", "Scout")
+        assert result == "Scout hello world"
+
+    def test_replaces_mention_in_middle_with_bot_name(self):
+        result = strip_bot_mention("hey <@U0APCSS3MDH> what's up", "U0APCSS3MDH", "Scout")
+        assert result == "hey Scout what's up"
+
+    def test_preserves_other_mentions_when_replacing_with_name(self):
+        result = strip_bot_mention("<@U0APCSS3MDH> hey <@U999OTHER>", "U0APCSS3MDH", "Scout")
+        assert result == "Scout hey <@U999OTHER>"
+
+    def test_mention_only_with_bot_name(self):
+        result = strip_bot_mention("<@U0APCSS3MDH>", "U0APCSS3MDH", "Scout")
+        assert result == "Scout"

--- a/libs/agno/tests/unit/os/routers/test_slack_helpers.py
+++ b/libs/agno/tests/unit/os/routers/test_slack_helpers.py
@@ -3,11 +3,10 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from agno.os.interfaces.slack.helpers import (
-    _bot_name_cache,
+    BotNameResolver,
     download_event_files_async,
     extract_event_context,
     member_name,
-    resolve_bot_name,
     resolve_slack_user,
     send_slack_message_async,
     should_respond,
@@ -281,49 +280,62 @@ class TestResolveSlackUser:
 # -- resolve_bot_name --
 
 
-class TestResolveBotName:
-    def setup_method(self):
-        _bot_name_cache.clear()
-
+class TestBotNameResolver:
     @pytest.mark.asyncio
     async def test_resolves_bot_display_name(self):
+        resolver = BotNameResolver()
         client = AsyncMock()
         client.users_info = AsyncMock(
             return_value={"user": {"name": "scout_bot", "profile": {"display_name": "Scout", "real_name": "Scout Bot"}}}
         )
-        name = await resolve_bot_name(client, "UBOT123")
+        name = await resolver.resolve(client, "UBOT123")
         assert name == "Scout"
 
     @pytest.mark.asyncio
     async def test_falls_back_to_real_name(self):
+        resolver = BotNameResolver()
         client = AsyncMock()
         client.users_info = AsyncMock(
             return_value={"user": {"name": "scout_bot", "profile": {"display_name": "", "real_name": "Scout Bot"}}}
         )
-        name = await resolve_bot_name(client, "UBOT456")
+        name = await resolver.resolve(client, "UBOT456")
         assert name == "Scout Bot"
 
     @pytest.mark.asyncio
     async def test_falls_back_to_username(self):
+        resolver = BotNameResolver()
         client = AsyncMock()
         client.users_info = AsyncMock(return_value={"user": {"name": "scout_bot", "profile": {}}})
-        name = await resolve_bot_name(client, "UBOT789")
+        name = await resolver.resolve(client, "UBOT789")
         assert name == "scout_bot"
 
     @pytest.mark.asyncio
     async def test_caches_result(self):
+        resolver = BotNameResolver()
         client = AsyncMock()
         client.users_info = AsyncMock(return_value={"user": {"profile": {"display_name": "Scout"}}})
-        await resolve_bot_name(client, "UCACHED")
-        await resolve_bot_name(client, "UCACHED")
+        await resolver.resolve(client, "UCACHED")
+        await resolver.resolve(client, "UCACHED")
         assert client.users_info.call_count == 1
 
     @pytest.mark.asyncio
     async def test_api_error_returns_none(self):
+        resolver = BotNameResolver()
         client = AsyncMock()
         client.users_info = AsyncMock(side_effect=RuntimeError("API error"))
-        name = await resolve_bot_name(client, "UFAIL")
+        name = await resolver.resolve(client, "UFAIL")
         assert name is None
+
+    @pytest.mark.asyncio
+    async def test_api_error_not_cached(self):
+        resolver = BotNameResolver()
+        client = AsyncMock()
+        client.users_info = AsyncMock(side_effect=RuntimeError("API error"))
+        await resolver.resolve(client, "UFAIL")
+        # Fix the client for the retry
+        client.users_info = AsyncMock(return_value={"user": {"profile": {"display_name": "Scout"}}})
+        name = await resolver.resolve(client, "UFAIL")
+        assert name == "Scout"
 
 
 # -- strip_bot_mention --


### PR DESCRIPTION
## Summary
- When a user @-mentions the bot in Slack (e.g., "hi @Scout"), the mention was being stripped entirely, leaving just "hi "
- Now the mention is replaced with the bot's actual Slack display name via `users.info` API, so the agent sees "hi Scout"
- Results are cached since bot names don't change during a session

## Changes
- Add `resolve_bot_name()` helper with caching to look up bot display name
- Update `strip_bot_mention()` to accept optional `bot_name` parameter
- Call `resolve_bot_name()` before `strip_bot_mention()` in both event handlers
- Add 9 new unit tests for name resolution and replacement

## Test plan
- [x] Unit tests pass (45 total, 9 new)
- [x] E2E tested with Agno Test Bot Prod in #slack-apps-testing
- [x] Verified bot response includes the mention text ("Agno Test Bot Prod test 2")