### PR TITLE
fix: WS auth fails closed on JWT validator misconfiguration

### DIFF
--- a/libs/agno/agno/os/middleware/user_scope.py
+++ b/libs/agno/agno/os/middleware/user_scope.py
@@ -15,6 +15,25 @@ itself. The trade is fewer moving parts and clearer dispatch, at the cost
 of a per-endpoint convention: every user-scoped read passes ``user_id``,
 every write goes through ``enforce_owner_on_entity`` before persisting.
 
+.. important::
+
+   **Adding a new router endpoint that handles user-owned data?**
+
+   You MUST call one of the scoping helpers (``get_scoped_user_id``,
+   ``resolve_db_and_scope``, or ``apply_scope_to_kwargs``) and thread the
+   resulting ``user_id`` into every DB read/write. Omitting this will
+   silently bypass user isolation with no runtime error.
+
+   Pattern for reads::
+
+       scoped_user_id = get_scoped_user_id(request)
+       db.get_sessions(user_id=scoped_user_id, ...)
+
+   Pattern for writes::
+
+       enforce_owner_on_entity(entity, request)
+       db.upsert_session(entity)
+
 Admin users (with the configured ``admin_scope``) and callers running with
 isolation disabled get ``None`` from ``get_scoped_user_id`` — both helpers
 become no-ops in that case, preserving the legacy unscoped behaviour.

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -403,9 +403,13 @@ def get_websocket_router(
 
                 elif action == "start-workflow":
                     # Enforce workflow-level RBAC whenever JWT auth is enabled.
-                    # Missing/empty scopes must deny, matching HTTP middleware semantics.
+                    # Check RBAC unconditionally — do not skip when workflow_id
+                    # is absent, otherwise an unauthenticated-scope caller can
+                    # bypass the permission gate by omitting workflow_id and
+                    # letting the downstream handler reject it *after* any
+                    # side-effects.
                     workflow_id = message.get("workflow_id")
-                    if jwt_auth_enabled and workflow_id:
+                    if jwt_auth_enabled:
                         user_scopes = websocket_user_context.get("scopes", [])
                         if not has_required_scopes(
                             user_scopes,

--- a/libs/agno/agno/os/router.py
+++ b/libs/agno/agno/os/router.py
@@ -304,9 +304,13 @@ def get_websocket_router(
         ws_admin_scope: str = ws_jwt_config.get("admin_scope") or AgentOSScope.ADMIN.value
         ws_user_isolation_enabled: bool = bool(ws_jwt_config.get("user_isolation", False))
         jwt_auth_enabled = jwt_validator is not None
+        # auth_required is True when JWTMiddleware is configured, even if the
+        # validator could not be constructed (e.g. bad JWKS path). This prevents
+        # silently falling through to unauthenticated mode on misconfiguration.
+        jwt_auth_required = bool(ws_jwt_config.get("auth_required", False))
 
         # Determine auth requirements - JWT takes precedence over legacy
-        requires_auth = jwt_auth_enabled or bool(settings.os_security_key)
+        requires_auth = jwt_auth_enabled or jwt_auth_required or bool(settings.os_security_key)
 
         await websocket_manager.connect(websocket, requires_auth=requires_auth)
 
@@ -326,7 +330,21 @@ def get_websocket_router(
                         await websocket.send_text(json.dumps({"event": "auth_error", "error": "Token is required"}))
                         continue
 
-                    if jwt_auth_enabled and jwt_validator:
+                    if jwt_auth_required and not jwt_auth_enabled:
+                        # JWTMiddleware is configured but the validator could
+                        # not be constructed (e.g. bad JWKS path). Reject
+                        # rather than silently falling through to legacy auth.
+                        await websocket.send_text(
+                            json.dumps(
+                                {
+                                    "event": "auth_error",
+                                    "error": "JWT authentication is misconfigured on the server",
+                                    "error_type": "server_error",
+                                }
+                            )
+                        )
+                        continue
+                    elif jwt_auth_enabled and jwt_validator:
                         # Use JWT validator for token validation. Honour the
                         # configured audience so verify_audience=True applies to
                         # WebSocket tokens, not just HTTP requests.
@@ -368,7 +386,7 @@ def get_websocket_router(
 
                 # Check authentication for all other actions (only when required)
                 elif requires_auth and not websocket_manager.is_authenticated(websocket):
-                    auth_type = "JWT" if jwt_auth_enabled else "bearer token"
+                    auth_type = "JWT" if (jwt_auth_enabled or jwt_auth_required) else "bearer token"
                     await websocket.send_text(
                         json.dumps(
                             {

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -324,6 +324,7 @@ async def _resume_stream_generator(
     run_id: str,
     last_event_index: Optional[int],
     session_id: Optional[str],
+    user_id: Optional[str] = None,
 ) -> AsyncGenerator:
     """SSE generator for the /resume endpoint.
 
@@ -338,7 +339,7 @@ async def _resume_stream_generator(
         # PATH 3: Not in buffer -- fall back to database
         if session_id and not isinstance(agent, RemoteAgent):
             try:
-                run_output = await agent.aget_run_output(run_id=run_id, session_id=session_id)
+                run_output = await agent.aget_run_output(run_id=run_id, session_id=session_id, user_id=user_id)
             except Exception as e:
                 error = {"event": "error", "error": f"Failed to fetch run from database: {str(e)}"}
                 yield f"event: error\ndata: {json.dumps(error)}\n\n"
@@ -581,7 +582,12 @@ def get_agent_router(
     ):
         kwargs = await get_request_kwargs(request, create_agent_run)
 
-        if hasattr(request.state, "user_id") and request.state.user_id is not None:
+        # Scoped non-admin callers always get their JWT sub as user_id.
+        # Admins and unscoped callers fall through to middleware/form values.
+        scoped_user_id = get_scoped_user_id(request)
+        if scoped_user_id is not None:
+            user_id = scoped_user_id
+        elif hasattr(request.state, "user_id") and request.state.user_id is not None:
             if user_id and user_id != request.state.user_id:
                 log_warning("User ID parameter passed in both request state and kwargs, using request state")
             user_id = request.state.user_id
@@ -1442,7 +1448,7 @@ def get_agent_router(
             )
 
         return StreamingResponse(
-            _resume_stream_generator(agent, run_id, last_event_index, session_id),  # type: ignore[arg-type]
+            _resume_stream_generator(agent, run_id, last_event_index, session_id, user_id=scoped_user_id),  # type: ignore[arg-type]
             media_type="text/event-stream",
         )
 

--- a/libs/agno/agno/os/routers/approvals/router.py
+++ b/libs/agno/agno/os/routers/approvals/router.py
@@ -171,15 +171,11 @@ def get_approval_router(os_db: Any, settings: Any) -> APIRouter:
         # Admin-only resolve when user_isolation is on. ``get_scoped_user_id``
         # returns a non-None value precisely when the caller is a non-admin
         # authenticated user under ``AuthorizationConfig(user_isolation=True)``
-        # — admins and isolation-off / no-JWT callers fall through and keep
-        # the legacy behaviour. Self-approve is disallowed in this mode
-        # because the row's ``user_id`` is the requester, not the approver.
+        # - admins and isolation-off / no-JWT callers fall through and keep
+        # the legacy behaviour. Return 404 (not 403) to avoid leaking the
+        # existence of the approval to non-admin callers.
         if get_scoped_user_id(request) is not None:
-            raise HTTPException(status_code=403, detail="Only an admin may resolve this approval")
-
-        # Owner check — non-admin callers cannot resolve other users' approvals.
-        # _load_approval_for_user raises 404 if the approval doesn't belong to them.
-        await _load_approval_for_user(approval_id, request)
+            raise HTTPException(status_code=404, detail="Approval not found")
 
         now = int(time.time())
         # Audit trail: ``resolved_by`` records the human who clicked resolve,
@@ -221,15 +217,11 @@ def get_approval_router(os_db: Any, settings: Any) -> APIRouter:
         approval_id: str,
         _: bool = Depends(auth_dependency),
     ) -> None:
-        # Admin-only delete under user_isolation (see ``resolve_approval`` for
-        # the same rationale). Non-admin scoped callers cannot delete any
-        # approval — including their own — because the row is the audit
-        # record of a requested action, not a personal note.
+        # Admin-only delete under user_isolation - return 404 to avoid
+        # leaking existence. Non-admin scoped callers cannot delete any
+        # approval because the row is an audit record.
         if get_scoped_user_id(request) is not None:
-            raise HTTPException(status_code=403, detail="Only an admin may delete this approval")
-
-        # Owner check — non-admin callers cannot delete other users' approvals.
-        await _load_approval_for_user(approval_id, request)
+            raise HTTPException(status_code=404, detail="Approval not found")
         deleted = await _db_call("delete_approval", approval_id)
         if not deleted:
             raise HTTPException(status_code=500, detail="Failed to delete approval")

--- a/libs/agno/agno/os/routers/memory/memory.py
+++ b/libs/agno/agno/os/routers/memory/memory.py
@@ -10,10 +10,7 @@ from agno.db.base import AsyncBaseDb, BaseDb
 from agno.db.schemas import UserMemory
 from agno.models.utils import get_model
 from agno.os.auth import get_auth_token_from_request, get_authentication_dependency
-from agno.os.middleware.user_scope import (
-    get_scoped_user_id,
-    resolve_db_and_scope,
-)
+from agno.os.middleware.user_scope import get_scoped_user_id, resolve_db_and_scope
 from agno.os.routers.memory.schemas import (
     DeleteMemoriesRequest,
     OptimizeMemoriesRequest,
@@ -94,16 +91,13 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
         db_id: Optional[str] = Query(default=None, description="Database ID to use for memory storage"),
         table: Optional[str] = Query(default=None, description="Table to use for memory storage"),
     ) -> UserMemorySchema:
-        # Force payload.user_id to the JWT user for non-admin callers. Admins
-        # (get_scoped_user_id returns None) may create on behalf of anyone.
-        scoped_user_id = get_scoped_user_id(request)
-        if scoped_user_id is not None:
-            payload.user_id = scoped_user_id
+        db, effective_user_id = await resolve_db_and_scope(request, dbs, db_id, table, fallback_user_id=payload.user_id)
+        # Scoped callers get their JWT sub; admins/unscoped get the payload value.
+        if effective_user_id is not None:
+            payload.user_id = effective_user_id
 
         if payload.user_id is None:
             raise HTTPException(status_code=400, detail="User ID is required")
-
-        db, _ = await resolve_db_and_scope(request, dbs, db_id, table)
 
         if isinstance(db, RemoteDb):
             auth_token = get_auth_token_from_request(request)
@@ -207,13 +201,11 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
         db_id: Optional[str] = Query(default=None, description="Database ID to use for deletion"),
         table: Optional[str] = Query(default=None, description="Table to use for deletion"),
     ) -> None:
-        db, _ = await resolve_db_and_scope(http_request, dbs, db_id, table)
-
-        # Non-admin callers may only act on their own memories. Admins keep
-        # act-on-behalf semantics (the user_id in the body is honoured).
-        scoped_user_id = get_scoped_user_id(http_request)
-        if scoped_user_id is not None:
-            request.user_id = scoped_user_id
+        db, effective_user_id = await resolve_db_and_scope(
+            http_request, dbs, db_id, table, fallback_user_id=request.user_id
+        )
+        if effective_user_id is not None:
+            request.user_id = effective_user_id
 
         if isinstance(db, RemoteDb):
             auth_token = get_auth_token_from_request(http_request)
@@ -489,16 +481,24 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
         db_id: Optional[str] = Query(default=None, description="Database ID to use for update"),
         table: Optional[str] = Query(default=None, description="Table to use for update"),
     ) -> UserMemorySchema:
-        # Force payload.user_id to the JWT user for non-admin callers. Admins
-        # (get_scoped_user_id returns None) may update memories belonging to anyone.
-        scoped_user_id = get_scoped_user_id(request)
-        if scoped_user_id is not None:
-            payload.user_id = scoped_user_id
+        db, effective_user_id = await resolve_db_and_scope(request, dbs, db_id, table, fallback_user_id=payload.user_id)
+        if effective_user_id is not None:
+            payload.user_id = effective_user_id
 
         if payload.user_id is None:
             raise HTTPException(status_code=400, detail="User ID is required")
 
-        db, _ = await resolve_db_and_scope(request, dbs, db_id, table)
+        # For scoped callers, verify the existing memory belongs to them
+        # before allowing the upsert. Without this, a caller could overwrite
+        # another user's memory_id by supplying it in the path.
+        scoped_user_id = get_scoped_user_id(request)
+        if scoped_user_id is not None and not isinstance(db, RemoteDb):
+            if isinstance(db, AsyncBaseDb):
+                existing = await cast(AsyncBaseDb, db).get_user_memory(memory_id=memory_id, user_id=scoped_user_id)
+            else:
+                existing = db.get_user_memory(memory_id=memory_id, user_id=scoped_user_id)
+            if existing is None:
+                raise HTTPException(status_code=404, detail="Memory not found")
 
         if isinstance(db, RemoteDb):
             auth_token = get_auth_token_from_request(request)
@@ -673,14 +673,12 @@ def attach_routes(router: APIRouter, dbs: dict[str, list[Union[BaseDb, AsyncBase
         from agno.memory import MemoryManager
         from agno.memory.strategies.types import MemoryOptimizationStrategyType
 
-        # Non-admin callers may only optimize their own memories. Admins keep
-        # act-on-behalf semantics.
-        scoped_user_id = get_scoped_user_id(http_request)
-        if scoped_user_id is not None:
-            request.user_id = scoped_user_id
-
         try:
-            db, _ = await resolve_db_and_scope(http_request, dbs, db_id, table)
+            db, effective_user_id = await resolve_db_and_scope(
+                http_request, dbs, db_id, table, fallback_user_id=request.user_id
+            )
+            if effective_user_id is not None:
+                request.user_id = effective_user_id
 
             if isinstance(db, RemoteDb):
                 auth_token = get_auth_token_from_request(http_request)

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -209,6 +209,7 @@ async def _resume_stream_generator(
     run_id: str,
     last_event_index: Optional[int],
     session_id: Optional[str],
+    user_id: Optional[str] = None,
 ) -> AsyncGenerator:
     """SSE generator for the /resume endpoint.
 
@@ -223,7 +224,7 @@ async def _resume_stream_generator(
         # PATH 3: Not in buffer -- fall back to database
         if session_id and not isinstance(team, RemoteTeam):
             try:
-                run_output = await team.aget_run_output(run_id=run_id, session_id=session_id)
+                run_output = await team.aget_run_output(run_id=run_id, session_id=session_id, user_id=user_id)
             except Exception as e:
                 error = {"event": "error", "error": f"Failed to fetch run from database: {str(e)}"}
                 yield f"event: error\ndata: {json.dumps(error)}\n\n"
@@ -577,7 +578,12 @@ def get_team_router(
     ):
         kwargs = await get_request_kwargs(request, create_team_run)
 
-        if hasattr(request.state, "user_id") and request.state.user_id is not None:
+        # Scoped non-admin callers always get their JWT sub as user_id.
+        # Admins and unscoped callers fall through to middleware/form values.
+        scoped_user_id = get_scoped_user_id(request)
+        if scoped_user_id is not None:
+            user_id = scoped_user_id
+        elif hasattr(request.state, "user_id") and request.state.user_id is not None:
             if user_id and user_id != request.state.user_id:
                 log_warning("User ID parameter passed in both request state and kwargs, using request state")
             user_id = request.state.user_id
@@ -937,7 +943,7 @@ def get_team_router(
             )
 
         return StreamingResponse(
-            _resume_stream_generator(team, run_id, last_event_index, session_id),
+            _resume_stream_generator(team, run_id, last_event_index, session_id, user_id=scoped_user_id),
             media_type="text/event-stream",
         )
 

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -464,15 +464,19 @@ async def handle_workflow_continue_via_websocket(
             await websocket.send_text(json.dumps({"event": "error", "error": "run_id is required"}))
             return
 
-        # Enforce ownership for non-admin callers when user isolation is enabled
+        # Enforce ownership for non-admin callers when user isolation is enabled.
+        # Mirrors the HTTP cancel/resume routes: a non-admin caller must own
+        # both the session and the run before we even fetch the paused state.
         if ws_auth and ws_auth.jwt_enabled and ws_auth.user_isolation_enabled and not ws_auth.is_admin and user_id:
             if not session_id:
                 await websocket.send_text(json.dumps({"event": "error", "error": SESSION_ID_REQUIRED}))
                 return
+            # Prefer the factory's db when this workflow_id is a factory entry;
+            # only fall back to os.db when no factory-specific db is configured.
+            # This matches the pattern the HTTP cancel/resume routes use.
+            factory = find_factory_by_id(workflow_id, os.workflows)
+            check_db = getattr(factory, "db", None) or os.db
             try:
-                from agno.os.utils import get_db
-
-                check_db = get_db(os)
                 await verify_run_in_session_via_db(
                     check_db,
                     session_id,

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -77,6 +77,23 @@ async def handle_workflow_via_websocket(
         user_id = message.get("user_id")
         factory_input = message.get("factory_input")
 
+        # Defense-in-depth: if the caller authenticated via JWT, ensure user_id
+        # matches the JWT sub for non-admin callers. The WS dispatcher in
+        # router.py already forces this, but the handler should not trust a
+        # client-supplied user_id if called from any other code path.
+        if ws_user_context:
+            jwt_user_id = ws_user_context.get("user_id")
+            if jwt_user_id:
+                from agno.os.scopes import AgentOSScope
+
+                scopes = ws_user_context.get("scopes", [])
+                admin_scope = AgentOSScope.ADMIN.value
+                is_admin = admin_scope in scopes
+                if is_admin:
+                    user_id = user_id or jwt_user_id
+                else:
+                    user_id = jwt_user_id
+
         if not workflow_id:
             await websocket.send_text(json.dumps({"event": "error", "error": "workflow_id is required"}))
             return
@@ -426,12 +443,18 @@ async def handle_workflow_subscription(
         )
 
 
-async def handle_workflow_continue_via_websocket(websocket: WebSocket, message: dict, os: "AgentOS"):
+async def handle_workflow_continue_via_websocket(
+    websocket: WebSocket,
+    message: dict,
+    os: "AgentOS",
+    ws_auth: Optional[WebSocketAuthContext] = None,
+):
     """Handle continuing a paused workflow run via WebSocket"""
     try:
         workflow_id = message.get("workflow_id")
         run_id = message.get("run_id")
         session_id = message.get("session_id")
+        user_id = message.get("user_id")
         step_requirements_data = message.get("step_requirements")
 
         if not workflow_id:
@@ -440,6 +463,27 @@ async def handle_workflow_continue_via_websocket(websocket: WebSocket, message: 
         if not run_id:
             await websocket.send_text(json.dumps({"event": "error", "error": "run_id is required"}))
             return
+
+        # Enforce ownership for non-admin callers when user isolation is enabled
+        if ws_auth and ws_auth.jwt_enabled and ws_auth.user_isolation_enabled and not ws_auth.is_admin and user_id:
+            if not session_id:
+                await websocket.send_text(json.dumps({"event": "error", "error": SESSION_ID_REQUIRED}))
+                return
+            try:
+                from agno.os.utils import get_db
+
+                check_db = get_db(os)
+                await verify_run_in_session_via_db(
+                    check_db,
+                    session_id,
+                    run_id,
+                    user_id,
+                    component_type="workflows",
+                    component_id=workflow_id,
+                )
+            except HTTPException:
+                await websocket.send_text(json.dumps({"event": "error", "error": f"Run {run_id} not found"}))
+                return
 
         workflow = get_workflow_by_id(
             workflow_id=workflow_id, workflows=os.workflows, db=os.db, registry=os.registry, create_fresh=True
@@ -454,7 +498,7 @@ async def handle_workflow_continue_via_websocket(websocket: WebSocket, message: 
             return
 
         # Load the paused run
-        existing_run = await workflow.aget_run_output(run_id=run_id, session_id=session_id)
+        existing_run = await workflow.aget_run_output(run_id=run_id, session_id=session_id, user_id=user_id)
         if existing_run is None:
             await websocket.send_text(json.dumps({"event": "error", "error": f"Run {run_id} not found"}))
             return
@@ -735,6 +779,7 @@ async def _resume_stream_generator(
     run_id: str,
     last_event_index: Optional[int],
     session_id: Optional[str],
+    user_id: Optional[str] = None,
 ) -> AsyncGenerator:
     """SSE generator for the /resume endpoint.
 
@@ -751,7 +796,7 @@ async def _resume_stream_generator(
         # PATH 3: Not in buffer -- fall back to database
         if session_id and not isinstance(workflow, RemoteWorkflow):
             try:
-                run_output = await workflow.aget_run_output(run_id=run_id, session_id=session_id)
+                run_output = await workflow.aget_run_output(run_id=run_id, session_id=session_id, user_id=user_id)
             except Exception as e:
                 error = {"event": "error", "error": f"Failed to fetch run from database: {str(e)}"}
                 yield f"event: error\ndata: {json.dumps(error)}\n\n"
@@ -1091,7 +1136,12 @@ def get_workflow_router(
     ):
         kwargs = await get_request_kwargs(request, create_workflow_run)
 
-        if hasattr(request.state, "user_id") and request.state.user_id is not None:
+        # Scoped non-admin callers always get their JWT sub as user_id.
+        # Admins and unscoped callers fall through to middleware/form values.
+        scoped_user_id = get_scoped_user_id(request)
+        if scoped_user_id is not None:
+            user_id = scoped_user_id
+        elif hasattr(request.state, "user_id") and request.state.user_id is not None:
             if user_id and user_id != request.state.user_id:
                 log_warning("User ID parameter passed in both request state and kwargs, using request state")
             user_id = request.state.user_id
@@ -1529,7 +1579,7 @@ def get_workflow_router(
             )
 
         return StreamingResponse(
-            _resume_stream_generator(workflow, run_id, last_event_index, session_id),
+            _resume_stream_generator(workflow, run_id, last_event_index, session_id, user_id=scoped_user_id),
             media_type="text/event-stream",
         )
 

--- a/libs/agno/agno/os/utils.py
+++ b/libs/agno/agno/os/utils.py
@@ -961,6 +961,7 @@ def resolve_ws_jwt_config(app: FastAPI) -> Dict[str, Any]:
         "audience": None,
         "admin_scope": None,
         "user_isolation": False,
+        "auth_required": False,
     }
 
     state = getattr(app, "state", None)
@@ -975,6 +976,7 @@ def resolve_ws_jwt_config(app: FastAPI) -> Dict[str, Any]:
             "audience": getattr(state, "jwt_audience", None),
             "admin_scope": getattr(state, "admin_scope", None),
             "user_isolation": bool(getattr(state, "user_isolation_enabled", False)),
+            "auth_required": True,
         }
 
     # Lazy resolution for manual setup: locate JWTMiddleware in user_middleware
@@ -1009,7 +1011,10 @@ def resolve_ws_jwt_config(app: FastAPI) -> Dict[str, Any]:
                 )
             except Exception as e:
                 log_warning(f"Could not lazily construct JWTValidator for WebSocket auth: {e}")
-                return blank
+                # JWTMiddleware IS configured, so auth was intended. Return
+                # auth_required=True so the WS endpoint rejects connections
+                # instead of silently falling through to unauthenticated mode.
+                return {**blank, "auth_required": True}
 
             verify_audience = bool(kwargs.get("verify_audience", False))
             audience = kwargs.get("audience")
@@ -1031,6 +1036,7 @@ def resolve_ws_jwt_config(app: FastAPI) -> Dict[str, Any]:
                 "audience": audience,
                 "admin_scope": admin_scope,
                 "user_isolation": user_isolation,
+                "auth_required": True,
             }
 
     return blank

--- a/libs/agno/tests/unit/os/test_router_user_id_threading.py
+++ b/libs/agno/tests/unit/os/test_router_user_id_threading.py
@@ -29,7 +29,6 @@ from starlette.middleware.base import BaseHTTPMiddleware
 
 from agno.os.settings import AgnoAPISettings
 
-
 # ---------------------------------------------------------------------------
 # Shared fixtures
 # ---------------------------------------------------------------------------
@@ -279,10 +278,11 @@ class TestApprovalsAdminOnlyResolve:
     def _resolve_payload(self):
         return {"status": "approved"}
 
-    # --- non-admin under isolation: 403 even on own row ---------------
+    # --- non-admin under isolation: 404 to avoid leaking existence ----
 
     def test_resolve_forbidden_for_non_admin_under_isolation(self, approvals_db, no_security_key):
         # The row belongs to the caller, but self-resolve is still blocked.
+        # Returns 404 (not 403) to avoid leaking the approval's existence.
         approvals_db.get_approval.return_value = {
             "approval_id": "a-1",
             "user_id": "jwt_alice",
@@ -290,7 +290,7 @@ class TestApprovalsAdminOnlyResolve:
         }
         app = _build_approvals_app(approvals_db, isolation=True)
         resp = TestClient(app).post("/approvals/a-1/resolve", json=self._resolve_payload())
-        assert resp.status_code == 403
+        assert resp.status_code == 404
         # Make sure we short-circuited before the DB update.
         approvals_db.update_approval.assert_not_called()
 
@@ -302,7 +302,7 @@ class TestApprovalsAdminOnlyResolve:
         }
         app = _build_approvals_app(approvals_db, isolation=True)
         resp = TestClient(app).delete("/approvals/a-1")
-        assert resp.status_code == 403
+        assert resp.status_code == 404
         approvals_db.delete_approval.assert_not_called()
 
     # --- isolation OFF: legacy behaviour preserved --------------------
@@ -331,8 +331,9 @@ class TestApprovalsAdminOnlyResolve:
 
     def test_resolve_allowed_for_admin(self, approvals_db, no_security_key):
         """An admin token (``agent_os:admin`` in scopes) bypasses the gate."""
-        from starlette.middleware.base import BaseHTTPMiddleware
         from fastapi import FastAPI
+        from starlette.middleware.base import BaseHTTPMiddleware
+
         from agno.os.routers.approvals.router import get_approval_router
 
         class _AdminMiddleware(BaseHTTPMiddleware):

--- a/libs/agno/tests/unit/os/test_ws_jwt_config.py
+++ b/libs/agno/tests/unit/os/test_ws_jwt_config.py
@@ -52,6 +52,7 @@ class TestResolveWsJwtConfigAgentOSPath:
         assert cfg["audience"] == "my-os"
         assert cfg["admin_scope"] == "custom:admin"
         assert cfg["user_isolation"] is True
+        assert cfg["auth_required"] is True
 
     def test_state_attrs_default_when_unset(self):
         validator = MagicMock(name="validator")
@@ -64,8 +65,9 @@ class TestResolveWsJwtConfigAgentOSPath:
         assert cfg["audience"] is None
         assert cfg["admin_scope"] is None
         # user_isolation must default to False even when the validator is set
-        # — this is the opt-in safety net for legacy deployments.
+        # - this is the opt-in safety net for legacy deployments.
         assert cfg["user_isolation"] is False
+        assert cfg["auth_required"] is True
 
 
 class TestResolveWsJwtConfigManualSetupPath:
@@ -103,6 +105,7 @@ class TestResolveWsJwtConfigManualSetupPath:
         assert cfg["audience"] == "manual-os"
         assert cfg["admin_scope"] == "ops:admin"
         assert cfg["user_isolation"] is True
+        assert cfg["auth_required"] is True
 
         # The resolver must cache results on app.state for subsequent calls
         # and for the HTTP middleware that will run later.
@@ -215,6 +218,7 @@ class TestResolveWsJwtConfigEdgeCases:
         app = MagicMock(spec=[])  # no state attribute
         cfg = resolve_ws_jwt_config(app)
         assert cfg["validator"] is None
+        assert cfg["auth_required"] is False
 
     def test_does_not_match_unrelated_middleware(self):
         """A non-JWT middleware entry must not be treated as JWT."""
@@ -227,6 +231,28 @@ class TestResolveWsJwtConfigEdgeCases:
 
         cfg = resolve_ws_jwt_config(app)
         assert cfg["validator"] is None
+        assert cfg["auth_required"] is False
+
+    def test_broken_validator_returns_auth_required_true(self):
+        """When JWTMiddleware is configured but the validator cannot be
+        constructed (e.g. bad JWKS path), the resolver must signal that
+        auth was intended so the WS endpoint rejects rather than silently
+        falling through to unauthenticated mode."""
+        entry = SimpleNamespace(
+            cls=JWTMiddleware,
+            kwargs={
+                # jwks_file pointing to a non-existent path triggers an
+                # exception inside JWTValidator construction.
+                "jwks_file": "/nonexistent/bad/path.json",
+                "algorithm": "RS256",
+            },
+        )
+        app = _make_fake_app(middleware_entries=[entry])
+
+        cfg = resolve_ws_jwt_config(app)
+
+        assert cfg["validator"] is None
+        assert cfg["auth_required"] is True
 
 
 class TestAdminScopeDefault:


### PR DESCRIPTION
## Summary

Review fixes for #7606. Addresses consistency gaps and security issues in per-user isolation across all AgentOS router endpoints.

### Commit 1: WS auth fails closed on JWT validator misconfiguration

- `resolve_ws_jwt_config()` now returns `auth_required=True` when JWTMiddleware is configured but the validator can't be built (e.g. bad JWKS path)
- The WS endpoint uses this flag to reject connections instead of silently degrading to unauthenticated mode
- Added docstring in `user_scope.py` documenting the per-endpoint isolation convention

### Commit 2: Consistent user isolation across all router endpoints

**Defense-in-depth fixes:**
- Thread `user_id` into `_resume_stream_generator` DB fallback path in all three component routers (agents, teams, workflows)
- Add ownership verification to `handle_workflow_continue_via_websocket` using `verify_run_in_session_via_db` (was completely unguarded)
- Add defense-in-depth `user_id` guard in `handle_workflow_via_websocket` so it validates JWT sub even if called outside the WS dispatcher

**Ownership check gaps:**
- Add pre-read ownership check to memory `update_memory` so scoped callers cannot overwrite another user's `memory_id` via blind upsert

**Consistency fixes:**
- Standardize memory router to use `resolve_db_and_scope` consistently across all endpoints (was mixing `get_scoped_user_id`-on-payload with `resolve_db_and_scope`)
- Change approvals resolve/delete from 403 to 404 for non-admin callers (consistent with all other routers - avoids leaking approval existence)
- Add `get_scoped_user_id` to `create_agent_run`, `create_team_run`, `create_workflow_run` (was relying solely on `request.state.user_id` from middleware, different pattern from every other endpoint)

### Commit 3: WS start-workflow RBAC must not skip check when workflow_id is absent

- The `start-workflow` RBAC gate was conditional on `workflow_id` being present in the message (`if jwt_auth_enabled and workflow_id`). A caller could omit `workflow_id` to bypass the `workflows:run` scope check entirely. The downstream handler rejects missing `workflow_id`, but the RBAC gate should fire first. Changed to check unconditionally when JWT auth is enabled.

## Type of change

- [x] Bug fix
- [x] Improvement

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue

---

## Verification

All 53 relevant OS unit tests pass. Updated 2 test assertions for the 403->404 change in approvals.