### PR TITLE
[fix] preserve existing trace context on upsert across SQL backends

### DIFF
--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -2572,12 +2572,13 @@ class AsyncMySQLDb(AsyncBaseDb):
                         else_=table.c.name,
                     ),
                     # Preserve existing non-null context values using COALESCE
-                    run_id=func.coalesce(insert_stmt.inserted.run_id, table.c.run_id),
-                    session_id=func.coalesce(insert_stmt.inserted.session_id, table.c.session_id),
-                    user_id=func.coalesce(insert_stmt.inserted.user_id, table.c.user_id),
-                    agent_id=func.coalesce(insert_stmt.inserted.agent_id, table.c.agent_id),
-                    team_id=func.coalesce(insert_stmt.inserted.team_id, table.c.team_id),
-                    workflow_id=func.coalesce(insert_stmt.inserted.workflow_id, table.c.workflow_id),
+                    # Existing value first so it wins; incoming fills NULLs only.
+                    run_id=func.coalesce(table.c.run_id, insert_stmt.inserted.run_id),
+                    session_id=func.coalesce(table.c.session_id, insert_stmt.inserted.session_id),
+                    user_id=func.coalesce(table.c.user_id, insert_stmt.inserted.user_id),
+                    agent_id=func.coalesce(table.c.agent_id, insert_stmt.inserted.agent_id),
+                    team_id=func.coalesce(table.c.team_id, insert_stmt.inserted.team_id),
+                    workflow_id=func.coalesce(table.c.workflow_id, insert_stmt.inserted.workflow_id),
                 )
                 await sess.execute(upsert_stmt)
 

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -2594,12 +2594,13 @@ class MySQLDb(BaseDb):
                         else_=table.c.name,
                     ),
                     # Preserve existing non-null context values using COALESCE
-                    run_id=func.coalesce(insert_stmt.inserted.run_id, table.c.run_id),
-                    session_id=func.coalesce(insert_stmt.inserted.session_id, table.c.session_id),
-                    user_id=func.coalesce(insert_stmt.inserted.user_id, table.c.user_id),
-                    agent_id=func.coalesce(insert_stmt.inserted.agent_id, table.c.agent_id),
-                    team_id=func.coalesce(insert_stmt.inserted.team_id, table.c.team_id),
-                    workflow_id=func.coalesce(insert_stmt.inserted.workflow_id, table.c.workflow_id),
+                    # Existing value first so it wins; incoming fills NULLs only.
+                    run_id=func.coalesce(table.c.run_id, insert_stmt.inserted.run_id),
+                    session_id=func.coalesce(table.c.session_id, insert_stmt.inserted.session_id),
+                    user_id=func.coalesce(table.c.user_id, insert_stmt.inserted.user_id),
+                    agent_id=func.coalesce(table.c.agent_id, insert_stmt.inserted.agent_id),
+                    team_id=func.coalesce(table.c.team_id, insert_stmt.inserted.team_id),
+                    workflow_id=func.coalesce(table.c.workflow_id, insert_stmt.inserted.workflow_id),
                 )
                 sess.execute(upsert_stmt)
 

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -2455,12 +2455,13 @@ class AsyncPostgresDb(AsyncBaseDb):
                             else_=table.c.name,
                         ),
                         # Preserve existing non-null context values using COALESCE
-                        "run_id": func.coalesce(insert_stmt.excluded.run_id, table.c.run_id),
-                        "session_id": func.coalesce(insert_stmt.excluded.session_id, table.c.session_id),
-                        "user_id": func.coalesce(insert_stmt.excluded.user_id, table.c.user_id),
-                        "agent_id": func.coalesce(insert_stmt.excluded.agent_id, table.c.agent_id),
-                        "team_id": func.coalesce(insert_stmt.excluded.team_id, table.c.team_id),
-                        "workflow_id": func.coalesce(insert_stmt.excluded.workflow_id, table.c.workflow_id),
+                        # Existing value first so it wins; incoming fills NULLs only.
+                        "run_id": func.coalesce(table.c.run_id, insert_stmt.excluded.run_id),
+                        "session_id": func.coalesce(table.c.session_id, insert_stmt.excluded.session_id),
+                        "user_id": func.coalesce(table.c.user_id, insert_stmt.excluded.user_id),
+                        "agent_id": func.coalesce(table.c.agent_id, insert_stmt.excluded.agent_id),
+                        "team_id": func.coalesce(table.c.team_id, insert_stmt.excluded.team_id),
+                        "workflow_id": func.coalesce(table.c.workflow_id, insert_stmt.excluded.workflow_id),
                     },
                 )
                 await sess.execute(upsert_stmt)

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -2891,12 +2891,13 @@ class PostgresDb(BaseDb):
                             else_=table.c.name,
                         ),
                         # Preserve existing non-null context values using COALESCE
