### PR TITLE
fix(team): inject LearningMachine context into Team system prompt

### DIFF
--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -480,6 +480,16 @@ def get_system_message(
             if knowledge_context:
                 system_message_content += knowledge_context + "\n"
 
+    # 2.3b Learnings — inject LearningMachine context into the system prompt (mirrors agent._messages.py)
+    if team._learning is not None and team.add_learnings_to_context:
+        learning_context = team._learning.build_context(
+            user_id=user_id,
+            session_id=session.session_id if session else None,
+            agent_id=team.id,
+        )
+        if learning_context:
+            system_message_content += learning_context + "\n"
+
     # 2.4 Memories
     if team.add_memories_to_context:
         _memory_manager_not_set = False
@@ -700,6 +710,26 @@ async def aget_system_message(
             )
             if knowledge_context:
                 system_message_content += knowledge_context + "\n"
+
+    # 2.3b Learnings — inject LearningMachine context into the system prompt (mirrors agent._messages.py)
+    if team._learning is not None and team.add_learnings_to_context:
+        learning_context = team._learning.build_context(
+            user_id=user_id,
+            session_id=session.session_id if session else None,
+            agent_id=team.id,
+        )
+        if learning_context:
+            system_message_content += learning_context + "\n"
+
+    # 2.3b Learnings (async) — inject LearningMachine context into the system prompt
+    if team._learning is not None and team.add_learnings_to_context:
+        learning_context = await team._learning.abuild_context(
+            user_id=user_id,
+            session_id=session.session_id if session else None,
+            agent_id=team.id,
+        )
+        if learning_context:
+            system_message_content += learning_context + "\n"
 
     # 2.4 Memories
     if team.add_memories_to_context:


### PR DESCRIPTION
Fixes #7595

## Problem

`Team` accepts `add_learnings_to_context: bool = True` and a `_learning: LearningMachine` instance, but `team/_messages.py`'s system-message builder never reads the flag and never calls `_learning.build_context()` or `abuild_context()`. Learning-store data (user profiles, session context) is silently absent from every Team run even when a `LearningMachine` is configured.

`Agent` already handles this correctly at `agent/_messages.py:400-407` (sync) and `:751-758` (async).

## Fix

Port the same pattern to the Team counterpart:

- **Sync** `get_system_message()`: calls `team._learning.build_context()` after the knowledge section (step 2.3b) when `add_learnings_to_context` is `True`
- **Async** `aget_system_message()`: calls `await team._learning.abuild_context()` in the same position

No change to public API or existing behaviour when `_learning` is `None`.