### PR TITLE
fix: align get_trace signature across all DB backends

### DIFF
--- a/libs/agno/agno/db/dynamo/dynamo.py
+++ b/libs/agno/agno/db/dynamo/dynamo.py
@@ -2384,21 +2384,32 @@ class DynamoDb(BaseDb):
                     "KeyConditionExpression": "run_id = :run_id",
                     "ExpressionAttributeValues": expression_values,
                     "ScanIndexForward": False,  # Descending order
-                    "Limit": 1,
                 }
                 if filter_parts:
+                    # DynamoDB applies Limit BEFORE FilterExpression. With
+                    # Limit=1 the newest non-matching row hides older matching
+                    # rows on subsequent pages, so paginate until we find a
+                    # match (per-run_id trace counts are tiny — typically 1).
                     query_kwargs["FilterExpression"] = " AND ".join(filter_parts)
                     query_kwargs["ExpressionAttributeNames"] = expression_names
+                else:
+                    # Fast path: no filter, just grab the newest item.
+                    query_kwargs["Limit"] = 1
 
-                response = self.client.query(**query_kwargs)
-                items = response.get("Items", [])
-                if items:
-                    trace_data = deserialize_from_dynamodb_item(items[0])
-                    # Use stored values (default to 0 if not present)
-                    trace_data.setdefault("total_spans", 0)
-                    trace_data.setdefault("error_count", 0)
-                    return Trace.from_dict(trace_data)
-                return None
+                while True:
+                    response = self.client.query(**query_kwargs)
+                    items = response.get("Items", [])
+                    if items:
+                        # Already FilterExpression-matched + DESC-sorted by
+                        # start_time, so the first item is the newest match.
+                        trace_data = deserialize_from_dynamodb_item(items[0])
+                        trace_data.setdefault("total_spans", 0)
+                        trace_data.setdefault("error_count", 0)
+                        return Trace.from_dict(trace_data)
+                    last_evaluated = response.get("LastEvaluatedKey")
+                    if not last_evaluated:
+                        return None
+                    query_kwargs["ExclusiveStartKey"] = last_evaluated
 
             else:
                 log_debug("get_trace called without any filter parameters")

