### PR TITLE
fix: inject LearningMachine context into Team system prompt

### DIFF
--- a/cookbook/03_teams/12_learning/07_team_user_profile.py
+++ b/cookbook/03_teams/12_learning/07_team_user_profile.py
@@ -1,0 +1,67 @@
+"""
+Team Learning: User Profile
+===========================
+Team learns and recalls user profile across sessions.
+
+This demonstrates that Team.add_learnings_to_context works correctly:
+- Session 1: Team extracts user profile from conversation
+- Session 2: Team recalls profile in new session (different session_id)
+"""
+
+from agno.agent import Agent
+from agno.db.postgres import PostgresDb
+from agno.models.openai import OpenAIResponses
+from agno.team import Team
+
+db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
+
+researcher = Agent(
+    name="Researcher",
+    model=OpenAIResponses(id="gpt-5.2"),
+    role="Research and provide detailed information.",
+)
+
+writer = Agent(
+    name="Writer",
+    model=OpenAIResponses(id="gpt-5.2"),
+    role="Write clear, concise content.",
+)
+
+team = Team(
+    name="Content Team",
+    model=OpenAIResponses(id="gpt-5.2"),
+    members=[researcher, writer],
+    db=db,
+    learning=True,
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    user_id = "profile_test@example.com"
+
+    print("\n" + "=" * 60)
+    print("SESSION 1: Share profile information")
+    print("=" * 60 + "\n")
+
+    team.print_response(
+        "Hi, I'm Marcus. I'm a DevOps engineer at a fintech startup. "
+        "I prefer practical examples over theory, and I work primarily with Kubernetes.",
+        user_id=user_id,
+        session_id="profile_session_1",
+        stream=True,
+    )
+
+    lm = team.learning_machine
+    print("\n--- Extracted Profile ---")
+    lm.user_profile_store.print(user_id=user_id)
+
+    print("\n" + "=" * 60)
+    print("SESSION 2: Team should recall profile (NEW SESSION)")
+    print("=" * 60 + "\n")
+
+    team.print_response(
+        "What do you know about me? Keep it brief.",
+        user_id=user_id,
+        session_id="profile_session_2",
+        stream=True,
+    )

--- a/cookbook/03_teams/12_learning/08_team_user_memory.py
+++ b/cookbook/03_teams/12_learning/08_team_user_memory.py
@@ -1,0 +1,68 @@
+"""
+Team Learning: User Memory
+==========================
+Team learns observations and context about the user across sessions.
+
+User memory captures:
+- Observations about the user's situation
+- Context from conversations
+- Patterns in user behavior
+"""
+
+from agno.agent import Agent
+from agno.db.postgres import PostgresDb
+from agno.models.openai import OpenAIResponses
+from agno.team import Team
+
+db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
+
+analyst = Agent(
+    name="Analyst",
+    model=OpenAIResponses(id="gpt-5.2"),
+    role="Analyze data and provide insights.",
+)
+
+advisor = Agent(
+    name="Advisor",
+    model=OpenAIResponses(id="gpt-5.2"),
+    role="Provide strategic recommendations.",
+)
+
+team = Team(
+    name="Strategy Team",
+    model=OpenAIResponses(id="gpt-5.2"),
+    members=[analyst, advisor],
+    db=db,
+    learning=True,
+    markdown=True,
+)
+
+if __name__ == "__main__":
+    user_id = "memory_test@example.com"
+
+    print("\n" + "=" * 60)
+    print("SESSION 1: Share context about current situation")
+    print("=" * 60 + "\n")
+
+    team.print_response(
+        "We're preparing for a Series A raise. Our MRR is $50K, growing 15% month-over-month. "
+        "Main challenge is our CAC is too high relative to LTV.",
+        user_id=user_id,
+        session_id="memory_session_1",
+        stream=True,
+    )
+
+    lm = team.learning_machine
+    print("\n--- Extracted Memories ---")
+    lm.user_memory_store.print(user_id=user_id)
+
+    print("\n" + "=" * 60)
+    print("SESSION 2: Follow up (team should remember context)")
+    print("=" * 60 + "\n")
+
+    team.print_response(
+        "Given what you know about our situation, what metrics should we focus on improving?",
+        user_id=user_id,
+        session_id="memory_session_2",
+        stream=True,
+    )

--- a/cookbook/03_teams/12_learning/09_team_async_learning.py
+++ b/cookbook/03_teams/12_learning/09_team_async_learning.py
@@ -1,0 +1,72 @@
+"""
+Team Learning: Async Mode
+=========================
+Demonstrates Team learning with async database operations.
+
+Uses AsyncPostgresDb for non-blocking database access.
+"""
+
+import asyncio
+
+from agno.agent import Agent
+from agno.db.postgres import AsyncPostgresDb
+from agno.models.openai import OpenAIResponses
+from agno.team import Team
+
+db = AsyncPostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
+
+researcher = Agent(
+    name="Researcher",
+    model=OpenAIResponses(id="gpt-5.2"),
+    role="Research topics thoroughly.",
+)
+
+summarizer = Agent(
+    name="Summarizer",
+    model=OpenAIResponses(id="gpt-5.2"),
+    role="Create concise summaries.",
+)
+
+team = Team(
+    name="Research Team",
+    model=OpenAIResponses(id="gpt-5.2"),
+    members=[researcher, summarizer],
+    db=db,
+    learning=True,
+    markdown=True,
+)
+
+
+async def main():
+    user_id = "async_test@example.com"
+
+    print("\n" + "=" * 60)
+    print("SESSION 1: Async learning extraction")
+    print("=" * 60 + "\n")
+
+    await team.aprint_response(
+        "I'm a backend engineer interested in distributed systems. "
+        "I prefer deep technical content with architecture diagrams.",
+        user_id=user_id,
+        session_id="async_session_1",
+        stream=True,
+    )
+
+    lm = team.learning_machine
+    print("\n--- Extracted Profile (Async) ---")
+    lm.user_profile_store.print(user_id=user_id)
+
+    print("\n" + "=" * 60)
+    print("SESSION 2: Async recall in new session")
+    print("=" * 60 + "\n")
+
+    await team.aprint_response(
+        "Based on my background, explain consensus algorithms.",
+        user_id=user_id,
+        session_id="async_session_2",
+        stream=True,
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/cookbook/03_teams/12_learning/10_team_agentic_learning.py
+++ b/cookbook/03_teams/12_learning/10_team_agentic_learning.py
@@ -1,0 +1,76 @@
+"""
+Team Learning: Agentic Mode
+===========================
+Team decides when to update user memory using tools.
+
+In agentic mode:
+- Learning is NOT automatic after each response
+- Team has tools to explicitly save/update memories
+- More control over what gets stored
+"""
+
+from agno.agent import Agent
+from agno.db.postgres import PostgresDb
+from agno.learn.machine import LearningMachine
+from agno.learn.mode import LearningMode
+from agno.models.openai import OpenAIResponses
+from agno.team import Team
+
+db = PostgresDb(db_url="postgresql+psycopg://ai:ai@localhost:5532/ai")
+
+planner = Agent(
+    name="Planner",
+    model=OpenAIResponses(id="gpt-5.2"),
+    role="Create project plans and timelines.",
+)
+
+executor = Agent(
+    name="Executor",
+    model=OpenAIResponses(id="gpt-5.2"),
+    role="Execute tasks and track progress.",
+)
+
+team = Team(
+    name="Project Team",
+    model=OpenAIResponses(id="gpt-5.2"),
+    members=[planner, executor],
+    db=db,
+    learning=LearningMachine(
+        db=db,
+        user_profile=True,
+        user_memory=LearningMode.AGENTIC,
+    ),
+    markdown=True,
+    show_members_responses=True,
+)
+
+if __name__ == "__main__":
+    user_id = "agentic_test@example.com"
+
+    print("\n" + "=" * 60)
+    print("SESSION 1: Team uses tools to save important context")
+    print("=" * 60 + "\n")
+
+    team.print_response(
+        "I'm launching a new product next month. Key dates: "
+        "beta on March 15, marketing push on March 20, GA on April 1. "
+        "Please save these important dates.",
+        user_id=user_id,
+        session_id="agentic_session_1",
+        stream=True,
+    )
+
+    lm = team.learning_machine
+    print("\n--- Saved Memories (Agentic) ---")
+    lm.user_memory_store.print(user_id=user_id)
+
+    print("\n" + "=" * 60)
+    print("SESSION 2: Recall saved context")
+    print("=" * 60 + "\n")
+
+    team.print_response(
+        "What are my upcoming launch milestones?",
+        user_id=user_id,
+        session_id="agentic_session_2",
+        stream=True,
+    )

--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -633,6 +633,10 @@ def _set_learning_machine(team: "Team") -> None:
             team.learning.model = team.model
         team._learning = team.learning
 
+        # PROPOSE/HITL modes need chat history for multi-turn confirmation
+        if team._learning.requires_history and not team.add_history_to_context:
+            team.add_history_to_context = True
+
 
 def _initialize_session(
     team: "Team",

--- a/libs/agno/agno/team/_messages.py
+++ b/libs/agno/agno/team/_messages.py
@@ -470,7 +470,17 @@ def get_system_message(
     # 2.2 Identity sections: description, role, instructions
     system_message_content += _build_identity_sections(team, instructions)
 
-    # 2.3 Knowledge base instructions
+    # 2.3 Learning context (user profile, user memory, session context)
+    if team._learning is not None and team.add_learnings_to_context:
+        learning_context = team._learning.build_context(
+            user_id=user_id,
+            session_id=session.session_id if session else None,
+            team_id=team.id,
+        )
+        if learning_context:
+            system_message_content += learning_context + "\n"
+
+    # 2.4 Knowledge base instructions
     if team.knowledge is not None and team.search_knowledge and team.add_search_knowledge_instructions:
         build_context_fn = getattr(team.knowledge, "build_context", None)
         if callable(build_context_fn):
@@ -480,7 +490,7 @@ def get_system_message(
             if knowledge_context:
                 system_message_content += knowledge_context + "\n"
 
-    # 2.4 Memories
+    # 2.5 Memories
     if team.add_memories_to_context:
         _memory_manager_not_set = False
         if not user_id:
@@ -691,7 +701,17 @@ async def aget_system_message(
     # 2.2 Identity sections: description, role, instructions
     system_message_content += _build_identity_sections(team, instructions)
 
-    # 2.3 Knowledge base instructions
+    # 2.3 Learning context (user profile, user memory, session context)
+    if team._learning is not None and team.add_learnings_to_context:
+        learning_context = await team._learning.abuild_context(
+            user_id=user_id,
+            session_id=session.session_id if session else None,
+            team_id=team.id,
+        )
+        if learning_context:
+            system_message_content += learning_context + "\n"
+
+    # 2.4 Knowledge base instructions
     if team.knowledge is not None and team.search_knowledge and team.add_search_knowledge_instructions:
         build_context_fn = getattr(team.knowledge, "build_context", None)
         if callable(build_context_fn):
@@ -701,7 +721,7 @@ async def aget_system_message(
             if knowledge_context:
                 system_message_content += knowledge_context + "\n"
 
-    # 2.4 Memories
+    # 2.5 Memories
     if team.add_memories_to_context:
         _memory_manager_not_set = False
         if not user_id:

--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -1991,7 +1991,7 @@ async def _arun_tasks(
         ahandle_reasoning,
     )
     from agno.team._telemetry import alog_team_telemetry
-    from agno.team._tools import _check_and_refresh_mcp_tools, _determine_tools_for_model
+    from agno.team._tools import _aget_learning_tools, _check_and_refresh_mcp_tools, _determine_tools_for_model
     from agno.team.task import TaskStatus, load_task_list
 
     log_debug(f"Team Task Run Start: {run_response.run_id}", center=True)
@@ -2035,6 +2035,7 @@ async def _arun_tasks(
         # 2. Determine tools for model (includes task management tools)
         team_run_context: Dict[str, Any] = {}
         await _check_and_refresh_mcp_tools(team)
+        learning_tools = await _aget_learning_tools(team, user_id, team_session)
         _tools = _determine_tools_for_model(
             team,
             model=team.model,
@@ -2055,6 +2056,7 @@ async def _arun_tasks(
             add_session_state_to_context=add_session_state_to_context,
             stream=False,
             stream_events=False,
+            learning_tools=learning_tools,
         )
 
         # 3. Prepare initial run messages
@@ -2322,7 +2324,7 @@ async def _arun_tasks_stream(
         ahandle_reasoning_stream,
     )
     from agno.team._telemetry import alog_team_telemetry
-    from agno.team._tools import _check_and_refresh_mcp_tools, _determine_tools_for_model
+    from agno.team._tools import _aget_learning_tools, _check_and_refresh_mcp_tools, _determine_tools_for_model
     from agno.team.task import TaskStatus, load_task_list
     from agno.utils.events import (
         create_team_task_iteration_completed_event,
@@ -2372,6 +2374,7 @@ async def _arun_tasks_stream(
         # 2. Determine tools for model (includes task management tools)
         team_run_context: Dict[str, Any] = {}
         await _check_and_refresh_mcp_tools(team)
+        learning_tools = await _aget_learning_tools(team, user_id, team_session)
         _tools = _determine_tools_for_model(
             team,
             model=team.model,
@@ -2392,6 +2395,7 @@ async def _arun_tasks_stream(
             add_session_state_to_context=add_session_state_to_context,
             stream=True,
             stream_events=stream_events,
+            learning_tools=learning_tools,
         )
 
         # 3. Prepare initial run messages
@@ -2841,7 +2845,7 @@ async def _arun(
         aparse_response_with_parser_model,
     )
     from agno.team._telemetry import alog_team_telemetry
-    from agno.team._tools import _check_and_refresh_mcp_tools, _determine_tools_for_model
+    from agno.team._tools import _aget_learning_tools, _check_and_refresh_mcp_tools, _determine_tools_for_model
 
     # Dispatch to task mode if applicable
     from agno.team.mode import TeamMode
@@ -2919,6 +2923,7 @@ async def _arun(
                 await _check_and_refresh_mcp_tools(
                     team,
                 )
+                learning_tools = await _aget_learning_tools(team, user_id, team_session)
                 _tools = _determine_tools_for_model(
                     team,
                     model=team.model,
@@ -2939,6 +2944,7 @@ async def _arun(
                     add_session_state_to_context=add_session_state_to_context,
                     stream=False,
                     stream_events=False,
+                    learning_tools=learning_tools,
                 )
 
                 # 3. Prepare run messages
@@ -3443,7 +3449,7 @@ async def _arun_stream(
         aparse_response_with_parser_model_stream,
     )
     from agno.team._telemetry import alog_team_telemetry
-    from agno.team._tools import _check_and_refresh_mcp_tools, _determine_tools_for_model
+    from agno.team._tools import _aget_learning_tools, _check_and_refresh_mcp_tools, _determine_tools_for_model
 
     # Fallback for tasks mode (streaming not yet supported)
     # Dispatch to task mode streaming if applicable
@@ -3526,6 +3532,7 @@ async def _arun_stream(
                 await _check_and_refresh_mcp_tools(
                     team,
                 )
+                learning_tools = await _aget_learning_tools(team, user_id, team_session)
                 _tools = _determine_tools_for_model(
                     team,
                     model=team.model,
@@ -3546,6 +3553,7 @@ async def _arun_stream(
                     add_session_state_to_context=add_session_state_to_context,
                     stream=True,
                     stream_events=stream_events,
+                    learning_tools=learning_tools,
                 )
 
                 # 3. Prepare run messages
@@ -6451,7 +6459,7 @@ async def _acontinue_run(
     from agno.team._hooks import _aexecute_post_hooks
     from agno.team._init import _disconnect_connectable_tools, _disconnect_mcp_tools
     from agno.team._telemetry import alog_team_telemetry
-    from agno.team._tools import _check_and_refresh_mcp_tools, _determine_tools_for_model
+    from agno.team._tools import _aget_learning_tools, _check_and_refresh_mcp_tools, _determine_tools_for_model
 
     log_debug(f"Team Continue Run: {run_response.run_id if run_response else run_id}", center=True)
 
@@ -6589,6 +6597,7 @@ async def _acontinue_run(
                     await _check_and_refresh_mcp_tools(team)
 
                     team_run_context: Dict[str, Any] = {}
+                    learning_tools = await _aget_learning_tools(team, user_id, team_session)
                     _tools = _determine_tools_for_model(
                         team,
                         model=team.model,
@@ -6598,6 +6607,7 @@ async def _acontinue_run(
                         session=team_session,
                         user_id=user_id,
                         async_mode=True,
+                        learning_tools=learning_tools,
                     )
 
                     input_messages = run_response.messages or []
@@ -6635,6 +6645,7 @@ async def _acontinue_run(
                     await _check_and_refresh_mcp_tools(team)
 
                     team_run_context: Dict[str, Any] = {}  # type: ignore[no-redef]
+                    learning_tools = await _aget_learning_tools(team, user_id, team_session)
                     _tools = _determine_tools_for_model(
                         team,
                         model=team.model,
@@ -6644,6 +6655,7 @@ async def _acontinue_run(
                         session=team_session,
                         user_id=user_id,
                         async_mode=True,
+                        learning_tools=learning_tools,
                     )
 
                     input_messages = run_response.messages or []
@@ -6787,7 +6799,7 @@ async def _acontinue_run_stream(
         aparse_response_with_parser_model_stream,
     )
     from agno.team._telemetry import alog_team_telemetry
-    from agno.team._tools import _check_and_refresh_mcp_tools, _determine_tools_for_model
+    from agno.team._tools import _aget_learning_tools, _check_and_refresh_mcp_tools, _determine_tools_for_model
     from agno.utils.events import create_team_run_continued_event
 
     log_debug(f"Team Continue Run Stream: {run_response.run_id if run_response else run_id}", center=True)
@@ -6926,6 +6938,7 @@ async def _acontinue_run_stream(
                     await _check_and_refresh_mcp_tools(team)
 
                     team_run_context: Dict[str, Any] = {}
+                    learning_tools = await _aget_learning_tools(team, user_id, team_session)
                     _tools = _determine_tools_for_model(
                         team,
                         model=team.model,
@@ -6937,6 +6950,7 @@ async def _acontinue_run_stream(
                         async_mode=True,
                         stream=True,
                         stream_events=stream_events,
+                        learning_tools=learning_tools,
                     )
 
                     input_messages = run_response.messages or []
@@ -7050,6 +7064,7 @@ async def _acontinue_run_stream(
                     await _check_and_refresh_mcp_tools(team)
 
                     team_run_context: Dict[str, Any] = {}  # type: ignore[no-redef]
+                    learning_tools = await _aget_learning_tools(team, user_id, team_session)
                     _tools = _determine_tools_for_model(
                         team,
                         model=team.model,
@@ -7061,6 +7076,7 @@ async def _acontinue_run_stream(
                         async_mode=True,
                         stream=True,
                         stream_events=stream_events,
+                        learning_tools=learning_tools,
                     )
 
                     input_messages = run_response.messages or []

--- a/libs/agno/agno/team/_tools.py
+++ b/libs/agno/agno/team/_tools.py
@@ -62,6 +62,21 @@ async def _aresolve_callable_resources(team: "Team", run_context: "RunContext") 
     await aresolve_callable_members(team, run_context)
 
 
+async def _aget_learning_tools(
+    team: "Team",
+    user_id: Optional[str] = None,
+    session: Optional[TeamSession] = None,
+) -> List[Callable]:
+    """Async helper to fetch learning tools for Team runs."""
+    if team._learning is None:
+        return []
+    return await team._learning.aget_tools(
+        user_id=user_id,
+        session_id=session.session_id if session else None,
+        team_id=team.id,
+    )
+
+
 async def _check_and_refresh_mcp_tools(team: "Team") -> None:
     # Connect MCP tools
     from agno.team._init import _connect_mcp_tools
@@ -114,6 +129,7 @@ def _determine_tools_for_model(
     stream: Optional[bool] = None,
     stream_events: Optional[bool] = None,
     check_mcp_tools: bool = True,
+    learning_tools: Optional[List[Callable]] = None,
 ) -> List[Union[Function, dict]]:
     # Connect tools that require connection management
     from functools import partial
@@ -174,13 +190,17 @@ def _determine_tools_for_model(
         _tools.append(_get_update_user_memory_function(team, user_id=user_id, async_mode=async_mode))
 
     # Add learning machine tools
+    # In async mode, caller should pre-fetch with await team._learning.aget_tools() and pass learning_tools
     if team._learning is not None:
-        learning_tools = team._learning.get_tools(
-            user_id=user_id,
-            session_id=session.session_id if session else None,
-            team_id=team.id,
-        )
-        _tools.extend(learning_tools)
+        if learning_tools is not None:
+            _tools.extend(learning_tools)
+        else:
+            _learning_tools = team._learning.get_tools(
+                user_id=user_id,
+                session_id=session.session_id if session else None,
+                team_id=team.id,
+            )
+            _tools.extend(_learning_tools)
 
     if team.enable_agentic_state:
         _tools.append(Function(name="update_session_state", entrypoint=partial(_update_session_state_tool, team)))

--- a/libs/agno/tests/unit/team/test_continue_run_requirements.py
+++ b/libs/agno/tests/unit/team/test_continue_run_requirements.py
@@ -927,6 +927,7 @@ class TestContinueRunApprovalResolution:
                 patch("agno.team._init._disconnect_connectable_tools"),
                 patch("agno.team._init._disconnect_mcp_tools", new=AsyncMock()),
                 patch("agno.team._tools._check_and_refresh_mcp_tools", new=AsyncMock()),
+                patch("agno.team._tools._aget_learning_tools", new=AsyncMock(return_value=[])),
                 patch("agno.team._tools._determine_tools_for_model", return_value=[]),
                 patch("agno.team._run._get_continue_run_messages", return_value=MagicMock(messages=[])),
                 patch("agno.team._run._ahandle_team_tool_call_updates", new=AsyncMock()),

--- a/libs/agno/tests/unit/team/test_team_learning.py
+++ b/libs/agno/tests/unit/team/test_team_learning.py
@@ -1,0 +1,400 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agno.agent.agent import Agent
+from agno.learn.config import LearnedKnowledgeConfig, LearningMode
+from agno.learn.machine import LearningMachine
+from agno.session import TeamSession
+from agno.team._init import _set_learning_machine
+from agno.team._messages import aget_system_message, get_system_message
+from agno.team.team import Team
+
+
+def _mock_knowledge():
+    kb = MagicMock()
+    kb.search.return_value = []
+    return kb
+
+
+def _create_mock_db_class():
+    from agno.db.base import BaseDb
+
+    abstract_methods = {}
+    for name in dir(BaseDb):
+        attr = getattr(BaseDb, name, None)
+        if getattr(attr, "__isabstractmethod__", False):
+            abstract_methods[name] = MagicMock()
+    return type("MockDb", (BaseDb,), abstract_methods)
+
+
+@pytest.fixture
+def mock_db():
+    MockDbClass = _create_mock_db_class()
+    db = MockDbClass()
+    db.to_dict = MagicMock(return_value={"type": "postgres", "id": "test-db"})
+    return db
+
+
+@pytest.fixture
+def mock_model():
+    model = MagicMock()
+    model.get_instructions_for_model = MagicMock(return_value=None)
+    model.get_system_message_for_model = MagicMock(return_value=None)
+    model.supports_native_structured_outputs = False
+    model.supports_json_schema_outputs = False
+    return model
+
+
+@pytest.fixture
+def member_agent():
+    return Agent(id="member-agent", name="Member Agent", role="A test member")
+
+
+# =============================================================================
+# Sync get_system_message tests
+# =============================================================================
+
+
+class TestGetSystemMessageLearningContext:
+    def test_learning_context_included_when_enabled(self, mock_db, mock_model, member_agent):
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[member_agent],
+            db=mock_db,
+            learning=True,
+            add_learnings_to_context=True,
+        )
+        team.model = mock_model
+        _set_learning_machine(team)
+
+        mock_context = "<user_profile>\nName: Test User\nRole: Developer\n</user_profile>"
+        team._learning.build_context = MagicMock(return_value=mock_context)
+
+        session = TeamSession(session_id="test-session")
+        msg = get_system_message(team, session)
+
+        assert msg is not None
+        assert mock_context in msg.content
+        team._learning.build_context.assert_called_once()
+
+    def test_learning_context_excluded_when_disabled(self, mock_db, mock_model, member_agent):
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[member_agent],
+            db=mock_db,
+            learning=True,
+            add_learnings_to_context=False,
+        )
+        team.model = mock_model
+        _set_learning_machine(team)
+
+        mock_context = "<user_profile>\nName: Test User\n</user_profile>"
+        team._learning.build_context = MagicMock(return_value=mock_context)
+
+        session = TeamSession(session_id="test-session")
+        msg = get_system_message(team, session)
+
+        assert msg is not None
+        assert "<user_profile>" not in msg.content
+        team._learning.build_context.assert_not_called()
+
+    def test_learning_context_not_called_when_no_learning(self, mock_model, member_agent):
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[member_agent],
+            learning=None,
+        )
+        team.model = mock_model
+
+        session = TeamSession(session_id="test-session")
+        msg = get_system_message(team, session)
+
+        assert msg is not None
+        assert team._learning is None
+
+    def test_build_context_receives_correct_args(self, mock_db, mock_model, member_agent):
+        team = Team(
+            id="my-team",
+            name="Test Team",
+            members=[member_agent],
+            db=mock_db,
+            learning=True,
+            add_learnings_to_context=True,
+        )
+        team.model = mock_model
+        _set_learning_machine(team)
+
+        team._learning.build_context = MagicMock(return_value="")
+
+        session = TeamSession(session_id="sess-123")
+
+        from agno.run import RunContext
+
+        run_context = RunContext(
+            run_id="test-run",
+            session_id="sess-123",
+            user_id="user-456",
+        )
+
+        get_system_message(team, session, run_context=run_context)
+
+        team._learning.build_context.assert_called_once_with(
+            user_id="user-456",
+            session_id="sess-123",
+            team_id="my-team",
+        )
+
+
+# =============================================================================
+# Async aget_system_message tests
+# =============================================================================
+
+
+class TestAgetSystemMessageLearningContext:
+    @pytest.mark.asyncio
+    async def test_async_learning_context_included(self, mock_db, mock_model, member_agent):
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[member_agent],
+            db=mock_db,
+            learning=True,
+            add_learnings_to_context=True,
+        )
+        team.model = mock_model
+        _set_learning_machine(team)
+
+        mock_context = "<user_memory>\nPrefers Python\n</user_memory>"
+        team._learning.abuild_context = AsyncMock(return_value=mock_context)
+
+        session = TeamSession(session_id="test-session")
+        msg = await aget_system_message(team, session)
+
+        assert msg is not None
+        assert mock_context in msg.content
+        team._learning.abuild_context.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_async_learning_context_excluded_when_disabled(self, mock_db, mock_model, member_agent):
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[member_agent],
+            db=mock_db,
+            learning=True,
+            add_learnings_to_context=False,
+        )
+        team.model = mock_model
+        _set_learning_machine(team)
+
+        team._learning.abuild_context = AsyncMock(return_value="<user_memory>Test</user_memory>")
+
+        session = TeamSession(session_id="test-session")
+        msg = await aget_system_message(team, session)
+
+        assert msg is not None
+        assert "<user_memory>" not in msg.content
+        team._learning.abuild_context.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_async_build_context_receives_correct_args(self, mock_db, mock_model, member_agent):
+        team = Team(
+            id="async-team",
+            name="Test Team",
+            members=[member_agent],
+            db=mock_db,
+            learning=True,
+            add_learnings_to_context=True,
+        )
+        team.model = mock_model
+        _set_learning_machine(team)
+
+        team._learning.abuild_context = AsyncMock(return_value="")
+
+        session = TeamSession(session_id="async-sess")
+
+        from agno.run import RunContext
+
+        run_context = RunContext(
+            run_id="async-run",
+            session_id="async-sess",
+            user_id="async-user",
+        )
+
+        await aget_system_message(team, session, run_context=run_context)
+
+        team._learning.abuild_context.assert_awaited_once_with(
+            user_id="async-user",
+            session_id="async-sess",
+            team_id="async-team",
+        )
+
+
+# =============================================================================
+# requires_history auto-enable tests
+# =============================================================================
+
+
+class TestSetLearningMachineHistory:
+    def _make_team(self, mode: LearningMode, add_history: bool = False, db=None) -> Team:
+        if db is None:
+            MockDbClass = _create_mock_db_class()
+            db = MockDbClass()
+            db.to_dict = MagicMock(return_value={"type": "postgres", "id": "test-db"})
+
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[Agent(id="a", name="A", role="test")],
+            db=db,
+            learning=LearningMachine(
+                learned_knowledge=LearnedKnowledgeConfig(
+                    mode=mode,
+                    knowledge=_mock_knowledge(),
+                ),
+            ),
+            add_history_to_context=add_history,
+        )
+        return team
+
+    def test_propose_enables_history(self):
+        team = self._make_team(LearningMode.PROPOSE)
+        assert team.add_history_to_context is False
+
+        _set_learning_machine(team)
+        assert team.add_history_to_context is True
+
+    def test_propose_preserves_existing_history_true(self):
+        team = self._make_team(LearningMode.PROPOSE, add_history=True)
+        _set_learning_machine(team)
+        assert team.add_history_to_context is True
+
+    def test_agentic_does_not_enable_history(self):
+        team = self._make_team(LearningMode.AGENTIC)
+        _set_learning_machine(team)
+        assert team.add_history_to_context is False
+
+    def test_always_does_not_enable_history(self):
+        team = self._make_team(LearningMode.ALWAYS)
+        _set_learning_machine(team)
+        assert team.add_history_to_context is False
+
+
+# =============================================================================
+# Learning context position tests
+# =============================================================================
+
+
+class TestLearningContextPosition:
+    def test_learning_context_after_identity_before_knowledge(self, mock_db, mock_model, member_agent):
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[member_agent],
+            db=mock_db,
+            learning=True,
+            add_learnings_to_context=True,
+            description="Test description",
+            role="Test role",
+            instructions="Test instructions",
+        )
+        team.model = mock_model
+        _set_learning_machine(team)
+
+        mock_learning = "<user_profile>\nTest Learning Content\n</user_profile>"
+        team._learning.build_context = MagicMock(return_value=mock_learning)
+
+        session = TeamSession(session_id="test-session")
+        msg = get_system_message(team, session)
+
+        content = msg.content
+
+        description_pos = content.find("<description>")
+        role_pos = content.find("<your_role>")
+        learning_pos = content.find("<user_profile>")
+
+        assert description_pos < learning_pos
+        assert role_pos < learning_pos
+
+    def test_empty_learning_context_not_added(self, mock_db, mock_model, member_agent):
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[member_agent],
+            db=mock_db,
+            learning=True,
+            add_learnings_to_context=True,
+        )
+        team.model = mock_model
+        _set_learning_machine(team)
+
+        team._learning.build_context = MagicMock(return_value="")
+
+        session = TeamSession(session_id="test-session")
+        msg = get_system_message(team, session)
+
+        assert "\n\n\n" not in msg.content
+
+
+# =============================================================================
+# Configuration tests
+# =============================================================================
+
+
+class TestTeamLearningConfig:
+    def test_add_learnings_to_context_default_true(self, member_agent):
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[member_agent],
+        )
+        assert team.add_learnings_to_context is True
+
+    def test_add_learnings_to_context_can_be_disabled(self, member_agent):
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[member_agent],
+            add_learnings_to_context=False,
+        )
+        assert team.add_learnings_to_context is False
+
+    def test_learning_true_creates_default_machine(self, mock_db, member_agent):
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[member_agent],
+            db=mock_db,
+            learning=True,
+        )
+        _set_learning_machine(team)
+
+        assert team._learning is not None
+        assert isinstance(team._learning, LearningMachine)
+
+    def test_learning_false_no_machine(self, mock_db, member_agent):
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[member_agent],
+            db=mock_db,
+            learning=False,
+        )
+        _set_learning_machine(team)
+
+        assert team._learning is None
+
+    def test_learning_without_db_warns(self, member_agent, caplog):
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[member_agent],
+            learning=True,
+        )
+        _set_learning_machine(team)
+
+        assert team._learning is None

--- a/libs/agno/tests/unit/team/test_team_learning.py
+++ b/libs/agno/tests/unit/team/test_team_learning.py
@@ -1,10 +1,21 @@
+"""
+Unit tests for Team learning context injection.
+
+Tests cover:
+- get_system_message / aget_system_message learning context injection
+- _set_learning_machine initialization and configuration
+- requires_history auto-enable for PROPOSE mode
+- Store combinations and edge cases
+"""
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from agno.agent.agent import Agent
-from agno.learn.config import LearnedKnowledgeConfig, LearningMode
+from agno.learn.config import LearnedKnowledgeConfig, LearningMode, UserMemoryConfig, UserProfileConfig
 from agno.learn.machine import LearningMachine
+from agno.run import RunContext
 from agno.session import TeamSession
 from agno.team._init import _set_learning_machine
 from agno.team._messages import aget_system_message, get_system_message
@@ -51,6 +62,21 @@ def member_agent():
     return Agent(id="member-agent", name="Member Agent", role="A test member")
 
 
+def _make_team_with_learning(mock_db, mock_model, member_agent, **kwargs) -> Team:
+    team = Team(
+        id="test-team",
+        name="Test Team",
+        members=[member_agent],
+        db=mock_db,
+        learning=True,
+        add_learnings_to_context=True,
+        **kwargs,
+    )
+    team.model = mock_model
+    _set_learning_machine(team)
+    return team
+
+
 # =============================================================================
 # Sync get_system_message tests
 # =============================================================================
@@ -58,16 +84,7 @@ def member_agent():
 
 class TestGetSystemMessageLearningContext:
     def test_learning_context_included_when_enabled(self, mock_db, mock_model, member_agent):
-        team = Team(
-            id="test-team",
-            name="Test Team",
-            members=[member_agent],
-            db=mock_db,
-            learning=True,
-            add_learnings_to_context=True,
-        )
-        team.model = mock_model
-        _set_learning_machine(team)
+        team = _make_team_with_learning(mock_db, mock_model, member_agent)
 
         mock_context = "<user_profile>\nName: Test User\nRole: Developer\n</user_profile>"
         team._learning.build_context = MagicMock(return_value=mock_context)
@@ -131,9 +148,6 @@ class TestGetSystemMessageLearningContext:
         team._learning.build_context = MagicMock(return_value="")
 
         session = TeamSession(session_id="sess-123")
-
-        from agno.run import RunContext
-
         run_context = RunContext(
             run_id="test-run",
             session_id="sess-123",
@@ -148,6 +162,75 @@ class TestGetSystemMessageLearningContext:
             team_id="my-team",
         )
 
+    def test_learning_context_not_added_when_build_context_returns_none(self, mock_db, mock_model, member_agent):
+        """Verify None from build_context doesn't add 'None' string to message."""
+        team = _make_team_with_learning(mock_db, mock_model, member_agent)
+        team._learning.build_context = MagicMock(return_value=None)
+
+        session = TeamSession(session_id="test-session")
+        msg = get_system_message(team, session)
+
+        assert msg is not None
+        assert "None" not in msg.content
+        team._learning.build_context.assert_called_once()
+
+    def test_learning_context_receives_none_values_without_run_context(self, mock_db, mock_model, member_agent):
+        """Verify build_context receives None for user_id when no run_context provided."""
+        team = _make_team_with_learning(mock_db, mock_model, member_agent)
+        team._learning.build_context = MagicMock(return_value="")
+
+        session = TeamSession(session_id="sess-123")
+        get_system_message(team, session, run_context=None)
+
+        team._learning.build_context.assert_called_once_with(
+            user_id=None,
+            session_id="sess-123",
+            team_id="test-team",
+        )
+
+    def test_learning_context_forwards_empty_user_id(self, mock_db, mock_model, member_agent):
+        """Verify empty string user_id is forwarded as-is, not normalized."""
+        team = _make_team_with_learning(mock_db, mock_model, member_agent)
+        team._learning.build_context = MagicMock(return_value="")
+
+        session = TeamSession(session_id="sess-123")
+        run_context = RunContext(
+            run_id="test-run",
+            session_id="sess-123",
+            user_id="",
+        )
+
+        get_system_message(team, session, run_context=run_context)
+
+        team._learning.build_context.assert_called_once_with(
+            user_id="",
+            session_id="sess-123",
+            team_id="test-team",
+        )
+
+    def test_custom_system_message_bypasses_learning_context(self, mock_db, mock_model, member_agent):
+        """Verify custom system_message returns early without calling build_context."""
+        custom_msg = "You are a custom assistant."
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[member_agent],
+            db=mock_db,
+            learning=True,
+            add_learnings_to_context=True,
+            system_message=custom_msg,
+        )
+        team.model = mock_model
+        _set_learning_machine(team)
+
+        team._learning.build_context = MagicMock(return_value="<user_profile>Test</user_profile>")
+
+        session = TeamSession(session_id="test-session")
+        msg = get_system_message(team, session)
+
+        assert msg.content == custom_msg
+        team._learning.build_context.assert_not_called()
+
 
 # =============================================================================
 # Async aget_system_message tests
@@ -157,16 +240,7 @@ class TestGetSystemMessageLearningContext:
 class TestAgetSystemMessageLearningContext:
     @pytest.mark.asyncio
     async def test_async_learning_context_included(self, mock_db, mock_model, member_agent):
-        team = Team(
-            id="test-team",
-            name="Test Team",
-            members=[member_agent],
-            db=mock_db,
-            learning=True,
-            add_learnings_to_context=True,
-        )
-        team.model = mock_model
-        _set_learning_machine(team)
+        team = _make_team_with_learning(mock_db, mock_model, member_agent)
 
         mock_context = "<user_memory>\nPrefers Python\n</user_memory>"
         team._learning.abuild_context = AsyncMock(return_value=mock_context)
@@ -216,9 +290,6 @@ class TestAgetSystemMessageLearningContext:
         team._learning.abuild_context = AsyncMock(return_value="")
 
         session = TeamSession(session_id="async-sess")
-
-        from agno.run import RunContext
-
         run_context = RunContext(
             run_id="async-run",
             session_id="async-sess",
@@ -233,13 +304,56 @@ class TestAgetSystemMessageLearningContext:
             team_id="async-team",
         )
 
+    @pytest.mark.asyncio
+    async def test_async_learning_context_not_added_when_returns_none(self, mock_db, mock_model, member_agent):
+        """Verify None from abuild_context doesn't add 'None' string to message."""
+        team = _make_team_with_learning(mock_db, mock_model, member_agent)
+        team._learning.abuild_context = AsyncMock(return_value=None)
+
+        session = TeamSession(session_id="test-session")
+        msg = await aget_system_message(team, session)
+
+        assert msg is not None
+        assert "None" not in msg.content
+        team._learning.abuild_context.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_async_empty_learning_context_not_added(self, mock_db, mock_model, member_agent):
+        """Verify empty string from abuild_context is skipped."""
+        team = _make_team_with_learning(mock_db, mock_model, member_agent)
+        team._learning.abuild_context = AsyncMock(return_value="")
+
+        session = TeamSession(session_id="test-session")
+        msg = await aget_system_message(team, session)
+
+        assert msg is not None
+        assert "\n\n\n" not in msg.content
+        team._learning.abuild_context.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_async_learning_context_receives_none_values_without_run_context(
+        self, mock_db, mock_model, member_agent
+    ):
+        """Verify abuild_context receives None for user_id when no run_context provided."""
+        team = _make_team_with_learning(mock_db, mock_model, member_agent)
+        team._learning.abuild_context = AsyncMock(return_value="")
+
+        session = TeamSession(session_id="async-sess")
+        await aget_system_message(team, session, run_context=None)
+
+        team._learning.abuild_context.assert_awaited_once_with(
+            user_id=None,
+            session_id="async-sess",
+            team_id="test-team",
+        )
+
 
 # =============================================================================
-# requires_history auto-enable tests
+# _set_learning_machine tests
 # =============================================================================
 
 
-class TestSetLearningMachineHistory:
+class TestSetLearningMachine:
     def _make_team(self, mode: LearningMode, add_history: bool = False, db=None) -> Team:
         if db is None:
             MockDbClass = _create_mock_db_class()
@@ -283,6 +397,170 @@ class TestSetLearningMachineHistory:
         _set_learning_machine(team)
         assert team.add_history_to_context is False
 
+    def test_learning_true_creates_default_machine_with_correct_config(self, mock_db, mock_model):
+        """Verify learning=True creates LearningMachine with team db/model and default stores."""
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[Agent(id="a", name="A", role="test")],
+            db=mock_db,
+            learning=True,
+        )
+        team.model = mock_model
+        _set_learning_machine(team)
+
+        assert team._learning is not None
+        assert isinstance(team._learning, LearningMachine)
+        assert team._learning.db is mock_db
+        assert team._learning.model is mock_model
+        assert team._learning.user_profile is True
+        assert team._learning.user_memory is True
+        assert team.learning is True
+
+    def test_learning_false_no_machine(self, mock_db):
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[Agent(id="a", name="A", role="test")],
+            db=mock_db,
+            learning=False,
+        )
+        _set_learning_machine(team)
+
+        assert team._learning is None
+        assert team._learning_init_attempted is True
+
+    def test_learning_none_sets_none_and_marks_attempted(self, mock_db):
+        """Verify learning=None sets _learning to None and marks init attempted."""
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[Agent(id="a", name="A", role="test")],
+            db=mock_db,
+            learning=None,
+        )
+        _set_learning_machine(team)
+
+        assert team._learning is None
+        assert team._learning_init_attempted is True
+
+    def test_learning_without_db_warns_and_does_not_create_machine(self):
+        """Verify learning=True without db logs warning and sets _learning to None."""
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[Agent(id="a", name="A", role="test")],
+            learning=True,
+        )
+        _set_learning_machine(team)
+
+        assert team._learning is None
+        assert team._learning_init_attempted is True
+
+    def test_injects_missing_db_and_model_into_provided_machine(self, mock_db, mock_model):
+        """Verify _set_learning_machine injects team db/model when machine has None."""
+        machine = LearningMachine(user_profile=True)
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[Agent(id="a", name="A", role="test")],
+            db=mock_db,
+            learning=machine,
+        )
+        team.model = mock_model
+        _set_learning_machine(team)
+
+        assert team._learning is machine
+        assert machine.db is mock_db
+        assert machine.model is mock_model
+
+    def test_preserves_existing_machine_db_and_model(self, mock_db, mock_model):
+        """Verify _set_learning_machine does not overwrite existing db/model on machine."""
+        MockDbClass = _create_mock_db_class()
+        existing_db = MockDbClass()
+        existing_model = MagicMock()
+
+        machine = LearningMachine(
+            db=existing_db,
+            model=existing_model,
+            user_profile=True,
+        )
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[Agent(id="a", name="A", role="test")],
+            db=mock_db,
+            learning=machine,
+        )
+        team.model = mock_model
+        _set_learning_machine(team)
+
+        assert team._learning is machine
+        assert machine.db is existing_db
+        assert machine.model is existing_model
+
+    def test_does_not_mutate_public_learning_field(self, mock_db, mock_model):
+        """Verify _set_learning_machine sets _learning without changing public learning field."""
+        machine = LearningMachine(user_profile=True)
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[Agent(id="a", name="A", role="test")],
+            db=mock_db,
+            learning=machine,
+        )
+        team.model = mock_model
+        _set_learning_machine(team)
+
+        assert team.learning is machine
+        assert team._learning is machine
+
+        team2 = Team(
+            id="test-team-2",
+            name="Test Team 2",
+            members=[Agent(id="b", name="B", role="test")],
+            db=mock_db,
+            learning=True,
+        )
+        _set_learning_machine(team2)
+
+        assert team2.learning is True
+        assert team2._learning is not None
+
+    def test_user_profile_propose_enables_history(self, mock_db):
+        """Verify UserProfileConfig with PROPOSE mode enables add_history_to_context."""
+        machine = LearningMachine(
+            user_profile=UserProfileConfig(mode=LearningMode.PROPOSE),
+        )
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[Agent(id="a", name="A", role="test")],
+            db=mock_db,
+            learning=machine,
+            add_history_to_context=False,
+        )
+        _set_learning_machine(team)
+
+        assert team.add_history_to_context is True
+
+    def test_user_memory_propose_enables_history(self, mock_db):
+        """Verify UserMemoryConfig with PROPOSE mode enables add_history_to_context."""
+        machine = LearningMachine(
+            user_memory=UserMemoryConfig(mode=LearningMode.PROPOSE),
+        )
+        team = Team(
+            id="test-team",
+            name="Test Team",
+            members=[Agent(id="a", name="A", role="test")],
+            db=mock_db,
+            learning=machine,
+            add_history_to_context=False,
+        )
+        _set_learning_machine(team)
+
+        assert team.add_history_to_context is True
+
 
 # =============================================================================
 # Learning context position tests
@@ -291,6 +569,7 @@ class TestSetLearningMachineHistory:
 
 class TestLearningContextPosition:
     def test_learning_context_after_identity_before_knowledge(self, mock_db, mock_model, member_agent):
+        """Verify learning context appears after description/role but before knowledge."""
         team = Team(
             id="test-team",
             name="Test Team",
@@ -312,7 +591,6 @@ class TestLearningContextPosition:
         msg = get_system_message(team, session)
 
         content = msg.content
-
         description_pos = content.find("<description>")
         role_pos = content.find("<your_role>")
         learning_pos = content.find("<user_profile>")
@@ -320,7 +598,11 @@ class TestLearningContextPosition:
         assert description_pos < learning_pos
         assert role_pos < learning_pos
 
-    def test_empty_learning_context_not_added(self, mock_db, mock_model, member_agent):
+    def test_learning_context_before_knowledge_context(self, mock_db, mock_model, member_agent):
+        """Verify learning context appears before knowledge context when both enabled."""
+        mock_knowledge = MagicMock()
+        mock_knowledge.build_context = MagicMock(return_value="<knowledge_marker>KB Content</knowledge_marker>")
+
         team = Team(
             id="test-team",
             name="Test Team",
@@ -328,10 +610,29 @@ class TestLearningContextPosition:
             db=mock_db,
             learning=True,
             add_learnings_to_context=True,
+            knowledge=mock_knowledge,
+            search_knowledge=True,
+            add_search_knowledge_instructions=True,
         )
         team.model = mock_model
         _set_learning_machine(team)
 
+        mock_learning = "<user_profile>\nLearning Content\n</user_profile>"
+        team._learning.build_context = MagicMock(return_value=mock_learning)
+
+        session = TeamSession(session_id="test-session")
+        msg = get_system_message(team, session)
+
+        content = msg.content
+        learning_pos = content.find("<user_profile>")
+        knowledge_pos = content.find("<knowledge_marker>")
+
+        assert learning_pos > 0
+        assert knowledge_pos > 0
+        assert learning_pos < knowledge_pos
+
+    def test_empty_learning_context_not_added(self, mock_db, mock_model, member_agent):
+        team = _make_team_with_learning(mock_db, mock_model, member_agent)
         team._learning.build_context = MagicMock(return_value="")
 
         session = TeamSession(session_id="test-session")
@@ -363,38 +664,40 @@ class TestTeamLearningConfig:
         )
         assert team.add_learnings_to_context is False
 
-    def test_learning_true_creates_default_machine(self, mock_db, member_agent):
-        team = Team(
-            id="test-team",
-            name="Test Team",
-            members=[member_agent],
-            db=mock_db,
-            learning=True,
-        )
-        _set_learning_machine(team)
 
-        assert team._learning is not None
-        assert isinstance(team._learning, LearningMachine)
+# =============================================================================
+# Parametrized edge case tests
+# =============================================================================
 
-    def test_learning_false_no_machine(self, mock_db, member_agent):
-        team = Team(
-            id="test-team",
-            name="Test Team",
-            members=[member_agent],
-            db=mock_db,
-            learning=False,
-        )
-        _set_learning_machine(team)
 
-        assert team._learning is None
+class TestLearningContextFalseyValues:
+    @pytest.mark.parametrize("context_value", [None, ""])
+    def test_falsey_learning_context_not_added_sync(self, mock_db, mock_model, member_agent, context_value):
+        """Verify both None and empty string don't pollute system message."""
+        team = _make_team_with_learning(mock_db, mock_model, member_agent)
+        team._learning.build_context = MagicMock(return_value=context_value)
 
-    def test_learning_without_db_warns(self, member_agent, caplog):
-        team = Team(
-            id="test-team",
-            name="Test Team",
-            members=[member_agent],
-            learning=True,
-        )
-        _set_learning_machine(team)
+        session = TeamSession(session_id="test-session")
+        msg = get_system_message(team, session)
 
-        assert team._learning is None
+        assert msg is not None
+        if context_value is None:
+            assert "None" not in msg.content
+        assert "\n\n\n" not in msg.content
+        team._learning.build_context.assert_called_once()
+
+    @pytest.mark.parametrize("context_value", [None, ""])
+    @pytest.mark.asyncio
+    async def test_falsey_learning_context_not_added_async(self, mock_db, mock_model, member_agent, context_value):
+        """Verify both None and empty string don't pollute async system message."""
+        team = _make_team_with_learning(mock_db, mock_model, member_agent)
+        team._learning.abuild_context = AsyncMock(return_value=context_value)
+
+        session = TeamSession(session_id="test-session")
+        msg = await aget_system_message(team, session)
+
+        assert msg is not None
+        if context_value is None:
+            assert "None" not in msg.content
+        assert "\n\n\n" not in msg.content
+        team._learning.abuild_context.assert_awaited_once()

--- a/libs/agno/tests/unit/team/test_team_learning.py
+++ b/libs/agno/tests/unit/team/test_team_learning.py
@@ -8,7 +8,7 @@ Tests cover:
 - Store combinations and edge cases
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 


### PR DESCRIPTION
## Summary

Fixes #7716 item 0: **Team does not inject LearningMachine context into the system prompt**

This PR achieves **full Agent parity** for Team learning integration.

## Changes

### 1. Learning context injection (`team/_messages.py`)
- `Team.add_learnings_to_context` was declared but `build_context()` was never called
- Added injection in both `get_system_message()` and `aget_system_message()`
- Pattern mirrors Agent exactly

### 2. Async learning tools (`team/_tools.py`, `team/_run.py`)
- Team used sync `get_tools()` even in async mode (blocking DB calls)
- Added `_aget_learning_tools()` async helper
- Updated all 8 async callers to pre-fetch learning tools asynchronously

### 3. Auto-enable history for PROPOSE/HITL (`team/_init.py`)
- Agent sets `add_history_to_context=True` when `learning.requires_history`
- Added same check to Team initialization

### 4. New cookbooks for Team learning
Added 4 cookbooks to match Agent's learning coverage:
- `07_team_user_profile.py` — cross-session profile recall
- `08_team_user_memory.py` — user memory/context recall  
- `09_team_async_learning.py` — async database operations
- `10_team_agentic_learning.py` — agentic mode with tools

## Agent Parity Status

| Area | Before | After |
|------|--------|-------|
| Inject learning context into system prompt | ❌ | ✓ |
| Async learning tools in async mode | ❌ | ✓ |
| Auto-enable history for PROPOSE/HITL | ❌ | ✓ |

## Testing

### Unit tests
```bash
pytest libs/agno/tests/unit/team/  # 373 passed
```

### E2E cookbooks verified (all 10)
- `01_team_always_learn.py` — cross-session recall ✓
- `02_team_configured_learning.py` — configured stores ✓
- `03_team_entity_memory.py` — entity relationships ✓
- `04_team_session_planning.py` — session context ✓
- `05_team_learned_knowledge.py` — semantic search ✓
- `06_team_decision_log.py` — decision logging ✓
- `07_team_user_profile.py` — profile recall ✓ (NEW)
- `08_team_user_memory.py` — memory recall ✓ (NEW)
- `09_team_async_learning.py` — async mode ✓ (NEW)
- `10_team_agentic_learning.py` — agentic mode ✓ (NEW)

## Files Changed

| File | Changes |
|------|---------|
| `team/_messages.py` | +20 lines — learning context injection |
| `team/_tools.py` | +32 lines — async helper + learning_tools param |
| `team/_run.py` | +22 lines — 8 async callers updated |
| `team/_init.py` | +4 lines — requires_history check |
| `cookbook/03_teams/12_learning/` | +4 new cookbooks |

## Checklist

- [x] Format/lint passes
- [x] Unit tests pass (373)
- [x] E2E cookbooks verified (10/10)
- [x] Both sync and async paths implemented
- [x] Matches Agent implementation exactly
- [x] New cookbooks added for coverage