### PR TITLE
fix: use stream_events instead of stream_steps for AG-UI teams

### DIFF
--- a/libs/agno/agno/os/interfaces/agui/router.py
+++ b/libs/agno/agno/os/interfaces/agui/router.py
@@ -96,7 +96,7 @@ async def run_team(team: Union[Team, RemoteTeam], input: RunAgentInput) -> Async
             input=user_input,
             session_id=input.thread_id,
             stream=True,
-            stream_steps=True,
+            stream_events=True,
             user_id=user_id,
             session_state=session_state,
             run_id=run_id,

--- a/libs/agno/tests/unit/os/interfaces/test_agui_router.py
+++ b/libs/agno/tests/unit/os/interfaces/test_agui_router.py
@@ -1,0 +1,64 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("ag_ui", reason="ag_ui not installed")
+
+from agno.os.interfaces.agui.router import run_agent, run_team
+
+
+class FakeRunInput:
+    def __init__(self):
+        self.messages = [MagicMock(role="user", content="test")]
+        self.thread_id = "test-thread"
+        self.run_id = "test-run"
+        self.forwarded_props = None
+        self.state = None
+
+
+class CaptureKwargsTeam:
+    def __init__(self):
+        self.captured_kwargs = {}
+
+    async def arun(self, **kwargs):
+        self.captured_kwargs = kwargs
+        return
+        yield
+
+
+class CaptureKwargsAgent:
+    def __init__(self):
+        self.captured_kwargs = {}
+
+    async def arun(self, **kwargs):
+        self.captured_kwargs = kwargs
+        return
+        yield
+
+
+@pytest.mark.asyncio
+async def test_run_team_passes_stream_events_not_stream_steps():
+    fake_team = CaptureKwargsTeam()
+    run_input = FakeRunInput()
+
+    events = []
+    async for event in run_team(fake_team, run_input):
+        events.append(event)
+
+    assert fake_team.captured_kwargs.get("stream") is True
+    assert fake_team.captured_kwargs.get("stream_events") is True
+    assert "stream_steps" not in fake_team.captured_kwargs
+
+
+@pytest.mark.asyncio
+async def test_run_agent_passes_stream_events():
+    fake_agent = CaptureKwargsAgent()
+    run_input = FakeRunInput()
+
+    events = []
+    async for event in run_agent(fake_agent, run_input):
+        events.append(event)
+
+    assert fake_agent.captured_kwargs.get("stream") is True
+    assert fake_agent.captured_kwargs.get("stream_events") is True
+    assert "stream_steps" not in fake_agent.captured_kwargs


### PR DESCRIPTION
## Summary

Fixes a typo introduced in #5092 (Oct 2025) that caused teams running via AG-UI to miss all intermediate streaming events.

- When `stream_intermediate_steps` was renamed to `stream_events` in #5092, the agent path was correctly updated but the team path was mistyped as `stream_steps`
- Since `Team.arun()` accepts `**kwargs`, the invalid parameter was silently swallowed
- Teams via AG-UI have been missing intermediate events (tool calls, reasoning steps, member delegations) for ~7 months

## The Bug

```python
# Agent path (line 57) - CORRECT
stream_events=True

# Team path (line 99) - WRONG (was stream_steps=True)
stream_events=True  # Fixed
```

## Impact

When `stream_events` is not set (defaults to `False`):
- No run lifecycle events (`TeamRunStartedEvent`, `TeamRunCompletedEvent`)
- No intermediate step events (reasoning, tool calls, member delegation)
- Only final content is streamed to AG-UI frontend

## Related Issues

- #5453 - Team streaming issues with `respond_directly=True` (potentially related symptom)
- #5092 - Original PR where the typo was introduced

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] Formatted and validated: `./scripts/format.sh && ./scripts/validate.sh`
- [x] Searched codebase - this is the only `stream_steps` usage in the entire lib