--- a/libs/agno/agno/db/dynamo/dynamo.py
+++ b/libs/agno/agno/db/dynamo/dynamo.py
@@ -2306,12 +2306,18 @@ class DynamoDb(BaseDb):
         self,
         trace_id: Optional[str] = None,
         run_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
     ):
         """Get a single trace by trace_id or other filters.
 
         Args:
             trace_id: The unique trace identifier.
             run_id: Filter by run ID (returns first match).
+            session_id: Filter by session ID (returns first match).
+            user_id: Filter by user ID (returns first match).
+            agent_id: Filter by agent ID (returns first match).
 
         Returns:
             Optional[Trace]: The trace if found, None otherwise.
@@ -2327,6 +2333,15 @@ class DynamoDb(BaseDb):
             if table_name is None:
                 return None
 
+            def _matches_additional_filters(trace_data: Dict[str, Any]) -> bool:
+                if user_id is not None and trace_data.get("user_id") != user_id:
+                    return False
+                if session_id is not None and trace_data.get("session_id") != session_id:
+                    return False
+                if agent_id is not None and trace_data.get("agent_id") != agent_id:
+                    return False
+                return True
+
             if trace_id:
                 # Direct lookup by primary key
                 response = self.client.get_item(
@@ -2336,21 +2351,46 @@ class DynamoDb(BaseDb):
                 item = response.get("Item")
                 if item:
                     trace_data = deserialize_from_dynamodb_item(item)
+                    if not _matches_additional_filters(trace_data):
+                        return None
                     trace_data.setdefault("total_spans", 0)
                     trace_data.setdefault("error_count", 0)
                     return Trace.from_dict(trace_data)
                 return None
 
             elif run_id:
-                # Query using GSI
-                response = self.client.query(
-                    TableName=table_name,
-                    IndexName="run_id-start_time-index",
-                    KeyConditionExpression="run_id = :run_id",
-                    ExpressionAttributeValues={":run_id": {"S": run_id}},
-                    ScanIndexForward=False,  # Descending order
-                    Limit=1,
-                )
+                # Query using GSI. Apply user_id/session_id/agent_id as a
+                # FilterExpression so DynamoDB drops non-matching items before
+                # returning the page.
+                filter_parts: List[str] = []
+                expression_values: Dict[str, Any] = {":run_id": {"S": run_id}}
+                expression_names: Dict[str, str] = {}
+                if user_id is not None:
+                    filter_parts.append("#user_id = :user_id")
+                    expression_names["#user_id"] = "user_id"
+                    expression_values[":user_id"] = {"S": user_id}
+                if session_id is not None:
+                    filter_parts.append("#session_id = :session_id")
+                    expression_names["#session_id"] = "session_id"
+                    expression_values[":session_id"] = {"S": session_id}
+                if agent_id is not None:
+                    filter_parts.append("#agent_id = :agent_id")
+                    expression_names["#agent_id"] = "agent_id"
+                    expression_values[":agent_id"] = {"S": agent_id}
+
+                query_kwargs: Dict[str, Any] = {
+                    "TableName": table_name,
+                    "IndexName": "run_id-start_time-index",
+                    "KeyConditionExpression": "run_id = :run_id",
+                    "ExpressionAttributeValues": expression_values,
+                    "ScanIndexForward": False,  # Descending order
+                    "Limit": 1,
+                }
+                if filter_parts:
+                    query_kwargs["FilterExpression"] = " AND ".join(filter_parts)
+                    query_kwargs["ExpressionAttributeNames"] = expression_names
+
+                response = self.client.query(**query_kwargs)
                 items = response.get("Items", [])
                 if items:
                     trace_data = deserialize_from_dynamodb_item(items[0])

--- a/libs/agno/agno/db/firestore/firestore.py
+++ b/libs/agno/agno/db/firestore/firestore.py
@@ -1974,12 +1974,18 @@ class FirestoreDb(BaseDb):
         self,
         trace_id: Optional[str] = None,
         run_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
     ):
         """Get a single trace by trace_id or other filters.
 
         Args:
             trace_id: The unique trace identifier.
             run_id: Filter by run ID (returns first match).
+            session_id: Filter by session ID (returns first match).
+            user_id: Filter by user ID (returns first match).
+            agent_id: Filter by agent ID (returns first match).
 
         Returns:
             Optional[Trace]: The trace if found, None otherwise.
@@ -1996,19 +2002,27 @@ class FirestoreDb(BaseDb):
                 return None
 
             if trace_id:
-                docs = collection_ref.where(filter=FieldFilter("trace_id", "==", trace_id)).limit(1).stream()
+                query = collection_ref.where(filter=FieldFilter("trace_id", "==", trace_id))
             elif run_id:
-                from google.cloud.firestore import Query
-
-                docs = (
-                    collection_ref.where(filter=FieldFilter("run_id", "==", run_id))
-                    .order_by("start_time", direction=Query.DESCENDING)
-                    .limit(1)
-                    .stream()
-                )
+                query = collection_ref.where(filter=FieldFilter("run_id", "==", run_id))
             else:
                 log_debug("get_trace called without any filter parameters")
                 return None
+
+            # Apply additional filters
+            if user_id is not None:
+                query = query.where(filter=FieldFilter("user_id", "==", user_id))
+            if session_id is not None:
+                query = query.where(filter=FieldFilter("session_id", "==", session_id))
+            if agent_id is not None:
+                query = query.where(filter=FieldFilter("agent_id", "==", agent_id))
+
+            if run_id and not trace_id:
+                from google.cloud.firestore import Query
+
+                query = query.order_by("start_time", direction=Query.DESCENDING)
+
+            docs = query.limit(1).stream()
 
             for doc in docs:
                 trace_data = doc.to_dict()