-                        "run_id": func.coalesce(insert_stmt.excluded.run_id, table.c.run_id),
-                        "session_id": func.coalesce(insert_stmt.excluded.session_id, table.c.session_id),
-                        "user_id": func.coalesce(insert_stmt.excluded.user_id, table.c.user_id),
-                        "agent_id": func.coalesce(insert_stmt.excluded.agent_id, table.c.agent_id),
-                        "team_id": func.coalesce(insert_stmt.excluded.team_id, table.c.team_id),
-                        "workflow_id": func.coalesce(insert_stmt.excluded.workflow_id, table.c.workflow_id),
+                        # Existing value first so it wins; incoming fills NULLs only.
+                        "run_id": func.coalesce(table.c.run_id, insert_stmt.excluded.run_id),
+                        "session_id": func.coalesce(table.c.session_id, insert_stmt.excluded.session_id),
+                        "user_id": func.coalesce(table.c.user_id, insert_stmt.excluded.user_id),
+                        "agent_id": func.coalesce(table.c.agent_id, insert_stmt.excluded.agent_id),
+                        "team_id": func.coalesce(table.c.team_id, insert_stmt.excluded.team_id),
+                        "workflow_id": func.coalesce(table.c.workflow_id, insert_stmt.excluded.workflow_id),
                     },
                 )
                 sess.execute(upsert_stmt)

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -2541,12 +2541,13 @@ class SingleStoreDb(BaseDb):
                         else_=table.c.name,
                     ),
                     # Preserve existing non-null context values using COALESCE
-                    run_id=func.coalesce(insert_stmt.inserted.run_id, table.c.run_id),
-                    session_id=func.coalesce(insert_stmt.inserted.session_id, table.c.session_id),
-                    user_id=func.coalesce(insert_stmt.inserted.user_id, table.c.user_id),
-                    agent_id=func.coalesce(insert_stmt.inserted.agent_id, table.c.agent_id),
-                    team_id=func.coalesce(insert_stmt.inserted.team_id, table.c.team_id),
-                    workflow_id=func.coalesce(insert_stmt.inserted.workflow_id, table.c.workflow_id),
+                    # Existing value first so it wins; incoming fills NULLs only.
+                    run_id=func.coalesce(table.c.run_id, insert_stmt.inserted.run_id),
+                    session_id=func.coalesce(table.c.session_id, insert_stmt.inserted.session_id),
+                    user_id=func.coalesce(table.c.user_id, insert_stmt.inserted.user_id),
+                    agent_id=func.coalesce(table.c.agent_id, insert_stmt.inserted.agent_id),
+                    team_id=func.coalesce(table.c.team_id, insert_stmt.inserted.team_id),
+                    workflow_id=func.coalesce(table.c.workflow_id, insert_stmt.inserted.workflow_id),
                 )
                 sess.execute(upsert_stmt)
 

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -2619,12 +2619,13 @@ class AsyncSqliteDb(AsyncBaseDb):
                             else_=table.c.name,
                         ),
                         # Preserve existing non-null context values using COALESCE
-                        "run_id": func.coalesce(insert_stmt.excluded.run_id, table.c.run_id),
-                        "session_id": func.coalesce(insert_stmt.excluded.session_id, table.c.session_id),
-                        "user_id": func.coalesce(insert_stmt.excluded.user_id, table.c.user_id),
-                        "agent_id": func.coalesce(insert_stmt.excluded.agent_id, table.c.agent_id),
-                        "team_id": func.coalesce(insert_stmt.excluded.team_id, table.c.team_id),
-                        "workflow_id": func.coalesce(insert_stmt.excluded.workflow_id, table.c.workflow_id),
+                        # Existing value first so it wins; incoming fills NULLs only.
+                        "run_id": func.coalesce(table.c.run_id, insert_stmt.excluded.run_id),
+                        "session_id": func.coalesce(table.c.session_id, insert_stmt.excluded.session_id),
+                        "user_id": func.coalesce(table.c.user_id, insert_stmt.excluded.user_id),
+                        "agent_id": func.coalesce(table.c.agent_id, insert_stmt.excluded.agent_id),
+                        "team_id": func.coalesce(table.c.team_id, insert_stmt.excluded.team_id),
+                        "workflow_id": func.coalesce(table.c.workflow_id, insert_stmt.excluded.workflow_id),
                     },
                 )
                 await sess.execute(upsert_stmt)

