### PR TITLE
fix: add aiohttp to slack extra dependencies

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -205,7 +205,7 @@ agui = ["ag-ui-protocol"]
 a2a = ["a2a-sdk>=0.3.0,<1.0"]
 
 # Dependencies for Slack integration
-slack = ["slack_sdk>=3.40.0"]
+slack = ["slack_sdk>=3.40.0", "aiohttp>=3.7.3,<4"]
 
 # Dependencies for Embedders
 huggingface = [


### PR DESCRIPTION
## Summary
- Adds `aiohttp>=3.7.3,<4` to the `slack` optional extra in pyproject.toml

## Problem
`AsyncWebClient` from `slack_sdk` imports `aiohttp` at **module load time**, not lazily. This means:
1. User runs `pip install agno[slack]`
2. User tries to use Slack interface
3. `ImportError: No module named 'aiohttp'`

This affects ALL Slack operations (streaming and non-streaming) because the import happens unconditionally.

## Why this version constraint
- `>=3.7.3` — when aiohttp stabilized the async context manager API used by AsyncWebClient
- `<4` — matches slack_sdk's own constraint for aiohttp

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Formatted and validated: `./scripts/format.sh` && `./scripts/validate.sh`
- [x] No new agents created in loops
- [x] Follows CLAUDE.md coding patterns