--- a/libs/agno/agno/db/gcs_json/gcs_json_db.py
+++ b/libs/agno/agno/db/gcs_json/gcs_json_db.py
@@ -1473,12 +1473,18 @@ class GcsJsonDb(BaseDb):
         self,
         trace_id: Optional[str] = None,
         run_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
     ):
         """Get a single trace by trace_id or other filters.
 
         Args:
             trace_id: The unique trace identifier.
             run_id: Filter by run ID (returns first match).
+            session_id: Filter by session ID (returns first match).
+            user_id: Filter by user ID (returns first match).
+            agent_id: Filter by agent ID (returns first match).
 
         Returns:
             Optional[Trace]: The trace if found, None otherwise.
@@ -1505,6 +1511,17 @@ class GcsJsonDb(BaseDb):
                     break
                 elif run_id and t.get("run_id") == run_id:
                     filtered.append(t)
+
+            if not filtered:
+                return None
+
+            # Apply additional filters
+            if user_id is not None:
+                filtered = [t for t in filtered if t.get("user_id") == user_id]
+            if session_id is not None:
+                filtered = [t for t in filtered if t.get("session_id") == session_id]
+            if agent_id is not None:
+                filtered = [t for t in filtered if t.get("agent_id") == agent_id]
 
             if not filtered:
                 return None

--- a/libs/agno/agno/db/in_memory/in_memory_db.py
+++ b/libs/agno/agno/db/in_memory/in_memory_db.py
@@ -1206,12 +1206,18 @@ class InMemoryDb(BaseDb):
         self,
         trace_id: Optional[str] = None,
         run_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
     ):
         """Get a single trace by trace_id or other filters.
 
         Args:
             trace_id: The unique trace identifier.
             run_id: Filter by run ID (returns first match).
+            session_id: Filter by session ID (returns first match).
+            user_id: Filter by user ID (returns first match).
+            agent_id: Filter by agent ID (returns first match).
 
         Returns:
             Optional[Trace]: The trace if found, None otherwise.

--- a/libs/agno/agno/db/json/json_db.py
+++ b/libs/agno/agno/db/json/json_db.py
@@ -1458,12 +1458,18 @@ class JsonDb(BaseDb):
         self,
         trace_id: Optional[str] = None,
         run_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
     ):
         """Get a single trace by trace_id or other filters.
 
         Args:
             trace_id: The unique trace identifier.
             run_id: Filter by run ID (returns first match).
+            session_id: Filter by session ID (returns first match).
+            user_id: Filter by user ID (returns first match).
+            agent_id: Filter by agent ID (returns first match).
 
         Returns:
             Optional[Trace]: The trace if found, None otherwise.
@@ -1486,6 +1492,17 @@ class JsonDb(BaseDb):
                     break
                 elif run_id and t.get("run_id") == run_id:
                     filtered.append(t)
+
+            if not filtered:
+                return None
+
+            # Apply additional filters
+            if user_id is not None:
+                filtered = [t for t in filtered if t.get("user_id") == user_id]
+            if session_id is not None:
+                filtered = [t for t in filtered if t.get("session_id") == session_id]
+            if agent_id is not None:
+                filtered = [t for t in filtered if t.get("agent_id") == agent_id]
 
             if not filtered:
                 return None

--- a/libs/agno/agno/db/mongo/async_mongo.py
+++ b/libs/agno/agno/db/mongo/async_mongo.py
@@ -2483,12 +2483,18 @@ class AsyncMongoDb(AsyncBaseDb):
         self,
         trace_id: Optional[str] = None,
         run_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
     ):
         """Get a single trace by trace_id or other filters.
 
         Args:
             trace_id: The unique trace identifier.
             run_id: Filter by run ID (returns first match).
+            session_id: Filter by session ID (returns first match).
+            user_id: Filter by user ID (returns first match).
+            agent_id: Filter by agent ID (returns first match).
 
         Returns:
             Optional[Trace]: The trace if found, None otherwise.
@@ -2515,6 +2521,14 @@ class AsyncMongoDb(AsyncBaseDb):
             else:
                 log_debug("get_trace called without any filter parameters")
                 return None
+
+            # Apply additional filters
+            if user_id is not None:
+                query["user_id"] = user_id
+            if session_id is not None:
+                query["session_id"] = session_id
+            if agent_id is not None:
+                query["agent_id"] = agent_id
 
             # Find trace with sorting by most recent
             result = await collection.find_one(query, sort=[("start_time", -1)])

