### PR TITLE
fix: preserve whitespace in string arguments to get_function_call

### DIFF
--- a/libs/agno/agno/utils/functions.py
+++ b/libs/agno/agno/utils/functions.py
@@ -59,7 +59,7 @@ def get_function_call(
                     elif _v == "false":
                         clean_arguments[k] = False
                     else:
-                        clean_arguments[k] = v.strip()
+                        clean_arguments[k] = v
                 else:
                     clean_arguments[k] = v
 


### PR DESCRIPTION
## Summary

Fixes #7871

### Problem

The `get_function_call` helper in `agno/utils/functions.py` was applying `.strip()` to every string argument before passing it to tool functions. This destroyed intentional whitespace characters (newlines, spaces, tabs) that tools might need.

### Example

A file editor tool trying to replace blank lines:
```python
arguments = {"old_string": "\n\n", "new_string": "\n"}
# After get_function_call: old_string becomes "" (empty!)
```

### Root Cause

The `.strip()` was added to coerce string-encoded booleans (`"True"`, `"False"`, `"None"`). However, the type coercion logic already uses `v.strip().lower()` for comparison on line 54, so the extra `.strip()` on the fallthrough branch (line 62) was:
1. **Redundant** for type coercion
2. **Harmful** for all other strings

### Fix

```python
# Before
else:
    clean_arguments[k] = v.strip()

# After  
else:
    clean_arguments[k] = v
```

### Testing

- String arguments with intentional whitespace are now preserved
- Type coercion for `"true"`/`"false"`/`"none"` still works (uses `v.strip().lower()` on line 54)

---
*Generated with Auto Bounty Hunter.*