--- a/libs/agno/agno/db/sqlite/sqlite.py
+++ b/libs/agno/agno/db/sqlite/sqlite.py
@@ -2502,12 +2502,13 @@ class SqliteDb(BaseDb):
                             else_=table.c.name,
                         ),
                         # Preserve existing non-null context values using COALESCE
-                        "run_id": func.coalesce(insert_stmt.excluded.run_id, table.c.run_id),
-                        "session_id": func.coalesce(insert_stmt.excluded.session_id, table.c.session_id),
-                        "user_id": func.coalesce(insert_stmt.excluded.user_id, table.c.user_id),
-                        "agent_id": func.coalesce(insert_stmt.excluded.agent_id, table.c.agent_id),
-                        "team_id": func.coalesce(insert_stmt.excluded.team_id, table.c.team_id),
-                        "workflow_id": func.coalesce(insert_stmt.excluded.workflow_id, table.c.workflow_id),
+                        # Existing value first so it wins; incoming fills NULLs only.
+                        "run_id": func.coalesce(table.c.run_id, insert_stmt.excluded.run_id),
+                        "session_id": func.coalesce(table.c.session_id, insert_stmt.excluded.session_id),
+                        "user_id": func.coalesce(table.c.user_id, insert_stmt.excluded.user_id),
+                        "agent_id": func.coalesce(table.c.agent_id, insert_stmt.excluded.agent_id),
+                        "team_id": func.coalesce(table.c.team_id, insert_stmt.excluded.team_id),
+                        "workflow_id": func.coalesce(table.c.workflow_id, insert_stmt.excluded.workflow_id),
                     },
                 )
                 sess.execute(upsert_stmt)

--- a/libs/agno/tests/integration/db/async_postgres/test_trace_upsert.py
+++ b/libs/agno/tests/integration/db/async_postgres/test_trace_upsert.py
@@ -14,6 +14,10 @@ The race condition window:
 import asyncio
 import uuid
 from datetime import datetime, timezone
+from typing import Optional
+
+import pytest
+from sqlalchemy import select
 
 from agno.db.postgres import AsyncPostgresDb
 from agno.tracing.schemas import Trace
@@ -92,6 +96,84 @@ async def cleanup_trace(db: AsyncPostgresDb, trace_id: str):
                 await sess.execute(delete(table).where(table.c.trace_id == trace_id))
     except Exception as e:
         print(f"Cleanup error (can be ignored): {e}")
+
+
+def _make_trace(
+    trace_id: str,
+    *,
+    session_id: Optional[str],
+    user_id: Optional[str] = None,
+    agent_id: Optional[str],
+    team_id: Optional[str],
+    workflow_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    name: str = "Test.run",
+) -> Trace:
+    """Build a Trace with explicit context for upsert tests."""
+    now = datetime.now(timezone.utc)
+    return Trace(
+        trace_id=trace_id,
+        name=name,
+        status="OK",
+        start_time=now,
+        end_time=now,
+        duration_ms=100,
+        total_spans=1,
+        error_count=0,
+        run_id=run_id,
+        session_id=session_id,
+        user_id=user_id,
+        agent_id=agent_id,
+        team_id=team_id,
+        workflow_id=workflow_id,
+        created_at=now,
+    )
+
+
+@pytest.mark.asyncio
+async def test_upsert_trace_preserves_existing_context(async_postgres_db_real):
+    """A second upsert with a different session_id must NOT overwrite the existing one.
+
+    Reproduces the bug where ON CONFLICT DO UPDATE used
+    ``COALESCE(excluded.session_id, table.c.session_id)`` (incoming wins),
+    silently rewriting an existing trace row's context whenever a second span
+    export shared the same trace_id under a different session.
+    """
+    db = async_postgres_db_real
+    trace_id = f"coalesce-test-{uuid.uuid4().hex[:8]}"
+
+    first = _make_trace(
+        trace_id,
+        session_id="team_session",
+        user_id="user_1",
+        agent_id=None,
+        team_id="team_x",
+    )
+    await db.upsert_trace(first)
+
+    # Second export shares the trace_id but carries a different session_id
+    # and a different agent_id (the original row had agent_id=None).
+    second = _make_trace(
+        trace_id,
+        session_id="rating_session",
+        user_id=None,
+        agent_id="agent_rating",
+        team_id=None,
+    )
+    await db.upsert_trace(second)
+
+    table = await db._get_table(table_type="traces")
+    assert table is not None
+    async with db.async_session_factory() as sess:
+        row = (await sess.execute(select(table).where(table.c.trace_id == trace_id))).fetchone()
+
+    assert row is not None
+    # Existing non-null context fields are preserved (incoming did NOT win).
+    assert row.session_id == "team_session"
+    assert row.team_id == "team_x"
+    assert row.user_id == "user_1"
+    # Field that was NULL on the first write gets filled by the incoming value.
+    assert row.agent_id == "agent_rating"
 
 
 async def run_race_test(db: AsyncPostgresDb, num_tasks: int = 10):


