### PR TITLE
fix: add allowed_hosts allowlist to LLMsTxtTools

### DIFF
--- a/cookbook/03_teams/22_metrics/06_loop_team_and_member_metrics.py
+++ b/cookbook/03_teams/22_metrics/06_loop_team_and_member_metrics.py
@@ -24,7 +24,6 @@ from agno.run.team import TeamRunOutput
 from agno.team import Team
 from rich.pretty import pprint
 
-
 endpoint = getenv("AZURE_OPENAI_ENDPOINT")
 api_key = getenv("AZURE_OPENAI_API_KEY")
 

--- a/libs/agno/agno/knowledge/reader/llms_txt_reader.py
+++ b/libs/agno/agno/knowledge/reader/llms_txt_reader.py
@@ -3,7 +3,7 @@ import re
 import uuid
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import httpx
 
@@ -47,6 +47,7 @@ class LLMsTxtReader(Reader):
         timeout: int = 60,
         proxy: Optional[str] = None,
         skip_optional: bool = False,
+        allowed_hosts: Optional[List[str]] = None,
         **kwargs,
     ):
         if chunking_strategy is None:
@@ -57,6 +58,9 @@ class LLMsTxtReader(Reader):
         self.timeout = timeout
         self.proxy = proxy
         self.skip_optional = skip_optional
+        self.allowed_hosts: Optional[set] = (
+            {host.lower() for host in allowed_hosts} if allowed_hosts is not None else None
+        )
 
     @classmethod
     def get_supported_chunking_strategies(cls) -> List[ChunkingStrategyType]:
@@ -73,6 +77,14 @@ class LLMsTxtReader(Reader):
         return [ContentType.URL]
 
     # Helpers
+
+    def _is_host_allowed(self, url: str) -> bool:
+        if self.allowed_hosts is None:
+            return True
+        host = urlparse(url).hostname
+        if not host:
+            return False
+        return host.lower() in self.allowed_hosts
 
     def _process_response(self, content_type: str, text: str) -> str:
         if any(t in content_type for t in ["text/plain", "text/markdown"]):
@@ -174,9 +186,16 @@ class LLMsTxtReader(Reader):
         return overview, entries
 
     def fetch_url(self, url: str) -> Optional[str]:
+        if not self._is_host_allowed(url):
+            log_warning(f"Host not in allowed_hosts: {url}")
+            return None
         try:
             response = fetch_with_retry(
-                url, max_retries=1, proxy=self.proxy, timeout=self.timeout, follow_redirects=True
+                url,
+                max_retries=1,
+                proxy=self.proxy,
+                timeout=self.timeout,
+                follow_redirects=self.allowed_hosts is None,
             )
             return self._process_response(response.headers.get("content-type", ""), response.text)
         except Exception as e:
@@ -184,9 +203,16 @@ class LLMsTxtReader(Reader):
             return None
 
     async def async_fetch_url(self, client: httpx.AsyncClient, url: str) -> Optional[str]:
+        if not self._is_host_allowed(url):
+            log_warning(f"Host not in allowed_hosts: {url}")
+            return None
         try:
             response = await async_fetch_with_retry(
-                url, client=client, max_retries=1, timeout=self.timeout, follow_redirects=True
+                url,
+                client=client,
+                max_retries=1,
+                timeout=self.timeout,
+                follow_redirects=self.allowed_hosts is None,
             )
             return self._process_response(response.headers.get("content-type", ""), response.text)
         except Exception as e:

--- a/libs/agno/agno/knowledge/reader/llms_txt_reader.py
+++ b/libs/agno/agno/knowledge/reader/llms_txt_reader.py
@@ -58,8 +58,8 @@ class LLMsTxtReader(Reader):
         self.timeout = timeout
         self.proxy = proxy
         self.skip_optional = skip_optional
