### PR TITLE
fix(message): parse JSON-stringified list content in Message.from_dict()

### DIFF
--- a/libs/agno/agno/models/message.py
+++ b/libs/agno/agno/models/message.py
@@ -139,6 +139,20 @@ class Message(BaseModel):
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "Message":
+        # If content was serialised as a JSON string (e.g. stored in Postgres as TEXT
+        # when it was originally a list of content-part dicts), parse it back to a list.
+        # This prevents "Invalid type for messages[N].content[0]: expected an object,
+        # but got a string instead" errors from OpenAI models. (#4184)
+        if "content" in data and isinstance(data["content"], str):
+            raw = data["content"].strip()
+            if raw.startswith("[") or raw.startswith("{"):
+                try:
+                    parsed = json.loads(raw)
+                    if isinstance(parsed, (list, dict)):
+                        data["content"] = parsed
+                except (json.JSONDecodeError, ValueError):
+                    pass  # keep as-is if it's a plain text string
+
         # Handle image reconstruction properly
         if "images" in data and data["images"]:
             reconstructed_images = []


### PR DESCRIPTION
Fixes #4184

## Problem

When agent sessions are stored in Postgres (or any backend that persists `content` as a `TEXT` column), list-type message content is serialised as a JSON string — e.g. `'[{"type": "text", "text": "..."}]'`. On reload, `Message.from_dict()` receives this as a plain Python `str` and passes it directly to the model.

OpenAI models (`gpt-4.1`, `chatgpt-4.1`, `o4-mini`, etc.) reject string content in positions they expect an object:
```
ModelProviderError: Invalid type for 'messages[7].content[0]':
expected an object, but got a string instead.
```

Gemini was unaffected because it accepts string content natively, which is why the bug only manifested with OpenAI models under Postgres storage (the bug was introduced in v1.6.0 when message serialisation changed).

## Fix

In `Message.from_dict()`, before all other reconstruction logic, check if `content` is a string that starts with `[` or `{`. If so, attempt `json.loads()`. If parsing succeeds and produces a list or dict, replace the string value. Plain text content (not starting with `[` or `{`) is left completely unchanged.