### PR TITLE
chore: remove deprecated `search_session_history` and `num_history_sessions` params

### DIFF
--- a/cookbook/02_agents/05_state_and_session/README.md
+++ b/cookbook/02_agents/05_state_and_session/README.md
@@ -14,7 +14,7 @@ Examples for session state management, chat history, and session persistence.
 - `session_state_events.py` - Session state change events.
 - `session_state_manual_update.py` - Manually update session state.
 - `session_state_multiple_users.py` - Session state with multiple users.
-- `search_session_history.py` - Search and read previous sessions (two-step pattern).
+- `search_past_sessions.py` - Search and read previous sessions (two-step pattern).
 - `session_summary.py` - Enable session summaries for context compression.
 
 ## Prerequisites

--- a/cookbook/02_agents/05_state_and_session/search_past_sessions.py
+++ b/cookbook/02_agents/05_state_and_session/search_past_sessions.py
@@ -1,6 +1,6 @@
 """
-Search Session History
-======================
+Search Past Sessions
+====================
 
 Demonstrates the two-step list-then-read pattern for accessing previous sessions.
 

--- a/cookbook/03_teams/07_session/README.md
+++ b/cookbook/03_teams/07_session/README.md
@@ -12,7 +12,7 @@ Examples for team workflows in session.
 
 - chat_history.py - Demonstrates chat history.
 - persistent_session.py - Demonstrates persistent session.
-- search_session_history.py - Search and read previous team sessions (two-step pattern).
+- search_past_sessions.py - Search and read previous team sessions (two-step pattern).
 - custom_session_summary.py - Demonstrates session_summary_manager and summary context.
 - session_options.py - Demonstrates session options.
 - session_summary.py - Demonstrates session summary.

--- a/cookbook/03_teams/07_session/TEST_LOG.md
+++ b/cookbook/03_teams/07_session/TEST_LOG.md
@@ -380,14 +380,14 @@ DEBUG **** Team Run End: 04434e8e-ec8b-44e4-8266-463958fe243e ****
 
 ---
 
-### search_session_history.py
+### search_past_sessions.py
 
 **Status:** FAIL
 
 **Description:** Example execution attempt
 
 **Result:** Traceback (most recent call last):
-  File "/Users/ab/conductor/workspaces/agno/tallinn/cookbook/03_teams/07_session/search_session_history.py", line 27, in <module>
+  File "/Users/ab/conductor/workspaces/agno/tallinn/cookbook/03_teams/07_session/search_past_sessions.py", line 27, in <module>
     db=AsyncSqliteDb(db_file="tmp/data.db"),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/Users/ab/conductor/workspaces/agno/tallinn/libs/agno/agno/db/sqlite/async_sqlite.py", line 124, in __init__

--- a/cookbook/03_teams/07_session/search_past_sessions.py
+++ b/cookbook/03_teams/07_session/search_past_sessions.py
@@ -1,6 +1,6 @@
 """
-Search Session History (Team)
-=============================
+Search Past Sessions (Team)
+===========================
 
 Demonstrates the two-step list-then-read pattern for accessing previous
 team sessions with user-scoped history access.

