### PR TITLE
fix: forward dependencies and metadata to `/continue` endpoints

### DIFF
--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from typing import TYPE_CHECKING, Any, AsyncGenerator, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional, Union, cast
 from uuid import uuid4
 
 from fastapi import (
@@ -203,7 +203,8 @@ async def agent_continue_response_streamer(
     user_id: Optional[str] = None,
     background_tasks: Optional[BackgroundTasks] = None,
     auth_token: Optional[str] = None,
-    **kwargs: Any,
+    dependencies: Optional[Dict[str, Any]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
 ) -> AsyncGenerator:
     """Default SSE generator for continue_run. Agent runs inline — client disconnect cancels agent."""
     try:
@@ -219,8 +220,9 @@ async def agent_continue_response_streamer(
             stream=True,
             stream_events=True,
             background_tasks=background_tasks,
+            dependencies=dependencies,
+            metadata=metadata,
             **extra_kwargs,
-            **kwargs,
         )
         async for run_response_chunk in continue_response:
             yield format_sse_event(run_response_chunk)  # type: ignore
@@ -255,7 +257,8 @@ async def agent_resumable_continue_response_streamer(
     user_id: Optional[str] = None,
     background_tasks: Optional[BackgroundTasks] = None,
     auth_token: Optional[str] = None,
-    **kwargs: Any,
+    dependencies: Optional[Dict[str, Any]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
 ) -> AsyncGenerator:
     """Resumable SSE generator for continue_run with background=True, stream=True.
 
@@ -281,8 +284,9 @@ async def agent_resumable_continue_response_streamer(
             stream=True,
             stream_events=True,
             background=True,
+            dependencies=dependencies,
+            metadata=metadata,
             **extra_kwargs,
-            **kwargs,
         ):
             yield sse_data
     except (InputCheckError, OutputCheckError) as e:
@@ -899,23 +903,45 @@ def get_agent_router(
             False,
             description="Run continue in background (survives client disconnect). Requires database. Use /resume to reconnect.",
         ),
+        dependencies: Optional[str] = Form(
+            None,
+            description=(
+                "JSON object of runtime dependencies (e.g. user tokens, request-scoped values) "
+                "made available to tools via run_context.dependencies."
+            ),
+        ),
+        metadata: Optional[str] = Form(
+            None,
+            description="JSON object of metadata attached to the run.",
+        ),
     ):
-        kwargs = await get_request_kwargs(request, continue_agent_run)
+        # Parse dependencies / metadata JSON form fields.
+        dependencies_dict: Optional[Dict[str, Any]] = None
+        if dependencies:
+            try:
+                dependencies_dict = json.loads(dependencies)
+            except json.JSONDecodeError:
+                raise HTTPException(status_code=400, detail="Invalid JSON in dependencies field")
+        metadata_dict: Optional[Dict[str, Any]] = None
+        if metadata:
+            try:
+                metadata_dict = json.loads(metadata)
+            except json.JSONDecodeError:
+                raise HTTPException(status_code=400, detail="Invalid JSON in metadata field")
 
         if hasattr(request.state, "user_id") and request.state.user_id is not None:
             user_id = request.state.user_id
         if hasattr(request.state, "session_id") and request.state.session_id is not None:
             session_id = request.state.session_id
+        # Request state from middleware overrides form-provided values.
         if hasattr(request.state, "dependencies") and request.state.dependencies is not None:
-            dependencies = request.state.dependencies
-            if "dependencies" in kwargs:
-                log_warning("Dependencies parameter passed in both request state and kwargs, using request state")
-            kwargs["dependencies"] = dependencies
+            if dependencies_dict is not None:
+                log_warning("Dependencies parameter passed in both request state and form, using request state")
+            dependencies_dict = request.state.dependencies
         if hasattr(request.state, "metadata") and request.state.metadata is not None:
-            metadata = request.state.metadata
-            if "metadata" in kwargs:
-                log_warning("Metadata parameter passed in both request state and kwargs, using request state")
-            kwargs["metadata"] = metadata
+            if metadata_dict is not None:
+                log_warning("Metadata parameter passed in both request state and form, using request state")
+            metadata_dict = request.state.metadata
 
         # Parse the JSON string manually
         try:
@@ -1009,7 +1035,8 @@ def get_agent_router(
                     user_id=user_id,
                     background_tasks=background_tasks,
                     auth_token=auth_token,
-                    **kwargs,
+                    dependencies=dependencies_dict,
+                    metadata=metadata_dict,
                 ),
                 media_type="text/event-stream",
             )
@@ -1023,7 +1050,8 @@ def get_agent_router(
                     user_id=user_id,
                     background_tasks=background_tasks,
                     auth_token=auth_token,
-                    **kwargs,
+                    dependencies=dependencies_dict,
+                    metadata=metadata_dict,
                 ),
                 media_type="text/event-stream",
             )
@@ -1043,8 +1071,9 @@ def get_agent_router(
                         user_id=user_id,
                         stream=False,
                         background_tasks=background_tasks,
+                        dependencies=dependencies_dict,
+                        metadata=metadata_dict,
                         **extra_kwargs,
-                        **kwargs,
                     ),
                 )
                 return run_response_obj.to_dict()

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -203,6 +203,7 @@ async def agent_continue_response_streamer(
     user_id: Optional[str] = None,
     background_tasks: Optional[BackgroundTasks] = None,
     auth_token: Optional[str] = None,
+    **kwargs: Any,
 ) -> AsyncGenerator:
     """Default SSE generator for continue_run. Agent runs inline — client disconnect cancels agent."""
     try:
@@ -219,6 +220,7 @@ async def agent_continue_response_streamer(
             stream_events=True,
             background_tasks=background_tasks,
             **extra_kwargs,
+            **kwargs,
         )
         async for run_response_chunk in continue_response:
             yield format_sse_event(run_response_chunk)  # type: ignore
@@ -253,6 +255,7 @@ async def agent_resumable_continue_response_streamer(
     user_id: Optional[str] = None,
     background_tasks: Optional[BackgroundTasks] = None,
     auth_token: Optional[str] = None,
+    **kwargs: Any,
 ) -> AsyncGenerator:
     """Resumable SSE generator for continue_run with background=True, stream=True.
 
@@ -279,6 +282,7 @@ async def agent_resumable_continue_response_streamer(
             stream_events=True,
             background=True,
             **extra_kwargs,
+            **kwargs,
         ):
             yield sse_data
     except (InputCheckError, OutputCheckError) as e:
@@ -896,10 +900,22 @@ def get_agent_router(
             description="Run continue in background (survives client disconnect). Requires database. Use /resume to reconnect.",
         ),
     ):
+        kwargs = await get_request_kwargs(request, continue_agent_run)
+
         if hasattr(request.state, "user_id") and request.state.user_id is not None:
             user_id = request.state.user_id
         if hasattr(request.state, "session_id") and request.state.session_id is not None:
             session_id = request.state.session_id
+        if hasattr(request.state, "dependencies") and request.state.dependencies is not None:
+            dependencies = request.state.dependencies
+            if "dependencies" in kwargs:
+                log_warning("Dependencies parameter passed in both request state and kwargs, using request state")
+            kwargs["dependencies"] = dependencies
+        if hasattr(request.state, "metadata") and request.state.metadata is not None:
+            metadata = request.state.metadata
+            if "metadata" in kwargs:
+                log_warning("Metadata parameter passed in both request state and kwargs, using request state")
+            kwargs["metadata"] = metadata
 
         # Parse the JSON string manually
         try:
@@ -993,6 +1009,7 @@ def get_agent_router(
                     user_id=user_id,
                     background_tasks=background_tasks,
                     auth_token=auth_token,
+                    **kwargs,
                 ),
                 media_type="text/event-stream",
             )
@@ -1006,6 +1023,7 @@ def get_agent_router(
                     user_id=user_id,
                     background_tasks=background_tasks,
                     auth_token=auth_token,
+                    **kwargs,
                 ),
                 media_type="text/event-stream",
             )
