### PR TITLE
fix: preserve MCP tool result metadata

### DIFF
--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -1335,3 +1335,4 @@ class ToolResult(BaseModel):
     videos: Optional[List[Video]] = None
     audios: Optional[List[Audio]] = None
     files: Optional[List[File]] = None
+    meta: Optional[Dict[str, Any]] = None

--- a/libs/agno/agno/utils/mcp.py
+++ b/libs/agno/agno/utils/mcp.py
@@ -1,6 +1,6 @@
 import json
 from functools import partial
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 from uuid import uuid4
 
 from agno.utils.log import log_debug, log_exception
@@ -78,10 +78,11 @@ def get_entrypoint_for_tool(
 
             log_debug(f"Calling MCP Tool '{tool_name}' with args: {kwargs}")
             result: CallToolResult = await active_session.call_tool(tool_name, kwargs)  # type: ignore
+            result_meta: Optional[Dict[str, Any]] = getattr(result, "meta", None)
 
             # Return an error if the tool call failed
             if result.isError:
-                return ToolResult(content=f"Error from MCP tool '{tool_name}': {result.content}")
+                return ToolResult(content=f"Error from MCP tool '{tool_name}': {result.content}", meta=result_meta)
 
             # Process the result content
             response_str = ""
@@ -161,6 +162,7 @@ def get_entrypoint_for_tool(
             return ToolResult(
                 content=response_str.strip(),
                 images=images if images else None,
+                meta=result_meta,
             )
         except Exception as e:
             log_exception(f"Failed to call MCP tool '{tool_name}': {e}")

--- a/libs/agno/tests/unit/tools/test_mcp.py
+++ b/libs/agno/tests/unit/tools/test_mcp.py
@@ -1,9 +1,12 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from mcp.types import TextContent
 
+from agno.tools.function import ToolResult
 from agno.tools.mcp import MCPTools, MultiMCPTools
 from agno.tools.mcp.params import SSEClientParams, StreamableHTTPClientParams
+from agno.utils.mcp import get_entrypoint_for_tool
 
 
 class _AsyncContextManager:
@@ -20,6 +23,10 @@ class _AsyncContextManager:
 class _AsyncExitStackStub:
     async def enter_async_context(self, context):
         return await context.__aenter__()
+
+
+class _MCPToolStub:
+    name = "get_data"
 
 
 @pytest.mark.asyncio
@@ -111,6 +118,43 @@ async def test_mcp_include_exclude_tools_bad_values(kwargs):
     with pytest.raises(ValueError, match="not present in the toolkit"):
         tools.session = session_mock
         await tools.build_tools()
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_result_preserves_meta():
+    session_mock = MagicMock()
+    session_mock.send_ping = AsyncMock()
+    session_mock.call_tool = AsyncMock()
+    session_mock.call_tool.return_value.isError = False
+    session_mock.call_tool.return_value.meta = {"trace_id": "abc-123"}
+    session_mock.call_tool.return_value.content = [TextContent(type="text", text="hello")]
+
+    entrypoint = get_entrypoint_for_tool(tool=_MCPToolStub(), session=session_mock)
+
+    result = await entrypoint(x="y")
+
+    assert result.content == "hello"
+    assert result.meta == {"trace_id": "abc-123"}
+    dumped_result = result.model_dump()
+    assert dumped_result["meta"] == {"trace_id": "abc-123"}
+    assert ToolResult.model_validate(dumped_result).meta == {"trace_id": "abc-123"}
+
+
+@pytest.mark.asyncio
+async def test_mcp_error_tool_result_preserves_meta():
+    session_mock = MagicMock()
+    session_mock.send_ping = AsyncMock()
+    session_mock.call_tool = AsyncMock()
+    session_mock.call_tool.return_value.isError = True
+    session_mock.call_tool.return_value.meta = {"trace_id": "error-123"}
+    session_mock.call_tool.return_value.content = [TextContent(type="text", text="bad")]
+
+    entrypoint = get_entrypoint_for_tool(tool=_MCPToolStub(), session=session_mock)
+
+    result = await entrypoint(x="y")
+
+    assert result.content.startswith("Error from MCP tool 'get_data'")
+    assert result.meta == {"trace_id": "error-123"}
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- add optional metadata storage to `ToolResult`
- pass MCP `CallToolResult.meta` through the MCP wrapper for success and MCP error results
- cover success/error propagation plus `model_dump` / `model_validate` round-trip behavior

Fixes #7658.

## Tests
- `.venv-test/bin/python -m pytest libs/agno/tests/unit/tools/test_mcp.py -q`
- `.venv-test/bin/ruff check libs/agno/agno/tools/function.py libs/agno/agno/utils/mcp.py libs/agno/tests/unit/tools/test_mcp.py`
- `.venv-test/bin/ruff format --check libs/agno/agno/tools/function.py libs/agno/agno/utils/mcp.py libs/agno/tests/unit/tools/test_mcp.py`
- `.venv-test/bin/mypy --config-file libs/agno/pyproject.toml --follow-imports=skip libs/agno/agno/tools/function.py libs/agno/agno/utils/mcp.py`

Note: `uv run --project libs/agno --extra dev ...` currently fails dependency resolution before running tests because of an unrelated `brave-search` metadata conflict with `a2a` optional dependency resolution, so I used a minimal local venv for focused validation.