### PR TITLE
fix: bind MCP tool `user_id` to JWT subject

### DIFF
--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -48,11 +48,11 @@ logger = logging.getLogger(__name__)
 
 def _resolve_user_id(caller_user_id: Optional[str]) -> Optional[str]:
     """Bind user_id to the JWT subject when an authenticated request is in flight."""
-    try:
-        from fastmcp.server.dependencies import get_http_request
+    from fastmcp.server.dependencies import get_http_request
 
+    try:
         request = get_http_request()
-    except Exception:
+    except RuntimeError:
         return caller_user_id
 
     state_user_id = getattr(getattr(request, "state", None), "user_id", None)

--- a/libs/agno/agno/os/mcp.py
+++ b/libs/agno/agno/os/mcp.py
@@ -46,6 +46,21 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _resolve_user_id(caller_user_id: Optional[str]) -> Optional[str]:
+    """Bind user_id to the JWT subject when an authenticated request is in flight."""
+    try:
+        from fastmcp.server.dependencies import get_http_request
+
+        request = get_http_request()
+    except Exception:
+        return caller_user_id
+
+    state_user_id = getattr(getattr(request, "state", None), "user_id", None)
+    if state_user_id is not None:
+        return state_user_id
+    return caller_user_id
+
+
 def get_mcp_server(
     os: "AgentOS",
 ) -> StarletteWithLifespan:
@@ -123,6 +138,7 @@ def get_mcp_server(
         sort_by: str = "created_at",
         sort_order: str = "desc",
     ) -> Dict[str, Any]:
+        user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
         session_type_enum = SessionType(session_type)
         if isinstance(db, RemoteDb):
@@ -186,6 +202,7 @@ def get_mcp_server(
         session_type: str = "agent",
         user_id: Optional[str] = None,
     ) -> Dict[str, Any]:
+        user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
         session_type_enum = SessionType(session_type)
 
@@ -234,6 +251,7 @@ def get_mcp_server(
     ) -> Dict[str, Any]:
         import time
 
+        user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
         session_type_enum = SessionType(session_type)
 