--- a/libs/agno/agno/db/mongo/mongo.py
+++ b/libs/agno/agno/db/mongo/mongo.py
@@ -2301,12 +2301,18 @@ class MongoDb(BaseDb):
         self,
         trace_id: Optional[str] = None,
         run_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
     ):
         """Get a single trace by trace_id or other filters.
 
         Args:
             trace_id: The unique trace identifier.
             run_id: Filter by run ID (returns first match).
+            session_id: Filter by session ID (returns first match).
+            user_id: Filter by user ID (returns first match).
+            agent_id: Filter by agent ID (returns first match).
 
         Returns:
             Optional[Trace]: The trace if found, None otherwise.
@@ -2333,6 +2339,14 @@ class MongoDb(BaseDb):
             else:
                 log_debug("get_trace called without any filter parameters")
                 return None
+
+            # Apply additional filters
+            if user_id is not None:
+                query["user_id"] = user_id
+            if session_id is not None:
+                query["session_id"] = session_id
+            if agent_id is not None:
+                query["agent_id"] = agent_id
 
             # Find trace with sorting by most recent
             result = collection.find_one(query, sort=[("start_time", -1)])

--- a/libs/agno/agno/db/mysql/async_mysql.py
+++ b/libs/agno/agno/db/mysql/async_mysql.py
@@ -2593,12 +2593,18 @@ class AsyncMySQLDb(AsyncBaseDb):
         self,
         trace_id: Optional[str] = None,
         run_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
     ):
         """Get a single trace by trace_id or other filters.
 
         Args:
             trace_id: The unique trace identifier.
             run_id: Filter by run ID (returns first match).
+            session_id: Filter by session ID (returns first match).
+            user_id: Filter by user ID (returns first match).
+            agent_id: Filter by agent ID (returns first match).
 
         Returns:
             Optional[Trace]: The trace if found, None otherwise.
@@ -2628,6 +2634,14 @@ class AsyncMySQLDb(AsyncBaseDb):
                 else:
                     log_debug("get_trace called without any filter parameters")
                     return None
+
+                # Apply additional filters
+                if user_id is not None:
+                    stmt = stmt.where(table.c.user_id == user_id)
+                if session_id is not None:
+                    stmt = stmt.where(table.c.session_id == session_id)
+                if agent_id is not None:
+                    stmt = stmt.where(table.c.agent_id == agent_id)
 
                 # Order by most recent and get first result
                 stmt = stmt.order_by(table.c.start_time.desc()).limit(1)

--- a/libs/agno/agno/db/mysql/mysql.py
+++ b/libs/agno/agno/db/mysql/mysql.py
@@ -2615,12 +2615,18 @@ class MySQLDb(BaseDb):
         self,
         trace_id: Optional[str] = None,
         run_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
     ):
         """Get a single trace by trace_id or other filters.
 
         Args:
             trace_id: The unique trace identifier.
             run_id: Filter by run ID (returns first match).
+            session_id: Filter by session ID (returns first match).
+            user_id: Filter by user ID (returns first match).
+            agent_id: Filter by agent ID (returns first match).
 
         Returns:
             Optional[Trace]: The trace if found, None otherwise.
@@ -2650,6 +2656,14 @@ class MySQLDb(BaseDb):
                 else:
                     log_debug("get_trace called without any filter parameters")
                     return None
+
+                # Apply additional filters
+                if user_id is not None:
+                    stmt = stmt.where(table.c.user_id == user_id)
+                if session_id is not None:
+                    stmt = stmt.where(table.c.session_id == session_id)
+                if agent_id is not None:
+                    stmt = stmt.where(table.c.agent_id == agent_id)
 
                 # Order by most recent and get first result
                 stmt = stmt.order_by(table.c.start_time.desc()).limit(1)

--- a/libs/agno/agno/db/postgres/async_postgres.py
+++ b/libs/agno/agno/db/postgres/async_postgres.py
@@ -2477,12 +2477,18 @@ class AsyncPostgresDb(AsyncBaseDb):
         self,
         trace_id: Optional[str] = None,
         run_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
     ):
         """Get a single trace by trace_id or other filters.
 
         Args:
             trace_id: The unique trace identifier.
             run_id: Filter by run ID (returns first match).
+            session_id: Filter by session ID (returns first match).
+            user_id: Filter by user ID (returns first match).
+            agent_id: Filter by agent ID (returns first match).
 
         Returns:
             Optional[Trace]: The trace if found, None otherwise.
