### PR TITLE
fix: bind WebSocket user_id to JWT subject to prevent IDOR

### DIFF
--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -926,7 +926,7 @@ def get_websocket_router(
                     await websocket.send_text(json.dumps({"event": "pong"}))
 
                 elif action == "start-workflow":
-                    # Bind user_id to JWT subject to prevent IDOR
+                    # Always override caller-supplied user_id with the JWT subject
                     if websocket_user_context and websocket_user_context.get("user_id"):
                         message["user_id"] = websocket_user_context["user_id"]
                     # Handle workflow execution directly via WebSocket
@@ -937,7 +937,7 @@ def get_websocket_router(
                     await handle_workflow_subscription(websocket, message, os)
 
                 elif action == "continue-workflow":
-                    # Bind user_id to JWT subject to prevent IDOR
+                    # Always override caller-supplied user_id with the JWT subject
                     if websocket_user_context and websocket_user_context.get("user_id"):
                         message["user_id"] = websocket_user_context["user_id"]
                     # Continue a paused workflow run

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -926,10 +926,9 @@ def get_websocket_router(
                     await websocket.send_text(json.dumps({"event": "pong"}))
 
                 elif action == "start-workflow":
-                    # Add user context to message if available from JWT auth
-                    if websocket_user_context:
-                        if "user_id" not in message and websocket_user_context.get("user_id"):
-                            message["user_id"] = websocket_user_context["user_id"]
+                    # Bind user_id to JWT subject to prevent IDOR
+                    if websocket_user_context and websocket_user_context.get("user_id"):
+                        message["user_id"] = websocket_user_context["user_id"]
                     # Handle workflow execution directly via WebSocket
                     await handle_workflow_via_websocket(websocket, message, os, ws_user_context=websocket_user_context)
 
@@ -938,10 +937,9 @@ def get_websocket_router(
                     await handle_workflow_subscription(websocket, message, os)
 
                 elif action == "continue-workflow":
-                    # Add user context to message if available from JWT auth
-                    if websocket_user_context:
-                        if "user_id" not in message and websocket_user_context.get("user_id"):
-                            message["user_id"] = websocket_user_context["user_id"]
+                    # Bind user_id to JWT subject to prevent IDOR
+                    if websocket_user_context and websocket_user_context.get("user_id"):
+                        message["user_id"] = websocket_user_context["user_id"]
                     # Continue a paused workflow run
                     await handle_workflow_continue_via_websocket(websocket, message, os)
 


### PR DESCRIPTION
## Summary

Follow-up to #7811 (MCP) and #7816 (HTTP routers). The WebSocket workflow handler has the same IDOR vulnerability: it only sets `user_id` from JWT claims when the caller **omits** it from the message. If a caller includes `user_id` in the WebSocket payload, it passes through unchecked, allowing impersonation.

The fix changes both `start-workflow` and `continue-workflow` actions to always override `user_id` with the JWT subject when JWT auth is active, matching the HTTP router behavior.

**Before:**
```python
if "user_id" not in message and websocket_user_context.get("user_id"):
    message["user_id"] = websocket_user_context["user_id"]
```

**After:**
```python
if websocket_user_context and websocket_user_context.get("user_id"):
    message["user_id"] = websocket_user_context["user_id"]
```

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

This completes the user_id binding audit across all entry points:
- MCP tools: #7811
- HTTP routers (traces, approvals): #7816
- WebSocket handler: this PR