### PR TITLE
fix: use SESSION_ID_REQUIRED constant in continue-run routes

### DIFF
--- a/libs/agno/agno/os/routers/agents/router.py
+++ b/libs/agno/agno/os/routers/agents/router.py
@@ -1009,7 +1009,7 @@ def get_agent_router(
         if (session_id is None or session_id == "") and not isinstance(agent, RemoteAgent):
             raise HTTPException(
                 status_code=400,
-                detail="session_id is required to continue a run",
+                detail=SESSION_ID_REQUIRED,
             )
 
         # Ownership check: a non-admin caller must own the session AND the run

--- a/libs/agno/agno/os/routers/teams/router.py
+++ b/libs/agno/agno/os/routers/teams/router.py
@@ -1047,7 +1047,7 @@ def get_team_router(
         if (session_id is None or session_id == "") and not isinstance(team, RemoteTeam):
             raise HTTPException(
                 status_code=400,
-                detail="session_id is required to continue a run",
+                detail=SESSION_ID_REQUIRED,
             )
 
         # Ownership check before status validation — see continue_agent_run.

--- a/libs/agno/agno/os/routers/workflows/router.py
+++ b/libs/agno/agno/os/routers/workflows/router.py
@@ -1358,7 +1358,7 @@ def get_workflow_router(
         scoped_user_id = get_scoped_user_id(request)
         if scoped_user_id is not None:
             if not session_id:
-                raise HTTPException(status_code=400, detail="session_id is required to continue a run")
+                raise HTTPException(status_code=400, detail=SESSION_ID_REQUIRED)
             await verify_run_in_session(
                 workflow,
                 session_id,

--- a/libs/agno/tests/integration/os/test_team_runs.py
+++ b/libs/agno/tests/integration/os/test_team_runs.py
@@ -167,7 +167,7 @@ def test_continue_team_run_requires_session_id_for_local_teams(test_os_client, t
     )
 
     assert response.status_code == 400
-    assert response.json()["detail"] == "session_id is required to continue a run"
+    assert response.json()["detail"] == "session_id is required for this action"
 
 
 def test_continue_team_run_allows_empty_requirements_payload(test_os_client, test_team: Team):

--- a/libs/agno/tests/integration/os/test_user_isolation_02.py
+++ b/libs/agno/tests/integration/os/test_user_isolation_02.py
@@ -459,8 +459,8 @@ class TestContinueRunOwnership:
             data={"tools": ""},
             headers=auth_header(token),
         )
-        # Either ownership-check 400 ("session_id required") or
-        # session_id-check 400 ("session_id is required to continue a run").
+        # Either ownership-check or session_id-check 400 (both now use
+        # SESSION_ID_REQUIRED = "session_id is required for this action").
         assert resp.status_code == 400, resp.text
 
     def test_agent_continue_foreign_run_returns_404(self, client):


### PR DESCRIPTION
## Summary

The cancel/resume routes already use the imported `SESSION_ID_REQUIRED` constant (`\"session_id is required for this action\"`), but the agent / team / workflow continue routes hardcoded `\"session_id is required to continue a run\"`. This PR aligns all three so the user-facing 400 message is consistent across the run lifecycle.

## Changes

- `libs/agno/agno/os/routers/agents/router.py` — `continue_agent_run`: hardcoded string → `SESSION_ID_REQUIRED`.
- `libs/agno/agno/os/routers/teams/router.py` — `continue_team_run`: same.
- `libs/agno/agno/os/routers/workflows/router.py` — `continue_workflow_run`: same.
- `libs/agno/tests/integration/os/test_team_runs.py` — updated the assertion that pinned the old message.
- `libs/agno/tests/integration/os/test_user_isolation_02.py` — refreshed a stale comment that referenced the old string.

The `SESSION_ID_REQUIRED` constant is already imported in all three router files. ruff/mypy clean; the 32 affected tests pass.

## Type of change

- [x] Bug fix
- [x] Improvement

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Tests updated