@@ -2512,6 +2518,14 @@ class AsyncPostgresDb(AsyncBaseDb):
                 else:
                     log_debug("get_trace called without any filter parameters")
                     return None
+
+                # Apply additional filters
+                if user_id is not None:
+                    stmt = stmt.where(table.c.user_id == user_id)
+                if session_id is not None:
+                    stmt = stmt.where(table.c.session_id == session_id)
+                if agent_id is not None:
+                    stmt = stmt.where(table.c.agent_id == agent_id)
 
                 # Order by most recent and get first result
                 stmt = stmt.order_by(table.c.start_time.desc()).limit(1)

--- a/libs/agno/agno/db/postgres/postgres.py
+++ b/libs/agno/agno/db/postgres/postgres.py
@@ -2913,12 +2913,18 @@ class PostgresDb(BaseDb):
         self,
         trace_id: Optional[str] = None,
         run_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
     ):
         """Get a single trace by trace_id or other filters.
 
         Args:
             trace_id: The unique trace identifier.
             run_id: Filter by run ID (returns first match).
+            session_id: Filter by session ID (returns first match).
+            user_id: Filter by user ID (returns first match).
+            agent_id: Filter by agent ID (returns first match).
 
         Returns:
             Optional[Trace]: The trace if found, None otherwise.
@@ -2948,6 +2954,14 @@ class PostgresDb(BaseDb):
                 else:
                     log_debug("get_trace called without any filter parameters")
                     return None
+
+                # Apply additional filters
+                if user_id is not None:
+                    stmt = stmt.where(table.c.user_id == user_id)
+                if session_id is not None:
+                    stmt = stmt.where(table.c.session_id == session_id)
+                if agent_id is not None:
+                    stmt = stmt.where(table.c.agent_id == agent_id)
 
                 # Order by most recent and get first result
                 stmt = stmt.order_by(table.c.start_time.desc()).limit(1)

--- a/libs/agno/agno/db/redis/redis.py
+++ b/libs/agno/agno/db/redis/redis.py
@@ -1821,12 +1821,18 @@ class RedisDb(BaseDb):
         self,
         trace_id: Optional[str] = None,
         run_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
     ):
         """Get a single trace by trace_id or other filters.
 
         Args:
             trace_id: The unique trace identifier.
             run_id: Filter by run ID (returns first match).
+            session_id: Filter by session ID (returns first match).
+            user_id: Filter by user ID (returns first match).
+            agent_id: Filter by agent ID (returns first match).
 
         Returns:
             Optional[Trace]: The trace if found, None otherwise.
@@ -1838,9 +1844,18 @@ class RedisDb(BaseDb):
         try:
             from agno.tracing.schemas import Trace as TraceSchema
 
+            def _matches_additional_filters(t: Dict[str, Any]) -> bool:
+                if user_id is not None and t.get("user_id") != user_id:
+                    return False
+                if session_id is not None and t.get("session_id") != session_id:
+                    return False
+                if agent_id is not None and t.get("agent_id") != agent_id:
+                    return False
+                return True
+
             if trace_id:
                 result = self._get_record("traces", trace_id)
-                if result:
+                if result and _matches_additional_filters(result):
                     # Calculate total_spans and error_count
                     all_spans = self._get_all_records("spans")
                     trace_spans = [s for s in all_spans if s.get("trace_id") == trace_id]
@@ -1851,7 +1866,7 @@ class RedisDb(BaseDb):
 
             elif run_id:
                 all_traces = self._get_all_records("traces")
-                matching = [t for t in all_traces if t.get("run_id") == run_id]
+                matching = [t for t in all_traces if t.get("run_id") == run_id and _matches_additional_filters(t)]
                 if matching:
                     # Sort by start_time descending and get most recent
                     matching.sort(key=lambda x: x.get("start_time", ""), reverse=True)