### PR DESCRIPTION
## Summary

`upsert_trace`'s ON CONFLICT DO UPDATE clause was calling
`func.coalesce(insert_stmt.<excluded|inserted>.X, table.c.X)` for every
context field (`run_id`, `session_id`, `user_id`, `agent_id`, `team_id`,
`workflow_id`). Because `COALESCE` returns its first non-NULL argument,
that order means the **incoming** value wins whenever it's set —
silently overwriting the existing row's context whenever a second span
export shares a `trace_id`.

The comment immediately above each upsert says:

> # Preserve existing non-null context values using COALESCE

…which is the opposite of what the code does today. Reversing the two
arguments to `func.coalesce(table.c.X, insert_stmt.<excluded|inserted>.X)`
makes the code match the comment: existing non-null values are
preserved, and incoming values only fill fields the first write left
NULL.

### Why this matters

When two spans end up sharing a `trace_id` but carry different
context — for example, an `Agent.arun()` call from inside a post-hook
that uses a different `session_id` than the outer team run — the
second export's context fields silently overwrote the first export's.
The trace row's `session_id` would then point at the inner agent's
session instead of the outer team's, and the AgentOS Traces UI's
`WHERE session_id = '<team session>'` query stopped returning the
affected rows.

After this fix, the trace row keeps its first-set context values, so
`get_trace`/`get_traces` queries continue to find the row under its
original `session_id` regardless of what later span exports look like.

The same buggy COALESCE pattern existed in every SQL backend, so the
fix is applied uniformly:

- `libs/agno/agno/db/postgres/postgres.py`
- `libs/agno/agno/db/postgres/async_postgres.py`
- `libs/agno/agno/db/sqlite/sqlite.py`
- `libs/agno/agno/db/sqlite/async_sqlite.py`
- `libs/agno/agno/db/mysql/mysql.py`
- `libs/agno/agno/db/mysql/async_mysql.py`
- `libs/agno/agno/db/singlestore/singlestore.py`

A regression test is included at
`libs/agno/tests/integration/db/async_postgres/test_trace_upsert.py::test_upsert_trace_preserves_existing_context`
that asserts a second upsert with a different `session_id` does not
overwrite the first row's non-null context, while NULL-valued fields
on the original write can still be filled by the later export.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — not applicable; internal correctness fix
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](https://github.com/agno-agi/agno/pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

This patch was prepared with Claude Code assistance; the change is six
small, mechanical argument-order swaps plus one test, all reviewed
line-by-line before commit.

---

## Additional Notes

There's a related upstream observation that this PR does **not** try to
address: in `openinference/instrumentation/agno/_runs_wrapper.py`,
top-level `Team` runs are forced to a fresh root span via
`trace_api.set_span_in_context(trace_api.INVALID_SPAN)`, but top-level
`Agent` runs inherit whatever ambient OTel context is active. Combined
with FastAPI `BackgroundTasks` (which execute within the same ASGI
request task, so the parent span's contextvars are still attached), an
inner `Agent.arun()` from a post-hook can end up sharing a `trace_id`
with the outer run. This PR makes that collision non-destructive at
the storage layer; whether the trace_id should collide upstream is a
separate question, happy to file against
`openinference-instrumentation-agno` if that's the right place.
