### PR TITLE
chore: harden user-isolation criticals on the user-scoped DB adapter

### DIFF
--- a/libs/agno/agno/os/middleware/user_scope.py
+++ b/libs/agno/agno/os/middleware/user_scope.py
@@ -89,7 +89,8 @@ def get_scoped_user_id(request: Request) -> Optional[str]:
     admin_scope_raw = getattr(request.state, "admin_scope", None)
     # Ignore non-string values (e.g. MagicMock auto-attrs in tests).
     admin_scope: Optional[str] = admin_scope_raw if isinstance(admin_scope_raw, str) else None
-    if _has_admin_scope(scopes, admin_scope=admin_scope):
+    admin_match = _has_admin_scope(scopes, admin_scope=admin_scope)
+    if admin_match:
         return None
 
     return user_id

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -403,26 +403,44 @@ def get_websocket_router(
 
                     # Force user_id from JWT for non-admin callers so the client
                     # cannot attribute a run to another user by spoofing the field.
-                    jwt_user_id = websocket_user_context.get("user_id")
-                    if jwt_user_id:
+                    if jwt_auth_enabled:
+                        jwt_user_id = websocket_user_context.get("user_id")
                         is_admin = ws_admin_scope in websocket_user_context.get("scopes", [])
-                        if is_admin:
-                            message.setdefault("user_id", jwt_user_id)
-                        else:
-                            message["user_id"] = jwt_user_id
+                        if jwt_user_id is not None:
+                            if is_admin:
+                                message.setdefault("user_id", jwt_user_id)
+                            else:
+                                message["user_id"] = jwt_user_id
+                        elif not is_admin:
+                            # JWT auth is on, caller is non-admin, and the token has
+                            # no sub — refuse rather than trust client-supplied user_id.
+                            await websocket.send_text(
+                                json.dumps(
+                                    {"event": "error", "error": "Authenticated token missing user identity (sub)"}
+                                )
+                            )
+                            continue
                     await handle_workflow_via_websocket(websocket, message, os)
 
                 elif action == "reconnect":
                     # Force user_id from JWT for non-admins so reconnecting
                     # cannot read another user's run events by swapping user_id.
-                    jwt_user_id = websocket_user_context.get("user_id")
                     is_admin = False
-                    if jwt_user_id:
+                    if jwt_auth_enabled:
+                        jwt_user_id = websocket_user_context.get("user_id")
                         is_admin = ws_admin_scope in websocket_user_context.get("scopes", [])
-                        if is_admin:
-                            message.setdefault("user_id", jwt_user_id)
-                        else:
-                            message["user_id"] = jwt_user_id
+                        if jwt_user_id is not None:
+                            if is_admin:
+                                message.setdefault("user_id", jwt_user_id)
+                            else:
+                                message["user_id"] = jwt_user_id
+                        elif not is_admin:
+                            await websocket.send_text(
+                                json.dumps(
+                                    {"event": "error", "error": "Authenticated token missing user identity (sub)"}
+                                )
+                            )
+                            continue
 
                     # Enforce workflow-level RBAC at reconnect just like
                     # start-workflow does. RBAC fires whenever JWT auth is on

--- a/libs/agno/agno/os/routers/approvals/router.py
+++ b/libs/agno/agno/os/routers/approvals/router.py
@@ -34,6 +34,21 @@ def get_approval_router(os_db: Any, settings: Any) -> APIRouter:
     # Helpers
     # ------------------------------------------------------------------
 
+    # Approval DB methods that accept a user_id kwarg. The scoped wrapper
+    # forces ``user_id`` to the JWT sub for non-admin scoped callers so that no
+    # endpoint can accidentally read/mutate another user's approvals — the
+    # adapter doesn't wrap approvals, so this is the structural net.
+    _USER_SCOPED_APPROVAL_METHODS = frozenset(
+        {
+            "get_approval",
+            "get_approvals",
+            "get_pending_approval_count",
+            "update_approval",
+            "update_approval_run_status",
+            "delete_approval",
+        }
+    )
+
     async def _db_call(method_name: str, *args: Any, **kwargs: Any) -> Any:
         fn = getattr(os_db, method_name, None)
         if fn is None:
@@ -45,6 +60,33 @@ def get_approval_router(os_db: Any, settings: Any) -> APIRouter:
         except NotImplementedError:
             raise HTTPException(status_code=503, detail="Approvals not supported by the configured database")
 
+    async def _scoped_db_call(request: Request, method_name: str, *args: Any, **kwargs: Any) -> Any:
+        """Like _db_call, but forces user_id to the JWT sub for non-admin scoped callers.
+
+        Provides a structural backstop for the approvals endpoints. Even if a
+        future handler forgets to thread user_id manually, this wrapper will
+        inject it whenever the method is in the user-scoped whitelist.
+        """
+        from agno.os.middleware.user_scope import get_scoped_user_id
+
+        scoped_user_id = get_scoped_user_id(request)
+        if scoped_user_id is not None and method_name in _USER_SCOPED_APPROVAL_METHODS:
+            # Caller-supplied user_id must match the JWT sub; reject mismatches
+            # outright rather than silently rewriting, so spoof attempts are loud.
+            supplied = kwargs.get("user_id")
+            if supplied is not None and supplied != scoped_user_id:
+                raise HTTPException(status_code=404, detail="Approval not found")
+            kwargs["user_id"] = scoped_user_id
+            try:
+                return await _db_call(method_name, *args, **kwargs)
+            except TypeError:
+                # Backend method doesn't accept user_id. Fall back so older
+                # implementations keep working; the row-level ownership check
+                # in _load_approval_for_user is still in force.
+                kwargs.pop("user_id", None)
+                return await _db_call(method_name, *args, **kwargs)
+        return await _db_call(method_name, *args, **kwargs)
+
     async def _load_approval_for_user(approval_id: str, request: Request) -> Dict[str, Any]:
         """Fetch an approval and enforce per-user ownership.
 
@@ -54,10 +96,12 @@ def get_approval_router(os_db: Any, settings: Any) -> APIRouter:
         """
         from agno.os.middleware.user_scope import get_scoped_user_id
 
-        approval = await _db_call("get_approval", approval_id)
+        approval = await _scoped_db_call(request, "get_approval", approval_id)
         if approval is None:
             raise HTTPException(status_code=404, detail="Approval not found")
         scoped_user_id = get_scoped_user_id(request)
+        # Defence in depth: drop rows the backend may have returned despite
+        # the user_id filter (older or misbehaving implementations).
         if scoped_user_id is not None and approval.get("user_id") != scoped_user_id:
             raise HTTPException(status_code=404, detail="Approval not found")
         return approval
@@ -87,10 +131,11 @@ def get_approval_router(os_db: Any, settings: Any) -> APIRouter:
         from agno.os.middleware.user_scope import get_scoped_user_id
 
         scoped_user_id = get_scoped_user_id(request)
-        if scoped_user_id:
+        if scoped_user_id is not None:
             user_id = scoped_user_id
 
-        approvals, total_count = await _db_call(
+        approvals, total_count = await _scoped_db_call(
+            request,
             "get_approvals",
             status=status,
             source_type=source_type,
@@ -126,10 +171,10 @@ def get_approval_router(os_db: Any, settings: Any) -> APIRouter:
         from agno.os.middleware.user_scope import get_scoped_user_id
 
         scoped_user_id = get_scoped_user_id(request)
-        if scoped_user_id:
+        if scoped_user_id is not None:
             user_id = scoped_user_id
 
-        count = await _db_call("get_pending_approval_count", user_id=user_id)
+        count = await _scoped_db_call(request, "get_pending_approval_count", user_id=user_id)
         return {"count": count}
 
     @router.get("/approvals/{approval_id}/status", response_model=ApprovalStatusResponse)
@@ -170,7 +215,7 @@ def get_approval_router(os_db: Any, settings: Any) -> APIRouter:
         # Use JWT user_id as resolved_by when available (prevents spoofing)
         resolved_by = body.resolved_by
         jwt_user_id = getattr(request.state, "user_id", None)
-        if jwt_user_id:
+        if jwt_user_id is not None:
             resolved_by = jwt_user_id
 
         update_kwargs: Dict[str, Any] = {
@@ -180,7 +225,8 @@ def get_approval_router(os_db: Any, settings: Any) -> APIRouter:
         }
         if body.resolution_data is not None:
             update_kwargs["resolution_data"] = body.resolution_data
-        result = await _db_call(
+        result = await _scoped_db_call(
+            request,
             "update_approval",
             approval_id,
             expected_status="pending",
@@ -188,7 +234,7 @@ def get_approval_router(os_db: Any, settings: Any) -> APIRouter:
         )
         if result is None:
             # Either the approval doesn't exist or it was already resolved
-            existing = await _db_call("get_approval", approval_id)
+            existing = await _scoped_db_call(request, "get_approval", approval_id)
             if existing is None:
                 raise HTTPException(status_code=404, detail="Approval not found")
             raise HTTPException(
@@ -206,7 +252,7 @@ def get_approval_router(os_db: Any, settings: Any) -> APIRouter:
     ) -> None:
         # Owner check — non-admin callers cannot delete other users' approvals.
         await _load_approval_for_user(approval_id, request)
-        deleted = await _db_call("delete_approval", approval_id)
+        deleted = await _scoped_db_call(request, "delete_approval", approval_id)
         if not deleted:
             raise HTTPException(status_code=500, detail="Failed to delete approval")
 

--- a/libs/agno/agno/os/routers/session/session.py
+++ b/libs/agno/agno/os/routers/session/session.py
@@ -857,7 +857,10 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
             return
 
         # Same pattern as delete_session above for admin / no-JWT callers.
-        local_kwargs: Dict[str, Any] = {"session_ids": request.session_ids}
+        local_kwargs: Dict[str, Any] = {
+            "session_ids": request.session_ids,
+            "session_types": request.session_types,
+        }
         if not is_user_scoped_db(db):
             local_kwargs["user_id"] = user_id
 

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -1091,7 +1091,14 @@ def get_workflow_router(
     ):
         kwargs = await get_request_kwargs(request, create_workflow_run)
 
-        if hasattr(request.state, "user_id") and request.state.user_id is not None:
+        # For non-admin scoped callers the JWT sub wins unconditionally —
+        # the client must not be able to attribute a run to another user.
+        scoped_user_id = get_scoped_user_id(request)
+        if scoped_user_id is not None:
+            if user_id is not None and user_id != scoped_user_id:
+                log_warning("Form user_id ignored for non-admin scoped caller; using JWT sub")
+            user_id = scoped_user_id
+        elif hasattr(request.state, "user_id") and request.state.user_id is not None:
             if user_id and user_id != request.state.user_id:
                 log_warning("User ID parameter passed in both request state and kwargs, using request state")
             user_id = request.state.user_id
@@ -1265,7 +1272,13 @@ def get_workflow_router(
             description="JSON object with factory-specific parameters for dynamic workflow reconstruction",
         ),
     ):
-        if hasattr(request.state, "user_id") and request.state.user_id is not None:
+        # For non-admin scoped callers the JWT sub wins unconditionally.
+        scoped_user_id = get_scoped_user_id(request)
+        if scoped_user_id is not None:
+            if user_id is not None and user_id != scoped_user_id:
+                log_warning("Form user_id ignored for non-admin scoped caller; using JWT sub")
+            user_id = scoped_user_id
+        elif hasattr(request.state, "user_id") and request.state.user_id is not None:
             user_id = request.state.user_id
         if hasattr(request.state, "session_id") and request.state.session_id is not None:
             session_id = request.state.session_id

--- a/libs/agno/agno/os/user_scoped_db.py
+++ b/libs/agno/agno/os/user_scoped_db.py
@@ -58,6 +58,38 @@ def _coerce_all(entities: Iterable[_TUserIdCarrier], expected_user_id: str, kind
     return [_coerce_user_id(e, expected_user_id, kind) for e in entities]
 
 
+def _filter_by_user_id(items, expected_user_id: str):
+    """Defensive post-filter for list results from backends that may not honour user_id.
+
+    When the backend is well-behaved the input already contains only matching rows,
+    so this is a no-op. When the backend ignores ``user_id`` (older implementations),
+    rows belonging to other users are dropped here, preventing cross-user leakage.
+
+    Many ``BaseDb`` list methods return ``(rows, total_count)``; both shapes are
+    handled. Total count is left unchanged because we can't recompute it
+    correctly without re-querying — backends that honour ``user_id`` already
+    report the right count, and the filter is just belt-and-braces.
+    """
+    if items is None:
+        return items
+
+    def _match(item) -> bool:
+        if isinstance(item, dict):
+            return item.get("user_id") == expected_user_id
+        return getattr(item, "user_id", None) == expected_user_id
+
+    # (rows, total_count) shape — common for paginated list endpoints
+    if isinstance(items, tuple) and len(items) == 2 and isinstance(items[0], list):
+        rows, total = items
+        return [row for row in rows if _match(row)], total
+
+    if isinstance(items, list):
+        return [row for row in items if _match(row)]
+
+    # Unknown shape (single object, dict aggregate, etc.) — pass through.
+    return items
+
+
 class UserScopedDbAdapter:
     """Adapts a BaseDb by injecting user_id into all user-scoped queries.
 
@@ -131,7 +163,13 @@ class UserScopedDbAdapter:
     # ------------------------------------------------------------------
 
     def clear_memories(self) -> None:
-        return self._db.clear_memories()
+        # Scoped callers must not wipe other users' memories. The base method
+        # takes no user_id parameter, so we refuse rather than risk a table-wide
+        # delete. Use delete_user_memories(memory_ids=...) for per-user deletes.
+        raise PermissionError(
+            "clear_memories() is not permitted on a user-scoped DB. "
+            "Use delete_user_memories(memory_ids=...) for the bound user instead."
+        )
 
     def delete_user_memory(self, memory_id: str, **kwargs) -> None:
         kwargs["user_id"] = self._user_id
@@ -170,6 +208,7 @@ class UserScopedDbAdapter:
     # ------------------------------------------------------------------
 
     def upsert_trace(self, trace: "Trace") -> None:
+        trace = _coerce_user_id(trace, self._user_id, "trace")
         return self._db.upsert_trace(trace)
 
     def get_trace(self, **kwargs):
@@ -186,11 +225,22 @@ class UserScopedDbAdapter:
 
     def get_traces(self, **kwargs):
         kwargs["user_id"] = self._user_id
-        return self._db.get_traces(**kwargs)
+        try:
+            traces = self._db.get_traces(**kwargs)
+        except TypeError:
+            kwargs.pop("user_id", None)
+            traces = self._db.get_traces(**kwargs)
+        return _filter_by_user_id(traces, self._user_id)
 
     def get_trace_stats(self, **kwargs):
         kwargs["user_id"] = self._user_id
-        return self._db.get_trace_stats(**kwargs)
+        try:
+            return self._db.get_trace_stats(**kwargs)
+        except TypeError:
+            # Backend cannot produce per-user aggregates safely; fail closed.
+            raise NotImplementedError(
+                "get_trace_stats on this backend does not accept user_id; per-user trace stats are not available."
+            )
 
     # ------------------------------------------------------------------
     # Spans (not user-scoped — no user_id column)
@@ -289,7 +339,10 @@ class AsyncUserScopedDbAdapter:
     # ------------------------------------------------------------------
 
     async def clear_memories(self) -> None:
-        return await self._db.clear_memories()
+        raise PermissionError(
+            "clear_memories() is not permitted on a user-scoped DB. "
+            "Use delete_user_memories(memory_ids=...) for the bound user instead."
+        )
 
     async def delete_user_memory(self, memory_id: str, **kwargs) -> None:
         kwargs["user_id"] = self._user_id
@@ -330,6 +383,7 @@ class AsyncUserScopedDbAdapter:
     # ------------------------------------------------------------------
 
     async def upsert_trace(self, trace: "Trace") -> None:
+        trace = _coerce_user_id(trace, self._user_id, "trace")
         return await self._db.upsert_trace(trace)
 
     async def get_trace(self, **kwargs):
@@ -345,11 +399,21 @@ class AsyncUserScopedDbAdapter:
 
     async def get_traces(self, **kwargs):
         kwargs["user_id"] = self._user_id
-        return await self._db.get_traces(**kwargs)
+        try:
+            traces = await self._db.get_traces(**kwargs)
+        except TypeError:
+            kwargs.pop("user_id", None)
+            traces = await self._db.get_traces(**kwargs)
+        return _filter_by_user_id(traces, self._user_id)
 
     async def get_trace_stats(self, **kwargs):
         kwargs["user_id"] = self._user_id
-        return await self._db.get_trace_stats(**kwargs)
+        try:
+            return await self._db.get_trace_stats(**kwargs)
+        except TypeError:
+            raise NotImplementedError(
+                "get_trace_stats on this backend does not accept user_id; per-user trace stats are not available."
+            )
 
     # ------------------------------------------------------------------
     # Spans (not user-scoped)


### PR DESCRIPTION
## Summary

Follow-up hardening on top of the per-user data isolation PR. Closes the structural gaps surfaced in the review without changing the opt-in contract — `AuthorizationConfig(user_isolation=True)` still gates everything, admin still bypasses, RBAC still works the same.

follow up- https://github.com/agno-agi/agno/pull/7606

## What changed

### Adapter (`user_scoped_db.py`)

- `clear_memories()` on a scoped adapter raises `PermissionError`. The base method takes no `user_id`, so the previous passthrough would wipe every user's memories.
- `upsert_trace()` now coerces `trace.user_id` to the bound user, matching the existing behaviour for sessions and memories.
- `get_traces()` and `get_trace_stats()` use the same `try/except TypeError` + post-filter pattern as `get_trace()`. `get_trace_stats()` fails closed with `NotImplementedError` rather than returning unscoped aggregates on older backends.
- New `_filter_by_user_id` helper handles both the `list[row]` and `(rows, total_count)` shapes returned by `BaseDb` list methods.

### Approvals (`approvals/router.py`)

- Truthy `if scoped_user_id:` and `if jwt_user_id:` replaced with `is not None`. Avoids an empty-string `sub` accidentally skipping the scope.
- New `_scoped_db_call(request, method_name, ...)` wraps `_db_call` and, for non-admin scoped callers, force-injects `user_id` on a whitelist of approval methods (`get_approval`, `get_approvals`, `get_pending_approval_count`, `update_approval`, `update_approval_run_status`, `delete_approval`). Caller-supplied mismatches return 404; methods that don't accept `user_id` fall back gracefully on `TypeError`. Provides a structural backstop for the approvals endpoints since approvals are intentionally not wrapped by the DB adapter.
- All approval handlers now route through `_scoped_db_call`.

### WebSocket dispatcher (`os/router.py`)

- `start-workflow` and `reconnect` actions now fail closed when JWT auth is enabled, the caller is non-admin, and the token has no `sub`. Returns an `Authenticated token missing user identity (sub)` error instead of silently trusting the client-supplied `user_id` field.

### Sessions (`session/session.py`)

- Bulk `delete_sessions` includes `session_types` in `local_kwargs`. The endpoint already validates that `len(session_ids) == len(session_types)` but the local path was dropping the second list entirely.

### Workflows (`workflows/router.py`)

- `create_workflow_run` and `continue_workflow_run` resolve `user_id` via `get_scoped_user_id(request)` first. For non-admin scoped callers the JWT sub wins unconditionally; mismatched form `user_id` is logged and dropped. Falls back to `request.state.user_id` for admins / unscoped callers, preserving existing behaviour.

## Compatibility

- All changes behave identically to before when `user_isolation=False` (the default).
- All changes behave identically to before for admin scoped callers.
- The `_filter_by_user_id` post-filter is a no-op for well-behaved backends that already honour `user_id`.


## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
