### PR TITLE
fix: `aget_last_run_output` returns None when agent.id is auto-generated during `arun()`

### DIFF
--- a/libs/agno/agno/utils/agent.py
+++ b/libs/agno/agno/utils/agent.py
@@ -634,6 +634,16 @@ def get_last_run_output_util(
     Returns:
         RunOutput: The last run response from the database.
     """
+    # Ensure id consistency with stored agent_id/team_id: arun() auto-derives
+    # an id from the name during initialization; do the same on reads so a
+    # fresh Agent(name="x") (id=None) still matches its persisted runs.
+    if entity.__class__.__name__ == "Team":
+        from agno.team._init import set_id
+    else:
+        from agno.agent._init import set_id
+
+    set_id(entity)  # type: ignore[arg-type]
+
     if session_id is not None:
         if _has_async_db(entity):
             raise ValueError("Async database not supported for sync functions")
@@ -677,6 +687,16 @@ async def aget_last_run_output_util(
     Returns:
         RunOutput: The last run response from the database.
     """
+    # Ensure id consistency with stored agent_id/team_id: arun() auto-derives
+    # an id from the name during initialization; do the same on reads so a
+    # fresh Agent(name="x") (id=None) still matches its persisted runs.
+    if entity.__class__.__name__ == "Team":
+        from agno.team._init import set_id
+    else:
+        from agno.agent._init import set_id
+
+    set_id(entity)  # type: ignore[arg-type]
+
     if session_id is not None:
         session = await entity.aget_session(session_id=session_id)
         if session is not None and session.runs is not None and len(session.runs) > 0:

--- a/libs/agno/agno/utils/agent.py
+++ b/libs/agno/agno/utils/agent.py
@@ -622,6 +622,28 @@ async def aget_run_output_util(
     return None
 
 
+def _ensure_entity_id(entity: Union["Agent", "Team"]) -> None:
+    """Auto-derive ``entity.id`` from ``entity.name`` when it is not set.
+
+    Mirrors what ``arun()`` / ``initialize_*()`` do during a run. Uses
+    ``isinstance`` rather than class-name comparison so the right ``set_id``
+    is picked even for subclasses, and so mypy can narrow the argument type.
+    Imports are local because ``Agent`` / ``Team`` would cause a circular
+    import at module load time.
+    """
+    from agno.agent.agent import Agent
+    from agno.team.team import Team
+
+    if isinstance(entity, Team):
+        from agno.team._init import set_id as set_team_id
+
+        set_team_id(entity)
+    elif isinstance(entity, Agent):
+        from agno.agent._init import set_id as set_agent_id
+
+        set_agent_id(entity)
+
+
 def get_last_run_output_util(
     entity: Union["Agent", "Team"], session_id: Optional[str] = None
 ) -> Optional[Union[RunOutput, TeamRunOutput]]:
@@ -634,17 +656,7 @@ def get_last_run_output_util(
     Returns:
         RunOutput: The last run response from the database.
     """
-    # Ensure id consistency with stored agent_id/team_id: arun() auto-derives
-    # an id from the name during initialization; do the same on reads so a
-    # fresh Agent(name="x") (id=None) still matches its persisted runs.
-    if entity.__class__.__name__ == "Team":
-        from agno.team._init import set_id as _set_team_id
-
-        _set_team_id(entity)  # type: ignore[arg-type]
-    else:
-        from agno.agent._init import set_id as _set_agent_id
-
-        _set_agent_id(entity)  # type: ignore[arg-type]
+    _ensure_entity_id(entity)
 
     if session_id is not None:
         if _has_async_db(entity):
@@ -689,17 +701,7 @@ async def aget_last_run_output_util(
     Returns:
         RunOutput: The last run response from the database.
     """
-    # Ensure id consistency with stored agent_id/team_id: arun() auto-derives
-    # an id from the name during initialization; do the same on reads so a
-    # fresh Agent(name="x") (id=None) still matches its persisted runs.
-    if entity.__class__.__name__ == "Team":
-        from agno.team._init import set_id as _set_team_id
-
-        _set_team_id(entity)  # type: ignore[arg-type]
-    else:
-        from agno.agent._init import set_id as _set_agent_id
-
-        _set_agent_id(entity)  # type: ignore[arg-type]
+    _ensure_entity_id(entity)
 
     if session_id is not None:
         session = await entity.aget_session(session_id=session_id)

--- a/libs/agno/agno/utils/agent.py
+++ b/libs/agno/agno/utils/agent.py
@@ -638,11 +638,13 @@ def get_last_run_output_util(
     # an id from the name during initialization; do the same on reads so a
     # fresh Agent(name="x") (id=None) still matches its persisted runs.
     if entity.__class__.__name__ == "Team":
-        from agno.team._init import set_id
-    else:
-        from agno.agent._init import set_id
+        from agno.team._init import set_id as _set_team_id
 
-    set_id(entity)  # type: ignore[arg-type]
+        _set_team_id(entity)  # type: ignore[arg-type]
+    else:
+        from agno.agent._init import set_id as _set_agent_id
+
+        _set_agent_id(entity)  # type: ignore[arg-type]
 
     if session_id is not None:
         if _has_async_db(entity):
@@ -691,11 +693,13 @@ async def aget_last_run_output_util(
     # an id from the name during initialization; do the same on reads so a
     # fresh Agent(name="x") (id=None) still matches its persisted runs.
     if entity.__class__.__name__ == "Team":
-        from agno.team._init import set_id
-    else:
-        from agno.agent._init import set_id
+        from agno.team._init import set_id as _set_team_id
 
-    set_id(entity)  # type: ignore[arg-type]
+        _set_team_id(entity)  # type: ignore[arg-type]
+    else:
+        from agno.agent._init import set_id as _set_agent_id
+
+        _set_agent_id(entity)  # type: ignore[arg-type]
 
     if session_id is not None:
         session = await entity.aget_session(session_id=session_id)

--- a/libs/agno/tests/integration/agent/test_agent_convenience_functions.py
+++ b/libs/agno/tests/integration/agent/test_agent_convenience_functions.py
@@ -365,6 +365,46 @@ async def test_aget_last_run_output(async_test_agent):
     assert last_output.run_id == response2.run_id
 
 
+def test_get_last_run_output_with_fresh_agent_instance(shared_db):
+    """A fresh Agent(name=...) instance with id=None must
+    still find runs persisted by an earlier instance with the same name. arun()
+    auto-derives the id from the name; the read path must do the same.
+    """
+    session_id = str(uuid.uuid4())
+
+    agent1 = Agent(name="convenience_test_agent", model=OpenAIChat(id="gpt-4o-mini"), db=shared_db)
+    response = agent1.run("Hello", session_id=session_id)
+    assert agent1.id is not None  # set_id() ran during run()
+
+    # New instance, same name, no explicit id -- mirrors the pause/continue pattern.
+    agent2 = Agent(name="convenience_test_agent", model=OpenAIChat(id="gpt-4o-mini"), db=shared_db)
+    assert agent2.id is None
+
+    last_output = agent2.get_last_run_output(session_id=session_id)
+    assert last_output is not None
+    assert last_output.run_id == response.run_id
+    # The util resolved the id as a side-effect, matching arun() behaviour.
+    assert agent2.id == agent1.id
+
+
+@pytest.mark.asyncio
+async def test_aget_last_run_output_with_fresh_agent_instance(async_shared_db):
+    """Async variant of the regression for #7838."""
+    session_id = str(uuid.uuid4())
+
+    agent1 = Agent(name="convenience_test_agent_async", model=OpenAIChat(id="gpt-4o-mini"), db=async_shared_db)
+    response = await agent1.arun("Hello", session_id=session_id)
+    assert agent1.id is not None
+
+    agent2 = Agent(name="convenience_test_agent_async", model=OpenAIChat(id="gpt-4o-mini"), db=async_shared_db)
+    assert agent2.id is None
+
+    last_output = await agent2.aget_last_run_output(session_id=session_id)
+    assert last_output is not None
+    assert last_output.run_id == response.run_id
+    assert agent2.id == agent1.id
+
+
 # Tests for delete_session() and adelete_session()
 def test_delete_session(test_agent):
     """Test delete_session removes a session."""


### PR DESCRIPTION
`get_last_run_output()` and `aget_last_run_output()` returned None when called on a fresh Agent (or Team) instance whose id had not been explicitly set, even though the session contained matching runs.

The runtime path (`arun() → initialize_agent() → set_id()`) auto-derives a deterministic id from name. The read path didn't, so a comparison like `run_output.agent_id == entity.id` failed (<derived-id> vs None).

Fixes #7838.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