--- a/cookbook/03_teams/TEST_LOG.md
+++ b/cookbook/03_teams/TEST_LOG.md
@@ -1115,11 +1115,11 @@ ImportError: infinity_client not installed, please run `pip install infinity_cli
 
 ---
 
-### session/search_session_history.py
+### session/search_past_sessions.py
 
 **Status:** PASS
 
-**Description:** Executed `.venvs/demo/bin/python cookbook/03_teams/07_session/search_session_history.py`.
+**Description:** Executed `.venvs/demo/bin/python cookbook/03_teams/07_session/search_past_sessions.py`.
 
 **Result:** Executed successfully.
 

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -867,8 +867,8 @@ def from_dict(cls: Type[Agent], data: Dict[str, Any], registry: Optional[Registr
         enable_agentic_state=config.get("enable_agentic_state", False),
         overwrite_db_session_state=config.get("overwrite_db_session_state", False),
         cache_session=config.get("cache_session", False),
-        search_past_sessions=config.get("search_past_sessions", config.get("search_session_history", False)),
-        num_past_sessions_to_search=config.get("num_past_sessions_to_search", config.get("num_history_sessions")),
+        search_past_sessions=config.get("search_past_sessions", False),
+        num_past_sessions_to_search=config.get("num_past_sessions_to_search"),
         num_past_session_runs_in_search=config.get(
             "num_past_session_runs_in_search", config.get("num_past_session_runs")
         ),

--- a/libs/agno/agno/agent/_storage.py
+++ b/libs/agno/agno/agent/_storage.py
@@ -853,6 +853,14 @@ def from_dict(cls: Type[Agent], data: Dict[str, Any], registry: Optional[Registr
     config.pop("team_id", None)
     config.pop("workflow_id", None)
 
+    if "search_session_history" in config:
+        log_debug("'search_session_history' has been deprecated. Use 'search_past_sessions' instead.")
+        config.pop("search_session_history", None)
+
+    if "num_history_sessions" in config:
+        log_debug("'num_history_sessions' has been deprecated. Use 'num_past_sessions_to_search' instead.")
+        config.pop("num_history_sessions", None)
+
     return cls(
         # --- Agent settings ---
         model=config.get("model"),

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -391,9 +391,6 @@ class Agent:
         search_past_sessions: Optional[bool] = False,
         num_past_sessions_to_search: Optional[int] = None,
         num_past_session_runs_in_search: Optional[int] = None,
-        # Deprecated params — kept for backward compatibility
-        search_session_history: Optional[bool] = None,
-        num_history_sessions: Optional[int] = None,
         dependencies: Optional[Dict[str, Any]] = None,
         add_dependencies_to_context: bool = False,
         db: Optional[Union[BaseDb, AsyncBaseDb]] = None,
@@ -511,12 +508,6 @@ class Agent:
         self.overwrite_db_session_state = overwrite_db_session_state
         self.enable_agentic_state = enable_agentic_state
         self.cache_session = cache_session
-
-        # Deprecated param mapping
-        if search_session_history is not None and not search_past_sessions:
-            search_past_sessions = search_session_history
-        if num_history_sessions is not None and num_past_sessions_to_search is None:
-            num_past_sessions_to_search = num_history_sessions
 
         self.search_past_sessions = search_past_sessions
         self.num_past_sessions_to_search = num_past_sessions_to_search

--- a/libs/agno/agno/team/_init.py
+++ b/libs/agno/agno/team/_init.py
@@ -87,9 +87,6 @@ def __init__(
     search_past_sessions: Optional[bool] = False,
     num_past_sessions_to_search: Optional[int] = None,
     num_past_session_runs_in_search: Optional[int] = None,
-    # Deprecated params — kept for backward compatibility
-    search_session_history: Optional[bool] = None,
-    num_history_sessions: Optional[int] = None,
     description: Optional[str] = None,
     instructions: Optional[Union[str, List[str], Callable]] = None,
     use_instruction_tags: bool = False,
@@ -251,12 +248,6 @@ def __init__(
 
     team.add_team_history_to_members = add_team_history_to_members
     team.num_team_history_runs = num_team_history_runs
-
-    # Deprecated param mapping
-    if search_session_history is not None and not search_past_sessions:
-        search_past_sessions = search_session_history
-    if num_history_sessions is not None and num_past_sessions_to_search is None:
-        num_past_sessions_to_search = num_history_sessions
 
     team.search_past_sessions = search_past_sessions
     team.num_past_sessions_to_search = num_past_sessions_to_search

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -862,6 +862,14 @@ def from_dict(
     #     from agno.compression.manager import CompressionManager
     #     config["compression_manager"] = CompressionManager.from_dict(config["compression_manager"])
 
+    if "search_session_history" in config:
+        log_debug("'search_session_history' has been deprecated. Use 'search_past_sessions' instead.")
+        config.pop("search_session_history", None)
+
+    if "num_history_sessions" in config:
+        log_debug("'num_history_sessions' has been deprecated. Use 'num_past_sessions_to_search' instead.")
+        config.pop("num_history_sessions", None)
+
     team = cast(
         "Team",
         cls(

--- a/libs/agno/agno/team/_storage.py
+++ b/libs/agno/agno/team/_storage.py
@@ -893,8 +893,8 @@ def from_dict(
             add_team_history_to_members=config.get("add_team_history_to_members", False),
             num_team_history_runs=config.get("num_team_history_runs", 3),
             share_member_interactions=config.get("share_member_interactions", False),
-            search_past_sessions=config.get("search_past_sessions", config.get("search_session_history", False)),
-            num_past_sessions_to_search=config.get("num_past_sessions_to_search", config.get("num_history_sessions")),
+            search_past_sessions=config.get("search_past_sessions", False),
+            num_past_sessions_to_search=config.get("num_past_sessions_to_search"),
             num_past_session_runs_in_search=config.get(
                 "num_past_session_runs_in_search", config.get("num_past_session_runs")
             ),

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -453,9 +453,6 @@ class Team:
         search_past_sessions: Optional[bool] = False,
         num_past_sessions_to_search: Optional[int] = None,
         num_past_session_runs_in_search: Optional[int] = None,
-        # Deprecated params — kept for backward compatibility
-        search_session_history: Optional[bool] = None,
-        num_history_sessions: Optional[int] = None,
         description: Optional[str] = None,
         instructions: Optional[Union[str, List[str], Callable]] = None,
         use_instruction_tags: bool = False,
@@ -576,8 +573,6 @@ class Team:
             search_past_sessions=search_past_sessions,
             num_past_sessions_to_search=num_past_sessions_to_search,
             num_past_session_runs_in_search=num_past_session_runs_in_search,
-            search_session_history=search_session_history,
-            num_history_sessions=num_history_sessions,
             description=description,
             instructions=instructions,
             use_instruction_tags=use_instruction_tags,

--- a/libs/agno/tests/integration/teams/test_history.py
+++ b/libs/agno/tests/integration/teams/test_history.py
@@ -195,7 +195,7 @@ def test_share_member_interactions(shared_db):
     assert "<member_interaction_context>" in acknowledge_agent_input_str
 
 
-def test_search_session_history(shared_db):
+def test_search_past_sessions(shared_db):
     """Test that the team can search through previous sessions when search_past_sessions=True."""
 
     team = Team(


### PR DESCRIPTION
## Summary

Removes the deprecated `search_session_history` and `num_history_sessions` params and adds debug log for the deprecated param.

```      
# Before
Agent(
      db=db,
      search_session_history=True,
      num_history_sessions=10,
)

# After
Agent(
      db=db,
      search_past_sessions=True,
      num_past_sessions_to_search=10,
)
```

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

- We will need to update docs and AgentOS to remove any references for it.