--- a/libs/agno/agno/db/singlestore/singlestore.py
+++ b/libs/agno/agno/db/singlestore/singlestore.py
@@ -2562,12 +2562,18 @@ class SingleStoreDb(BaseDb):
         self,
         trace_id: Optional[str] = None,
         run_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
     ):
         """Get a single trace by trace_id or other filters.
 
         Args:
             trace_id: The unique trace identifier.
             run_id: Filter by run ID (returns first match).
+            session_id: Filter by session ID (returns first match).
+            user_id: Filter by user ID (returns first match).
+            agent_id: Filter by agent ID (returns first match).
 
         Returns:
             Optional[Trace]: The trace if found, None otherwise.
@@ -2597,6 +2603,14 @@ class SingleStoreDb(BaseDb):
                 else:
                     log_debug("get_trace called without any filter parameters")
                     return None
+
+                # Apply additional filters
+                if user_id is not None:
+                    stmt = stmt.where(table.c.user_id == user_id)
+                if session_id is not None:
+                    stmt = stmt.where(table.c.session_id == session_id)
+                if agent_id is not None:
+                    stmt = stmt.where(table.c.agent_id == agent_id)
 
                 # Order by most recent and get first result
                 stmt = stmt.order_by(table.c.start_time.desc()).limit(1)

--- a/libs/agno/agno/db/sqlite/async_sqlite.py
+++ b/libs/agno/agno/db/sqlite/async_sqlite.py
@@ -2641,12 +2641,18 @@ class AsyncSqliteDb(AsyncBaseDb):
         self,
         trace_id: Optional[str] = None,
         run_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
     ):
         """Get a single trace by trace_id or other filters.
 
         Args:
             trace_id: The unique trace identifier.
             run_id: Filter by run ID (returns first match).
+            session_id: Filter by session ID (returns first match).
+            user_id: Filter by user ID (returns first match).
+            agent_id: Filter by agent ID (returns first match).
 
         Returns:
             Optional[Trace]: The trace if found, None otherwise.
@@ -2676,6 +2682,14 @@ class AsyncSqliteDb(AsyncBaseDb):
                 else:
                     log_debug("get_trace called without any filter parameters")
                     return None
+
+                # Apply additional filters
+                if user_id is not None:
+                    stmt = stmt.where(table.c.user_id == user_id)
+                if session_id is not None:
+                    stmt = stmt.where(table.c.session_id == session_id)
+                if agent_id is not None:
+                    stmt = stmt.where(table.c.agent_id == agent_id)
 
                 # Order by most recent and get first result
                 stmt = stmt.order_by(table.c.start_time.desc()).limit(1)

--- a/libs/agno/agno/db/surrealdb/surrealdb.py
+++ b/libs/agno/agno/db/surrealdb/surrealdb.py
@@ -1579,12 +1579,18 @@ class SurrealDb(BaseDb):
         self,
         trace_id: Optional[str] = None,
         run_id: Optional[str] = None,
+        session_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
     ):
         """Get a single trace by trace_id or other filters.
 
         Args:
             trace_id: The unique trace identifier.
             run_id: Filter by run ID (returns first match).
+            session_id: Filter by session ID (returns first match).
+            user_id: Filter by user ID (returns first match).
+            agent_id: Filter by agent ID (returns first match).
 
         Returns:
             Optional[Trace]: The trace if found, None otherwise.
@@ -1597,17 +1603,39 @@ class SurrealDb(BaseDb):
             table = self._get_table("traces", create_table_if_not_found=False)
             spans_table = self._get_table("spans", create_table_if_not_found=False)
 
+            # Build optional AND clauses applied to both lookup paths.
+            extra_conditions = []
+            extra_params: Dict[str, Any] = {}
+            if user_id is not None:
+                extra_conditions.append("user_id = $user_id")
+                extra_params["user_id"] = user_id
+            if session_id is not None:
+                extra_conditions.append("session_id = $session_id")
+                extra_params["session_id"] = session_id
+            if agent_id is not None:
+                extra_conditions.append("agent_id = $agent_id")
+                extra_params["agent_id"] = agent_id
+            extra_where = (" AND " + " AND ".join(extra_conditions)) if extra_conditions else ""
+
             if trace_id:
                 record = RecordID(table, trace_id)
-                trace_data = self._query_one("SELECT * FROM ONLY $record", {"record": record}, dict)
+                if extra_conditions:
+                    query = dedent(f"""
+                        SELECT * FROM {table}
+                        WHERE id = $record{extra_where}
+                        LIMIT 1
+                    """)
+                    trace_data = self._query_one(query, {"record": record, **extra_params}, dict)
+                else:
+                    trace_data = self._query_one("SELECT * FROM ONLY $record", {"record": record}, dict)
             elif run_id:
                 query = dedent(f"""
                     SELECT * FROM {table}
