### PR TITLE
[fix] race in _safe_hook_call_async under asyncio.gather over parallel FunctionCalls

### DIFF
--- a/libs/agno/agno/run/base.py
+++ b/libs/agno/agno/run/base.py
@@ -1,6 +1,8 @@
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import Any, Dict, List, Optional, Type, Union
+from typing import Any, Dict, Iterator, List, Optional, Type, Union
 
 from pydantic import BaseModel
 
@@ -10,6 +12,23 @@ from agno.models.message import Citations, Message, MessageReferences
 from agno.models.metrics import RunMetrics
 from agno.reasoning.step import ReasoningStep
 from agno.utils.log import log_error
+
+# Per-task override for RunContext.messages, set by _safe_hook_call(_async).
+# Task-local via ContextVar, so concurrent hooks under asyncio.gather don't
+# clobber each other's view. None outside hooks; reads fall through to the field.
+_run_context_messages_view: ContextVar[Optional[List[Message]]] = ContextVar(
+    "agno_run_context_messages_view", default=None
+)
+
+
+@contextmanager
+def _protect_messages_view(messages: List[Message]) -> Iterator[None]:
+    """Install a task-local override for RunContext.messages reads."""
+    token = _run_context_messages_view.set(messages)
+    try:
+        yield
+    finally:
+        _run_context_messages_view.reset(token)
 
 
 @dataclass
@@ -27,16 +46,24 @@ class RunContext:
     session_state: Optional[Dict[str, Any]] = None
     output_schema: Optional[Union[Type[BaseModel], Dict[str, Any]]] = None
 
-    # Live reference to the current run's message list. Available in tool hooks
-    # via run_context.messages. Hooks receive a shallow copy (via _safe_hook_call)
-    # so accidental list mutations (.clear(), .append()) won't corrupt the run.
-    # Individual Message objects are shared references — do not mutate them.
+    # Live reference to the run's message list. Inside a hook, reads of
+    # rc.messages are redirected to a per-task shallow-copy view so list
+    # mutations (.clear()/.append()) don't corrupt the live list. Writes
+    # (rc.messages = ...) always go to the underlying field. Individual
+    # Message objects are shared references — do not mutate them.
     messages: Optional[List[Message]] = None
 
     # Runtime-resolved callable factory results
     tools: Optional[List[Any]] = None
     knowledge: Optional[Any] = None
     members: Optional[List[Any]] = None
+
+    def __getattribute__(self, name: str) -> Any:
+        if name == "messages":
+            override = _run_context_messages_view.get()
+            if override is not None:
+                return override
+        return object.__getattribute__(self, name)
 
 
 @dataclass

--- a/libs/agno/agno/tools/function.py
+++ b/libs/agno/agno/tools/function.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, validate_call
 from agno.exceptions import AgentRunException
 from agno.media import Audio, File, Image, Video
 from agno.run import RunContext
+from agno.run.base import _protect_messages_view
 from agno.utils.log import log_debug, log_exception, log_warning
 
 T = TypeVar("T")
@@ -801,34 +802,24 @@ class FunctionCall(BaseModel):
     def _safe_hook_call(self, hook: Callable, hook_args: Dict[str, Any]) -> Any:
         """Call a hook with list-structure-safe messages.
 
-        Temporarily replaces run_context.messages with a shallow copy so the
-        hook cannot corrupt the live message list (e.g. .clear(), .append()).
-        Individual Message objects are still shared references — this protects
-        list structure only, not message contents. The live reference is
-        restored after the hook returns (or raises).
+        Installs a task-local override so reads of run_context.messages from
+        the hook see a shallow copy — list mutations (.clear(), .append())
+        can't corrupt the live list, and parallel hooks under asyncio.gather
+        don't race on a shared attribute. Individual Message objects are still
+        shared references — this protects list structure only, not contents.
         """
         rc = self.function._run_context
-        if rc is not None and rc.messages is not None:
-            live_ref = rc.messages
-            rc.messages = list(live_ref)
-            try:
-                return hook(**hook_args)
-            finally:
-                rc.messages = live_ref
-        else:
+        if rc is None or rc.messages is None:
+            return hook(**hook_args)
+        with _protect_messages_view(list(rc.messages)):
             return hook(**hook_args)
 
     async def _safe_hook_call_async(self, hook: Callable, hook_args: Dict[str, Any]) -> Any:
-        """Async variant of _safe_hook_call."""
+        """Async variant of _safe_hook_call. See _safe_hook_call for the contract."""
         rc = self.function._run_context
-        if rc is not None and rc.messages is not None:
-            live_ref = rc.messages
-            rc.messages = list(live_ref)
-            try:
-                return await hook(**hook_args)
-            finally:
-                rc.messages = live_ref
-        else:
+        if rc is None or rc.messages is None:
+            return await hook(**hook_args)
+        with _protect_messages_view(list(rc.messages)):
             return await hook(**hook_args)
 
     def _handle_pre_hook(self):

--- a/libs/agno/tests/unit/tools/test_functions.py
+++ b/libs/agno/tests/unit/tools/test_functions.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any, Callable, Dict, List, Optional
 
 import pytest
@@ -1121,3 +1122,45 @@ def test_tool_hook_receives_messages_via_run_context():
     # Verify it's a copy (not the same reference), so hook mutations don't affect the run
     assert captured_messages is not run_context.messages
     assert captured_messages == run_context.messages
