### PR TITLE
fix(workflow): honor cancellation in executor HITL continue path

### DIFF
--- a/libs/agno/agno/workflow/workflow.py
+++ b/libs/agno/agno/workflow/workflow.py
@@ -5495,6 +5495,10 @@ class Workflow:
                         workflow_run_response=workflow_run_response,
                     )
 
+                    # Honor cancellation requested while the executor was running — without this
+                    # the single-step workflow would fall through to completion (see #7929).
+                    raise_if_cancelled(workflow_run_response.run_id)  # type: ignore
+
                     if is_executor_pause(step_output):
                         resolved = resolve_executor_pause(step, workflow_run_response)
                         if resolved:
@@ -6292,6 +6296,10 @@ class Workflow:
 
                     if step_output is None:
                         step_output = StepOutput(content="")
+
+                    # Honor cancellation requested while the executor was running — without this
+                    # the single-step workflow would fall through to completion (see #7929).
+                    raise_if_cancelled(workflow_run_response.run_id)  # type: ignore
 
                     if is_executor_pause(step_output):
                         resolved = resolve_executor_pause(step, workflow_run_response)
@@ -7378,6 +7386,10 @@ class Workflow:
                         workflow_run_response=workflow_run_response,
                     )
 
+                    # Honor cancellation requested while the executor was running — without this
+                    # the single-step workflow would fall through to completion (see #7929).
+                    await araise_if_cancelled(workflow_run_response.run_id)  # type: ignore
+
                     if is_executor_pause(step_output):
                         resolved = resolve_executor_pause(step, workflow_run_response)
                         if resolved:
@@ -7892,6 +7904,10 @@ class Workflow:
 
                     if step_output is None:
                         step_output = StepOutput(content="")
+
+                    # Honor cancellation requested while the executor was running — without this
+                    # the single-step workflow would fall through to completion (see #7929).
+                    await araise_if_cancelled(workflow_run_response.run_id)  # type: ignore
 
                     if is_executor_pause(step_output):
                         resolved = resolve_executor_pause(step, workflow_run_response)


### PR DESCRIPTION
`acancel_run` had no effect when a workflow step's tool used `external_execution` and the workflow was driven through `acontinue_run`. The four executor-HITL branches in `Workflow._*continue_run*` route events back to the paused agent/team but never call `(a)raise_if_cancelled`, so a single-step workflow falls through to `WorkflowCompletedEvent` regardless of the cancellation flag set during routing.

Check the cancellation registry immediately after routing returns in all four variants (sync, async, sync-stream, async-stream) so cancellation surfaces consistently with the non-HITL path.

Fixes #7929