### PR TITLE
fix: include assembled history in RunMessages.get_input_messages

### DIFF
--- a/libs/agno/agno/run/messages.py
+++ b/libs/agno/agno/run/messages.py
@@ -21,7 +21,22 @@ class RunMessages:
     extra_messages: Optional[List[Message]] = None
 
     def get_input_messages(self) -> List[Message]:
-        """Get the input messages for the model."""
+        """Get the input messages for the model.
+
+        When ``messages`` has been assembled by the agent (system + history +
+        user + tool messages), prefer it so callers receive the full context.
+        ``extra_messages`` are appended without duplicating any already in
+        ``messages``. Otherwise, fall back to the system + user + extra shape
+        for callers that build the list piecewise.
+        """
+        if self.messages:
+            input_messages = list(self.messages)
+            if self.extra_messages:
+                for msg in self.extra_messages:
+                    if msg not in input_messages:
+                        input_messages.append(msg)
+            return input_messages
+
         input_messages = []
         if self.system_message is not None:
             input_messages.append(self.system_message)

--- a/libs/agno/tests/unit/run/test_run_messages.py
+++ b/libs/agno/tests/unit/run/test_run_messages.py
@@ -1,0 +1,78 @@
+"""Unit tests for ``RunMessages.get_input_messages``.
+
+Regression: when an agent runs with ``add_history_to_context=True`` the agent
+populates ``run_messages.messages`` with [system, *history, user, ...] before
+invoking downstream consumers (e.g. the reasoning manager). The previous
+implementation rebuilt the list from ``system_message + user_message +
+extra_messages`` and silently dropped the history, so a reasoning sub-agent
+seeded from this method received no prior context.
+
+``get_input_messages`` now prefers the assembled ``messages`` list and only
+falls back to the piecewise shape when ``messages`` is empty.
+"""
+
+from agno.models.message import Message
+from agno.run.messages import RunMessages
+
+
+def test_returns_assembled_messages_when_populated() -> None:
+    system = Message(role="system", content="sys")
+    history_user = Message(role="user", content="My name is Alex.")
+    history_assistant = Message(role="assistant", content="Hi Alex.")
+    current_user = Message(role="user", content="What's my name?")
+
+    rm = RunMessages(
+        messages=[system, history_user, history_assistant, current_user],
+        system_message=system,
+        user_message=current_user,
+    )
+
+    out = rm.get_input_messages()
+
+    assert out == [system, history_user, history_assistant, current_user]
+    # Defensive copy: callers can mutate without affecting the original.
+    assert out is not rm.messages
+
+
+def test_falls_back_to_piecewise_when_messages_empty() -> None:
+    system = Message(role="system", content="sys")
+    user = Message(role="user", content="hi")
+    extra = Message(role="user", content="more")
+
+    rm = RunMessages(system_message=system, user_message=user, extra_messages=[extra])
+
+    assert rm.get_input_messages() == [system, user, extra]
+
+
+def test_appends_extra_messages_not_already_in_messages() -> None:
+    system = Message(role="system", content="sys")
+    user = Message(role="user", content="hi")
+    extra_new = Message(role="user", content="follow up")
+
+    rm = RunMessages(
+        messages=[system, user],
+        system_message=system,
+        user_message=user,
+        extra_messages=[extra_new],
+    )
+
+    assert rm.get_input_messages() == [system, user, extra_new]
+
+
+def test_dedupes_extra_messages_already_in_messages() -> None:
+    system = Message(role="system", content="sys")
+    user = Message(role="user", content="hi")
+    # Same Message object referenced from both messages and extra_messages —
+    # must not be duplicated in the output.
+    rm = RunMessages(
+        messages=[system, user],
+        system_message=system,
+        user_message=user,
+        extra_messages=[user],
+    )
+
+    assert rm.get_input_messages() == [system, user]
+
+
+def test_returns_empty_list_when_nothing_set() -> None:
+    assert RunMessages().get_input_messages() == []


### PR DESCRIPTION
## Summary

The reasoning manager seeds its sub-agents with `run_messages.get_input_messages()`. The previous implementation ignored `self.messages` and returned only `system_message + user_message + extra_messages`, dropping the assembled history. With `reasoning=True` and `add_history_to_context=True` this manifests as the sub-agent reasoning about turn N as if turns 1..N-1 never happened; the resulting CoT is then injected into the main run via update_messages_with_reasoning` and the final reply inherits the "no prior context" framing even though history was loaded on the parent.

**Fix:** prefer `self.messages` when populated and append any `extra_messages` not already present (dedupe by identity-or-equality membership). Fall back to the piecewise shape when `messages` is empty so callers that build the list incrementally are unaffected.

`get_input_messages` has no callers outside `agno/reasoning/manager.py` (six sites — both default-CoT call sites and the four native-reasoning event helpers), so the change is contained to the reasoning path.

Fixes #7991

### Reproducer

```python
from agno.agent import Agent
from agno.db.sqlite import SqliteDb
from agno.models.openai import OpenAIResponses

agent = Agent(
    model=OpenAIResponses(id="gpt-5.4-mini"),  # not a native reasoning model -> default CoT path
    db=SqliteDb(db_file="/tmp/agno_repro.db"),
    session_id="repro-session",
    add_history_to_context=True,
    reasoning=True,
)

agent.run("My name is Alex.")
print(agent.run("What's my name?").content)
```

**Before this PR**

```
I don't have access to your name from our conversation.
```

The main agent loaded turn 1 into `run_messages.messages`, but the reasoning
sub-agent only received `[system_message, "What's my name?"]` — history was
dropped, so its CoT concluded the user hadn't shared their name. That CoT
was then injected into the main run and the final reply inherited the framing.

**After this PR**

```
Your name is Alex.
```

`get_input_messages()` now returns the assembled list (system + turn-1 user +
turn-1 assistant + current user), so the sub-agent reasons with full context.





Files touched:
- `libs/agno/agno/run/messages.py` — `get_input_messages` prefers `self.messages` and dedupes `extra_messages`.
- `libs/agno/tests/unit/run/test_run_messages.py` — five tests cover the assembled-list, piecewise fallback, append-new-extras, dedupe, and empty cases.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)