### PR TITLE
fix: Preserve leading/trailing spaces

### DIFF
--- a/libs/agno/agno/utils/functions.py
+++ b/libs/agno/agno/utils/functions.py
@@ -59,7 +59,9 @@ def get_function_call(
                     elif _v == "false":
                         clean_arguments[k] = False
                     else:
-                        clean_arguments[k] = v.strip()
+                        # Preserve intentional whitespace (newlines, leading/trailing spaces).
+                        # Coercion above already used strip() only for null/boolean detection.
+                        clean_arguments[k] = v
                 else:
                     clean_arguments[k] = v
 

--- a/libs/agno/tests/unit/utils/test_functions.py
+++ b/libs/agno/tests/unit/utils/test_functions.py
@@ -98,7 +98,7 @@ def test_get_function_call_non_dict_arguments(sample_functions):
 
 
 def test_get_function_call_argument(sample_functions):
-    """Test argument sanitization for boolean and null values."""
+    """Test string coercion for boolean and null values; preserve other string whitespace."""
     arguments = json.dumps(
         {
             "param1": "None",
@@ -118,8 +118,23 @@ def test_get_function_call_argument(sample_functions):
         "param1": None,
         "param2": True,
         "param3": False,
-        "param4": "test",
+        "param4": "  test  ",
     }
+
+
+def test_get_function_call_preserves_newline_only_string_arguments(sample_functions):
+    """String args that are only newlines/spaces must not be stripped to empty (e.g. file edit tools)."""
+    arguments = json.dumps({"param1": "\n\n", "param2": "  \t  ", "param3": "\n \n"})
+    result = get_function_call(
+        name="test_function",
+        arguments=arguments,
+        functions=sample_functions,
+    )
+    assert result is not None
+    assert result.error is None
+    assert result.arguments["param1"] == "\n\n"
+    assert result.arguments["param2"] == "  \t  "
+    assert result.arguments["param3"] == "\n \n"
 
 
 def test_get_function_call_argument_advanced(sample_functions):


### PR DESCRIPTION
Here’s what changed.

**libs/agno/agno/utils/functions.py**

- In the else branch for non-coerced strings, v.strip() was replaced with v so intentional whitespace (newlines, leading/trailing spaces/tabs) is kept.
- None / True / False coercion is unchanged: it still uses v.strip().lower() only for those comparisons.

**libs/agno/tests/unit/utils/test_functions.py**

- **test_get_function_call_argument**: param4 is now expected to stay " test " instead of "test".
- **test_get_function_call_preserves_newline_only_string_arguments**: covers "\n\n", " \t ", and "\n \n" so newline-only / whitespace-heavy args are not wiped.

(If applicable, issue number: #7871)

## Type of change

- [*] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
