### PR TITLE
fix: preserve Gemini unknown error details

### DIFF
--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -63,6 +63,20 @@ except ImportError:
     ToolParallelAiSearch = None
 
 
+def _format_unknown_gemini_error(error: Exception) -> str:
+    error_type = type(error)
+    if error_type.__module__ in ("builtins", "__main__"):
+        error_name = error_type.__qualname__
+    else:
+        error_name = f"{error_type.__module__}.{error_type.__qualname__}"
+
+    error_message = str(error).strip()
+    if error_message:
+        return f"{error_name}: {error_message}"
+
+    return error_name
+
+
 @dataclass
 class Gemini(Model):
     """
@@ -567,8 +581,9 @@ class Gemini(Model):
         except RetryableModelProviderError:
             raise
         except Exception as e:
-            log_error(f"Unknown error from Gemini API: {str(e)}")
-            raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
+            error_message = _format_unknown_gemini_error(e)
+            log_error(f"Unknown error from Gemini API: {error_message}")
+            raise ModelProviderError(message=error_message, model_name=self.name, model_id=self.id) from e
 
     def invoke_stream(
         self,
@@ -621,8 +636,9 @@ class Gemini(Model):
         except RetryableModelProviderError:
             raise
         except Exception as e:
-            log_error(f"Unknown error from Gemini API: {str(e)}")
-            raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
+            error_message = _format_unknown_gemini_error(e)
+            log_error(f"Unknown error from Gemini API: {error_message}")
+            raise ModelProviderError(message=error_message, model_name=self.name, model_id=self.id) from e
 
     async def ainvoke(
         self,
@@ -680,8 +696,9 @@ class Gemini(Model):
         except RetryableModelProviderError:
             raise
         except Exception as e:
-            log_error(f"Unknown error from Gemini API: {str(e)}")
-            raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
+            error_message = _format_unknown_gemini_error(e)
+            log_error(f"Unknown error from Gemini API: {error_message}")
+            raise ModelProviderError(message=error_message, model_name=self.name, model_id=self.id) from e
 
     async def ainvoke_stream(
         self,
@@ -737,8 +754,9 @@ class Gemini(Model):
         except RetryableModelProviderError:
             raise
         except Exception as e:
-            log_error(f"Unknown error from Gemini API: {str(e)}")
-            raise ModelProviderError(message=str(e), model_name=self.name, model_id=self.id) from e
+            error_message = _format_unknown_gemini_error(e)
+            log_error(f"Unknown error from Gemini API: {error_message}")
+            raise ModelProviderError(message=error_message, model_name=self.name, model_id=self.id) from e
 
     def _format_messages(self, messages: List[Message], compress_tool_results: bool = False):
         """

--- a/libs/agno/tests/unit/models/google/test_gemini.py
+++ b/libs/agno/tests/unit/models/google/test_gemini.py
@@ -4,9 +4,37 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agno.exceptions import ModelProviderError
 from agno.media import File
-from agno.models.google.gemini import Gemini
+from agno.models.google.gemini import Gemini, _format_unknown_gemini_error
 from agno.models.message import Message
+
+
+@pytest.mark.parametrize(
+    "error, expected",
+    [
+        (TimeoutError(), "TimeoutError"),
+        (ValueError("bad request"), "ValueError: bad request"),
+    ],
+)
+def test_format_unknown_gemini_error_includes_type(error, expected):
+    assert _format_unknown_gemini_error(error) == expected
+
+
+def test_gemini_invoke_unknown_error_includes_type_and_preserves_cause():
+    model = Gemini(api_key="test-key")
+    original_error = TimeoutError()
+    mock_client = MagicMock()
+    mock_client.models.generate_content.side_effect = original_error
+
+    with patch.object(model, "get_client", return_value=mock_client):
+        with patch("agno.models.google.gemini.log_error") as mock_log_error:
+            with pytest.raises(ModelProviderError) as exc_info:
+                model.invoke([Message(role="user", content="Hello")], Message(role="assistant"))
+
+    assert exc_info.value.message == "TimeoutError"
+    assert exc_info.value.__cause__ is original_error
+    mock_log_error.assert_called_once_with("Unknown error from Gemini API: TimeoutError")
 
 
 def test_gemini_get_client_with_credentials_vertexai():


### PR DESCRIPTION
## Summary
- include the exception type when Gemini generic exceptions are wrapped as `ModelProviderError`
- avoid blank unknown-error logs for empty-message exceptions such as `TimeoutError()`
- add regression coverage for the formatter and sync invoke wrapper

Fixes #7600.

## Tests
- `.venv-test/bin/python -m pytest libs/agno/tests/unit/models/google/test_gemini.py -q`
- `.venv-test/bin/python -m ruff check libs/agno/agno/models/google/gemini.py libs/agno/tests/unit/models/google/test_gemini.py`
- `git diff --check`