-                    WHERE run_id = $run_id
+                    WHERE run_id = $run_id{extra_where}
                     ORDER BY start_time DESC
                     LIMIT 1
                 """)
-                trace_data = self._query_one(query, {"run_id": run_id}, dict)
+                trace_data = self._query_one(query, {"run_id": run_id, **extra_params}, dict)
             else:
                 log_debug("get_trace called without any filter parameters")
                 return None

--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -1003,7 +1003,7 @@ def get_agent_router(
         if (session_id is None or session_id == "") and not isinstance(agent, RemoteAgent):
             raise HTTPException(
                 status_code=400,
-                detail="session_id is required to continue a run",
+                detail=SESSION_ID_REQUIRED,
             )
 
         # Ownership check: a non-admin caller must own the session AND the run

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -1041,7 +1041,7 @@ def get_team_router(
         if (session_id is None or session_id == "") and not isinstance(team, RemoteTeam):
             raise HTTPException(
                 status_code=400,
-                detail="session_id is required to continue a run",
+                detail=SESSION_ID_REQUIRED,
             )
 
         # Ownership check before status validation — see continue_agent_run.

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -1296,7 +1296,7 @@ def get_workflow_router(
         scoped_user_id = get_scoped_user_id(request)
         if scoped_user_id is not None:
             if not session_id:
-                raise HTTPException(status_code=400, detail="session_id is required to continue a run")
+                raise HTTPException(status_code=400, detail=SESSION_ID_REQUIRED)
             await verify_run_in_session(
                 workflow,
                 session_id,

--- a/libs/agno/tests/integration/os/test_team_runs.py
+++ b/libs/agno/tests/integration/os/test_team_runs.py
@@ -167,7 +167,7 @@ def test_continue_team_run_requires_session_id_for_local_teams(test_os_client, t
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"] == "session_id is required to continue a run"
+    assert response.json()["detail"] == "session_id is required for this action"
 
 
 def test_continue_team_run_allows_empty_requirements_payload(test_os_client, test_team: Team):

--- a/libs/agno/tests/integration/os/test_user_isolation_pr_fixes.py
+++ b/libs/agno/tests/integration/os/test_user_isolation_pr_fixes.py
@@ -456,8 +456,8 @@ class TestContinueRunOwnership:
             data={"tools": ""},
             headers=auth_header(token),
         )
-        # Either ownership-check 400 ("session_id required") or
-        # session_id-check 400 ("session_id is required to continue a run").
+        # Either ownership-check or session_id-check 400 (both now use
+        # SESSION_ID_REQUIRED = "session_id is required for this action").
         assert resp.status_code == 400, resp.text
 
     def test_agent_continue_foreign_run_returns_404(self, client):

--- a/libs/agno/tests/unit/db/test_get_trace_signature.py
+++ b/libs/agno/tests/unit/db/test_get_trace_signature.py
@@ -1,0 +1,62 @@
+"""Regression test: every DB backend's ``get_trace`` accepts the kwargs the
+trace router passes (``user_id``, ``session_id``, ``agent_id``).
+
+Without this, adding user_id scoping to ``GET /traces/{trace_id}`` silently
+500s on every backend except sqlite because the route passes a kwarg the
+implementation doesn't accept (TypeError caught by the route's bare except).
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+from typing import List, Tuple
+
+import pytest
+
+REQUIRED_KWARGS = {"trace_id", "run_id", "session_id", "user_id", "agent_id"}
+
+# (module path, class name) — covers every concrete BaseDb / AsyncBaseDb subclass.
+BACKENDS: List[Tuple[str, str]] = [
+    ("agno.db.postgres.postgres", "PostgresDb"),
+    ("agno.db.postgres.async_postgres", "AsyncPostgresDb"),
+    ("agno.db.mysql.mysql", "MySQLDb"),
+    ("agno.db.mysql.async_mysql", "AsyncMySQLDb"),
+    ("agno.db.sqlite.sqlite", "SqliteDb"),
+    ("agno.db.sqlite.async_sqlite", "AsyncSqliteDb"),
+    ("agno.db.singlestore.singlestore", "SingleStoreDb"),
+    ("agno.db.mongo.mongo", "MongoDb"),
+    ("agno.db.mongo.async_mongo", "AsyncMongoDb"),
+    ("agno.db.dynamo.dynamo", "DynamoDb"),
+    ("agno.db.firestore.firestore", "FirestoreDb"),
+    ("agno.db.redis.redis", "RedisDb"),
+    ("agno.db.json.json_db", "JsonDb"),
+    ("agno.db.in_memory.in_memory_db", "InMemoryDb"),
+    ("agno.db.gcs_json.gcs_json_db", "GcsJsonDb"),
+    ("agno.db.surrealdb.surrealdb", "SurrealDb"),
+]
+
+
+@pytest.mark.parametrize(("module_path", "class_name"), BACKENDS)
+def test_get_trace_accepts_required_kwargs(module_path: str, class_name: str) -> None:
+    """Every concrete backend's ``get_trace`` must accept the trace router's kwargs."""
+    try:
+        module = importlib.import_module(module_path)
+    except ImportError as exc:
+        pytest.skip(f"Backend {module_path} not installed: {exc}")
+
+    db_cls = getattr(module, class_name, None)
+    if db_cls is None:
+        pytest.fail(f"{class_name} not found in {module_path}")
+
+    method = getattr(db_cls, "get_trace", None)
+    assert method is not None, f"{class_name} is missing get_trace"
+
+    sig = inspect.signature(method)
+    params = set(sig.parameters)
+    missing = REQUIRED_KWARGS - params
+    assert not missing, (
+        f"{class_name}.get_trace is missing required kwargs: {missing}. "
+        f"The traces router passes user_id/session_id/agent_id; backends that "
+        f"don't accept them will TypeError at call time."
+    )


