### PR TITLE
feat: add Snowflake data warehouse tools

### DIFF
--- a/cookbook/91_tools/snowflake_tools.py
+++ b/cookbook/91_tools/snowflake_tools.py
@@ -1,0 +1,124 @@
+"""
+Snowflake Tools
+=============================
+
+Demonstrates Snowflake data warehouse tools for querying data,
+exploring schemas, and managing warehouse objects.
+
+Prerequisites:
+    1. Install: ``pip install snowflake-connector-python``
+    2. Set environment variables:
+       ```
+       export SNOWFLAKE_ACCOUNT=xy12345.us-east-1
+       export SNOWFLAKE_USER=my_user
+       export SNOWFLAKE_PASSWORD=my_password
+       export SNOWFLAKE_WAREHOUSE=COMPUTE_WH       # optional
+       export SNOWFLAKE_DATABASE=MY_DB              # optional
+       export SNOWFLAKE_SCHEMA=PUBLIC               # optional
+       export SNOWFLAKE_ROLE=ANALYST                # optional
+       ```
+
+    For key pair auth, set SNOWFLAKE_PRIVATE_KEY_PATH instead of SNOWFLAKE_PASSWORD:
+       ```
+       export SNOWFLAKE_PRIVATE_KEY_PATH=/path/to/rsa_key.p8
+       ```
+       Requires: ``pip install cryptography``
+"""
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools.snowflake import SnowflakeTools
+
+# ---------------------------------------------------------------------------
+# Create Agents
+# ---------------------------------------------------------------------------
+
+# Example 1: Read-only data analyst agent (default)
+analyst_agent = Agent(
+    name="Snowflake Analyst",
+    model=OpenAIChat(id="gpt-4o"),
+    tools=[SnowflakeTools()],
+    description="You are a data analyst that can explore and query a Snowflake data warehouse.",
+    instructions=[
+        "Use get_current_context first to see which warehouse, database, and schema are active.",
+        "Use list_databases, list_schemas, and list_tables to explore the warehouse before querying.",
+        "Use describe_table to understand column types before writing SQL.",
+        "Always use LIMIT in queries to avoid returning too many rows.",
+    ],
+    markdown=True,
+)
+
+# Example 2: Full access agent with DDL and query history
+admin_agent = Agent(
+    name="Snowflake Admin",
+    model=OpenAIChat(id="gpt-4o"),
+    tools=[
+        SnowflakeTools(
+            enable_get_query_history=True,
+            enable_execute_ddl=True,
+            enable_insert_record=True,
+            enable_update_records=True,
+            enable_delete_records=True,
+            enable_call_procedure=True,
+        )
+    ],
+    description="You are a Snowflake admin with full read, write, and DDL capabilities.",
+    instructions=[
+        "Confirm with the user before executing any DDL or delete statements.",
+        "Use describe_table to check column names before inserting or updating records.",
+        "Use query history to help debug slow queries.",
+    ],
+    markdown=True,
+)
+
+# Example 3: Minimal agent with only query access
+query_agent = Agent(
+    name="Snowflake Query Runner",
+    model=OpenAIChat(id="gpt-4o"),
+    tools=[
+        SnowflakeTools(
+            enable_query=True,
+            enable_list_databases=False,
+            enable_list_schemas=False,
+            enable_list_tables=False,
+            enable_describe_table=False,
+            enable_get_current_context=False,
+        )
+    ],
+    description="You are a focused query runner. Execute SQL queries provided by the user.",
+    markdown=True,
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    # Check current context
+    analyst_agent.print_response(
+        "What warehouse, database, and schema am I connected to?",
+        stream=True,
+    )
+
+    # Explore the warehouse
+    analyst_agent.print_response(
+        "List all databases in this Snowflake account",
+        stream=True,
+    )
+
+    # Explore schemas
+    analyst_agent.print_response(
+        "What schemas are available in the default database?",
+        stream=True,
+    )
+
+    # Describe a table
+    analyst_agent.print_response(
+        "Describe the columns in the CUSTOMERS table",
+        stream=True,
+    )
+
+    # Query data
+    analyst_agent.print_response(
+        "Find the top 10 customers by total order amount",
+        stream=True,
+    )

--- a/libs/agno/agno/tools/snowflake.py
+++ b/libs/agno/agno/tools/snowflake.py
@@ -1,0 +1,559 @@
+"""
+Snowflake data warehouse tools for Agno agents.
+
+Provides SQL query execution, schema discovery, and metadata operations
+for Snowflake data warehouses.
+
+Requirements:
+    ``pip install snowflake-connector-python``
+
+Authentication (pick one):
+    **Username / Password** — set SNOWFLAKE_ACCOUNT, SNOWFLAKE_USER,
+    SNOWFLAKE_PASSWORD, and optionally SNOWFLAKE_WAREHOUSE, SNOWFLAKE_DATABASE,
+    SNOWFLAKE_SCHEMA, SNOWFLAKE_ROLE env vars.
+
+    **Key Pair** — set SNOWFLAKE_ACCOUNT, SNOWFLAKE_USER, SNOWFLAKE_PRIVATE_KEY_PATH,
+    and optionally SNOWFLAKE_PASSWORD (if the key is encrypted).
+    Requires: ``pip install cryptography``
+"""
+
+import json
+import re
+import textwrap
+from os import getenv
+from typing import Any, Dict, List, Optional
+
+from agno.tools import Toolkit
+from agno.utils.log import logger
+
+try:
+    import snowflake.connector  # type: ignore[import-not-found]
+except ImportError:
+    raise ImportError(
+        "`snowflake-connector-python` not installed. Please install using `pip install snowflake-connector-python`."
+    )
+
+# Regex to validate Snowflake identifiers (database, schema, table names)
+# Allows alphanumeric, underscores, dots (for qualified names), and quoted identifiers
+_VALID_IDENTIFIER = re.compile(r'^[A-Za-z0-9_.]+$|^"[^"]+"$|^[A-Za-z0-9_.]*"[^"]+"[A-Za-z0-9_.]*$')
+
+SNOWFLAKE_INSTRUCTIONS = textwrap.dedent("""\
+    You have access to Snowflake data warehouse tools for querying data and exploring schemas.
+
+    ## Querying
+    - Use the query tool to execute read-only SQL: `SELECT * FROM my_table LIMIT 10`
+    - The query tool only allows SELECT statements.
+    - Results are capped at max_rows to avoid overwhelming context.
+    - Use LIMIT in your queries to control result size.
+
+    ## Schema Discovery
+    - Use get_current_context to see the active warehouse, database, schema, and role.
+    - Use list_databases, list_schemas, list_tables to explore the warehouse structure.
+    - Use describe_table to see column names, types, and nullability before writing queries.
+
+    ## Write Operations (if enabled)
+    - Use insert_record to add a single row to a table.
+    - Use update_records to modify rows matching a WHERE condition.
+    - Use delete_records to remove rows matching a WHERE condition (WHERE is required).
+    - Use call_procedure to execute stored procedures.
+
+    ## Best Practices
+    - Always explore the schema before writing queries on unfamiliar tables.
+    - Use fully qualified names (database.schema.table) when the context is ambiguous.
+    - Use get_current_context first to understand which database/schema is active.
+    - Use describe_table before insert_record or update_records to check column names and types.""")
+
+
+class SnowflakeTools(Toolkit):
+    _requires_connect: bool = True
+
+    def __init__(
+        self,
+        account: Optional[str] = None,
+        user: Optional[str] = None,
+        password: Optional[str] = None,
+        warehouse: Optional[str] = None,
+        database: Optional[str] = None,
+        schema: Optional[str] = None,
+        role: Optional[str] = None,
+        private_key_path: Optional[str] = None,
+        max_rows: int = 500,
+        enable_query: bool = True,
+        enable_list_databases: bool = True,
+        enable_list_schemas: bool = True,
+        enable_list_tables: bool = True,
+        enable_describe_table: bool = True,
+        enable_get_current_context: bool = True,
+        enable_get_query_history: bool = False,
+        enable_execute_ddl: bool = False,
+        enable_insert_record: bool = False,
+        enable_update_records: bool = False,
+        enable_delete_records: bool = False,
+        enable_call_procedure: bool = False,
+        all: bool = False,
+        instructions: Optional[str] = None,
+        add_instructions: bool = True,
+        **kwargs,
+    ):
+        self.instructions = instructions if instructions else (SNOWFLAKE_INSTRUCTIONS if add_instructions else None)
+        self.max_rows = max_rows
+
+        self.account = account or getenv("SNOWFLAKE_ACCOUNT")
+        self.user = user or getenv("SNOWFLAKE_USER")
+        self.password = password or getenv("SNOWFLAKE_PASSWORD")
+        self.warehouse = warehouse or getenv("SNOWFLAKE_WAREHOUSE")
+        self.database = database or getenv("SNOWFLAKE_DATABASE")
+        self.schema = schema or getenv("SNOWFLAKE_SCHEMA")
+        self.role = role or getenv("SNOWFLAKE_ROLE")
+        self.private_key_path = private_key_path or getenv("SNOWFLAKE_PRIVATE_KEY_PATH")
+
+        if not self.account or not self.user:
+            raise ValueError(
+                "Snowflake credentials not configured. Provide at minimum:\n"
+                "  - account + user + password (Username/Password auth)\n"
+                "  - account + user + private_key_path (Key Pair auth)\n"
+                "All values can be set via SNOWFLAKE_* environment variables."
+            )
+
+        if not self.password and not self.private_key_path:
+            raise ValueError("Snowflake authentication requires either password or private_key_path.")
+
+        self._conn: Optional[Any] = None
+
+        tools: List[Any] = []
+        if all or enable_query:
+            tools.append(self.query)
+        if all or enable_list_databases:
+            tools.append(self.list_databases)
+        if all or enable_list_schemas:
+            tools.append(self.list_schemas)
+        if all or enable_list_tables:
+            tools.append(self.list_tables)
+        if all or enable_describe_table:
+            tools.append(self.describe_table)
+        if all or enable_get_current_context:
+            tools.append(self.get_current_context)
+        if all or enable_get_query_history:
+            tools.append(self.get_query_history)
+        if all or enable_execute_ddl:
+            tools.append(self.execute_ddl)
+        if all or enable_insert_record:
+            tools.append(self.insert_record)
+        if all or enable_update_records:
+            tools.append(self.update_records)
+        if all or enable_delete_records:
+            tools.append(self.delete_records)
+        if all or enable_call_procedure:
+            tools.append(self.call_procedure)
+
+        super().__init__(name="snowflake_tools", tools=tools, instructions=self.instructions, **kwargs)
+
+    @staticmethod
+    def _validate_identifier(name: str) -> bool:
+        """Validate a Snowflake identifier to prevent SQL injection."""
+        return bool(_VALID_IDENTIFIER.match(name))
+
+    def _get_connect_kwargs(self) -> Dict[str, Any]:
+        """Build connection kwargs for snowflake.connector.connect()."""
+        kwargs: Dict[str, Any] = {
+            "account": self.account,
+            "user": self.user,
+        }
+        if self.private_key_path:
+            try:
+                from cryptography.hazmat.backends import default_backend
+                from cryptography.hazmat.primitives import serialization
+            except ImportError:
+                raise ImportError(
+                    "`cryptography` not installed. Key pair auth requires it. "
+                    "Please install using `pip install cryptography`."
+                )
+
+            with open(self.private_key_path, "rb") as key_file:
+                p_key = serialization.load_pem_private_key(
+                    key_file.read(),
+                    password=self.password.encode() if self.password else None,
+                    backend=default_backend(),
+                )
+            kwargs["private_key"] = p_key.private_bytes(
+                encoding=serialization.Encoding.DER,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+        else:
+            kwargs["password"] = self.password
+        if self.warehouse:
+            kwargs["warehouse"] = self.warehouse
+        if self.database:
+            kwargs["database"] = self.database
+        if self.schema:
+            kwargs["schema"] = self.schema
+        if self.role:
+            kwargs["role"] = self.role
+        return kwargs
+
+    def connect(self) -> None:
+        """Establish the Snowflake connection."""
+        if self._conn is not None:
+            return
+        try:
+            self._conn = snowflake.connector.connect(**self._get_connect_kwargs())
+        except Exception:
+            logger.exception("Error connecting to Snowflake")
+            raise
+
+    def close(self) -> None:
+        """Close the Snowflake connection."""
+        if self._conn is not None:
+            try:
+                self._conn.close()
+            except Exception:
+                pass
+            self._conn = None
+
+    def _execute(self, sql: str) -> List[Dict[str, Any]]:
+        """Execute SQL and return results as a list of dicts."""
+        if self._conn is None:
+            self.connect()
+        try:
+            cursor = self._conn.cursor()  # type: ignore[union-attr]
+            try:
+                cursor.execute(sql)
+                columns = [desc[0] for desc in cursor.description] if cursor.description else []
+                rows = cursor.fetchmany(self.max_rows)
+                return [dict(zip(columns, row)) for row in rows]
+            finally:
+                cursor.close()
+        except snowflake.connector.errors.DatabaseError:
+            # Connection may have dropped — reconnect and retry once
+            logger.warning("Snowflake connection error, reconnecting...")
+            self.close()
+            self.connect()
+            cursor = self._conn.cursor()  # type: ignore[union-attr]
+            try:
+                cursor.execute(sql)
+                columns = [desc[0] for desc in cursor.description] if cursor.description else []
+                rows = cursor.fetchmany(self.max_rows)
+                return [dict(zip(columns, row)) for row in rows]
+            finally:
+                cursor.close()
+
+    def query(self, sql: str) -> str:
+        """
+        Execute a read-only SQL query against Snowflake and return the results.
+        Only SELECT statements are allowed.
+
+        Args:
+            sql: The SQL SELECT query string. Use LIMIT to control result size.
+        """
+        stripped = sql.strip().rstrip(";").strip()
+        if not stripped.upper().startswith("SELECT") and not stripped.upper().startswith("WITH"):
+            return json.dumps({"error": "Only SELECT and WITH (CTE) queries are allowed. Use execute_ddl for DDL."})
+        try:
+            results = self._execute(sql)
+            return json.dumps({"rows": len(results), "data": results}, default=str)
+        except Exception as e:
+            logger.exception("Error executing Snowflake query")
+            return json.dumps({"error": str(e)})
+
+    def list_databases(self) -> str:
+        """List all databases accessible to the current user."""
+        try:
+            results = self._execute("SHOW DATABASES")
+            databases = [
+                {
+                    "name": row.get("name"),
+                    "owner": row.get("owner"),
+                    "created_on": row.get("created_on"),
+                }
+                for row in results
+            ]
+            return json.dumps({"total": len(databases), "databases": databases}, default=str)
+        except Exception as e:
+            logger.exception("Error listing Snowflake databases")
+            return json.dumps({"error": str(e)})
+
+    def list_schemas(self, database: str = "") -> str:
+        """
+        List schemas in a database.
+
+        Args:
+            database: Database name. If empty, uses the default database from the connection.
+        """
+        try:
+            if database:
+                if not self._validate_identifier(database):
+                    return json.dumps({"error": f"Invalid database name: {database}"})
+                sql = f"SHOW SCHEMAS IN DATABASE {database}"
+            else:
+                sql = "SHOW SCHEMAS"
+            results = self._execute(sql)
+            schemas = [
+                {
+                    "name": row.get("name"),
+                    "database_name": row.get("database_name"),
+                    "owner": row.get("owner"),
+                }
+                for row in results
+            ]
+            return json.dumps({"total": len(schemas), "schemas": schemas}, default=str)
+        except Exception as e:
+            logger.exception("Error listing Snowflake schemas")
+            return json.dumps({"error": str(e)})
+
+    def list_tables(self, database: str = "", schema: str = "") -> str:
+        """
+        List tables and views in a schema.
+
+        Args:
+            database: Database name. If empty, uses the default database.
+            schema: Schema name. If empty, uses the default schema.
+        """
+        try:
+            if database and not self._validate_identifier(database):
+                return json.dumps({"error": f"Invalid database name: {database}"})
+            if schema and not self._validate_identifier(schema):
+                return json.dumps({"error": f"Invalid schema name: {schema}"})
+
+            if database and schema:
+                sql = f"SHOW TABLES IN {database}.{schema}"
+            elif schema:
+                sql = f"SHOW TABLES IN SCHEMA {schema}"
+            else:
+                sql = "SHOW TABLES"
+            results = self._execute(sql)
+            tables = [
+                {
+                    "name": row.get("name"),
+                    "database_name": row.get("database_name"),
+                    "schema_name": row.get("schema_name"),
+                    "kind": row.get("kind"),
+                    "rows": row.get("rows"),
+                }
+                for row in results
+            ]
+            return json.dumps({"total": len(tables), "tables": tables}, default=str)
+        except Exception as e:
+            logger.exception("Error listing Snowflake tables")
+            return json.dumps({"error": str(e)})
+
+    def describe_table(self, table: str) -> str:
+        """
+        Get column names, types, and nullability for a table.
+
+        Args:
+            table: Fully qualified table name (e.g. MY_DB.PUBLIC.MY_TABLE) or just the table name.
+        """
+        if not self._validate_identifier(table):
+            return json.dumps({"error": f"Invalid table name: {table}"})
+        try:
+            results = self._execute(f"DESCRIBE TABLE {table}")
+            columns = [
+                {
+                    "name": row.get("name"),
+                    "type": row.get("type"),
+                    "nullable": row.get("null?", "").upper() == "Y",
+                    "default": row.get("default"),
+                    "primary_key": row.get("primary key", "").upper() == "Y",
+                    "comment": row.get("comment"),
+                }
+                for row in results
+            ]
+            return json.dumps({"table": table, "columns": columns}, default=str)
+        except Exception as e:
+            logger.exception(f"Error describing Snowflake table {table}")
+            return json.dumps({"error": str(e)})
+
+    def get_current_context(self) -> str:
+        """Get the current active warehouse, database, schema, and role."""
+        try:
+            results = self._execute(
+                "SELECT CURRENT_WAREHOUSE() AS warehouse, CURRENT_DATABASE() AS database, "
+                "CURRENT_SCHEMA() AS schema, CURRENT_ROLE() AS role, CURRENT_USER() AS user"
+            )
+            if results:
+                return json.dumps(results[0], default=str)
+            return json.dumps({"error": "Could not retrieve current context."})
+        except Exception as e:
+            logger.exception("Error getting Snowflake context")
+            return json.dumps({"error": str(e)})
+
+    def get_query_history(self, limit: int = 20) -> str:
+        """
+        Get recent query history for the current user.
+
+        Args:
+            limit: Maximum number of queries to return. Default 20.
+        """
+        try:
+            safe_limit = max(1, min(int(limit), 100))
+            sql = (
+                "SELECT query_id, query_text, database_name, schema_name, "
+                "warehouse_name, execution_status, start_time, total_elapsed_time "
+                "FROM TABLE(information_schema.query_history()) "
+                f"ORDER BY start_time DESC LIMIT {safe_limit}"
+            )
+            results = self._execute(sql)
+            return json.dumps({"total": len(results), "queries": results}, default=str)
+        except Exception as e:
+            logger.exception("Error getting Snowflake query history")
+            return json.dumps({"error": str(e)})
+
+    def execute_ddl(self, sql: str) -> str:
+        """
+        Execute a DDL statement (CREATE, ALTER, DROP, GRANT, etc.).
+
+        Args:
+            sql: The DDL SQL statement to execute.
+        """
+        try:
+            results = self._execute(sql)
+            return json.dumps({"status": "success", "result": results}, default=str)
+        except Exception as e:
+            logger.exception("Error executing Snowflake DDL")
+            return json.dumps({"error": str(e)})
+
+    def insert_record(self, table: str, record_data: str) -> str:
+        """
+        Insert a single record into a Snowflake table.
+
+        Args:
+            table: Fully qualified table name (e.g. MY_DB.PUBLIC.MY_TABLE) or just the table name.
+            record_data: JSON string of column name-value pairs.
+                Example: '{"NAME": "Alice", "EMAIL": "alice@example.com"}'
+        """
+        if not self._validate_identifier(table):
+            return json.dumps({"error": f"Invalid table name: {table}"})
+        try:
+            data = json.loads(record_data) if isinstance(record_data, str) else record_data
+        except json.JSONDecodeError as e:
+            return json.dumps({"error": f"Invalid JSON in record_data: {e}"})
+
+        if not isinstance(data, dict) or not data:
+            return json.dumps({"error": "record_data must be a non-empty JSON object."})
+
+        try:
+            columns = ", ".join(data.keys())
+            placeholders = ", ".join(["%s"] * len(data))
+            sql = f"INSERT INTO {table} ({columns}) VALUES ({placeholders})"
+
+            if self._conn is None:
+                self.connect()
+            cursor = self._conn.cursor()  # type: ignore[union-attr]
+            try:
+                cursor.execute(sql, list(data.values()))
+                return json.dumps({"status": "success", "table": table, "rows_inserted": 1}, default=str)
+            finally:
+                cursor.close()
+        except Exception as e:
+            logger.exception(f"Error inserting record into {table}")
+            return json.dumps({"error": str(e)})
+
+    def update_records(self, table: str, set_values: str, where_clause: str) -> str:
+        """
+        Update records in a Snowflake table.
+
+        Args:
+            table: Fully qualified table name (e.g. MY_DB.PUBLIC.MY_TABLE) or just the table name.
+            set_values: JSON string of column name-value pairs to update.
+                Example: '{"STATUS": "active", "UPDATED_AT": "2024-01-01"}'
+            where_clause: SQL WHERE condition (without the WHERE keyword).
+                Example: 'ID = 123' or 'STATUS = ''inactive'' AND CREATED_AT < ''2024-01-01'''
+        """
+        if not self._validate_identifier(table):
+            return json.dumps({"error": f"Invalid table name: {table}"})
+        if not where_clause or not where_clause.strip():
+            return json.dumps({"error": "where_clause is required to prevent accidental full-table updates."})
+
+        try:
+            data = json.loads(set_values) if isinstance(set_values, str) else set_values
+        except json.JSONDecodeError as e:
+            return json.dumps({"error": f"Invalid JSON in set_values: {e}"})
+
+        if not isinstance(data, dict) or not data:
+            return json.dumps({"error": "set_values must be a non-empty JSON object."})
+
+        try:
+            set_parts = ", ".join([f"{col} = %s" for col in data.keys()])
+            sql = f"UPDATE {table} SET {set_parts} WHERE {where_clause}"
+
+            if self._conn is None:
+                self.connect()
+            cursor = self._conn.cursor()  # type: ignore[union-attr]
+            try:
+                cursor.execute(sql, list(data.values()))
+                rows_updated = cursor.rowcount
+                return json.dumps({"status": "success", "table": table, "rows_updated": rows_updated}, default=str)
+            finally:
+                cursor.close()
+        except Exception as e:
+            logger.exception(f"Error updating records in {table}")
+            return json.dumps({"error": str(e)})
+
+    def delete_records(self, table: str, where_clause: str) -> str:
+        """
+        Delete records from a Snowflake table. A WHERE clause is required.
+
+        Args:
+            table: Fully qualified table name (e.g. MY_DB.PUBLIC.MY_TABLE) or just the table name.
+            where_clause: SQL WHERE condition (without the WHERE keyword).
+                Example: 'ID = 123' or 'STATUS = ''inactive'''
+        """
+        if not self._validate_identifier(table):
+            return json.dumps({"error": f"Invalid table name: {table}"})
+        if not where_clause or not where_clause.strip():
+            return json.dumps({"error": "where_clause is required to prevent accidental full-table deletes."})
+
+        try:
+            sql = f"DELETE FROM {table} WHERE {where_clause}"
+
+            if self._conn is None:
+                self.connect()
+            cursor = self._conn.cursor()  # type: ignore[union-attr]
+            try:
+                cursor.execute(sql)
+                rows_deleted = cursor.rowcount
+                return json.dumps({"status": "success", "table": table, "rows_deleted": rows_deleted}, default=str)
+            finally:
+                cursor.close()
+        except Exception as e:
+            logger.exception(f"Error deleting records from {table}")
+            return json.dumps({"error": str(e)})
+
+    def call_procedure(self, procedure: str, args: str = "[]") -> str:
+        """
+        Call a Snowflake stored procedure.
+
+        Args:
+            procedure: Fully qualified procedure name (e.g. MY_DB.PUBLIC.MY_PROC) or just the name.
+            args: JSON array of arguments to pass to the procedure.
+                Example: '["arg1", 42, true]'
+        """
+        if not self._validate_identifier(procedure):
+            return json.dumps({"error": f"Invalid procedure name: {procedure}"})
+        try:
+            parsed_args = json.loads(args) if isinstance(args, str) else args
+        except json.JSONDecodeError as e:
+            return json.dumps({"error": f"Invalid JSON in args: {e}"})
+
+        if not isinstance(parsed_args, list):
+            return json.dumps({"error": "args must be a JSON array."})
+
+        try:
+            placeholders = ", ".join(["%s"] * len(parsed_args)) if parsed_args else ""
+            sql = f"CALL {procedure}({placeholders})"
+
+            if self._conn is None:
+                self.connect()
+            cursor = self._conn.cursor()  # type: ignore[union-attr]
+            try:
+                cursor.execute(sql, parsed_args if parsed_args else None)
+                columns = [desc[0] for desc in cursor.description] if cursor.description else []
+                rows = cursor.fetchall()
+                results = [dict(zip(columns, row)) for row in rows]
+                return json.dumps({"status": "success", "result": results}, default=str)
+            finally:
+                cursor.close()
+        except Exception as e:
+            logger.exception(f"Error calling procedure {procedure}")
+            return json.dumps({"error": str(e)})

--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -136,6 +136,7 @@ redshift = ["redshift-connector"]
 reportlab = ["reportlab"]
 salesforce = ["simple-salesforce"]
 scrapegraph = ["scrapegraph-py>=2.0.0"]
+snowflake = ["snowflake-connector-python"]
 todoist = ["todoist-api-python"]
 valyu = ["valyu"]
 webex = ["webexpythonsdk"]
@@ -265,6 +266,7 @@ tools = [
   "agno[parallel]",
   "agno[salesforce]",
   "agno[scrapegraph]",
+  "agno[snowflake]",
   "agno[valyu]",
   "agno[yfinance]",
   "agno[confluence]",
@@ -463,6 +465,7 @@ module = [
   "clip.*",
   "cohere.*",
   "crawl4ai.*",
+  "cryptography.*",
   "daytona.*",
   "daytona_api_client.*",
   "discord.*",
@@ -547,6 +550,7 @@ module = [
   "setuptools.*",
   "simplejson.*",
   "slack_sdk.*",
+  "snowflake.*",
   "spider.*",
   "sqlalchemy.*",
   "starlette.*",

--- a/libs/agno/tests/unit/tools/test_snowflake.py
+++ b/libs/agno/tests/unit/tools/test_snowflake.py
@@ -1,0 +1,615 @@
+"""Unit tests for SnowflakeTools class."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agno.tools.snowflake import SnowflakeTools
+
+
+@pytest.fixture
+def mock_sf_connector():
+    with patch("agno.tools.snowflake.snowflake.connector") as mock_mod:
+        mock_conn = MagicMock()
+        mock_mod.connect.return_value = mock_conn
+        mock_mod.errors.DatabaseError = Exception
+        yield mock_conn
+
+
+@pytest.fixture
+def sf_tools(mock_sf_connector):
+    tools = SnowflakeTools(
+        account="test-account",
+        user="test-user",
+        password="test-pass",
+        warehouse="TEST_WH",
+        database="TEST_DB",
+        schema="PUBLIC",
+        all=True,
+    )
+    tools._conn = mock_sf_connector
+    return tools
+
+
+def _mock_cursor(mock_conn, description, rows):
+    """Helper to set up a mock cursor with description and rows."""
+    cursor = MagicMock()
+    cursor.description = description
+    cursor.fetchmany.return_value = rows
+    mock_conn.cursor.return_value = cursor
+    return cursor
+
+
+# ---------------------------------------------------------------------------
+# Init Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSnowflakeInit:
+    def test_init_with_credentials(self, mock_sf_connector):
+        tools = SnowflakeTools(
+            account="my-account",
+            user="my-user",
+            password="my-pass",
+        )
+        assert tools.account == "my-account"
+        assert tools.user == "my-user"
+        assert tools.password == "my-pass"
+
+    def test_init_with_env_variables(self, mock_sf_connector):
+        with patch.dict(
+            "os.environ",
+            {
+                "SNOWFLAKE_ACCOUNT": "env-account",
+                "SNOWFLAKE_USER": "env-user",
+                "SNOWFLAKE_PASSWORD": "env-pass",
+                "SNOWFLAKE_WAREHOUSE": "ENV_WH",
+                "SNOWFLAKE_DATABASE": "ENV_DB",
+                "SNOWFLAKE_SCHEMA": "ENV_SCHEMA",
+                "SNOWFLAKE_ROLE": "ENV_ROLE",
+            },
+        ):
+            tools = SnowflakeTools()
+            assert tools.account == "env-account"
+            assert tools.user == "env-user"
+            assert tools.warehouse == "ENV_WH"
+            assert tools.database == "ENV_DB"
+            assert tools.schema == "ENV_SCHEMA"
+            assert tools.role == "ENV_ROLE"
+
+    def test_init_with_key_pair(self, mock_sf_connector):
+        tools = SnowflakeTools(
+            account="my-account",
+            user="my-user",
+            private_key_path="/path/to/key.p8",
+        )
+        assert tools.private_key_path == "/path/to/key.p8"
+        assert tools.password is None
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_init_no_credentials_raises(self, mock_sf_connector):
+        with pytest.raises(ValueError, match="credentials not configured"):
+            SnowflakeTools()
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_init_no_auth_method_raises(self, mock_sf_connector):
+        with pytest.raises(ValueError, match="password or private_key_path"):
+            SnowflakeTools(account="acct", user="usr")
+
+    def test_tool_registration_all(self, mock_sf_connector):
+        tools = SnowflakeTools(
+            account="acct",
+            user="usr",
+            password="pwd",
+            all=True,
+        )
+        fn_names = {fn.name for fn in tools.functions.values()}
+        assert "query" in fn_names
+        assert "list_databases" in fn_names
+        assert "list_schemas" in fn_names
+        assert "list_tables" in fn_names
+        assert "describe_table" in fn_names
+        assert "get_current_context" in fn_names
+        assert "get_query_history" in fn_names
+        assert "execute_ddl" in fn_names
+        assert "insert_record" in fn_names
+        assert "update_records" in fn_names
+        assert "delete_records" in fn_names
+        assert "call_procedure" in fn_names
+
+    def test_default_registration(self, mock_sf_connector):
+        tools = SnowflakeTools(
+            account="acct",
+            user="usr",
+            password="pwd",
+        )
+        fn_names = {fn.name for fn in tools.functions.values()}
+        assert "query" in fn_names
+        assert "list_databases" in fn_names
+        assert "list_schemas" in fn_names
+        assert "list_tables" in fn_names
+        assert "describe_table" in fn_names
+        assert "get_current_context" in fn_names
+        # Disabled by default
+        assert "get_query_history" not in fn_names
+        assert "execute_ddl" not in fn_names
+        assert "insert_record" not in fn_names
+        assert "update_records" not in fn_names
+        assert "delete_records" not in fn_names
+        assert "call_procedure" not in fn_names
+
+    def test_requires_connect_flag(self, mock_sf_connector):
+        tools = SnowflakeTools(
+            account="acct",
+            user="usr",
+            password="pwd",
+        )
+        assert tools.requires_connect is True
+
+
+# ---------------------------------------------------------------------------
+# Connection Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConnection:
+    def test_connect(self, mock_sf_connector):
+        tools = SnowflakeTools(
+            account="acct",
+            user="usr",
+            password="pwd",
+        )
+        tools._conn = None
+        with patch("agno.tools.snowflake.snowflake.connector") as mock_mod:
+            mock_mod.connect.return_value = MagicMock()
+            tools.connect()
+            assert tools._conn is not None
+            mock_mod.connect.assert_called_once()
+
+    def test_connect_reuses_existing(self, sf_tools, mock_sf_connector):
+        original_conn = sf_tools._conn
+        sf_tools.connect()
+        assert sf_tools._conn is original_conn
+
+    def test_close(self, sf_tools, mock_sf_connector):
+        sf_tools.close()
+        mock_sf_connector.close.assert_called_once()
+        assert sf_tools._conn is None
+
+    def test_close_when_not_connected(self, mock_sf_connector):
+        tools = SnowflakeTools(
+            account="acct",
+            user="usr",
+            password="pwd",
+        )
+        tools._conn = None
+        tools.close()  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Query Tests
+# ---------------------------------------------------------------------------
+
+
+class TestQuery:
+    def test_query_success(self, sf_tools, mock_sf_connector):
+        _mock_cursor(
+            mock_sf_connector,
+            description=[("ID",), ("NAME",)],
+            rows=[(1, "Alice"), (2, "Bob")],
+        )
+
+        result = json.loads(sf_tools.query(sql="SELECT ID, NAME FROM USERS"))
+        assert result["rows"] == 2
+        assert result["data"][0]["ID"] == 1
+        assert result["data"][1]["NAME"] == "Bob"
+
+    def test_query_empty_result(self, sf_tools, mock_sf_connector):
+        _mock_cursor(
+            mock_sf_connector,
+            description=[("ID",)],
+            rows=[],
+        )
+
+        result = json.loads(sf_tools.query(sql="SELECT ID FROM USERS WHERE 1=0"))
+        assert result["rows"] == 0
+        assert result["data"] == []
+
+    def test_query_blocks_non_select(self, sf_tools):
+        result = json.loads(sf_tools.query(sql="DELETE FROM USERS"))
+        assert "error" in result
+        assert "Only SELECT" in result["error"]
+
+    def test_query_blocks_insert(self, sf_tools):
+        result = json.loads(sf_tools.query(sql="INSERT INTO USERS VALUES (1)"))
+        assert "error" in result
+
+    def test_query_blocks_update(self, sf_tools):
+        result = json.loads(sf_tools.query(sql="UPDATE USERS SET name='x'"))
+        assert "error" in result
+
+    def test_query_blocks_drop(self, sf_tools):
+        result = json.loads(sf_tools.query(sql="DROP TABLE USERS"))
+        assert "error" in result
+
+    def test_query_allows_with_cte(self, sf_tools, mock_sf_connector):
+        _mock_cursor(
+            mock_sf_connector,
+            description=[("ID",)],
+            rows=[(1,)],
+        )
+
+        result = json.loads(sf_tools.query(sql="WITH cte AS (SELECT 1 AS id) SELECT * FROM cte"))
+        assert result["rows"] == 1
+
+    def test_query_error(self, sf_tools, mock_sf_connector):
+        mock_sf_connector.cursor.side_effect = Exception("Connection lost")
+
+        result = json.loads(sf_tools.query(sql="SELECT 1"))
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Metadata Tests
+# ---------------------------------------------------------------------------
+
+
+class TestMetadata:
+    def test_list_databases(self, sf_tools, mock_sf_connector):
+        _mock_cursor(
+            mock_sf_connector,
+            description=[("name",), ("owner",), ("created_on",)],
+            rows=[("DB1", "SYSADMIN", "2024-01-01"), ("DB2", "SYSADMIN", "2024-02-01")],
+        )
+
+        result = json.loads(sf_tools.list_databases())
+        assert result["total"] == 2
+        assert result["databases"][0]["name"] == "DB1"
+
+    def test_list_schemas(self, sf_tools, mock_sf_connector):
+        _mock_cursor(
+            mock_sf_connector,
+            description=[("name",), ("database_name",), ("owner",)],
+            rows=[("PUBLIC", "MY_DB", "SYSADMIN"), ("RAW", "MY_DB", "SYSADMIN")],
+        )
+
+        result = json.loads(sf_tools.list_schemas(database="MY_DB"))
+        assert result["total"] == 2
+        assert result["schemas"][0]["name"] == "PUBLIC"
+
+    def test_list_schemas_default(self, sf_tools, mock_sf_connector):
+        _mock_cursor(
+            mock_sf_connector,
+            description=[("name",), ("database_name",), ("owner",)],
+            rows=[("PUBLIC", "TEST_DB", "SYSADMIN")],
+        )
+
+        result = json.loads(sf_tools.list_schemas())
+        assert result["total"] == 1
+
+    def test_list_schemas_invalid_identifier(self, sf_tools):
+        result = json.loads(sf_tools.list_schemas(database="DROP TABLE; --"))
+        assert "error" in result
+        assert "Invalid database name" in result["error"]
+
+    def test_list_tables(self, sf_tools, mock_sf_connector):
+        _mock_cursor(
+            mock_sf_connector,
+            description=[("name",), ("database_name",), ("schema_name",), ("kind",), ("rows",)],
+            rows=[
+                ("CUSTOMERS", "MY_DB", "PUBLIC", "TABLE", 1000),
+                ("ORDERS", "MY_DB", "PUBLIC", "TABLE", 5000),
+            ],
+        )
+
+        result = json.loads(sf_tools.list_tables(database="MY_DB", schema="PUBLIC"))
+        assert result["total"] == 2
+        assert result["tables"][0]["name"] == "CUSTOMERS"
+        assert result["tables"][1]["rows"] == 5000
+
+    def test_list_tables_invalid_identifier(self, sf_tools):
+        result = json.loads(sf_tools.list_tables(database="valid", schema="DROP TABLE; --"))
+        assert "error" in result
+        assert "Invalid schema name" in result["error"]
+
+    def test_describe_table(self, sf_tools, mock_sf_connector):
+        _mock_cursor(
+            mock_sf_connector,
+            description=[("name",), ("type",), ("null?",), ("default",), ("primary key",), ("comment",)],
+            rows=[
+                ("ID", "NUMBER(38,0)", "N", None, "Y", "Primary key"),
+                ("NAME", "VARCHAR(100)", "Y", None, "N", "Customer name"),
+                ("EMAIL", "VARCHAR(255)", "Y", None, "N", None),
+            ],
+        )
+
+        result = json.loads(sf_tools.describe_table(table="CUSTOMERS"))
+        assert result["table"] == "CUSTOMERS"
+        assert len(result["columns"]) == 3
+        assert result["columns"][0]["name"] == "ID"
+        assert result["columns"][0]["nullable"] is False
+        assert result["columns"][0]["primary_key"] is True
+        assert result["columns"][1]["nullable"] is True
+
+    def test_describe_table_invalid_identifier(self, sf_tools):
+        result = json.loads(sf_tools.describe_table(table="DROP TABLE; --"))
+        assert "error" in result
+        assert "Invalid table name" in result["error"]
+
+    def test_get_current_context(self, sf_tools, mock_sf_connector):
+        _mock_cursor(
+            mock_sf_connector,
+            description=[("warehouse",), ("database",), ("schema",), ("role",), ("user",)],
+            rows=[("COMPUTE_WH", "MY_DB", "PUBLIC", "ANALYST", "MY_USER")],
+        )
+
+        result = json.loads(sf_tools.get_current_context())
+        assert result["warehouse"] == "COMPUTE_WH"
+        assert result["database"] == "MY_DB"
+        assert result["schema"] == "PUBLIC"
+        assert result["role"] == "ANALYST"
+
+
+# ---------------------------------------------------------------------------
+# DDL and History Tests
+# ---------------------------------------------------------------------------
+
+
+class TestDDLAndHistory:
+    def test_execute_ddl(self, sf_tools, mock_sf_connector):
+        _mock_cursor(
+            mock_sf_connector,
+            description=[("status",)],
+            rows=[("Table MY_TABLE successfully created.",)],
+        )
+
+        result = json.loads(sf_tools.execute_ddl(sql="CREATE TABLE MY_TABLE (id INT)"))
+        assert result["status"] == "success"
+
+    def test_get_query_history(self, sf_tools, mock_sf_connector):
+        _mock_cursor(
+            mock_sf_connector,
+            description=[
+                ("query_id",),
+                ("query_text",),
+                ("database_name",),
+                ("schema_name",),
+                ("warehouse_name",),
+                ("execution_status",),
+                ("start_time",),
+                ("total_elapsed_time",),
+            ],
+            rows=[
+                ("abc-123", "SELECT 1", "MY_DB", "PUBLIC", "WH", "SUCCESS", "2024-01-01", 100),
+            ],
+        )
+
+        result = json.loads(sf_tools.get_query_history(limit=5))
+        assert result["total"] == 1
+        assert result["queries"][0]["query_id"] == "abc-123"
+
+    def test_get_query_history_limit_capped(self, sf_tools, mock_sf_connector):
+        _mock_cursor(
+            mock_sf_connector,
+            description=[
+                ("query_id",),
+                ("query_text",),
+                ("database_name",),
+                ("schema_name",),
+                ("warehouse_name",),
+                ("execution_status",),
+                ("start_time",),
+                ("total_elapsed_time",),
+            ],
+            rows=[],
+        )
+
+        # Should not exceed 100 even if user passes a larger value
+        sf_tools.get_query_history(limit=999)
+        cursor = mock_sf_connector.cursor.return_value
+        executed_sql = cursor.execute.call_args[0][0]
+        assert "LIMIT 100" in executed_sql
+
+
+# ---------------------------------------------------------------------------
+# Identifier Validation Tests
+# ---------------------------------------------------------------------------
+
+
+class TestIdentifierValidation:
+    def test_valid_simple_name(self):
+        assert SnowflakeTools._validate_identifier("MY_TABLE") is True
+
+    def test_valid_qualified_name(self):
+        assert SnowflakeTools._validate_identifier("MY_DB.PUBLIC.MY_TABLE") is True
+
+    def test_valid_quoted_name(self):
+        assert SnowflakeTools._validate_identifier('"my table"') is True
+
+    def test_invalid_semicolon(self):
+        assert SnowflakeTools._validate_identifier("table; DROP TABLE") is False
+
+    def test_invalid_dash_dash(self):
+        assert SnowflakeTools._validate_identifier("table -- comment") is False
+
+    def test_invalid_empty(self):
+        assert SnowflakeTools._validate_identifier("") is False
+
+
+# ---------------------------------------------------------------------------
+# Error Handling Tests
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    def test_list_databases_error(self, sf_tools, mock_sf_connector):
+        mock_sf_connector.cursor.side_effect = Exception("Permission denied")
+
+        result = json.loads(sf_tools.list_databases())
+        assert "error" in result
+
+    def test_describe_table_error(self, sf_tools, mock_sf_connector):
+        mock_sf_connector.cursor.side_effect = Exception("Table not found")
+
+        result = json.loads(sf_tools.describe_table(table="NONEXISTENT"))
+        assert "error" in result
+
+    def test_execute_ddl_error(self, sf_tools, mock_sf_connector):
+        mock_sf_connector.cursor.side_effect = Exception("Syntax error")
+
+        result = json.loads(sf_tools.execute_ddl(sql="DROP TABLE"))
+        assert "error" in result
+
+    def test_get_current_context_error(self, sf_tools, mock_sf_connector):
+        mock_sf_connector.cursor.side_effect = Exception("Connection error")
+
+        result = json.loads(sf_tools.get_current_context())
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Write Operation Tests
+# ---------------------------------------------------------------------------
+
+
+class TestInsertRecord:
+    def test_insert_success(self, sf_tools, mock_sf_connector):
+        cursor = MagicMock()
+        mock_sf_connector.cursor.return_value = cursor
+
+        result = json.loads(
+            sf_tools.insert_record(table="CUSTOMERS", record_data='{"NAME": "Alice", "EMAIL": "alice@test.com"}')
+        )
+        assert result["status"] == "success"
+        assert result["table"] == "CUSTOMERS"
+        assert result["rows_inserted"] == 1
+        cursor.execute.assert_called_once()
+
+    def test_insert_invalid_json(self, sf_tools):
+        result = json.loads(sf_tools.insert_record(table="CUSTOMERS", record_data="not json"))
+        assert "error" in result
+        assert "Invalid JSON" in result["error"]
+
+    def test_insert_empty_data(self, sf_tools):
+        result = json.loads(sf_tools.insert_record(table="CUSTOMERS", record_data="{}"))
+        assert "error" in result
+        assert "non-empty" in result["error"]
+
+    def test_insert_invalid_table(self, sf_tools):
+        result = json.loads(sf_tools.insert_record(table="DROP TABLE; --", record_data='{"NAME": "x"}'))
+        assert "error" in result
+        assert "Invalid table name" in result["error"]
+
+    def test_insert_error(self, sf_tools, mock_sf_connector):
+        mock_sf_connector.cursor.side_effect = Exception("Permission denied")
+
+        result = json.loads(sf_tools.insert_record(table="CUSTOMERS", record_data='{"NAME": "x"}'))
+        assert "error" in result
+
+
+class TestUpdateRecords:
+    def test_update_success(self, sf_tools, mock_sf_connector):
+        cursor = MagicMock()
+        cursor.rowcount = 3
+        mock_sf_connector.cursor.return_value = cursor
+
+        result = json.loads(
+            sf_tools.update_records(
+                table="CUSTOMERS",
+                set_values='{"STATUS": "active"}',
+                where_clause="REGION = 'US'",
+            )
+        )
+        assert result["status"] == "success"
+        assert result["rows_updated"] == 3
+
+    def test_update_missing_where(self, sf_tools):
+        result = json.loads(sf_tools.update_records(table="CUSTOMERS", set_values='{"STATUS": "x"}', where_clause=""))
+        assert "error" in result
+        assert "where_clause is required" in result["error"]
+
+    def test_update_invalid_json(self, sf_tools):
+        result = json.loads(sf_tools.update_records(table="CUSTOMERS", set_values="bad", where_clause="ID = 1"))
+        assert "error" in result
+        assert "Invalid JSON" in result["error"]
+
+    def test_update_invalid_table(self, sf_tools):
+        result = json.loads(sf_tools.update_records(table="DROP; --", set_values='{"X": 1}', where_clause="ID = 1"))
+        assert "error" in result
+        assert "Invalid table name" in result["error"]
+
+    def test_update_error(self, sf_tools, mock_sf_connector):
+        mock_sf_connector.cursor.side_effect = Exception("Column not found")
+
+        result = json.loads(sf_tools.update_records(table="CUSTOMERS", set_values='{"X": 1}', where_clause="ID = 1"))
+        assert "error" in result
+
+
+class TestDeleteRecords:
+    def test_delete_success(self, sf_tools, mock_sf_connector):
+        cursor = MagicMock()
+        cursor.rowcount = 5
+        mock_sf_connector.cursor.return_value = cursor
+
+        result = json.loads(sf_tools.delete_records(table="CUSTOMERS", where_clause="STATUS = 'inactive'"))
+        assert result["status"] == "success"
+        assert result["rows_deleted"] == 5
+
+    def test_delete_missing_where(self, sf_tools):
+        result = json.loads(sf_tools.delete_records(table="CUSTOMERS", where_clause=""))
+        assert "error" in result
+        assert "where_clause is required" in result["error"]
+
+    def test_delete_invalid_table(self, sf_tools):
+        result = json.loads(sf_tools.delete_records(table="DROP; --", where_clause="ID = 1"))
+        assert "error" in result
+        assert "Invalid table name" in result["error"]
+
+    def test_delete_error(self, sf_tools, mock_sf_connector):
+        mock_sf_connector.cursor.side_effect = Exception("Permission denied")
+
+        result = json.loads(sf_tools.delete_records(table="CUSTOMERS", where_clause="ID = 1"))
+        assert "error" in result
+
+
+class TestCallProcedure:
+    def test_call_success(self, sf_tools, mock_sf_connector):
+        cursor = MagicMock()
+        cursor.description = [("result",)]
+        cursor.fetchall.return_value = [("done",)]
+        mock_sf_connector.cursor.return_value = cursor
+
+        result = json.loads(sf_tools.call_procedure(procedure="MY_PROC", args='["arg1", 42]'))
+        assert result["status"] == "success"
+        assert result["result"][0]["result"] == "done"
+
+    def test_call_no_args(self, sf_tools, mock_sf_connector):
+        cursor = MagicMock()
+        cursor.description = [("status",)]
+        cursor.fetchall.return_value = [("ok",)]
+        mock_sf_connector.cursor.return_value = cursor
+
+        result = json.loads(sf_tools.call_procedure(procedure="MY_PROC"))
+        assert result["status"] == "success"
+
+    def test_call_invalid_args(self, sf_tools):
+        result = json.loads(sf_tools.call_procedure(procedure="MY_PROC", args="not json"))
+        assert "error" in result
+        assert "Invalid JSON" in result["error"]
+
+    def test_call_args_not_array(self, sf_tools):
+        result = json.loads(sf_tools.call_procedure(procedure="MY_PROC", args='{"key": "val"}'))
+        assert "error" in result
+        assert "JSON array" in result["error"]
+
+    def test_call_invalid_procedure_name(self, sf_tools):
+        result = json.loads(sf_tools.call_procedure(procedure="DROP; --", args="[]"))
+        assert "error" in result
+        assert "Invalid procedure name" in result["error"]
+
+    def test_call_error(self, sf_tools, mock_sf_connector):
+        mock_sf_connector.cursor.side_effect = Exception("Procedure not found")
+
+        result = json.loads(sf_tools.call_procedure(procedure="NONEXISTENT"))
+        assert "error" in result


### PR DESCRIPTION
Closes #7778

## Summary

Add SnowflakeTools toolkit with 12 tools for querying, schema discovery, and data manipulation in Snowflake data warehouses.

### Read tools (enabled by default)
- query: Execute read-only SELECT/WITH SQL queries
- list_databases, list_schemas, list_tables: Schema exploration
- describe_table: Column names, types, nullability
- get_current_context: Active warehouse, database, schema, role

### Write tools (disabled by default)
- insert_record, update_records, delete_records: DML operations
- execute_ddl: CREATE/ALTER/DROP statements
- call_procedure: Execute stored procedures
- get_query_history: Recent query history

### Security
- SQL identifier validation to prevent injection
- query tool blocks non-SELECT statements
- delete/update require WHERE clause
- Parameterized queries for insert/update/call_procedure
- Connection auto-reconnect on DatabaseError

### Auth
- Username/Password
- Key Pair (RSA) with optional encrypted key support

## Type of change

- [x] New feature

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Documentation updated
- [x] Examples and guides updated
- [x] Tested in clean environment
- [x] Tests added/updated

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue

## Additional Notes

62 unit tests covering init, connection, queries, metadata, write operations, identifier validation, stored procedures, and error handling. All passing.