### PR TITLE
[fix] sql injection in Clickhouse.delete_by_metadata (#7866)

### DIFF
--- a/libs/agno/agno/vectordb/clickhouse/clickhousedb.py
+++ b/libs/agno/agno/vectordb/clickhouse/clickhousedb.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 from hashlib import md5
 from typing import Any, Dict, List, Optional, Union
 
@@ -17,6 +18,13 @@ from agno.knowledge.embedder import Embedder
 from agno.utils.log import log_debug, log_error, log_info, log_warning, logger
 from agno.vectordb.base import VectorDb
 from agno.vectordb.distance import Distance
+
+# Safe JSON-path identifier regex used to validate metadata keys before they are
+# bound into a ClickHouse parameterized DELETE. A safe key is a simple identifier
+# (letter/underscore start, then alphanumerics/underscores) optionally followed
+# by dotted segments, each itself a simple identifier. Compiled once at module
+# load to avoid per-call regex compilation.
+_SAFE_METADATA_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$")
 
 
 class Clickhouse(VectorDb):
@@ -679,22 +687,53 @@ class Clickhouse(VectorDb):
         Returns:
             bool: True if documents were deleted, False otherwise
         """
+        log_debug(f"ClickHouse VectorDB : Deleting documents with metadata {metadata}")
+
+        # Preserve the empty-dict early return as ``False`` without executing
+        # any DELETE. Placed before key validation so that the (vacuously
+        # empty) key set does not run through the regex.
+        if not metadata:
+            return False
+
+        # Validate every metadata key against the safe JSON-path identifier regex
+        # BEFORE any SQL is issued. This raise MUST occur outside the
+        # ``try`` / ``except Exception`` block below so that ``ValueError``
+        # propagates to the caller rather than being swallowed and converted
+        # to ``return False``.
+        for key in metadata.keys():
+            if not _SAFE_METADATA_KEY_RE.match(key):
+                raise ValueError(f"Invalid metadata key {key!r}: must match {_SAFE_METADATA_KEY_RE.pattern}")
+
         try:
-            log_debug(f"ClickHouse VectorDB : Deleting documents with metadata {metadata}")
             parameters = self._get_base_parameters()
 
-            # Build WHERE clause for metadata matching using proper ClickHouse JSON syntax
+            # Build WHERE clause for metadata matching using ClickHouse named parameter
+            # substitution. Both keys (already validated against the safe JSON-path regex
+            # above) and values are bound as typed parameters; the only Python-side
+            # interpolation in the assembled SQL is the parameter names ``k_{i}`` /
+            # ``v_{i}``, which are agent-controlled integers, not caller-controlled data.
+            # The ``isinstance`` dispatch order (``bool`` before ``int``/``float``) is
+            # preserved exactly because ``bool`` is a subclass of ``int`` in Python.
             where_conditions = []
-            for key, value in metadata.items():
+            for i, (key, value) in enumerate(metadata.items()):
+                key_param = f"k_{i}"
+                val_param = f"v_{i}"
+                parameters[key_param] = key
                 if isinstance(value, bool):
-                    where_conditions.append(f"JSONExtractBool(toString(filters), '{key}') = {str(value).lower()}")
+                    parameters[val_param] = value
+                    where_conditions.append(
+                        f"JSONExtractBool(toString(filters), {{{key_param}:String}}) = {{{val_param}:Bool}}"
+                    )
                 elif isinstance(value, (int, float)):
-                    where_conditions.append(f"JSONExtractFloat(toString(filters), '{key}') = {value}")
+                    parameters[val_param] = float(value)
+                    where_conditions.append(
+                        f"JSONExtractFloat(toString(filters), {{{key_param}:String}}) = {{{val_param}:Float64}}"
+                    )
                 else:
-                    where_conditions.append(f"JSONExtractString(toString(filters), '{key}') = '{value}'")
-
-            if not where_conditions:
-                return False
+                    parameters[val_param] = str(value)
+                    where_conditions.append(
+                        f"JSONExtractString(toString(filters), {{{key_param}:String}}) = {{{val_param}:String}}"
+                    )
 
             where_clause = " AND ".join(where_conditions)
 

--- a/libs/agno/tests/unit/vectordb/clickhouse/test_delete_by_metadata_injection.py
+++ b/libs/agno/tests/unit/vectordb/clickhouse/test_delete_by_metadata_injection.py
@@ -1,0 +1,266 @@
+"""
+Bug condition exploration tests for `Clickhouse.delete_by_metadata`.
+
+These tests encode the EXPECTED (fixed) behavior described in
+`.kiro/specs/clickhouse-delete-by-metadata-sqli/bugfix.md` and the corresponding
+design document. The bug is direct f-string interpolation of caller-supplied
+metadata keys and string values into the DELETE WHERE clause in
+`libs/agno/agno/vectordb/clickhouse/clickhousedb.py`.
+
+These tests are EXPECTED TO FAIL on the unfixed code (failure confirms the bug
+exists). They will PASS once the fix is in place — that is, once every metadata
+key and value is bound as a typed ClickHouse named parameter and unsafe keys
+are rejected with `ValueError` before any SQL is issued.
+
+Validates: Requirements 1.1, 1.2, 1.3, 2.1, 2.2, 2.3
+"""
+
+from typing import Any, Dict, List, Optional, Tuple
+from unittest.mock import MagicMock, patch
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from agno.vectordb.clickhouse import Clickhouse
+
+# ---------------------------------------------------------------------------
+# SQL meta-characters that the bug condition treats as injection signals.
+# Mirrors `containsSqlMetaCharacter` from the design document.
+# ---------------------------------------------------------------------------
+SQL_META_CHARS: Tuple[str, ...] = ("'", "\\", ";", "--", "/*", "*/")
+
+
+def _contains_sql_meta(s: str) -> bool:
+    return any(meta in s for meta in SQL_META_CHARS)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build a Clickhouse with a mocked client that records every
+# `client.command(...)` invocation as `(sql_text, parameters_dict)` tuples.
+# ---------------------------------------------------------------------------
+def _make_clickhouse() -> Tuple[Clickhouse, MagicMock, List[Tuple[str, Dict[str, Any]]]]:
+    """Construct a Clickhouse instance backed by a recording mock client.
+
+    Returns:
+        (clickhouse_instance, mock_client, command_calls)
+        where `command_calls` is a list of (sql_text, parameters_dict) captured
+        from every call to `mock_client.command(...)`.
+    """
+    captured: List[Tuple[str, Dict[str, Any]]] = []
+
+    mock_client = MagicMock()
+
+    def _record_command(sql_text: str, parameters: Optional[Dict[str, Any]] = None, *args, **kwargs):
+        # Defensive copy so later mutations of `parameters` don't poison capture.
+        captured.append((sql_text, dict(parameters) if parameters is not None else {}))
+        return None
+
+    mock_client.command.side_effect = _record_command
+
+    mock_embedder = MagicMock()
+    mock_embedder.dimensions = 1024
+
+    with patch("clickhouse_connect.get_client", return_value=mock_client):
+        db = Clickhouse(
+            table_name="test_table",
+            host="localhost",
+            database_name="test_db",
+            embedder=mock_embedder,
+            client=mock_client,
+        )
+
+    return db, mock_client, captured
+
+
+# ---------------------------------------------------------------------------
+# Concrete deterministic cases (Property 1: Bug Condition)
+# Each case asserts the FIXED behavior. On the UNFIXED code these MUST FAIL.
+# ---------------------------------------------------------------------------
+
+
+def test_value_with_sql_tautology_is_parameterized_not_interpolated():
+    """Value injection: ``{"source": "' OR '1'='1"}``.
+
+    On the fixed code the value MUST appear only in `parameters=`, never as a
+    literal substring of the SQL text.
+
+    Validates: Requirements 1.1, 2.1
+    """
+    db, mock_client, captured = _make_clickhouse()
+
+    result = db.delete_by_metadata({"source": "' OR '1'='1"})
+
+    assert result is True, "fixed code must return True for safe-key + str value"
+    assert len(captured) == 1, "client.command must be invoked exactly once"
+    sql_text, parameters = captured[0]
+
+    assert "' OR '1'='1" not in sql_text, (
+        f"value must not be interpolated into SQL text; expected parameter binding. SQL was: {sql_text!r}"
+    )
+    assert parameters.get("v_0") == "' OR '1'='1", (
+        f"value must be bound as parameter v_0; parameters were: {parameters!r}"
+    )
+
+
+def test_unsafe_key_raises_value_error_and_does_not_invoke_command():
+    """Key injection: ``{"x') = '1' OR ('1": "1"}``.
+
+    On the fixed code the unsafe key MUST be rejected with `ValueError` BEFORE
+    any DELETE statement is issued.
+
+    Validates: Requirements 1.2, 2.2
+    """
+    db, mock_client, captured = _make_clickhouse()
+
+    with pytest.raises(ValueError):
+        db.delete_by_metadata({"x') = '1' OR ('1": "1"})
+
+    assert mock_client.command.call_count == 0, "client.command must NEVER be invoked when a key fails the safe regex"
+    assert captured == [], "no SQL must be captured for an unsafe-key call"
+
+
+def test_value_with_unbalanced_quote_is_parameterized_and_not_swallowed():
+    """Single-quote in value: ``{"author": "O'Brien"}``.
+
+    On the unfixed code this produces malformed SQL (`= 'O'Brien'`) and the
+    broad `except Exception` swallows the ClickHouse parse error so the method
+    returns False. On the fixed code the value is bound as a parameter, no
+    parse error occurs, and the call returns True.
+
+    Validates: Requirements 1.3, 2.3
+    """
+    db, mock_client, captured = _make_clickhouse()
+
+    result = db.delete_by_metadata({"author": "O'Brien"})
+
+    assert result is True, (
+        "fixed code must return True; the broad-exception path must not be"
+        " triggered for a legitimate single-quote-in-value input"
+    )
+    assert len(captured) == 1, "client.command must be invoked exactly once"
+    sql_text, parameters = captured[0]
+
+    assert "= 'O'Brien'" not in sql_text, "fixed SQL must not contain the malformed literal '= \\'O\\'Brien\\''"
+    assert "O'Brien" not in sql_text, (
+        f"fixed SQL must not contain the value as a literal substring; SQL was: {sql_text!r}"
+    )
+    assert parameters.get("v_0") == "O'Brien", f"value must be bound as parameter v_0; parameters were: {parameters!r}"
+
+
+def test_value_with_trailing_backslash_is_parameterized():
+    """Value with trailing backslash: ``{"path": "C:\\\\"}`` (Python literal
+    ``"C:\\"``, i.e. ``C:`` followed by one backslash).
+
+    On the unfixed code the trailing backslash either rewrites the predicate or
+    triggers a parse error. On the fixed code the value is bound verbatim as a
+    `String` parameter.
+
+    Validates: Requirements 2.1, 2.3
+    """
+    db, mock_client, captured = _make_clickhouse()
+
+    result = db.delete_by_metadata({"path": "C:\\"})
+
+    assert result is True
+    assert len(captured) == 1
+    sql_text, parameters = captured[0]
+
+    assert "C:\\" not in sql_text, f"fixed SQL must not contain the value as a literal substring; SQL was: {sql_text!r}"
+    assert parameters.get("v_0") == "C:\\", (
+        f"value must be bound verbatim as parameter v_0; parameters were: {parameters!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property-based tests (Hypothesis)
+# ---------------------------------------------------------------------------
+
+
+# A printable-text strategy with each generated string forced to contain at
+# least one SQL meta-character. This keeps generation deterministic and
+# focused on the bug condition.
+_meta_char_st = st.sampled_from(SQL_META_CHARS)
+_filler_text_st = st.text(
+    alphabet=st.characters(
+        # Limit to printable Latin letters/digits/symbols so the literal
+        # substring check is unambiguous.
+        min_codepoint=0x20,
+        max_codepoint=0x7E,
+    ),
+    max_size=20,
+)
+
+
+@st.composite
+def _str_value_with_sql_meta(draw) -> str:
+    prefix = draw(_filler_text_st)
+    meta = draw(_meta_char_st)
+    suffix = draw(_filler_text_st)
+    return prefix + meta + suffix
+
+
+# Safe identifier-shaped key (matches the JSON-path safe regex from the spec).
+_safe_key_st = st.from_regex(r"\A[A-Za-z_][A-Za-z0-9_]{0,15}\Z", fullmatch=True)
+
+
+@settings(max_examples=50, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(key=_safe_key_st, value=_str_value_with_sql_meta())
+def test_pbt_string_values_with_sql_meta_chars_are_never_interpolated(key: str, value: str):
+    """For arbitrary safe keys and any string value containing at least one SQL
+    meta-character, the value MUST appear only in `parameters=`, never as a
+    literal substring of the emitted SQL text. The call MUST return True.
+
+    Validates: Requirements 2.1, 2.3
+    """
+    db, mock_client, captured = _make_clickhouse()
+
+    result = db.delete_by_metadata({key: value})
+
+    assert result is True
+    assert len(captured) == 1
+    sql_text, parameters = captured[0]
+
+    assert value not in sql_text, (
+        f"value must not appear as a literal substring of the emitted SQL; key={key!r} value={value!r} sql={sql_text!r}"
+    )
+    assert parameters.get("v_0") == value, f"value must be bound as parameter v_0; parameters={parameters!r}"
+
+
+# Unsafe-key strategy — covers empty strings, leading-digit names, whitespace,
+# and explicit injection meta-characters. We post-filter to guarantee the
+# generated key is genuinely unsafe (does not match the safe-key regex).
+_SAFE_KEY_RE_PATTERN = r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$"
+
+
+def _is_unsafe_key(s: str) -> bool:
+    import re as _re
+
+    return _re.match(_SAFE_KEY_RE_PATTERN, s) is None
+
+
+_unsafe_key_st = st.one_of(
+    st.just(""),  # empty
+    st.from_regex(r"\A[0-9][A-Za-z0-9_]*\Z", fullmatch=True),  # leading digit
+    st.from_regex(r"\A[A-Za-z_]+ [A-Za-z_]+\Z", fullmatch=True),  # contains space
+    st.from_regex(r"\A.*['();].*\Z", fullmatch=True),  # contains injection chars
+    st.from_regex(r"\A.*--.*\Z", fullmatch=True),  # contains SQL comment marker
+).filter(_is_unsafe_key)
+
+
+@settings(max_examples=50, deadline=None, suppress_health_check=[HealthCheck.too_slow, HealthCheck.filter_too_much])
+@given(unsafe_key=_unsafe_key_st)
+def test_pbt_unsafe_keys_always_raise_value_error(unsafe_key: str):
+    """For arbitrary keys that fail the safe JSON-path regex,
+    `delete_by_metadata` MUST raise `ValueError` and MUST NOT invoke
+    `client.command`.
+
+    Validates: Requirement 2.2
+    """
+    db, mock_client, captured = _make_clickhouse()
+
+    with pytest.raises(ValueError):
+        db.delete_by_metadata({unsafe_key: "1"})
+
+    assert mock_client.command.call_count == 0, f"client.command must not be invoked for unsafe key {unsafe_key!r}"
+    assert captured == [], f"no SQL must be captured for unsafe key {unsafe_key!r}"

--- a/libs/agno/tests/unit/vectordb/clickhouse/test_delete_by_metadata_preservation.py
+++ b/libs/agno/tests/unit/vectordb/clickhouse/test_delete_by_metadata_preservation.py
@@ -1,0 +1,484 @@
+"""
+Preservation tests for `Clickhouse.delete_by_metadata`.
+
+These tests encode the BASELINE behavior that must be preserved across the
+SQL-injection fix described in
+`.kiro/specs/clickhouse-delete-by-metadata-sqli/`.
+
+Methodology (observation-first):
+
+- All assertions encode behavior observed on the UNFIXED code AND known to
+  remain stable on the FIXED code. They MUST pass on the unfixed code, and
+  they MUST continue to pass after the fix in Task 3 is applied.
+- For inputs whose SQL text differs between unfixed (literal interpolation)
+  and fixed (named-parameter binding), only observable post-conditions that
+  are stable across both implementations are asserted: return value,
+  ``client.command`` invocation count, ``JSONExtract*`` function selection,
+  the `` AND ``-join structure, and the presence of ``log_debug`` /
+  ``log_info`` calls. The exact emitted SQL string is intentionally NOT
+  asserted in these preservation tests.
+
+Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8
+"""
+
+import inspect
+from typing import Any, Dict, List, Optional, Tuple, Union
+from unittest.mock import MagicMock, patch
+
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from agno.vectordb.clickhouse import Clickhouse
+
+# ---------------------------------------------------------------------------
+# Constants - mirror design.md
+# ---------------------------------------------------------------------------
+SQL_META_CHARS: Tuple[str, ...] = ("'", "\\", ";", "--", "/*", "*/")
+
+
+def _count_jsonextract(sql_text: str) -> int:
+    """Number of ``JSONExtract{String,Float,Bool}`` calls emitted in ``sql_text``."""
+    return sql_text.count("JSONExtractString") + sql_text.count("JSONExtractFloat") + sql_text.count("JSONExtractBool")
+
+
+# ---------------------------------------------------------------------------
+# Mock client helpers
+# ---------------------------------------------------------------------------
+def _make_clickhouse() -> Tuple[Clickhouse, MagicMock, List[Tuple[str, Dict[str, Any]]]]:
+    """Construct a Clickhouse instance backed by a recording mock client.
+
+    Returns:
+        (clickhouse_instance, mock_client, command_calls)
+        where ``command_calls`` is the list of ``(sql_text, parameters_dict)``
+        tuples captured from every call to ``mock_client.command(...)``.
+    """
+    captured: List[Tuple[str, Dict[str, Any]]] = []
+
+    mock_client = MagicMock()
+
+    def _record_command(sql_text: str, parameters: Optional[Dict[str, Any]] = None, *args, **kwargs):
+        captured.append((sql_text, dict(parameters) if parameters is not None else {}))
+        return None
+
+    mock_client.command.side_effect = _record_command
+
+    mock_embedder = MagicMock()
+    mock_embedder.dimensions = 1024
+
+    with patch("clickhouse_connect.get_client", return_value=mock_client):
+        db = Clickhouse(
+            table_name="test_table",
+            host="localhost",
+            database_name="test_db",
+            embedder=mock_embedder,
+            client=mock_client,
+        )
+
+    return db, mock_client, captured
+
+
+def _make_clickhouse_with_raising_client(exc: Exception) -> Tuple[Clickhouse, MagicMock]:
+    """Construct a Clickhouse instance whose mock ``client.command`` raises ``exc``."""
+    mock_client = MagicMock()
+    mock_client.command.side_effect = exc
+
+    mock_embedder = MagicMock()
+    mock_embedder.dimensions = 1024
+
+    with patch("clickhouse_connect.get_client", return_value=mock_client):
+        db = Clickhouse(
+            table_name="test_table",
+            host="localhost",
+            database_name="test_db",
+            embedder=mock_embedder,
+            client=mock_client,
+        )
+
+    return db, mock_client
+
+
+# ---------------------------------------------------------------------------
+# Concrete observation cases
+# Each asserts the OBSERVED behavior on the UNFIXED code that the FIXED code
+# must preserve.
+# ---------------------------------------------------------------------------
+
+
+def test_signature_unchanged():
+    """The public method signature must remain
+    ``delete_by_metadata(self, metadata: Dict[str, Any]) -> bool``.
+
+    Validates: Requirement 3.8
+    """
+    sig = inspect.signature(Clickhouse.delete_by_metadata)
+    params = list(sig.parameters.values())
+
+    assert [p.name for p in params] == ["self", "metadata"], f"unexpected parameters: {[p.name for p in params]!r}"
+    assert sig.return_annotation is bool, f"unexpected return annotation: {sig.return_annotation!r}"
+
+    metadata_param = sig.parameters["metadata"]
+    # Annotation may be a typing.Dict[str, Any] generic alias; just sanity-check it
+    # references Dict and Any in its repr — implementation detail of typing varies
+    # by Python version, so be tolerant here.
+    annotation_repr = repr(metadata_param.annotation)
+    assert "Dict" in annotation_repr or "dict" in annotation_repr, (
+        f"metadata annotation should be a Dict; got {annotation_repr!r}"
+    )
+
+
+def test_log_debug_called_once_at_method_entry_for_success_path():
+    """``log_debug`` is called exactly once at method entry with the
+    documented format string. This holds for unfixed and fixed code.
+
+    Validates: Requirement 3.8
+    """
+    db, _mock_client, _captured = _make_clickhouse()
+
+    metadata = {"category": "tech"}
+    with patch("agno.vectordb.clickhouse.clickhousedb.log_debug") as mock_log_debug:
+        result = db.delete_by_metadata(metadata)
+
+    assert result is True
+    assert mock_log_debug.call_count == 1, (
+        f"log_debug must be called exactly once; was called {mock_log_debug.call_count} times"
+    )
+    (call_args, _call_kwargs) = mock_log_debug.call_args
+    assert call_args == (f"ClickHouse VectorDB : Deleting documents with metadata {metadata}",), (
+        f"unexpected log_debug message: {call_args!r}"
+    )
+
+
+def test_log_debug_called_once_at_method_entry_for_empty_dict():
+    """``log_debug`` is called exactly once at method entry even when the
+    metadata dict is empty (the early-return path).
+
+    Validates: Requirement 3.8
+    """
+    db, mock_client, _captured = _make_clickhouse()
+
+    with patch("agno.vectordb.clickhouse.clickhousedb.log_debug") as mock_log_debug:
+        result = db.delete_by_metadata({})
+
+    assert result is False
+    assert mock_log_debug.call_count == 1
+    assert mock_client.command.call_count == 0
+
+
+def test_string_value_uses_jsonextractstring_and_returns_true():
+    """``delete_by_metadata({"category": "tech"})`` returns True; the SQL
+    uses ``JSONExtractString``.
+
+    Validates: Requirements 3.1, 3.5
+    """
+    db, _mock_client, captured = _make_clickhouse()
+
+    result = db.delete_by_metadata({"category": "tech"})
+
+    assert result is True
+    assert len(captured) == 1
+    sql_text, _params = captured[0]
+    assert "JSONExtractString" in sql_text
+    assert _count_jsonextract(sql_text) == 1
+
+
+def test_int_value_uses_jsonextractfloat_and_returns_true():
+    """``delete_by_metadata({"year": 2024})`` returns True; SQL uses
+    ``JSONExtractFloat``.
+
+    Validates: Requirement 3.2
+    """
+    db, _mock_client, captured = _make_clickhouse()
+
+    result = db.delete_by_metadata({"year": 2024})
+
+    assert result is True
+    assert len(captured) == 1
+    sql_text, _params = captured[0]
+    assert "JSONExtractFloat" in sql_text
+    assert "JSONExtractBool" not in sql_text
+    assert "JSONExtractString" not in sql_text
+
+
+def test_float_value_uses_jsonextractfloat_and_returns_true():
+    """``delete_by_metadata({"score": 0.5})`` returns True; SQL uses
+    ``JSONExtractFloat``.
+
+    Validates: Requirement 3.2
+    """
+    db, _mock_client, captured = _make_clickhouse()
+
+    result = db.delete_by_metadata({"score": 0.5})
+
+    assert result is True
+    assert len(captured) == 1
+    sql_text, _params = captured[0]
+    assert "JSONExtractFloat" in sql_text
+    assert "JSONExtractBool" not in sql_text
+
+
+def test_bool_value_uses_jsonextractbool_dispatched_before_int_float():
+    """``delete_by_metadata({"published": True})`` returns True; SQL uses
+    ``JSONExtractBool`` (``bool`` is dispatched BEFORE the ``int``/``float``
+    branch, since ``bool`` is a subclass of ``int`` in Python).
+
+    Validates: Requirement 3.3
+    """
+    db, _mock_client, captured = _make_clickhouse()
+
+    result = db.delete_by_metadata({"published": True})
+
+    assert result is True
+    assert len(captured) == 1
+    sql_text, _params = captured[0]
+    assert "JSONExtractBool" in sql_text, "bool must dispatch to JSONExtractBool, not JSONExtractFloat"
+    assert "JSONExtractFloat" not in sql_text
+
+
+def test_multi_key_dict_emits_and_combined_conditions():
+    """``delete_by_metadata({"category": "tech", "year": 2024})`` returns True;
+    the SQL has both conditions joined by `` AND ``.
+
+    Validates: Requirement 3.4
+    """
+    db, _mock_client, captured = _make_clickhouse()
+
+    result = db.delete_by_metadata({"category": "tech", "year": 2024})
+
+    assert result is True
+    assert len(captured) == 1
+    sql_text, _params = captured[0]
+    # Exactly one condition per dict entry, joined with " AND "
+    assert _count_jsonextract(sql_text) == 2
+    assert " AND " in sql_text
+    # And both function selections are present
+    assert "JSONExtractString" in sql_text
+    assert "JSONExtractFloat" in sql_text
+
+
+def test_empty_dict_returns_false_and_command_never_called():
+    """``delete_by_metadata({})`` returns False and ``client.command`` is
+    NEVER called.
+
+    Validates: Requirement 3.6
+    """
+    db, mock_client, captured = _make_clickhouse()
+
+    result = db.delete_by_metadata({})
+
+    assert result is False
+    assert mock_client.command.call_count == 0
+    assert captured == []
+
+
+def test_unexpected_client_exception_returns_false_and_logs_info():
+    """When ``client.command`` raises an unexpected exception, the method
+    returns False and ``log_info`` is called once with a message containing
+    the exception text and the metadata representation.
+
+    Validates: Requirement 3.7
+    """
+    metadata = {"k": "v"}
+    db, mock_client = _make_clickhouse_with_raising_client(Exception("boom"))
+
+    with patch("agno.vectordb.clickhouse.clickhousedb.log_info") as mock_log_info:
+        result = db.delete_by_metadata(metadata)
+
+    assert result is False
+    assert mock_client.command.call_count == 1
+    assert mock_log_info.call_count == 1, (
+        f"log_info must be called exactly once on unexpected exception; was called {mock_log_info.call_count} times"
+    )
+    (log_args, _log_kwargs) = mock_log_info.call_args
+    assert len(log_args) == 1
+    log_message = log_args[0]
+    assert "boom" in log_message, f"log_info message should contain 'boom'; got {log_message!r}"
+    assert repr(metadata) in log_message or str(metadata) in log_message, (
+        f"log_info message should contain the metadata repr/str; got {log_message!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Property-based tests (Hypothesis)
+#
+# These properties encode behavior that is stable on BOTH the unfixed and the
+# fixed code: return value, command-invocation count, JSONExtract* function
+# selection, and `` AND ``-join structure. The exact SQL text differs between
+# the two implementations (literal interpolation vs named-parameter binding),
+# so it is intentionally not asserted here.
+# ---------------------------------------------------------------------------
+
+
+# Safe identifier-shaped key (matches the JSON-path safe regex from the spec).
+_safe_key_st = st.from_regex(r"\A[A-Za-z_][A-Za-z0-9_]{0,15}\Z", fullmatch=True)
+
+
+# String value strategy that excludes every SQL meta-character listed in
+# the design (single quote, backslash, semicolon, dash, slash, star). This
+# guarantees the value cannot break out of the f-string-interpolated form
+# used by the UNFIXED code and is therefore safe to compare across both
+# implementations.
+_safe_str_value_st = st.text(
+    alphabet=st.characters(
+        min_codepoint=0x20,
+        max_codepoint=0x7E,
+        blacklist_characters="'\\;-/*",
+    ),
+    max_size=20,
+)
+
+
+# Mixed-type value strategy for the safe-input property.
+_safe_mixed_value_st = st.one_of(
+    _safe_str_value_st,
+    st.integers(min_value=-1_000_000, max_value=1_000_000),
+    st.floats(min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False),
+    st.booleans(),
+)
+
+
+@settings(max_examples=50, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(
+    metadata=st.dictionaries(
+        keys=_safe_key_st,
+        values=_safe_mixed_value_st,
+        min_size=1,
+        max_size=5,
+    )
+)
+def test_pbt_safe_inputs_preserve_original_behavior(metadata: Dict[str, Any]):
+    """For any dict whose keys match the safe JSON-path regex and whose
+    string values exclude SQL meta-characters, the observable post-conditions
+    must match the recorded baseline:
+
+    - ``return_value == True``
+    - ``client.command`` is invoked exactly once
+    - the number of emitted conditions equals ``len(metadata)`` (one
+      ``JSONExtract*`` call per entry)
+
+    The exact SQL text is intentionally not compared because it differs
+    between the unfixed and fixed implementations.
+
+    Validates: Requirements 3.1, 3.2, 3.3, 3.5
+    """
+    db, _mock_client, captured = _make_clickhouse()
+
+    result = db.delete_by_metadata(metadata)
+
+    assert result is True
+    assert len(captured) == 1
+    sql_text, _params = captured[0]
+    assert _count_jsonextract(sql_text) == len(metadata), (
+        f"expected one JSONExtract* call per dict entry; metadata={metadata!r} sql={sql_text!r}"
+    )
+
+
+@settings(max_examples=30, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(key=_safe_key_st, value=st.booleans())
+def test_pbt_bool_dispatched_before_int_float(key: str, value: bool):
+    """For ``bool`` values the emitted SQL MUST use ``JSONExtractBool`` and
+    MUST NOT use ``JSONExtractFloat``. Since ``bool`` is a subclass of
+    ``int`` in Python, this guards against silent coercion to ``1.0`` /
+    ``0.0`` via the int/float branch.
+
+    The exact bound-parameter form differs between unfixed (literal
+    ``true``/``false`` in the SQL) and fixed (a ``Bool``-typed parameter),
+    so only the ``JSONExtractBool`` selection is asserted here.
+
+    Validates: Requirement 3.3
+    """
+    db, _mock_client, captured = _make_clickhouse()
+
+    result = db.delete_by_metadata({key: value})
+
+    assert result is True
+    assert len(captured) == 1
+    sql_text, _params = captured[0]
+    assert "JSONExtractBool" in sql_text, (
+        f"bool value must dispatch to JSONExtractBool; key={key!r} value={value!r} sql={sql_text!r}"
+    )
+    assert "JSONExtractFloat" not in sql_text, (
+        f"bool must not dispatch to JSONExtractFloat; key={key!r} value={value!r} sql={sql_text!r}"
+    )
+
+
+# A non-bool numeric value: int (excluding True/False) or finite float.
+_non_bool_numeric_st = st.one_of(
+    st.integers(min_value=-1_000_000, max_value=1_000_000),
+    st.floats(min_value=-1e6, max_value=1e6, allow_nan=False, allow_infinity=False),
+).filter(lambda v: not isinstance(v, bool))
+
+
+@settings(max_examples=50, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(key=_safe_key_st, value=_non_bool_numeric_st)
+def test_pbt_int_float_use_jsonextractfloat(key: str, value: Union[int, float]):
+    """For ``int`` (excluding ``bool``) and ``float`` values, the emitted
+    SQL MUST use ``JSONExtractFloat``.
+
+    Validates: Requirement 3.2
+    """
+    # Sanity guard: the strategy must never produce a bool here.
+    assert not isinstance(value, bool)
+
+    db, _mock_client, captured = _make_clickhouse()
+
+    result = db.delete_by_metadata({key: value})
+
+    assert result is True
+    assert len(captured) == 1
+    sql_text, _params = captured[0]
+    assert "JSONExtractFloat" in sql_text, (
+        f"int/float must dispatch to JSONExtractFloat; key={key!r} value={value!r} sql={sql_text!r}"
+    )
+
+
+@settings(max_examples=50, deadline=None, suppress_health_check=[HealthCheck.too_slow])
+@given(
+    metadata=st.dictionaries(
+        keys=_safe_key_st,
+        values=_safe_mixed_value_st,
+        min_size=2,
+        max_size=5,
+    )
+)
+def test_pbt_and_combined_matching_preserved(metadata: Dict[str, Any]):
+    """For dicts of size >= 2 with mixed value types, the emitted SQL MUST:
+
+    - join all conditions with `` AND `` (so the operator appears exactly
+      ``len(metadata) - 1`` times),
+    - emit exactly one ``JSONExtract*`` call per dict entry.
+
+    Validates: Requirement 3.4
+    """
+    db, _mock_client, captured = _make_clickhouse()
+
+    result = db.delete_by_metadata(metadata)
+
+    assert result is True
+    assert len(captured) == 1
+    sql_text, _params = captured[0]
+
+    n = len(metadata)
+    assert _count_jsonextract(sql_text) == n, (
+        f"expected exactly {n} JSONExtract* calls; metadata={metadata!r} sql={sql_text!r}"
+    )
+    assert sql_text.count(" AND ") == n - 1, (
+        f"expected exactly {n - 1} ' AND ' separators; metadata={metadata!r} sql={sql_text!r}"
+    )
+
+
+def test_pbt_empty_dict_returns_false_no_command():
+    """For the single input ``{}``, ``delete_by_metadata`` MUST return
+    ``False`` and ``client.command`` MUST NEVER be invoked.
+
+    This is encoded as a property over the (degenerate) single-element
+    domain ``{ {} }`` so it sits alongside the other PBT entries.
+
+    Validates: Requirement 3.6
+    """
+    db, mock_client, captured = _make_clickhouse()
+
+    result = db.delete_by_metadata({})
+
+    assert result is False
+    assert mock_client.command.call_count == 0
+    assert captured == []

--- a/libs/agno/tests/unit/vectordb/test_clickhousedb.py
+++ b/libs/agno/tests/unit/vectordb/test_clickhousedb.py
@@ -521,10 +521,18 @@ def test_delete_by_metadata(mock_clickhouse):
     result = mock_clickhouse.delete_by_metadata({"type": "test"})
     assert result is True
 
-    # Verify the delete command was executed with proper WHERE clause
+    # Verify the delete command was executed with proper WHERE clause.
+    # Metadata keys and values are bound as named ClickHouse parameters
+    # (`k_{i}:String` / `v_{i}:String|Float64|Bool`) rather than interpolated
+    # into the SQL text, to prevent SQL injection (see issue #7866).
     mock_clickhouse.client.command.assert_called_with(
-        "DELETE FROM {database_name:Identifier}.{table_name:Identifier} WHERE JSONExtractString(toString(filters), 'type') = 'test'",
-        parameters={"table_name": mock_clickhouse.table_name, "database_name": mock_clickhouse.database_name},
+        "DELETE FROM {database_name:Identifier}.{table_name:Identifier} WHERE JSONExtractString(toString(filters), {k_0:String}) = {v_0:String}",
+        parameters={
+            "table_name": mock_clickhouse.table_name,
+            "database_name": mock_clickhouse.database_name,
+            "k_0": "type",
+            "v_0": "test",
+        },
     )
 
     # Test deletion with complex metadata
@@ -534,8 +542,15 @@ def test_delete_by_metadata(mock_clickhouse):
 
     # Verify the delete command was executed with multiple conditions
     mock_clickhouse.client.command.assert_called_with(
-        "DELETE FROM {database_name:Identifier}.{table_name:Identifier} WHERE JSONExtractString(toString(filters), 'cuisine') = 'Thai' AND JSONExtractBool(toString(filters), 'spicy') = true",
-        parameters={"table_name": mock_clickhouse.table_name, "database_name": mock_clickhouse.database_name},
+        "DELETE FROM {database_name:Identifier}.{table_name:Identifier} WHERE JSONExtractString(toString(filters), {k_0:String}) = {v_0:String} AND JSONExtractBool(toString(filters), {k_1:String}) = {v_1:Bool}",
+        parameters={
+            "table_name": mock_clickhouse.table_name,
+            "database_name": mock_clickhouse.database_name,
+            "k_0": "cuisine",
+            "v_0": "Thai",
+            "k_1": "spicy",
+            "v_1": True,
+        },
     )
 
     # Test deletion with empty metadata


### PR DESCRIPTION
Bind every metadata key and value as a typed ClickHouse named parameter, and validate keys against a safe JSON-path regex before any SQL is issued. The previous implementation interpolated metadata into the WHERE clause via f-string, allowing values like "' OR '1'='1" to rewrite the predicate into a tautology and mass-delete the table. Mirrors the parameter-binding pattern already used by Clickhouse.update_metadata in the same file.

Adds property-based tests covering both the bug condition (Hypothesis-generated unsafe keys and meta-character-bearing values) and preservation (signature, log_debug, JSONExtract* dispatch, AND-combined matching, empty-dict early return, broad-exception path). Updates the existing test_delete_by_metadata to assert against the parameterized SQL form.

Fixes #7866.

## Summary

Describe key changes, mention related issues or motivation for the changes.

(If applicable, issue number: #\_\_\_\_)

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Improvement
- [x] Model update
- [x] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