-        self.allowed_hosts: Optional[set] = (
-            {host.lower() for host in allowed_hosts} if allowed_hosts is not None else None
+        self.allowed_hosts: Optional[List[str]] = (
+            [host.lower() for host in allowed_hosts] if allowed_hosts is not None else None
         )
 
     @classmethod
@@ -78,7 +78,7 @@ class LLMsTxtReader(Reader):
 
     # Helpers
 
-    def _is_host_allowed(self, url: str) -> bool:
+    def is_host_allowed(self, url: str) -> bool:
         if self.allowed_hosts is None:
             return True
         host = urlparse(url).hostname
@@ -186,8 +186,8 @@ class LLMsTxtReader(Reader):
         return overview, entries
 
     def fetch_url(self, url: str) -> Optional[str]:
-        if not self._is_host_allowed(url):
-            log_warning(f"Host not in allowed_hosts: {url}")
+        if not self.is_host_allowed(url):
+            log_debug(f"Host not in allowed_hosts: {url}")
             return None
         try:
             response = fetch_with_retry(
@@ -203,8 +203,8 @@ class LLMsTxtReader(Reader):
             return None
 
     async def async_fetch_url(self, client: httpx.AsyncClient, url: str) -> Optional[str]:
-        if not self._is_host_allowed(url):
-            log_warning(f"Host not in allowed_hosts: {url}")
+        if not self.is_host_allowed(url):
+            log_debug(f"Host not in allowed_hosts: {url}")
             return None
         try:
             response = await async_fetch_with_retry(

--- a/libs/agno/agno/tools/llms_txt.py
+++ b/libs/agno/agno/tools/llms_txt.py
@@ -23,13 +23,13 @@ class LLMsTxtTools(Toolkit):
         self.max_urls = max_urls
         self.timeout = timeout
         self.skip_optional = skip_optional
-        self.allowed_hosts: Optional[List[str]] = allowed_hosts
         self.reader = LLMsTxtReader(
             max_urls=max_urls,
             timeout=timeout,
             skip_optional=skip_optional,
             allowed_hosts=allowed_hosts,
         )
+        self.allowed_hosts: Optional[List[str]] = self.reader.allowed_hosts
 
         tools: List[Callable] = []
         async_tools_list: List[tuple] = []
@@ -76,7 +76,7 @@ class LLMsTxtTools(Toolkit):
         Returns:
             str: JSON with the overview and list of available documentation pages
         """
-        if not self.reader._is_host_allowed(url):
+        if not self.reader.is_host_allowed(url):
             return f"Host is not in allowed_hosts; refusing to fetch {url}"
         try:
             log_info(f"Reading llms.txt index from {url}")
@@ -100,7 +100,7 @@ class LLMsTxtTools(Toolkit):
         Returns:
             str: JSON with the overview and list of available documentation pages
         """
-        if not self.reader._is_host_allowed(url):
+        if not self.reader.is_host_allowed(url):
             return f"Host is not in allowed_hosts; refusing to fetch {url}"
         try:
             log_info(f"Reading llms.txt index from {url}")
@@ -126,7 +126,7 @@ class LLMsTxtTools(Toolkit):
         Returns:
             str: The text content of the page
         """
-        if not self.reader._is_host_allowed(url):
+        if not self.reader.is_host_allowed(url):
             return f"Host is not in allowed_hosts; refusing to fetch {url}"
         try:
             log_debug(f"Fetching URL: {url}")
@@ -148,7 +148,7 @@ class LLMsTxtTools(Toolkit):
         Returns:
             str: The text content of the page
         """
-        if not self.reader._is_host_allowed(url):
+        if not self.reader.is_host_allowed(url):
             return f"Host is not in allowed_hosts; refusing to fetch {url}"
         try:
             log_debug(f"Fetching URL: {url}")
@@ -174,7 +174,7 @@ class LLMsTxtTools(Toolkit):
         if self.knowledge is None:
             return "Knowledge base not provided"
 
-        if not self.reader._is_host_allowed(url):
+        if not self.reader.is_host_allowed(url):
             return f"Host is not in allowed_hosts; refusing to fetch {url}"
         try:
             log_info(f"Reading llms.txt from {url}")
@@ -196,7 +196,7 @@ class LLMsTxtTools(Toolkit):
         if self.knowledge is None:
             return "Knowledge base not provided"
 
-        if not self.reader._is_host_allowed(url):
+        if not self.reader.is_host_allowed(url):
             return f"Host is not in allowed_hosts; refusing to fetch {url}"
         try:
             log_info(f"Reading llms.txt from {url}")

--- a/libs/agno/agno/tools/llms_txt.py
+++ b/libs/agno/agno/tools/llms_txt.py
@@ -16,16 +16,19 @@ class LLMsTxtTools(Toolkit):
         max_urls: int = 20,
         timeout: int = 60,
         skip_optional: bool = False,
+        allowed_hosts: Optional[List[str]] = None,
         **kwargs,
     ):
         self.knowledge: Optional[Knowledge] = knowledge
         self.max_urls = max_urls
         self.timeout = timeout
         self.skip_optional = skip_optional
+        self.allowed_hosts: Optional[List[str]] = allowed_hosts
         self.reader = LLMsTxtReader(
             max_urls=max_urls,
             timeout=timeout,
             skip_optional=skip_optional,
+            allowed_hosts=allowed_hosts,
         )
 
         tools: List[Callable] = []
@@ -73,6 +76,8 @@ class LLMsTxtTools(Toolkit):
         Returns:
             str: JSON with the overview and list of available documentation pages
         """
+        if not self.reader._is_host_allowed(url):
+            return f"Host is not in allowed_hosts; refusing to fetch {url}"
         try:
             log_info(f"Reading llms.txt index from {url}")
             llms_txt_content = self.reader.fetch_url(url)
@@ -95,6 +100,8 @@ class LLMsTxtTools(Toolkit):
         Returns:
             str: JSON with the overview and list of available documentation pages
         """
+        if not self.reader._is_host_allowed(url):
+            return f"Host is not in allowed_hosts; refusing to fetch {url}"
         try:
             log_info(f"Reading llms.txt index from {url}")
             async with self._async_client() as client:
@@ -119,6 +126,8 @@ class LLMsTxtTools(Toolkit):
         Returns:
             str: The text content of the page
         """
+        if not self.reader._is_host_allowed(url):
+            return f"Host is not in allowed_hosts; refusing to fetch {url}"
         try:
             log_debug(f"Fetching URL: {url}")
             content = self.reader.fetch_url(url)
@@ -139,6 +148,8 @@ class LLMsTxtTools(Toolkit):
         Returns:
             str: The text content of the page
         """
+        if not self.reader._is_host_allowed(url):
+            return f"Host is not in allowed_hosts; refusing to fetch {url}"
         try:
             log_debug(f"Fetching URL: {url}")
             async with self._async_client() as client:
@@ -163,6 +174,8 @@ class LLMsTxtTools(Toolkit):
         if self.knowledge is None:
             return "Knowledge base not provided"
 
+        if not self.reader._is_host_allowed(url):
+            return f"Host is not in allowed_hosts; refusing to fetch {url}"
         try:
             log_info(f"Reading llms.txt from {url}")
             self.knowledge.insert(url=url, reader=self.reader)
@@ -183,6 +196,8 @@ class LLMsTxtTools(Toolkit):
         if self.knowledge is None:
             return "Knowledge base not provided"
 
+        if not self.reader._is_host_allowed(url):
+            return f"Host is not in allowed_hosts; refusing to fetch {url}"
         try:
             log_info(f"Reading llms.txt from {url}")
             await self.knowledge.ainsert(url=url, reader=self.reader)

--- a/libs/agno/tests/integration/workflows/test_workflow_cancellation.py
+++ b/libs/agno/tests/integration/workflows/test_workflow_cancellation.py
@@ -13,7 +13,6 @@ from agno.run.workflow import WorkflowCancelledEvent
 from agno.workflow import Step, Workflow
 from agno.workflow.types import StepInput, StepOutput
 
-
 # ============================================================================
 # FIXTURES
 # ============================================================================

--- a/libs/agno/tests/unit/tools/test_llms_txt.py
+++ b/libs/agno/tests/unit/tools/test_llms_txt.py
@@ -540,3 +540,175 @@ def test_knowledge_error_handling(tools_with_knowledge):
 
     assert "Error" in result
     assert "RuntimeError" in result
+
+
+# ============================================================================
+# READER: ALLOWED HOSTS
+# ============================================================================
+
+
+def test_reader_allowed_hosts_default_none():
+    reader = LLMsTxtReader()
+    assert reader.allowed_hosts is None
+    assert reader._is_host_allowed("http://anything.example/path") is True
+
+
+def test_reader_allowed_hosts_normalizes_case():
+    reader = LLMsTxtReader(allowed_hosts=["Docs.Agno.COM"])
+    assert reader._is_host_allowed("https://docs.agno.com/x") is True
+    assert reader._is_host_allowed("https://DOCS.AGNO.COM/x") is True
+    assert reader._is_host_allowed("https://other.example/x") is False
+
+
+def test_reader_allowed_hosts_ignores_port_and_userinfo():
+    reader = LLMsTxtReader(allowed_hosts=["docs.agno.com"])
+    assert reader._is_host_allowed("https://docs.agno.com:8443/x") is True
+    assert reader._is_host_allowed("https://user:pass@docs.agno.com/x") is True
+    assert reader._is_host_allowed("http://docs.agno.com@evil.example/x") is False
+
+
+def test_reader_allowed_hosts_blocks_localhost_and_metadata():
+    reader = LLMsTxtReader(allowed_hosts=["docs.agno.com"])
+    assert reader._is_host_allowed("http://127.0.0.1:8000/admin") is False
+    assert reader._is_host_allowed("http://localhost:8000/admin") is False
+    assert reader._is_host_allowed("http://169.254.169.254/latest/meta-data") is False
+
+
+def test_reader_fetch_url_blocks_disallowed():
+    reader = LLMsTxtReader(allowed_hosts=["docs.agno.com"])
+
+    with patch("agno.knowledge.reader.llms_txt_reader.fetch_with_retry") as mock_fetch:
+        result = reader.fetch_url("http://127.0.0.1:8000/admin")
+
+    assert result is None
+    mock_fetch.assert_not_called()
+
+
+def test_reader_fetch_url_passes_follow_redirects_false_when_allowlisted():
+    reader = LLMsTxtReader(allowed_hosts=["docs.agno.com"])
+    response = _mock_httpx_response("Doc content", "text/plain")
+
+    with patch("agno.knowledge.reader.llms_txt_reader.fetch_with_retry", return_value=response) as mock_fetch:
+        result = reader.fetch_url("https://docs.agno.com/page")
+
+    assert result == "Doc content"
+    assert mock_fetch.call_args.kwargs.get("follow_redirects") is False
+
+
+def test_reader_fetch_url_follows_redirects_when_no_allowlist():
+    reader = LLMsTxtReader()
+    response = _mock_httpx_response("Doc content", "text/plain")
+
+    with patch("agno.knowledge.reader.llms_txt_reader.fetch_with_retry", return_value=response) as mock_fetch:
+        reader.fetch_url("https://example.com/page")
+
+    assert mock_fetch.call_args.kwargs.get("follow_redirects") is True
+
+
+def test_reader_fetch_url_returns_none_on_redirect_when_allowlisted():
+    reader = LLMsTxtReader(allowed_hosts=["docs.agno.com"])
+    error = httpx.HTTPStatusError("redirect", request=MagicMock(), response=MagicMock(status_code=302))
+
+    with patch("agno.knowledge.reader.llms_txt_reader.fetch_with_retry", side_effect=error):
+        result = reader.fetch_url("https://docs.agno.com/old")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_reader_async_fetch_url_blocks_disallowed():
+    reader = LLMsTxtReader(allowed_hosts=["docs.agno.com"])
+    client = AsyncMock()
+
+    with patch("agno.knowledge.reader.llms_txt_reader.async_fetch_with_retry") as mock_fetch:
+        result = await reader.async_fetch_url(client, "http://localhost:8000/admin")
+
+    assert result is None
+    mock_fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_reader_async_fetch_url_passes_follow_redirects_false_when_allowlisted():
+    reader = LLMsTxtReader(allowed_hosts=["docs.agno.com"])
+    response = _mock_httpx_response("Doc content", "text/plain")
+    client = AsyncMock()
+
+    with patch(
+        "agno.knowledge.reader.llms_txt_reader.async_fetch_with_retry",
+        new=AsyncMock(return_value=response),
+    ) as mock_fetch:
+        await reader.async_fetch_url(client, "https://docs.agno.com/page")
+
+    assert mock_fetch.call_args.kwargs.get("follow_redirects") is False
+
+
+# ============================================================================
+# TOOLKIT: ALLOWED HOSTS
+# ============================================================================
+
+
+def test_tools_allowed_hosts_propagates_to_reader():
+    t = LLMsTxtTools(allowed_hosts=["Docs.Agno.com", "cdn.agno.com"])
+    assert t.allowed_hosts == ["Docs.Agno.com", "cdn.agno.com"]
+    assert t.reader.allowed_hosts == {"docs.agno.com", "cdn.agno.com"}
+
+
+def test_tools_get_index_rejects_disallowed_host():
+    t = LLMsTxtTools(allowed_hosts=["docs.agno.com"])
+
+    with patch("agno.knowledge.reader.llms_txt_reader.fetch_with_retry") as mock_fetch:
+        result = t.get_llms_txt_index("http://127.0.0.1:8000/llms.txt")
+
+    assert "not in allowed_hosts" in result
+    mock_fetch.assert_not_called()
+
+
+def test_tools_read_url_rejects_disallowed_host():
+    t = LLMsTxtTools(allowed_hosts=["docs.agno.com"])
+
+    with patch("agno.knowledge.reader.llms_txt_reader.fetch_with_retry") as mock_fetch:
+        result = t.read_llms_txt_url("http://169.254.169.254/latest/meta-data")
+
+    assert "not in allowed_hosts" in result
+    mock_fetch.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tools_aread_url_rejects_disallowed_host():
+    t = LLMsTxtTools(allowed_hosts=["docs.agno.com"])
+
+    with patch("agno.knowledge.reader.llms_txt_reader.async_fetch_with_retry") as mock_fetch:
+        result = await t.aread_llms_txt_url("http://localhost:8000/admin")
+
+    assert "not in allowed_hosts" in result
+    mock_fetch.assert_not_called()
+
+
+def test_tools_load_knowledge_rejects_disallowed_host():
+    mock_knowledge = MagicMock()
+    t = LLMsTxtTools(knowledge=mock_knowledge, allowed_hosts=["docs.agno.com"])
+
+    result = t.read_llms_txt_and_load_knowledge("http://internal.svc/llms.txt")
+
+    assert "not in allowed_hosts" in result
+    mock_knowledge.insert.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tools_aload_knowledge_rejects_disallowed_host():
+    mock_knowledge = MagicMock()
+    mock_knowledge.ainsert = AsyncMock()
+    t = LLMsTxtTools(knowledge=mock_knowledge, allowed_hosts=["docs.agno.com"])
+
+    result = await t.aread_llms_txt_and_load_knowledge("http://internal.svc/llms.txt")
+
+    assert "not in allowed_hosts" in result
+    mock_knowledge.ainsert.assert_not_called()
+
+
+def test_tools_default_no_allowed_hosts_is_unchanged():
+    """Default behavior (no allowed_hosts) must remain unchanged."""
+    t = LLMsTxtTools()
+    assert t.allowed_hosts is None
+    assert t.reader.allowed_hosts is None
+    assert t.reader._is_host_allowed("http://anything.example/x") is True

--- a/libs/agno/tests/unit/tools/test_llms_txt.py
+++ b/libs/agno/tests/unit/tools/test_llms_txt.py
@@ -550,28 +550,28 @@ def test_knowledge_error_handling(tools_with_knowledge):
 def test_reader_allowed_hosts_default_none():
     reader = LLMsTxtReader()
     assert reader.allowed_hosts is None
-    assert reader._is_host_allowed("http://anything.example/path") is True
+    assert reader.is_host_allowed("http://anything.example/path") is True
 
 
 def test_reader_allowed_hosts_normalizes_case():
     reader = LLMsTxtReader(allowed_hosts=["Docs.Agno.COM"])
-    assert reader._is_host_allowed("https://docs.agno.com/x") is True
-    assert reader._is_host_allowed("https://DOCS.AGNO.COM/x") is True
-    assert reader._is_host_allowed("https://other.example/x") is False
+    assert reader.is_host_allowed("https://docs.agno.com/x") is True
+    assert reader.is_host_allowed("https://DOCS.AGNO.COM/x") is True
+    assert reader.is_host_allowed("https://other.example/x") is False
 
 
 def test_reader_allowed_hosts_ignores_port_and_userinfo():
     reader = LLMsTxtReader(allowed_hosts=["docs.agno.com"])
-    assert reader._is_host_allowed("https://docs.agno.com:8443/x") is True
-    assert reader._is_host_allowed("https://user:pass@docs.agno.com/x") is True
-    assert reader._is_host_allowed("http://docs.agno.com@evil.example/x") is False
+    assert reader.is_host_allowed("https://docs.agno.com:8443/x") is True
+    assert reader.is_host_allowed("https://user:pass@docs.agno.com/x") is True
+    assert reader.is_host_allowed("http://docs.agno.com@evil.example/x") is False
 
 
 def test_reader_allowed_hosts_blocks_localhost_and_metadata():
     reader = LLMsTxtReader(allowed_hosts=["docs.agno.com"])
-    assert reader._is_host_allowed("http://127.0.0.1:8000/admin") is False
-    assert reader._is_host_allowed("http://localhost:8000/admin") is False
-    assert reader._is_host_allowed("http://169.254.169.254/latest/meta-data") is False
+    assert reader.is_host_allowed("http://127.0.0.1:8000/admin") is False
+    assert reader.is_host_allowed("http://localhost:8000/admin") is False
+    assert reader.is_host_allowed("http://169.254.169.254/latest/meta-data") is False
 
 
 def test_reader_fetch_url_blocks_disallowed():
@@ -649,8 +649,8 @@ async def test_reader_async_fetch_url_passes_follow_redirects_false_when_allowli
 
 def test_tools_allowed_hosts_propagates_to_reader():
     t = LLMsTxtTools(allowed_hosts=["Docs.Agno.com", "cdn.agno.com"])
-    assert t.allowed_hosts == ["Docs.Agno.com", "cdn.agno.com"]
-    assert t.reader.allowed_hosts == {"docs.agno.com", "cdn.agno.com"}
+    assert t.allowed_hosts == ["docs.agno.com", "cdn.agno.com"]
+    assert t.allowed_hosts is t.reader.allowed_hosts
 
 
 def test_tools_get_index_rejects_disallowed_host():
@@ -711,4 +711,4 @@ def test_tools_default_no_allowed_hosts_is_unchanged():
     t = LLMsTxtTools()
     assert t.allowed_hosts is None
     assert t.reader.allowed_hosts is None
-    assert t.reader._is_host_allowed("http://anything.example/x") is True
+    assert t.reader.is_host_allowed("http://anything.example/x") is True


### PR DESCRIPTION
## Summary

`LLMsTxtTools` accepts arbitrary URLs from the model and performs outbound HTTP fetches before any guardrail can inspect them. With no allowlist, a prompt-injected agent can be steered into hitting internal services such as `http://127.0.0.1:8000/admin` or the cloud metadata endpoint `http://169.254.169.254/latest/meta-data` — classic SSRF.

This PR adds an opt-in `allowed_hosts: Optional[List[str]] = None` constructor parameter to both `LLMsTxtTools` and `LLMsTxtReader`. When set:

- Only URLs whose hostname is in the allowlist are fetched (case-insensitive match on the parsed URL hostname; ports / paths / queries / userinfo ignored).
- HTTP redirects are not followed, since a permitted host could otherwise 3xx-bounce the request to an internal target.

Default `None` preserves the existing behavior — no breaking change.

```python
# Before — vulnerable
LLMsTxtTools()

# After — locked down to docs hosts
LLMsTxtTools(allowed_hosts=["docs.agno.com"])
```

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

### Implementation

- New constructor param `allowed_hosts` on `LLMsTxtReader`
- New `_is_host_allowed(url)` helper
- `fetch_url` and `async_fetch_url` guard at the top with the host check, then call the existing `fetch_with_retry` / `async_fetch_with_retry` helpers with `follow_redirects=self.allowed_hosts is None` so the same single code path handles both modes.
- `LLMsTxtTools` accepts `allowed_hosts` and passes it through to the reader. Each public tool method inlines an early-return host check so the agent gets a clear `"Host is not in allowed_hosts; refusing to fetch <url>"` message

### Behaviour

| Scenario | `allowed_hosts=None` (default) | `allowed_hosts=["docs.agno.com"]` |
|---|---|---|
| Fetch `https://docs.agno.com/anything/path?q=1` | Fetched | Fetched |
| Fetch `http://127.0.0.1:8000/admin` | **Fetched (SSRF)** | Refused, returns clear error |
| Fetch `http://169.254.169.254/latest/meta-data` | **Fetched (SSRF)** | Refused |
| Server returns 302 → `http://localhost:8000/admin` | Followed (SSRF) | Refused — not followed |
| Server returns 302 → same-host `/new-page` | Followed | Refused (use canonical URLs) |
| `read_llms_txt_and_load_knowledge` with entries pointing to internal hosts | Internal handler hit | Entries skipped, internal handler **never** contacted |

The host allowlist is hostname-only by design: any path under an allowed hostname works (so the agent can roam `docs.agno.com/agents/intro`, `docs.agno.com/api/...`, etc.). Subdomains must be listed explicitly; `localhost` and `127.0.0.1` are distinct entries.