### PR TITLE
fix: disable agno[mistral] (mistralai quarantined on PyPI)

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -231,7 +231,7 @@ models = [
   "agno[ibm]",
   # "agno[litellm]",  # Temporarily disabled - litellm compromised on PyPI (March 24, 2026)
   "agno[meta]",
-  "agno[mistral]",
+  # "agno[mistral]",  # Temporarily disabled - mistralai quarantined on PyPI (May 12, 2026)
   "agno[ollama]",
   "agno[openai]",
   "agno[portkey]"


### PR DESCRIPTION
mistralai is quarantined on PyPI, breaking `agno[tests]` install in CI.