### PR TITLE
fix(utils): preserve intentional whitespace in get_function_call string arguments

### DIFF
--- a/libs/agno/agno/utils/functions.py
+++ b/libs/agno/agno/utils/functions.py
@@ -59,7 +59,7 @@ def get_function_call(
                     elif _v == "false":
                         clean_arguments[k] = False
                     else:
-                        clean_arguments[k] = v.strip()
+                        clean_arguments[k] = v
                 else:
                     clean_arguments[k] = v
 

--- a/libs/agno/tests/unit/utils/test_functions.py
+++ b/libs/agno/tests/unit/utils/test_functions.py
@@ -118,7 +118,7 @@ def test_get_function_call_argument(sample_functions):
         "param1": None,
         "param2": True,
         "param3": False,
-        "param4": "test",
+        "param4": "  test  ",  # whitespace preserved
     }
 
 
@@ -177,3 +177,72 @@ def test_get_function_call_no_arguments(sample_functions):
     assert result is not None
     assert result.arguments is None
     assert result.error is None
+
+
+def test_get_function_call_preserves_leading_trailing_whitespace(sample_functions):
+    """String arguments with surrounding whitespace must be passed through unchanged.
+
+    Regression test for #7871: get_function_call used to call .strip() on the
+    final string value, silently destroying intentional leading/trailing spaces
+    and newlines (e.g. arguments to string-replace tools).
+    """
+    arguments = json.dumps({"param1": "  leading and trailing  "})
+    result = get_function_call(
+        name="test_function",
+        arguments=arguments,
+        functions=sample_functions,
+    )
+    assert result is not None
+    assert result.error is None
+    assert result.arguments == {"param1": "  leading and trailing  "}
+
+
+def test_get_function_call_preserves_newlines_in_arguments(sample_functions):
+    """Newlines inside string arguments must survive get_function_call unchanged.
+
+    Tools that search/replace multi-line content (e.g. consecutive blank lines)
+    pass newline-only strings like "
+
+
+" as arguments.  Before #7871 these
+    were silently stripped to "", causing the tool to fail with a confusing
+    empty-string error.
+    """
+    arguments = json.dumps({"param1": "
+
+
+"})
+    result = get_function_call(
+        name="test_function",
+        arguments=arguments,
+        functions=sample_functions,
+    )
+    assert result is not None
+    assert result.error is None
+    assert result.arguments == {"param1": "
+
+
+"}
+
+
+def test_get_function_call_coercion_still_works_with_surrounding_whitespace(sample_functions):
+    """Type coercion (None/True/False) still works even when the string has surrounding
+    whitespace — the coercion uses a stripped+lowercased copy, not the original value.
+    """
+    arguments = json.dumps({
+        "param1": "  None  ",
+        "param2": " True ",
+        "param3": " false ",
+    })
+    result = get_function_call(
+        name="test_function",
+        arguments=arguments,
+        functions=sample_functions,
+    )
+    assert result is not None
+    assert result.error is None
+    assert result.arguments == {
+        "param1": None,
+        "param2": True,
+        "param3": False,
+    }


### PR DESCRIPTION
## Summary

Fixes #7871.

`get_function_call` (in `agno/utils/functions.py`) called `.strip()` on every string argument before passing it to the tool function:

```python
# before
clean_arguments[k] = v.strip()  # destroyed intentional whitespace
```

The `.strip()` was introduced for the boolean/null coercion check, but that check already operates on a temporary `_v = v.strip().lower()`. The original value `v` was stripped a second time unconditionally in the `else` branch, silently destroying leading/trailing spaces, tabs, and newlines.

### Impact

Tools that pass whitespace-significant strings (e.g. a string-replace tool passing `"\n\n\n"` as `old_string`) received `""` instead, and failed with a misleading "old_string must not be empty" error.

## Changes

| File | Change |
|------|--------|
| `libs/agno/agno/utils/functions.py` | Remove `.strip()` in the `else` branch — pass `v` unchanged |
| `libs/agno/tests/unit/utils/test_functions.py` | Fix existing test that asserted the buggy stripping behaviour; add 3 new tests |

### New tests

- `test_get_function_call_preserves_leading_trailing_whitespace` — spaces preserved
- `test_get_function_call_preserves_newlines_in_arguments` — newlines preserved (the primary regression case)
- `test_get_function_call_coercion_still_works_with_surrounding_whitespace` — None/True/False coercion still works when the string has surrounding whitespace

### Why coercion is unaffected

The coercion check uses a stripped copy (`_v`) only for the type comparison. The actual stored value now uses the original `v` directly:

```python
_v = v.strip().lower()
if _v in ("none", "null"):  clean_arguments[k] = None
elif _v == "true":          clean_arguments[k] = True
elif _v == "false":         clean_arguments[k] = False
else:
    clean_arguments[k] = v  # was v.strip(); now just v
```
