### PR TITLE
feat: add api client header to gemini connectors

### DIFF
--- a/libs/agno/agno/knowledge/embedder/google.py
+++ b/libs/agno/agno/knowledge/embedder/google.py
@@ -52,6 +52,16 @@ class GeminiEmbedder(Embedder):
         if self.client_params:
             _client_params.update(self.client_params)
 
+        http_options = _client_params.get("http_options", {})
+        if isinstance(http_options, dict):
+            headers = http_options.get("headers", {})
+            if isinstance(headers, dict):
+                from agno import __version__ as agno_version
+
+                headers["x-goog-api-client"] = f"agno/{agno_version}"
+                http_options["headers"] = headers
+                _client_params["http_options"] = http_options
+
         self.gemini_client = genai.Client(**_client_params)
 
         return self.gemini_client

--- a/libs/agno/agno/knowledge/embedder/google.py
+++ b/libs/agno/agno/knowledge/embedder/google.py
@@ -3,6 +3,7 @@ from os import getenv
 from typing import Any, Dict, List, Optional, Tuple
 
 from agno.knowledge.embedder.base import Embedder
+from agno.utils.gemini import inject_agno_client_header
 from agno.utils.log import log_error, log_info, log_warning
 
 try:
@@ -52,15 +53,7 @@ class GeminiEmbedder(Embedder):
         if self.client_params:
             _client_params.update(self.client_params)
 
-        http_options = _client_params.get("http_options", {})
-        if isinstance(http_options, dict):
-            headers = http_options.get("headers", {})
-            if isinstance(headers, dict):
-                from agno import __version__ as agno_version
-
-                headers["x-goog-api-client"] = f"agno/{agno_version}"
-                http_options["headers"] = headers
-                _client_params["http_options"] = http_options
+        _client_params = inject_agno_client_header(_client_params)
 
         self.gemini_client = genai.Client(**_client_params)
 

--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -21,7 +21,12 @@ from agno.models.metrics import MessageMetrics
 from agno.models.response import ModelResponse
 from agno.run.agent import RunOutput
 from agno.tools.function import Function
-from agno.utils.gemini import format_function_definitions, format_image_for_message, prepare_response_schema
+from agno.utils.gemini import (
+    format_function_definitions,
+    format_image_for_message,
+    inject_agno_client_header,
+    prepare_response_schema,
+)
 from agno.utils.log import log_debug, log_error, log_info, log_warning
 from agno.utils.tokens import count_schema_tokens, count_text_tokens, count_tool_tokens
 
@@ -196,15 +201,7 @@ class Gemini(Model):
         if self.client_params:
             client_params.update(self.client_params)
 
-        http_options = client_params.get("http_options", {})
-        if isinstance(http_options, dict):
-            headers = http_options.get("headers", {})
-            if isinstance(headers, dict):
-                from agno import __version__ as agno_version
-
-                headers["x-goog-api-client"] = f"agno/{agno_version}"
-                http_options["headers"] = headers
-                client_params["http_options"] = http_options
+        client_params = inject_agno_client_header(client_params)
 
         self.client = genai.Client(**client_params)
         return self.client

--- a/libs/agno/agno/models/google/gemini.py
+++ b/libs/agno/agno/models/google/gemini.py
@@ -196,6 +196,16 @@ class Gemini(Model):
         if self.client_params:
             client_params.update(self.client_params)
 
+        http_options = client_params.get("http_options", {})
+        if isinstance(http_options, dict):
+            headers = http_options.get("headers", {})
+            if isinstance(headers, dict):
+                from agno import __version__ as agno_version
+
+                headers["x-goog-api-client"] = f"agno/{agno_version}"
+                http_options["headers"] = headers
+                client_params["http_options"] = http_options
+
         self.client = genai.Client(**client_params)
         return self.client
 

--- a/libs/agno/agno/tools/nano_banana.py
+++ b/libs/agno/agno/tools/nano_banana.py
@@ -69,7 +69,12 @@ class NanoBananaTools(Toolkit):
     def create_image(self, prompt: str) -> ToolResult:
         """Generate an image from a text prompt."""
         try:
