### PR TITLE
fix: ssrf-knowledge follow-ups — restore default redirects, unify WebSearchReader

### DIFF
--- a/cookbook/07_knowledge/03_production/05_ssrf_allowed_hosts.py
+++ b/cookbook/07_knowledge/03_production/05_ssrf_allowed_hosts.py
@@ -41,7 +41,7 @@ knowledge = Knowledge(
 )
 
 agent = Agent(
-    model=OpenAIResponses(id="gpt-5.2"),
+    model=OpenAIResponses(id="gpt-5.4"),
     knowledge=knowledge,
     search_knowledge=True,
     markdown=True,

--- a/libs/agno/agno/knowledge/reader/llms_txt_reader.py
+++ b/libs/agno/agno/knowledge/reader/llms_txt_reader.py
@@ -193,6 +193,7 @@ class LLMsTxtReader(Reader):
                     max_retries=1,
                     proxy=self.proxy,
                     timeout=self.timeout,
+                    follow_redirects=True,
                 )
             else:
                 # Per-redirect host check: follow redirects but validate each hop's
@@ -220,6 +221,7 @@ class LLMsTxtReader(Reader):
                     client=client,
                     max_retries=1,
                     timeout=self.timeout,
+                    follow_redirects=True,
                 )
             else:
                 # Build a local client so we can attach the per-redirect host-check hook

--- a/libs/agno/agno/knowledge/reader/web_search_reader.py
+++ b/libs/agno/agno/knowledge/reader/web_search_reader.py
@@ -2,7 +2,7 @@ import asyncio
 import random
 import time
 from dataclasses import dataclass, field
-from typing import Dict, List, Literal, Optional, Set
+from typing import Any, Dict, List, Literal, Optional, Set
 from urllib.parse import urlparse
 
 import httpx
@@ -11,7 +11,12 @@ from agno.knowledge.chunking.semantic import SemanticChunking
 from agno.knowledge.chunking.strategy import ChunkingStrategy, ChunkingStrategyType
 from agno.knowledge.document.base import Document
 from agno.knowledge.reader.base import Reader
-from agno.knowledge.reader.utils.url_validation import is_host_allowed, validate_allowed_hosts
+from agno.knowledge.reader.utils.url_validation import (
+    is_host_allowed,
+    make_async_redirect_guard,
+    make_redirect_guard,
+    validate_allowed_hosts,
+)
 from agno.knowledge.types import ContentType
 from agno.utils.log import log_debug, log_error, log_warning, logger
 
@@ -180,15 +185,17 @@ class WebSearchReader(Reader):
     def _fetch_url_content(self, url: str) -> Optional[str]:
         """Fetch content from a URL with retry logic"""
         headers = {"User-Agent": self.user_agent}
-        # Disable redirect-following when an allowlist is set so a permitted host
-        # can't 3xx-bounce the request to an internal target.
-        follow_redirects = self.allowed_hosts is None
+        guard = make_redirect_guard(self.allowed_hosts)
 
         for attempt in range(self.max_retries):
             try:
-                response = httpx.get(
-                    url, headers=headers, timeout=self.request_timeout, follow_redirects=follow_redirects
-                )
+                if guard is None:
+                    response = httpx.get(url, headers=headers, timeout=self.request_timeout, follow_redirects=True)
+                else:
+                    # Per-redirect host check: follow redirects but validate each hop's
+                    # target against the allowlist via the request event hook.
+                    with httpx.Client(timeout=self.request_timeout, event_hooks={"request": [guard]}) as client:
+                        response = client.get(url, headers=headers, follow_redirects=True)
                 response.raise_for_status()
 
                 # Check if it's HTML content
@@ -306,9 +313,12 @@ class WebSearchReader(Reader):
 
             try:
                 headers = {"User-Agent": self.user_agent}
-                follow_redirects = self.allowed_hosts is None
-                async with httpx.AsyncClient(timeout=self.request_timeout) as client:
-                    response = await client.get(url, headers=headers, follow_redirects=follow_redirects)
+                guard = make_async_redirect_guard(self.allowed_hosts)
+                client_kwargs: Dict[str, Any] = {"timeout": self.request_timeout}
+                if guard is not None:
+                    client_kwargs["event_hooks"] = {"request": [guard]}
+                async with httpx.AsyncClient(**client_kwargs) as client:
+                    response = await client.get(url, headers=headers, follow_redirects=True)
                     response.raise_for_status()
 
                     content_type = response.headers.get("content-type", "").lower()

--- a/libs/agno/tests/unit/tools/test_llms_txt.py
+++ b/libs/agno/tests/unit/tools/test_llms_txt.py
@@ -631,9 +631,7 @@ def test_reader_fetch_url_returns_none_when_redirect_target_disallowed():
     mock_client.__enter__.return_value = mock_client
     # Simulate the hook firing inside client.get(...) when httpx re-issues the
     # request to the disallowed redirect target.
-    mock_client.get.side_effect = httpx.RequestError(
-        "Host not in allowed_hosts: 127.0.0.1", request=MagicMock()
-    )
+    mock_client.get.side_effect = httpx.RequestError("Host not in allowed_hosts: 127.0.0.1", request=MagicMock())
 
     with patch("agno.knowledge.reader.llms_txt_reader.httpx.Client", return_value=mock_client):
         result = reader.fetch_url("https://docs.agno.com/old")


### PR DESCRIPTION
## Summary

Three fixes layered on top of #7892 (ssrf-knowledge):

- `LLMsTxtReader.fetch_url` / `async_fetch_url` now pass `follow_redirects=True` to `fetch_with_retry` in the no-allowlist branch.
- `WebSearchReader._fetch_url_content` (sync + async) replaces `follow_redirects = self.allowed_hosts is None` with the same per-redirect event-hook pattern used by `WebsiteReader` and `LLMsTxtReader`.
- Cookbook `05_ssrf_allowed_hosts.py`: bump model id `gpt-5.2` → `gpt-5.4` per CLAUDE.md.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

The 162 unit tests in the SSRF-touching modules continue to pass. Cookbook runs end-to-end against real `docs.agno.com` + OpenAI Responses (`gpt-5.4`).