### PR TITLE
fix: _update_content and _aupdate_content insert missing rows instead of silently skipping

### DIFF
--- a/libs/agno/agno/knowledge/knowledge.py
+++ b/libs/agno/agno/knowledge/knowledge.py
@@ -2525,31 +2525,30 @@ class Knowledge(RemoteKnowledge):
                 log_warning("Content id is required to update Knowledge content")
                 return None
 
-            # TODO: we shouldn't check for content here, we should trust the upsert method to handle conflicts
             content_row = self.contents_db.get_knowledge_content(content.id)
             if content_row is None:
-                log_warning(f"Content row not found for id: {content.id}, cannot update status")
-                return None
-
-            # Apply safe string handling for updates as well
-            if content.name is not None:
-                content_row.name = self._ensure_string_field(content.name, "content.name", default="")
-            if content.description is not None:
-                content_row.description = self._ensure_string_field(
-                    content.description, "content.description", default=""
-                )
-            if content.metadata is not None:
-                content_row.metadata = merge_user_metadata(content_row.metadata, content.metadata)
-            if content.status is not None:
-                content_row.status = content.status
-            if content.status_message is not None:
-                content_row.status_message = self._ensure_string_field(
-                    content.status_message, "content.status_message", default=""
-                )
-            if content.external_id is not None:
-                content_row.external_id = self._ensure_string_field(
-                    content.external_id, "content.external_id", default=""
-                )
+                log_warning(f"Content row not found for id: {content.id}, inserting new row via upsert")
+                content_row = self._build_knowledge_row(content)
+            else:
+                # Apply safe string handling for updates as well
+                if content.name is not None:
+                    content_row.name = self._ensure_string_field(content.name, "content.name", default="")
+                if content.description is not None:
+                    content_row.description = self._ensure_string_field(
+                        content.description, "content.description", default=""
+                    )
+                if content.metadata is not None:
+                    content_row.metadata = merge_user_metadata(content_row.metadata, content.metadata)
+                if content.status is not None:
+                    content_row.status = content.status
+                if content.status_message is not None:
+                    content_row.status_message = self._ensure_string_field(
+                        content.status_message, "content.status_message", default=""
+                    )
+                if content.external_id is not None:
+                    content_row.external_id = self._ensure_string_field(
+                        content.external_id, "content.external_id", default=""
+                    )
             content_row.updated_at = int(time.time())
             self.contents_db.upsert_knowledge_content(knowledge_row=content_row)
 
@@ -2569,34 +2568,33 @@ class Knowledge(RemoteKnowledge):
                 log_warning("Content id is required to update Knowledge content")
                 return None
 
-            # TODO: we shouldn't check for content here, we should trust the upsert method to handle conflicts
             if isinstance(self.contents_db, AsyncBaseDb):
                 content_row = await self.contents_db.get_knowledge_content(content.id)
             else:
                 content_row = self.contents_db.get_knowledge_content(content.id)
             if content_row is None:
-                log_warning(f"Content row not found for id: {content.id}, cannot update status")
-                return None
-
-            # Apply safe string handling for updates
-            if content.name is not None:
-                content_row.name = self._ensure_string_field(content.name, "content.name", default="")
-            if content.description is not None:
-                content_row.description = self._ensure_string_field(
-                    content.description, "content.description", default=""
-                )
-            if content.metadata is not None:
-                content_row.metadata = merge_user_metadata(content_row.metadata, content.metadata)
-            if content.status is not None:
-                content_row.status = content.status
-            if content.status_message is not None:
-                content_row.status_message = self._ensure_string_field(
-                    content.status_message, "content.status_message", default=""
-                )
-            if content.external_id is not None:
-                content_row.external_id = self._ensure_string_field(
-                    content.external_id, "content.external_id", default=""
-                )
+                log_warning(f"Content row not found for id: {content.id}, inserting new row via upsert")
+                content_row = self._build_knowledge_row(content)
+            else:
+                # Apply safe string handling for updates
+                if content.name is not None:
+                    content_row.name = self._ensure_string_field(content.name, "content.name", default="")
+                if content.description is not None:
+                    content_row.description = self._ensure_string_field(
+                        content.description, "content.description", default=""
+                    )
+                if content.metadata is not None:
+                    content_row.metadata = merge_user_metadata(content_row.metadata, content.metadata)
+                if content.status is not None:
+                    content_row.status = content.status
+                if content.status_message is not None:
+                    content_row.status_message = self._ensure_string_field(
+                        content.status_message, "content.status_message", default=""
+                    )
+                if content.external_id is not None:
+                    content_row.external_id = self._ensure_string_field(
+                        content.external_id, "content.external_id", default=""
+                    )
 
             content_row.updated_at = int(time.time())
             if isinstance(self.contents_db, AsyncBaseDb):


### PR DESCRIPTION
## Summary

Fixes #7754

- When `_update_content` or `_aupdate_content` is called with a `Content` whose id does not yet exist in `contents_db`, both methods previously logged `"Content row not found for id: ..., cannot update status"` and returned `None` — the row was never written.
- Both sync and async variants now fall back to **building a new `KnowledgeRow` via `_build_knowledge_row(content)`** and proceeding with `upsert_knowledge_content`, trusting the backend to insert the missing row.
- A `log_warning` is still emitted on the fallback path so operators can see that an insert (rather than an update) took place.
- The duplicate TODO comment (`# TODO: we shouldn't check for content here ...`) has been removed as the logic now follows the intended design.

## Changes

`libs/agno/agno/knowledge/knowledge.py`
- `_update_content`: replace early-return-on-None with `_build_knowledge_row(content)` fallback + upsert
- `_aupdate_content`: same fix for the async path

## Test plan

- [ ] Create a `Knowledge` instance with a `SqliteDb` attached as `contents_db`
- [ ] Build a `Content` with an `id` that does **not** exist in the contents table
- [ ] Call `knowledge._update_content(content)` — verify the row is now written and the return value is not `None`
- [ ] Repeat with `await knowledge._aupdate_content(content)` for the async path
- [ ] Call with an existing id — verify partial-update + metadata merge still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)