### PR TITLE
chore: update S3 bucket URL from phidata-public to agno-public

### DIFF
--- a/cookbook/90_models/langdb/data_analyst.py
+++ b/cookbook/90_models/langdb/data_analyst.py
@@ -12,7 +12,7 @@ from agno.tools.duckdb import DuckDbTools
 
 duckdb_tools = DuckDbTools()
 duckdb_tools.create_table_from_path(
-    path="https://phidata-public.s3.amazonaws.com/demo_data/IMDB-Movie-Data.csv",
+    path="https://agno-public.s3.amazonaws.com/demo_data/IMDB-Movie-Data.csv",
     table="movies",
 )
 


### PR DESCRIPTION
This PR updates the hardcoded S3 bucket URL in the langdb data analyst example. Changed 'phidata-public' to 'agno-public' to ensure the demo script points to the correct rebranded infrastructure. This prevents potential broken links as the project transitions to the Agno brand.

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