+
+
+@pytest.mark.asyncio
+async def test_async_pre_hook_does_not_pin_run_context_messages_under_gather():
+    """Regression: under asyncio.gather over parallel FunctionCalls sharing a
+    RunContext, _safe_hook_call_async previously left rc.messages pinned to a
+    stale shallow copy taken mid-batch — so a follow-up hook (e.g. a retry)
+    saw stale messages forever. The ContextVar-backed protected view is
+    task-local, so the live rc.messages list is never mutated."""
+    live_messages = [Message(role="user", content="hi")]
+    run_context = RunContext(run_id="test-run", session_id="test-session")
+    run_context.messages = live_messages
+
+    seen_lengths: List[int] = []
+
+    async def reading_pre_hook(run_context: RunContext) -> None:
+        # Yield so sibling hooks can interleave inside the wrapper.
+        await asyncio.sleep(0)
+        seen_lengths.append(len(run_context.messages))
+
+    @tool(pre_hook=reading_pre_hook)
+    async def test_func(param1: int) -> int:
+        return param1
+
+    test_func.process_entrypoint()
+    test_func._run_context = run_context
+
+    batch = [FunctionCall(function=test_func, arguments={"param1": i}) for i in range(3)]
+    await asyncio.gather(*(c.aexecute() for c in batch))
+
+    # The live list must not have been clobbered by the wrapper.
+    assert run_context.messages is live_messages
+
+    # Simulate the run loop appending a new message between hook batches.
+    live_messages.append(Message(role="assistant", content="response"))
+
+    # A retried hook must see the updated list (len=2). On the broken code,
+    # rc.messages was pinned to a stale len=1 copy and this stayed 1.
+    retry = FunctionCall(function=test_func, arguments={"param1": 99})
+    await retry.aexecute()
+
+    assert seen_lengths == [1, 1, 1, 2]


### PR DESCRIPTION
## Summary

`FunctionCall._safe_hook_call_async` wraps every hook in a swap-and-restore around `run_context.messages`. It saves the current list to a local `live_ref`, swaps in a shallow copy for the hook to read, then puts `live_ref` back in `finally`. This works for a single hook, but it breaks under `asyncio.gather`.

When a Team or Agent emits parallel tool calls, all of those `FunctionCall`s share the same `_run_context` object. As each hook hits its `await`, the next coroutine wakes up, does its own swap, and saves whatever copy the previous one left behind into its own `live_ref`. Only the first hook's `live_ref` actually points at the original list. When the `finally` blocks run, the last one wins, and `rc.messages` ends up stuck on a frozen shallow copy taken somewhere in the middle of the batch.

After that, anything that reads `rc.messages` keeps seeing the stale snapshot. In production this shows up as a guardrail `pre_hook` blocking every retry of a single tool, because it keeps re-evaluating the original (broken) call instead of the model's corrected one. The model is doing the right thing; the hook just cannot see it.

The fix replaces the shared swap with a task-local override via a `ContextVar`. Each asyncio task automatically gets its own value, so concurrent hooks can no longer overwrite each other. The protection contract from #6652 still holds. Outside hooks, `rc.messages` is the live list. Inside hooks, reads return a shallow copy through `RunContext.__getattribute__`. Writes (`rc.messages = ...`) always go to the underlying field.

Fixes #7851.

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: not applicable, this is an internal mechanism
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR addresses this issue with the same approach
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

### Comparison with #7861

#7861 fixes the same race using a per-`RunContext` reentrant async lock around the swap-restore. This PR takes a different route for two reasons:

1. It keeps hook concurrency. A lock makes every hook on a `RunContext` queue up behind the others, which defeats the point of running tool calls in parallel under `asyncio.gather`. Production hooks (analytics, tracing, guardrails) often `await` on DB writes or LLM calls, so serializing them would turn a 5-tool batch into a 5-hook line.
2. It fixes both paths. The sync `_safe_hook_call` uses the same shared-attribute pattern, so this PR uses the same context manager for both. #7861 only patches the async path.

`ContextVar` is the standard library's primitive for task-local state under asyncio. The fix uses the normal token-based set/reset pattern, and there is no behavior change for users reading `rc.messages` outside hooks.

### AI tool disclosure

This PR was drafted with help from Claude Code (Opus 4.7). I reviewed every line, picked the `ContextVar` approach over the lock approach myself, and verified the regression test fails on `main` and passes on this branch by stashing and re-running.

---

## Additional Notes

### Regression test

`test_async_pre_hook_does_not_pin_run_context_messages_under_gather` in `libs/agno/tests/unit/tools/test_functions.py` reproduces the race deterministically. It runs 3 parallel `FunctionCall`s with an async `pre_hook` that awaits, then makes a follow-up call after the batch. On `main`, the assertion `rc.messages is live_messages` fails. The two lists have the same content but different identity, which is the stale-copy pin. With this patch it passes.

All 51 existing hook tests in `test_functions.py` still pass, including the 4 `captured_messages is not run_context.messages` assertions that verify the "hook sees a copy" contract from #6652.

### Verification commands

```
./scripts/format.sh    # clean
./scripts/validate.sh  # ruff and mypy clean across 843 source files
pytest libs/agno/tests/unit/tools/test_functions.py  # 51 passed
```