### PR TITLE
fix: pin `tree-sitter-language-pack`<1.8.0 to unblock chonkie code chunker

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -184,7 +184,12 @@ text = ["aiofiles"]
 csv = ["aiofiles"]
 excel = ["openpyxl", "xlrd"]
 markdown = ["unstructured<0.18.31", "markdown", "aiofiles"]
-chonkie = ["chonkie[semantic]", "chonkie[code]", "chonkie"]
+chonkie = [
+    "chonkie[semantic]",
+    "chonkie[code]",
+    "chonkie",
+    "tree-sitter-language-pack<1.8.0",  # 1.8.0 removed SupportedLanguage; unblock when chonkie migrates to v1.8 API
+]
 
 # Dependencies for AG-UI integration
 agui = ["ag-ui-protocol"]


### PR DESCRIPTION
## Summary

- `tree-sitter-language-pack` 1.8.0 removed `SupportedLanguage` as part of a v1 rewrite.
- chonkie's `CodeChunker` still imports it at construction time, breaking `pytest libs/agno/tests/unit/knowledge/chunking/test_code_chunking.py` on `main` failing CI run: https://github.com/agno-agi/agno/actions/runs/25633948991/job/75242444274 with error: `ImportError: cannot import name 'SupportedLanguage' from 'tree_sitter_language_pack'`
- Pinning `<1.8.0` restores CI green while chonkie migrates to the v1.8, follow-up issue in chonkie: https://github.com/chonkie-inc/chonkie/issues/583.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Current: 

<img width="1021" height="151" alt="image" src="https://github.com/user-attachments/assets/c8de59d4-cb56-4503-b5d8-a3346ec3347a" />

With this PR: 

<img width="742" height="145" alt="image" src="https://github.com/user-attachments/assets/f34bad57-5673-41b5-821d-1dfd8a988002" />


<img width="1437" height="462" alt="Screenshot 2026-05-11 at 3 29 02 PM" src="https://github.com/user-attachments/assets/415d1a52-8f1c-44e6-aff7-0a686de172b2" />



Successful CI run: https://github.com/agno-agi/agno/actions/runs/25661743897/job/75323842056?pr=7869