@@ -1026,6 +1044,7 @@ def get_agent_router(
                         stream=False,
                         background_tasks=background_tasks,
                         **extra_kwargs,
+                        **kwargs,
                     ),
                 )
                 return run_response_obj.to_dict()

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from typing import TYPE_CHECKING, Any, AsyncGenerator, List, Optional, Union
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Dict, List, Optional, Union
 from uuid import uuid4
 
 from fastapi import (
@@ -387,6 +387,8 @@ async def team_continue_response_streamer(
     user_id: Optional[str] = None,
     background_tasks: Optional[BackgroundTasks] = None,
     auth_token: Optional[str] = None,
+    dependencies: Optional[Dict[str, Any]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
 ) -> AsyncGenerator:
     """Continue a paused team run and yield streaming response."""
     try:
@@ -403,6 +405,8 @@ async def team_continue_response_streamer(
             stream=True,
             stream_events=True,
             background_tasks=background_tasks,
+            dependencies=dependencies,
+            metadata=metadata,
             **extra_kwargs,
         )
         async for run_response_chunk in continue_response:
@@ -437,6 +441,8 @@ async def team_resumable_continue_response_streamer(
     user_id: Optional[str] = None,
     background_tasks: Optional[BackgroundTasks] = None,
     auth_token: Optional[str] = None,
+    dependencies: Optional[Dict[str, Any]] = None,
+    metadata: Optional[Dict[str, Any]] = None,
 ) -> AsyncGenerator:
     """Resumable SSE generator for continue_run with background=True, stream=True.
 
@@ -462,6 +468,8 @@ async def team_resumable_continue_response_streamer(
             stream=True,
             stream_events=True,
             background=True,
+            dependencies=dependencies,
+            metadata=metadata,
             **extra_kwargs,
         ):
             yield sse_data
@@ -902,11 +910,45 @@ def get_team_router(
         user_id: Optional[str] = Form(None),
         stream: bool = Form(True),
         background: bool = Form(False),
+        dependencies: Optional[str] = Form(
+            None,
+            description=(
+                "JSON object of runtime dependencies (e.g. user tokens, request-scoped values) "
+                "made available to tools via run_context.dependencies."
+            ),
+        ),
+        metadata: Optional[str] = Form(
+            None,
+            description="JSON object of metadata attached to the run.",
+        ),
     ):
+        # Parse dependencies / metadata JSON form fields.
+        dependencies_dict: Optional[Dict[str, Any]] = None
+        if dependencies:
+            try:
+                dependencies_dict = json.loads(dependencies)
+            except json.JSONDecodeError:
+                raise HTTPException(status_code=400, detail="Invalid JSON in dependencies field")
+        metadata_dict: Optional[Dict[str, Any]] = None
+        if metadata:
+            try:
+                metadata_dict = json.loads(metadata)
+            except json.JSONDecodeError:
+                raise HTTPException(status_code=400, detail="Invalid JSON in metadata field")
+
         if hasattr(request.state, "user_id") and request.state.user_id is not None:
             user_id = request.state.user_id
         if hasattr(request.state, "session_id") and request.state.session_id is not None:
             session_id = request.state.session_id
+        # Request state from middleware overrides form-provided values.
+        if hasattr(request.state, "dependencies") and request.state.dependencies is not None:
+            if dependencies_dict is not None:
+                log_warning("Dependencies parameter passed in both request state and form, using request state")
+            dependencies_dict = request.state.dependencies
+        if hasattr(request.state, "metadata") and request.state.metadata is not None:
+            if metadata_dict is not None:
+                log_warning("Metadata parameter passed in both request state and form, using request state")
+            metadata_dict = request.state.metadata
 
         # Parse the JSON string manually
         try:
@@ -994,6 +1036,8 @@ def get_team_router(
                     user_id=user_id,
                     background_tasks=background_tasks,
                     auth_token=auth_token,
+                    dependencies=dependencies_dict,
+                    metadata=metadata_dict,
                 ),
                 media_type="text/event-stream",
             )
@@ -1007,6 +1051,8 @@ def get_team_router(
                     user_id=user_id,
                     background_tasks=background_tasks,
                     auth_token=auth_token,
+                    dependencies=dependencies_dict,
+                    metadata=metadata_dict,
                 ),
                 media_type="text/event-stream",
             )
@@ -1024,6 +1070,8 @@ def get_team_router(
                     user_id=user_id,
                     stream=False,
                     background_tasks=background_tasks,
+                    dependencies=dependencies_dict,
+                    metadata=metadata_dict,
                     **extra_kwargs,
                 )
                 return run_response_obj.to_dict()

--- a/libs/agno/tests/integration/os/test_agent_runs.py
+++ b/libs/agno/tests/integration/os/test_agent_runs.py
@@ -147,3 +147,99 @@ def test_kwargs_propagate_to_run_context(test_os_client, test_agent: Agent):
     assert response_json["run_id"] is not None
     assert response_json["agent_id"] == test_agent.id
     assert response_json["content"] is not None
+
+
+# ---------------------------------------------------------------------------
+# /continue dependencies + metadata forwarding (full e2e through HITL pause)
+# ---------------------------------------------------------------------------
+
+
+def test_continue_agent_run_forwards_dependencies_and_metadata_e2e(test_os_client, test_agent: Agent):
+    """End-to-end: /runs pauses for confirmation, /continue forwards dependencies
+    and metadata so the resumed tool can read run_context.dependencies.
+    """
+    from agno.tools import tool
+
+    captured: dict = {}
+
+    @tool(requires_confirmation=True)
+    def delete_resource(resource_id: str, run_context: RunContext) -> str:
+        """Delete a resource."""
+        captured["dependencies"] = run_context.dependencies
+        captured["metadata"] = run_context.metadata
+        return f"Deleted {resource_id}"
+
+    test_agent.tools = [delete_resource]
+    test_agent.instructions = ["When asked to delete a resource, call delete_resource with the given id."]
+
+    # Step 1: /runs -> tool pauses for confirmation
+    run_response = test_os_client.post(
+        f"/agents/{test_agent.id}/runs",
+        data={
+            "message": "delete resource abc-123",
+            "stream": "false",
+            "session_id": "deps-session-1",
+            "dependencies": json.dumps({"user_token": "INITIAL"}),
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert run_response.status_code == 200
+    run_json = run_response.json()
+    run_id = run_json["run_id"]
+    paused_tools = run_json.get("tools") or []
+    assert paused_tools, f"expected paused tools, got: {run_json}"
+
+    # Step 2: /continue with confirmed tool + dependencies + metadata
+    confirmed = [{**t, "confirmed": True} for t in paused_tools]
+    continue_response = test_os_client.post(
+        f"/agents/{test_agent.id}/runs/{run_id}/continue",
+        data={
+            "tools": json.dumps(confirmed),
+            "session_id": "deps-session-1",
+            "stream": "false",
+            "dependencies": json.dumps({"user_token": "CONTINUE_TOKEN"}),
+            "metadata": json.dumps({"trace_id": "trace-xyz"}),
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    assert continue_response.status_code == 200
+    # The resumed tool actually ran and saw the dependencies / metadata we sent.
+    assert captured["dependencies"] == {"user_token": "CONTINUE_TOKEN"}
+    assert captured["metadata"] == {"trace_id": "trace-xyz"}
+
+
+def test_continue_agent_run_invalid_dependencies_returns_400(test_os_client, test_agent: Agent):
+    """Malformed JSON in the dependencies field returns a 400 with a clear detail.
+
+    Uses a dummy session_id because validation runs before the run is loaded.
+    """
+    response = test_os_client.post(
+        f"/agents/{test_agent.id}/runs/run-123/continue",
+        data={
+            "tools": "",
+            "session_id": "session-123",
+            "stream": "false",
+            "dependencies": "not-json",
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    assert response.status_code == 400
+    assert "dependencies" in response.json()["detail"].lower()
+
+
+def test_continue_agent_run_invalid_metadata_returns_400(test_os_client, test_agent: Agent):
+    response = test_os_client.post(
+        f"/agents/{test_agent.id}/runs/run-123/continue",
+        data={
+            "tools": "",
+            "session_id": "session-123",
+            "stream": "false",
+            "metadata": "{not json",
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    assert response.status_code == 400
+    assert "metadata" in response.json()["detail"].lower()

--- a/libs/agno/tests/integration/os/test_team_runs.py
+++ b/libs/agno/tests/integration/os/test_team_runs.py
@@ -199,3 +199,103 @@ def test_continue_team_run_allows_empty_requirements_payload(test_os_client, tes
     # type signatures are satisfied.  The continue_run dispatch treats [] as "no
     # client-provided requirements" via a truthy check (`if requirements:`).
     assert mock_continue_run.call_args.kwargs["requirements"] == []
+
+
+# ---------------------------------------------------------------------------
+# /continue dependencies + metadata forwarding (full e2e through HITL pause)
+# ---------------------------------------------------------------------------
+
+
+def test_continue_team_run_forwards_dependencies_and_metadata_e2e(test_os_client, test_team: Team):
+    """End-to-end: /runs pauses for confirmation, /continue forwards dependencies
+    and metadata so the resumed tool can read run_context.dependencies.
+    """
+    from agno.tools import tool
+
+    captured: dict = {}
+
+    @tool(requires_confirmation=True)
+    def delete_resource(resource_id: str, run_context: RunContext) -> str:
+        """Delete a resource."""
+        captured["dependencies"] = run_context.dependencies
+        captured["metadata"] = run_context.metadata
+        return f"Deleted {resource_id}"
+
+    # Configure the team for HITL: clear members, give it the tool directly.
+    test_team.members = []
+    test_team.tools = [delete_resource]
+    test_team.instructions = ["When asked to delete a resource, call delete_resource with the given id."]
+
+    # Step 1: /runs -> team pauses for confirmation
+    run_response = test_os_client.post(
+        f"/teams/{test_team.id}/runs",
+        data={
+            "message": "delete resource abc-123",
+            "stream": "false",
+            "session_id": "team-deps-session-1",
+            "dependencies": json.dumps({"user_token": "INITIAL"}),
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert run_response.status_code == 200
+    run_json = run_response.json()
+    run_id = run_json["run_id"]
+    requirements = run_json.get("requirements") or []
+    assert requirements, f"expected paused requirements, got: {run_json}"
+
+    # Step 2: /continue with confirmed requirements + dependencies + metadata
+    confirmed_reqs = []
+    for r in requirements:
+        te = dict(r.get("tool_execution") or {})
+        te["confirmed"] = True
+        confirmed_reqs.append({**r, "tool_execution": te, "confirmation": True})
+
+    continue_response = test_os_client.post(
+        f"/teams/{test_team.id}/runs/{run_id}/continue",
+        data={
+            "requirements": json.dumps(confirmed_reqs),
+            "session_id": "team-deps-session-1",
+            "stream": "false",
+            "dependencies": json.dumps({"user_token": "CONTINUE_TOKEN"}),
+            "metadata": json.dumps({"trace_id": "trace-xyz"}),
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    assert continue_response.status_code == 200
+    # The resumed tool actually ran and saw the dependencies / metadata we sent.
+    assert captured["dependencies"] == {"user_token": "CONTINUE_TOKEN"}
+    assert captured["metadata"] == {"trace_id": "trace-xyz"}
+
+
+def test_continue_team_run_invalid_dependencies_returns_400(test_os_client, test_team: Team):
+    """Malformed JSON in the dependencies field returns a 400 with a clear detail."""
+    response = test_os_client.post(
+        f"/teams/{test_team.id}/runs/run-123/continue",
+        data={
+            "requirements": "",
+            "session_id": "session-123",
+            "stream": "false",
+            "dependencies": "not-json",
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    assert response.status_code == 400
+    assert "dependencies" in response.json()["detail"].lower()
+
+
+def test_continue_team_run_invalid_metadata_returns_400(test_os_client, test_team: Team):
+    response = test_os_client.post(
+        f"/teams/{test_team.id}/runs/run-123/continue",
+        data={
+            "requirements": "",
+            "session_id": "session-123",
+            "stream": "false",
+            "metadata": "{not json",
+        },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    assert response.status_code == 400
+    assert "metadata" in response.json()["detail"].lower()

--- a/libs/agno/tests/unit/os/test_agent_continue_dependencies.py
+++ b/libs/agno/tests/unit/os/test_agent_continue_dependencies.py
@@ -1,0 +1,35 @@
+from typing import Any, Dict, cast
+
+import pytest
+
+from agno.os.routers.agents.router import agent_continue_response_streamer
+
+
+class _DummyAgent:
+    def __init__(self) -> None:
+        self.kwargs: Dict[str, Any] = {}
+
+    def acontinue_run(self, **kwargs: Any):
+        self.kwargs = kwargs
+
+        async def _empty_stream():
+            if False:
+                yield None
+
+        return _empty_stream()
+
+
+@pytest.mark.asyncio
+async def test_continue_streamer_forwards_dependencies():
+    agent = _DummyAgent()
+    _ = [
+        event
+        async for event in agent_continue_response_streamer(
+            agent=cast(Any, agent),
+            run_id="run-1",
+            dependencies={"user_token": "token-123"},
+        )
+    ]
+
+    assert "dependencies" in agent.kwargs
+    assert agent.kwargs["dependencies"] == {"user_token": "token-123"}


### PR DESCRIPTION
## Summary

The AgentOS `/continue` endpoints for both agents and teams silently dropped dependencies and metadata. A HITL tool that read `run_context.dependencies["user_token"]` worked on the initial `/runs` call but crashed during `/continue` because the run context arrived without the dependencies the client had sent.

(If applicable, issue number: #7830)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