-            client = genai.Client(api_key=self.api_key)
+            from agno import __version__ as agno_version
+
+            client = genai.Client(
+                api_key=self.api_key,
+                http_options={"headers": {"x-goog-api-client": f"agno/{agno_version}"}},
+            )
             log_debug(f"NanoBanana generating image with prompt: {prompt}")
 
             cfg = types.GenerateContentConfig(

--- a/libs/agno/agno/tools/nano_banana.py
+++ b/libs/agno/agno/tools/nano_banana.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 from agno.media import Image
 from agno.tools import Toolkit
 from agno.tools.function import ToolResult
+from agno.utils.gemini import inject_agno_client_header
 from agno.utils.log import log_debug, logger
 
 try:
@@ -69,12 +70,7 @@ class NanoBananaTools(Toolkit):
     def create_image(self, prompt: str) -> ToolResult:
         """Generate an image from a text prompt."""
         try:
-            from agno import __version__ as agno_version
-
-            client = genai.Client(
-                api_key=self.api_key,
-                http_options={"headers": {"x-goog-api-client": f"agno/{agno_version}"}},
-            )
+            client = genai.Client(**inject_agno_client_header({"api_key": self.api_key}))
             log_debug(f"NanoBanana generating image with prompt: {prompt}")
 
             cfg = types.GenerateContentConfig(

--- a/libs/agno/agno/utils/gemini.py
+++ b/libs/agno/agno/utils/gemini.py
@@ -19,6 +19,34 @@ except ImportError:
     raise ImportError("`google-genai` not installed. Please install it using `pip install google-genai`")
 
 
+def inject_agno_client_header(client_params: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Add the `x-goog-api-client: agno/<version>` header to a Gemini client's http_options.
+
+    Google requests partner integrations to identify themselves via this header
+    (https://ai.google.dev/gemini-api/docs/partner-integration#client-id) so they
+    can track usage and apply partner-specific behavior. We use a Google-specific
+    header rather than User-Agent so user-supplied User-Agent values aren't overridden.
+
+    Args:
+        client_params: The kwargs dict that will be passed to `genai.Client(...)`.
+
+    Returns:
+        The same dict, with `http_options.headers["x-goog-api-client"]` set.
+        Existing headers and http_options keys are preserved.
+    """
+    from agno import __version__ as agno_version
+
+    http_options = client_params.get("http_options", {})
+    if isinstance(http_options, dict):
+        headers = http_options.get("headers", {})
+        if isinstance(headers, dict):
+            headers["x-goog-api-client"] = f"agno/{agno_version}"
+            http_options["headers"] = headers
+            client_params["http_options"] = http_options
+    return client_params
+
+
 def prepare_response_schema(pydantic_model: Type[BaseModel]) -> Union[Type[BaseModel], Schema]:
     """
     Prepare a Pydantic model for use as Gemini response schema.

--- a/libs/agno/tests/unit/models/google/test_gemini.py
+++ b/libs/agno/tests/unit/models/google/test_gemini.py
@@ -249,14 +249,14 @@ class TestGeminiTimeout:
             assert kwargs["http_options"]["timeout"] == 30000
 
     def test_timeout_none_does_not_set_http_options(self):
-        """Test that no http_options are added when timeout is None."""
+        """Test that timeout is not added to http_options when timeout is None."""
         model = Gemini(api_key="test-key", timeout=None)
 
         with patch("agno.models.google.gemini.genai.Client") as mock_client_cls:
             model.get_client()
 
             _, kwargs = mock_client_cls.call_args
-            assert "http_options" not in kwargs
+            assert "timeout" not in kwargs.get("http_options", {})
 
     def test_timeout_fractional_seconds(self):
         """Test that fractional seconds are correctly converted to integer milliseconds."""
@@ -298,6 +298,40 @@ class TestGeminiTimeout:
             _, kwargs = mock_client_cls.call_args
             assert kwargs["http_options"]["timeout"] == 10000
             assert kwargs["vertexai"] is True
+
+
+class TestGeminiHeaders:
+    def test_api_client_header_present(self):
+        """Test that the API client header is automatically added."""
+        from agno import __version__ as agno_version
+
+        model = Gemini(api_key="test-key")
+
+        with patch("agno.models.google.gemini.genai.Client") as mock_client_cls:
+            model.get_client()
+
+            _, kwargs = mock_client_cls.call_args
+            assert "http_options" in kwargs
+            assert "headers" in kwargs["http_options"]
+            assert kwargs["http_options"]["headers"]["x-goog-api-client"] == f"agno/{agno_version}"
+
+    def test_api_client_header_with_client_params(self):
+        """Test that the API client header merges with existing headers in client_params."""
+        from agno import __version__ as agno_version
+
+        model = Gemini(
+            api_key="test-key",
+            client_params={"http_options": {"headers": {"custom-header": "value"}}},
+        )
+
+        with patch("agno.models.google.gemini.genai.Client") as mock_client_cls:
+            model.get_client()
+
+            _, kwargs = mock_client_cls.call_args
+            assert "http_options" in kwargs
+            assert "headers" in kwargs["http_options"]
+            assert kwargs["http_options"]["headers"]["x-goog-api-client"] == f"agno/{agno_version}"
+            assert kwargs["http_options"]["headers"]["custom-header"] == "value"
 
 
 def test_parallel_search_requires_vertexai():

--- a/libs/agno/tests/unit/utils/test_gemini.py
+++ b/libs/agno/tests/unit/utils/test_gemini.py
@@ -1,6 +1,7 @@
 from agno.utils.gemini import (
     convert_schema,
     format_function_definitions,
+    inject_agno_client_header,
     needs_conversion,
     prepare_response_schema,
 )
@@ -686,3 +687,54 @@ def test_convert_schema_property_without_type_has_title():
     assert "value" in result.properties
     # Value property should have title even though it doesn't have a type
     assert result.properties["value"].title == "Value"
+
+
+# ---------------------------------------------------------------------------
+# inject_agno_client_header
+# ---------------------------------------------------------------------------
+
+
+def test_inject_header_into_empty_params():
+    """Adds http_options.headers with x-goog-api-client when none exist."""
+    from agno import __version__ as agno_version
+
+    result = inject_agno_client_header({})
+    assert result["http_options"]["headers"]["x-goog-api-client"] == f"agno/{agno_version}"
+
+
+def test_inject_header_preserves_existing_headers():
+    """Existing custom headers should be preserved alongside the new one."""
+    from agno import __version__ as agno_version
+
+    params = {"http_options": {"headers": {"custom-header": "value"}}}
+    result = inject_agno_client_header(params)
+    assert result["http_options"]["headers"]["custom-header"] == "value"
+    assert result["http_options"]["headers"]["x-goog-api-client"] == f"agno/{agno_version}"
+
+
+def test_inject_header_preserves_other_http_options():
+    """Other http_options keys (e.g., timeout) should be preserved."""
+    from agno import __version__ as agno_version
+
+    params = {"http_options": {"timeout": 30000}}
+    result = inject_agno_client_header(params)
+    assert result["http_options"]["timeout"] == 30000
+    assert result["http_options"]["headers"]["x-goog-api-client"] == f"agno/{agno_version}"
+
+
+def test_inject_header_preserves_other_client_params():
+    """Other client_params keys (e.g., api_key) should be preserved."""
+    params = {"api_key": "test-key", "vertexai": False}
+    result = inject_agno_client_header(params)
+    assert result["api_key"] == "test-key"
+    assert result["vertexai"] is False
+    assert "x-goog-api-client" in result["http_options"]["headers"]
+
+
+def test_inject_header_overrides_existing_x_goog_api_client():
+    """If an x-goog-api-client header is already set, it should be overwritten."""
+    from agno import __version__ as agno_version
+
+    params = {"http_options": {"headers": {"x-goog-api-client": "stale/0.0.0"}}}
+    result = inject_agno_client_header(params)
+    assert result["http_options"]["headers"]["x-goog-api-client"] == f"agno/{agno_version}"


### PR DESCRIPTION
## Summary

Add the API client header to Gemini connectors.

## Type of change

- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)
  - Not entirely, but Gemini CLI did the initial work

---

## Additional Notes

Following integration [best practices](https://ai.google.dev/gemini-api/docs/partner-integration#client-id)

fixes: #7833