@@ -324,6 +342,7 @@ def get_mcp_server(
         session_type: str = "agent",
         user_id: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
+        user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
         session_type_enum = SessionType(session_type)
 
@@ -384,6 +403,7 @@ def get_mcp_server(
         session_type: str = "agent",
         user_id: Optional[str] = None,
     ) -> Dict[str, Any]:
+        user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
         session_type_enum = SessionType(session_type)
 
@@ -442,6 +462,7 @@ def get_mcp_server(
         session_type: str = "agent",
         user_id: Optional[str] = None,
     ) -> Dict[str, Any]:
+        user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
         session_type_enum = SessionType(session_type)
 
@@ -490,6 +511,7 @@ def get_mcp_server(
         summary: Optional[Dict[str, Any]] = None,
         user_id: Optional[str] = None,
     ) -> Dict[str, Any]:
+        user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
         session_type_enum = SessionType(session_type)
 
@@ -565,6 +587,7 @@ def get_mcp_server(
         db_id: str,
         user_id: Optional[str] = None,
     ) -> str:
+        user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
 
         if isinstance(db, RemoteDb):
@@ -591,6 +614,7 @@ def get_mcp_server(
         session_types: Optional[List[str]] = None,
         user_id: Optional[str] = None,
     ) -> str:
+        user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
 
         if isinstance(db, RemoteDb):
@@ -617,6 +641,7 @@ def get_mcp_server(
         user_id: str,
         topics: Optional[List[str]] = None,
     ) -> UserMemorySchema:
+        user_id = _resolve_user_id(user_id) or user_id
         db = await get_db(os.dbs, db_id)
 
         if isinstance(db, RemoteDb):
@@ -665,6 +690,7 @@ def get_mcp_server(
         db_id: str,
         user_id: Optional[str] = None,
     ) -> UserMemorySchema:
+        user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
 
         if isinstance(db, RemoteDb):
@@ -699,6 +725,7 @@ def get_mcp_server(
         sort_by: str = "updated_at",
         sort_order: str = "desc",
     ) -> Dict[str, Any]:
+        user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
 
         if isinstance(db, RemoteDb):
@@ -764,6 +791,7 @@ def get_mcp_server(
         user_id: str,
         topics: Optional[List[str]] = None,
     ) -> UserMemorySchema:
+        user_id = _resolve_user_id(user_id) or user_id
         db = await get_db(os.dbs, db_id)
 
         if isinstance(db, RemoteDb):
@@ -809,6 +837,7 @@ def get_mcp_server(
         memory_id: str,
         user_id: Optional[str] = None,
     ) -> str:
+        user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
 
         if isinstance(db, RemoteDb):
@@ -834,6 +863,7 @@ def get_mcp_server(
         db_id: str,
         user_id: Optional[str] = None,
     ) -> str:
+        user_id = _resolve_user_id(user_id)
         db = await get_db(os.dbs, db_id)
 
         if isinstance(db, RemoteDb):

--- a/libs/agno/tests/unit/os/test_client_user_id.py
+++ b/libs/agno/tests/unit/os/test_client_user_id.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -6,6 +7,7 @@ from fastapi.testclient import TestClient
 
 from agno.client import AgentOSClient
 from agno.db.base import SessionType
+from agno.os.mcp import _resolve_user_id
 
 # ---------------------------------------------------------------------------
 # SDK Client tests — verify user_id is serialized into HTTP request params
@@ -274,3 +276,51 @@ def test_router_rename_session_receives_user_id_from_query(test_app, mock_db):
     assert call_kwargs["user_id"] == "alice"
     assert call_kwargs["session_id"] == "sess-1"
     assert call_kwargs["session_name"] == "Renamed"
+
+
+# ---------------------------------------------------------------------------
+# MCP handler tests — verify _resolve_user_id binds caller-supplied user_id
+# to request.state.user_id (the JWT subject), mirroring the HTTP router
+# behavior. Without this, MCP tools accept any user_id from the caller
+# and forward it to the DB — a multi-tenant IDOR.
+# ---------------------------------------------------------------------------
+
+
+def _fake_request(user_id):
+    """Mimic what JWTMiddleware writes to request.state."""
+    return SimpleNamespace(state=SimpleNamespace(user_id=user_id))
+
+
+@patch("fastmcp.server.dependencies.get_http_request")
+def test_mcp_jwt_subject_overrides_caller_user_id(mock_get_request):
+    """The IDOR fix: caller passes user_id='bob' but JWT subject is 'alice'."""
+    mock_get_request.return_value = _fake_request("alice")
+    assert _resolve_user_id("bob") == "alice"
+
+
+@patch("fastmcp.server.dependencies.get_http_request")
+def test_mcp_jwt_subject_used_when_caller_omits_user_id(mock_get_request):
+    mock_get_request.return_value = _fake_request("alice")
+    assert _resolve_user_id(None) == "alice"
+
+
+@patch("fastmcp.server.dependencies.get_http_request")
+def test_mcp_caller_user_id_kept_when_state_has_no_user_id(mock_get_request):
+    """JWT middleware not active: state exists but user_id was never set."""
+    mock_get_request.return_value = SimpleNamespace(state=SimpleNamespace())
+    assert _resolve_user_id("alice") == "alice"
+    assert _resolve_user_id(None) is None
+
+
+@patch("fastmcp.server.dependencies.get_http_request")
+def test_mcp_caller_user_id_kept_when_request_has_no_state(mock_get_request):
+    mock_get_request.return_value = SimpleNamespace()
+    assert _resolve_user_id("alice") == "alice"
+
+
+@patch("fastmcp.server.dependencies.get_http_request")
+def test_mcp_no_http_context_falls_back_to_caller(mock_get_request):
+    """Tool invoked outside an HTTP request — preserves no-auth behavior."""
+    mock_get_request.side_effect = RuntimeError("no request context")
+    assert _resolve_user_id("alice") == "alice"
+    assert _resolve_user_id(None) is None

--- a/libs/agno/tests/unit/os/test_client_user_id.py
+++ b/libs/agno/tests/unit/os/test_client_user_id.py
@@ -324,3 +324,11 @@ def test_mcp_no_http_context_falls_back_to_caller(mock_get_request):
     mock_get_request.side_effect = RuntimeError("no request context")
     assert _resolve_user_id("alice") == "alice"
     assert _resolve_user_id(None) is None
+
+
+@patch("fastmcp.server.dependencies.get_http_request")
+def test_mcp_unexpected_exception_propagates(mock_get_request):
+    """Non-RuntimeError exceptions are real bugs and must not be silently swallowed."""
+    mock_get_request.side_effect = AttributeError("future API change")
+    with pytest.raises(AttributeError):
+        _resolve_user_id("alice")


### PR DESCRIPTION
## Summary

Fixes a multi-tenant IDOR in the MCP tool handlers exposed by `AgentOS`. The MCP tool handlers accept a `user_id` argument from whoever calls the tool, and pass it straight to the database without any authorisation check.

So currently an authenticated user (alice) can call any of the affected MCP tools with `user_id="bob"` and read or modify another tenant's sessions, memories, etc.

## Changes

Adds a single helper, `_resolve_user_id`, in `libs/agno/agno/os/mcp.py` that mirrors the existing HTTP-router behavior: when an authenticated request is in flight, the JWT-bound `request.state.user_id` overrides whatever the caller passed. Falls back to the caller-supplied value when no JWT subject or HTTP context is present, preserving behavior for AgentOS deployments run without `authorization=True`. 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
