### PR TITLE
fix: warn on duplicate tool names when registering on agent or team

### DIFF
--- a/libs/agno/agno/agent/_tools.py
+++ b/libs/agno/agno/agent/_tools.py
@@ -372,6 +372,10 @@ def parse_tools(
             toolkit_functions = tool.get_async_functions() if async_mode else tool.get_functions()
             for name, _func in toolkit_functions.items():
                 if name in _function_names:
+                    log_warning(
+                        f"Duplicate tool name '{name}' from toolkit '{tool.name}' "
+                        f"already registered on agent; skipping the duplicate."
+                    )
                     continue
                 _function_names.append(name)
                 _func = _func.model_copy(deep=True)
@@ -398,6 +402,7 @@ def parse_tools(
 
         elif isinstance(tool, Function):
             if tool.name in _function_names:
+                log_warning(f"Duplicate tool name '{tool.name}' already registered on agent; skipping the duplicate.")
                 continue
             _function_names.append(tool.name)
 
@@ -425,6 +430,9 @@ def parse_tools(
                 function_name = tool.__name__
 
                 if function_name in _function_names:
+                    log_warning(
+                        f"Duplicate tool name '{function_name}' already registered on agent; skipping the duplicate."
+                    )
                     continue
                 _function_names.append(function_name)
 

--- a/libs/agno/agno/team/_tools.py
+++ b/libs/agno/agno/team/_tools.py
@@ -326,6 +326,10 @@ def _determine_tools_for_model(
             toolkit_functions = tool.get_async_functions() if async_mode else tool.get_functions()
             for name, _func in toolkit_functions.items():
                 if name in _function_names:
+                    log_warning(
+                        f"Duplicate tool name '{name}' from toolkit '{tool.name}' "
+                        f"already registered on team; skipping the duplicate."
+                    )
                     continue
                 _function_names.append(name)
                 _func = _func.model_copy(deep=True)
@@ -355,6 +359,7 @@ def _determine_tools_for_model(
 
         elif isinstance(tool, Function):
             if tool.name in _function_names:
+                log_warning(f"Duplicate tool name '{tool.name}' already registered on team; skipping the duplicate.")
                 continue
             _function_names.append(tool.name)
             tool = tool.model_copy(deep=True)
@@ -381,6 +386,9 @@ def _determine_tools_for_model(
                 _func = Function.from_callable(tool, strict=strict)
                 _func = _func.model_copy(deep=True)
                 if _func.name in _function_names:
+                    log_warning(
+                        f"Duplicate tool name '{_func.name}' already registered on team; skipping the duplicate."
+                    )
                     continue
                 _function_names.append(_func.name)
 


### PR DESCRIPTION
Previously, when a tool with a function name that collided with an
already-registered tool was added to an Agent or Team, the duplicate
was silently dropped. This made it hard to diagnose missing tools.
Now we log a warning at each skip site (Toolkit functions, Function
objects, and raw callables) on both Agent and Team.