### PR TITLE
fix(session): use async model call in aset_session_name to avoid blocking event loop

### DIFF
--- a/libs/agno/agno/agent/_session.py
+++ b/libs/agno/agno/agent/_session.py
@@ -433,6 +433,64 @@ def generate_session_name(agent: Agent, session: AgentSession, max_retries: int 
     return content.replace('"', "").strip()
 
 
+async def agenerate_session_name(
+    agent: Agent, session: AgentSession, max_retries: int = 3, _attempt: int = 0
+) -> str:
+    """
+    Asynchronously generate a name for the session using the first few messages.
+
+    Mirrors :func:`generate_session_name` but calls ``agent.model.aresponse``
+    so that the async event loop is not blocked while waiting for the LLM.
+
+    Args:
+        agent: The Agent instance.
+        session (AgentSession): The session to generate a name for.
+        max_retries: Maximum number of retries if generation fails.
+        _attempt: Current attempt number (used internally for recursion).
+    Returns:
+        str: The generated session name.
+    """
+    if agent.model is None:
+        raise Exception("Model not set")
+
+    gen_session_name_prompt = "Conversation\n"
+
+    messages_for_generating_session_name = session.get_messages()
+
+    for message in messages_for_generating_session_name:
+        gen_session_name_prompt += f"{message.role.upper()}: {message.content}\n"
+
+    gen_session_name_prompt += "\n\nConversation Name: "
+
+    system_message = Message(
+        role=agent.system_message_role,
+        content="Please provide a suitable name for this conversation in maximum 5 words. "
+        "Remember, do not exceed 5 words.",
+    )
+    user_message = Message(role=agent.user_message_role, content=gen_session_name_prompt)
+    generate_name_messages = [system_message, user_message]
+
+    # Generate name asynchronously so the event loop is not blocked
+    generated_name = await agent.model.aresponse(messages=generate_name_messages)
+    content = generated_name.content
+    if content is None:
+        if _attempt >= max_retries:
+            return "New Session"
+        log_error("Generated name is None. Trying again.")
+        return await agenerate_session_name(
+            agent, session=session, max_retries=max_retries, _attempt=_attempt + 1
+        )
+
+    if len(content.split()) > 5:
+        if _attempt >= max_retries:
+            return " ".join(content.split()[:5])
+        log_error("Generated name is too long. It should be less than 5 words. Trying again.")
+        return await agenerate_session_name(
+            agent, session=session, max_retries=max_retries, _attempt=_attempt + 1
+        )
+    return content.replace('"', "").strip()
+
+
 def get_session_name(agent: Agent, session_id: Optional[str] = None) -> str:
     """
     Get the session name for the given session ID.

--- a/libs/agno/agno/agent/agent.py
+++ b/libs/agno/agno/agent/agent.py
@@ -981,6 +981,9 @@ class Agent:
     def generate_session_name(self, session: AgentSession) -> str:
         return _session.generate_session_name(self, session=session)
 
+    async def agenerate_session_name(self, session: AgentSession) -> str:
+        return await _session.agenerate_session_name(self, session=session)
+
     def get_session_name(self, session_id: Optional[str] = None) -> str:
         return _session.get_session_name(self, session_id=session_id)
 

--- a/libs/agno/agno/team/_session.py
+++ b/libs/agno/agno/team/_session.py
@@ -306,6 +306,62 @@ def generate_session_name(team: "Team", session: TeamSession, _retries: int = 0)
     return content.replace('"', "").strip()
 
 
+async def agenerate_session_name(
+    team: "Team", session: TeamSession, _retries: int = 0
+) -> str:
+    """
+    Asynchronously generate a name for the team session.
+
+    Mirrors :func:`generate_session_name` but calls ``team.model.aresponse``
+    so that the async event loop is not blocked while waiting for the LLM.
+
+    Args:
+        team: The Team instance.
+        session: The TeamSession to generate a name for.
+        _retries: Internal retry counter (do not set manually).
+    Returns:
+        str: The generated session name.
+    """
+    max_retries = 3
+
+    if team.model is None:
+        raise Exception("Model not set")
+
+    gen_session_name_prompt = "Team Conversation\n"
+
+    messages_for_generating_session_name = session.get_messages()
+
+    for message in messages_for_generating_session_name:
+        gen_session_name_prompt += f"{message.role.upper()}: {message.content}\n"
+
+    gen_session_name_prompt += "\n\nTeam Session Name: "
+
+    system_message = Message(
+        role=team.system_message_role,
+        content="Please provide a suitable name for this conversation in maximum 5 words. "
+        "Remember, do not exceed 5 words.",
+    )
+    user_message = Message(role="user", content=gen_session_name_prompt)
+    generate_name_messages = [system_message, user_message]
+
+    # Generate name asynchronously so the event loop is not blocked
+    generated_name = await team.model.aresponse(messages=generate_name_messages)
+    content = generated_name.content
+    if content is None:
+        if _retries < max_retries:
+            log_error("Generated name is None. Trying again.")
+            return await agenerate_session_name(team, session=session, _retries=_retries + 1)
+        log_error("Generated name is None after max retries. Using fallback.")
+        return "Team Session"
+    if len(content.split()) > 15:
+        if _retries < max_retries:
+            log_error("Generated name is too long. Trying again.")
+            return await agenerate_session_name(team, session=session, _retries=_retries + 1)
+        log_error("Generated name is too long after max retries. Using fallback.")
+        return "Team Session"
+    return content.replace('"', "").strip()
+
+
 def set_session_name(
     team: "Team", session_id: Optional[str] = None, autogenerate: bool = False, session_name: Optional[str] = None
 ) -> TeamSession:

--- a/libs/agno/agno/team/team.py
+++ b/libs/agno/agno/team/team.py
@@ -1560,6 +1560,9 @@ class Team:
     def generate_session_name(self, session: TeamSession) -> str:
         return _session.generate_session_name(self, session=session)
 
+    async def agenerate_session_name(self, session: TeamSession) -> str:
+        return await _session.agenerate_session_name(self, session=session)
+
     def set_session_name(
         self, session_id: Optional[str] = None, autogenerate: bool = False, session_name: Optional[str] = None
     ) -> TeamSession:

--- a/libs/agno/agno/utils/agent.py
+++ b/libs/agno/agno/utils/agent.py
@@ -746,7 +746,7 @@ async def aset_session_name_util(
 
     # -*- Generate name for session
     if autogenerate:
-        session_name = entity.generate_session_name(session=session)  # type: ignore
+        session_name = await entity.agenerate_session_name(session=session)  # type: ignore
         log_debug(f"Generated Session Name: {session_name}")
     elif session_name is None:
         raise Exception("No session name provided")


### PR DESCRIPTION
## Summary

Fixes #7719.

`aset_session_name_util` (the shared async utility backing `Agent.aset_session_name` and `Team.aset_session_name`) called the **synchronous** `entity.generate_session_name()`, which internally calls `model.response()`. Because `model.response()` makes a blocking HTTP call, this held the interpreter thread for the entire duration of the LLM call — stalling every other coroutine waiting in the event loop.

### Root cause

```python
# libs/agno/agno/utils/agent.py — before
async def aset_session_name_util(entity, ...):
    ...
    if autogenerate:
        session_name = entity.generate_session_name(session=session)  # ← sync, blocks
```

`generate_session_name` → `model.response()` → blocking HTTP → all concurrent async requests serialised.

### Fix

1. **Add `async def agenerate_session_name`** to `agent/_session.py` and `team/_session.py` — exact mirrors of the sync versions but using `model.aresponse()` (the existing async model call already used throughout agno).

2. **Wire up delegating methods** on `Agent` and `Team` (`self.agenerate_session_name` → `_session.agenerate_session_name`).

3. **Fix `aset_session_name_util`** to `await entity.agenerate_session_name()` instead of calling the sync version.

```python
# libs/agno/agno/utils/agent.py — after
async def aset_session_name_util(entity, ...):
    ...
    if autogenerate:
        session_name = await entity.agenerate_session_name(session=session)  # ← async
```

### Why this blocked in practice

Setting a session name is triggered inside async streaming runs. When the proxy called `await team.arun(stream=True)` for multiple concurrent sessions, each `aset_session_name` call would acquire the thread through the blocking `model.response()` call. The event loop could not interleave any other coroutine until the LLM responded, effectively making concurrent session-name generation sequential.

## Changes

| File | Change |
|------|--------|
| `libs/agno/agno/agent/_session.py` | Add `async def agenerate_session_name` (uses `model.aresponse`) |
| `libs/agno/agno/team/_session.py` | Add `async def agenerate_session_name` (uses `model.aresponse`) |
| `libs/agno/agno/agent/agent.py` | Add `async def agenerate_session_name` delegation |
| `libs/agno/agno/team/team.py` | Add `async def agenerate_session_name` delegation |
| `libs/agno/agno/utils/agent.py` | Change `entity.generate_session_name()` → `await entity.agenerate_session_name()` |