### PR DESCRIPTION
## Summary

The new traces router (PR #7606) passes `user_id=effective_user_id` to `db.get_trace()` so non-admin scoped callers can't read other users' trace details. Only `SqliteDb` was updated to accept the extra kwarg — every other backend still has the 2-arg `(trace_id, run_id)` signature.

On any non-sqlite deployment (i.e. essentially every production deployment per CLAUDE.md), the call raises `TypeError: get_trace() got an unexpected keyword argument 'user_id'`, which the route catches in its bare `except Exception` and surfaces as HTTP 500 with the TypeError message exposed in the body. This breaks `GET /traces/{trace_id}` regardless of whether `user_isolation` is enabled, because the route always passes `user_id` (None when unscoped).

This PR aligns every concrete backend with `BaseDb.get_trace`'s abstract signature `(trace_id, run_id, session_id, user_id, agent_id)` and actually applies the filters.

## Backends updated

- SQLAlchemy: `postgres`, `async_postgres`, `mysql`, `async_mysql`, `async_sqlite`, `singlestore` — `.where()` clauses against `table.c.user_id` etc.
- `mongo`, `async_mongo` — add to the `query: Dict` dict before `find_one`.
- `firestore` — chained `FieldFilter` `.where()` calls.
- `dynamo` — `FilterExpression` on the GSI Query path; post-fetch verification on the `GetItem` path (DynamoDB can't filter a single-key get).
- `redis`, `json`, `gcs_json` — Python-side filter (same idiom these backends already use).
- `surrealdb` — extra AND clauses appended to the SQL `WHERE`.
- `in_memory` — signature-only update; `get_trace` was already `raise NotImplementedError`.

## Regression test

`libs/agno/tests/unit/db/test_get_trace_signature.py` parametrizes over all 16 concrete backends and asserts each one's `get_trace` accepts `{trace_id, run_id, session_id, user_id, agent_id}`. Backends whose optional deps aren't installed skip rather than fail.

```
10 passed, 6 skipped in 0.33s
```

Sql/format/mypy clean on the touched files. Full unit-test suite passes (the 7 unrelated failures are slack store-media tests that fail because slack deps aren't installed locally).

## Type of change

- [x] Bug fix

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Tests added (signature regression test covering all backends)