### PR TITLE
Add Coinbase Agentic Wallet MCP tools

### DIFF
--- a/cookbook/91_tools/cdp_wallet_tools.py
+++ b/cookbook/91_tools/cdp_wallet_tools.py
@@ -1,0 +1,42 @@
+"""
+Coinbase Agentic Wallet MCP Tools
+=================================
+Connect an Agno agent to the installed Coinbase Agentic Wallet MCP bundle.
+
+Install the MCP bundle once:
+    npx @coinbase/payments-mcp
+
+The installer creates ~/.payments-mcp/bundle.js. CDPWalletTools wraps that
+installed bundle with Agno's MCPTools so agents can inspect wallet state,
+discover x402 services, and pay for services within user-controlled wallet
+limits.
+"""
+
+import asyncio
+
+from agno.agent import Agent
+from agno.models.openai import OpenAIChat
+from agno.tools.cdp_wallet import CDPWalletTools
+
+
+async def run_agent(message: str) -> None:
+    async with CDPWalletTools() as wallet:
+        agent = Agent(
+            model=OpenAIChat(id="gpt-5-mini"),
+            tools=[wallet],
+            markdown=True,
+            instructions=[
+                "Check wallet balance and spending limits before paid calls.",
+                "Use x402 discovery before selecting a paid service.",
+                "Do not exceed the wallet limits shown by the MCP tools.",
+            ],
+        )
+        await agent.aprint_response(message, stream=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(
+        run_agent(
+            "Show me my wallet status and find x402 crypto data services under five cents."
+        )
+    )

--- a/libs/agno/agno/tools/cdp_wallet.py
+++ b/libs/agno/agno/tools/cdp_wallet.py
@@ -1,0 +1,43 @@
+import shlex
+from pathlib import Path
+from typing import Optional, Union
+
+from agno.tools.mcp import MCPTools
+
+
+class CDPWalletTools(MCPTools):
+    """Connect Agno agents to Coinbase Agentic Wallet MCP."""
+
+    def __init__(
+        self,
+        bundle_path: Optional[Union[str, Path]] = None,
+        command: Optional[str] = None,
+        timeout_seconds: int = 30,
+        tool_name_prefix: Optional[str] = "cdp_wallet",
+        **kwargs,
+    ):
+        """Initialize the Coinbase Agentic Wallet MCP toolkit.
+
+        Args:
+            bundle_path: Path to the installed payments-mcp bundle. Defaults to
+                ~/.payments-mcp/bundle.js after running `npx @coinbase/payments-mcp`.
+            command: Full stdio command to run. Overrides bundle_path when set.
+            timeout_seconds: Read timeout for MCP calls.
+            tool_name_prefix: Prefix applied to exposed MCP tool names.
+            **kwargs: Additional MCPTools arguments such as include_tools, exclude_tools, or env.
+        """
+        self.bundle_path = Path(bundle_path).expanduser() if bundle_path is not None else self.default_bundle_path()
+
+        super().__init__(
+            command=command or f"node {shlex.quote(str(self.bundle_path))}",
+            transport="stdio",
+            timeout_seconds=timeout_seconds,
+            tool_name_prefix=tool_name_prefix,
+            **kwargs,
+        )
+        self.name = "cdp_wallet_tools"
+
+    @staticmethod
+    def default_bundle_path() -> Path:
+        """Return the default local bundle path created by the Coinbase installer."""
+        return Path.home() / ".payments-mcp" / "bundle.js"

--- a/libs/agno/tests/unit/tools/test_cdp_wallet.py
+++ b/libs/agno/tests/unit/tools/test_cdp_wallet.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+from agno.tools.cdp_wallet import CDPWalletTools
+
+
+def test_cdp_wallet_defaults_to_installed_bundle(monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: Path("/Users/tester"))
+
+    tools = CDPWalletTools()
+
+    assert tools.name == "cdp_wallet_tools"
+    assert tools.transport == "stdio"
+    assert tools.tool_name_prefix == "cdp_wallet"
+    assert tools.bundle_path == Path("/Users/tester/.payments-mcp/bundle.js")
+    assert tools.server_params is not None
+    assert tools.server_params.command == "node"
+    assert tools.server_params.args == ["/Users/tester/.payments-mcp/bundle.js"]
+
+
+def test_cdp_wallet_accepts_bundle_path_override(tmp_path):
+    bundle_path = tmp_path / "payments mcp" / "bundle.js"
+
+    tools = CDPWalletTools(bundle_path=bundle_path, timeout_seconds=45)
+
+    assert tools.timeout_seconds == 45
+    assert tools.bundle_path == bundle_path
+    assert tools.server_params is not None
+    assert tools.server_params.command == "node"
+    assert tools.server_params.args == [str(bundle_path)]
+
+
+def test_cdp_wallet_accepts_command_override():
+    tools = CDPWalletTools(command="node /tmp/custom-payments-mcp.js", tool_name_prefix=None)
+
+    assert tools.tool_name_prefix is None
+    assert tools.server_params is not None
+    assert tools.server_params.command == "node"
+    assert tools.server_params.args == ["/tmp/custom-payments-mcp.js"]


### PR DESCRIPTION
## Summary

Adds `CDPWalletTools`, a small `MCPTools` wrapper for the installed Coinbase Agentic Wallet / Payments MCP bundle.

The wrapper defaults to the bundle path created by the official installer:

```bash
npx @coinbase/payments-mcp
# creates ~/.payments-mcp/bundle.js
```

It then runs that bundle over stdio via Agno's existing MCP integration, with a `cdp_wallet` tool prefix by default. A custom bundle path or full command can be supplied for non-default installs.

Closes #7884.

## Changes

- Add `agno.tools.cdp_wallet.CDPWalletTools`
- Add focused unit coverage for default path, bundle path override, and command override
- Add a cookbook example for wallet status and x402 service discovery

## Validation

```bash
libs/agno/.venv/bin/python -m pytest libs/agno/tests/unit/tools/test_cdp_wallet.py -q
libs/agno/.venv/bin/python -m ruff check libs/agno/agno/tools/cdp_wallet.py libs/agno/tests/unit/tools/test_cdp_wallet.py cookbook/91_tools/cdp_wallet_tools.py
libs/agno/.venv/bin/python -m ruff format --check libs/agno/agno/tools/cdp_wallet.py libs/agno/tests/unit/tools/test_cdp_wallet.py cookbook/91_tools/cdp_wallet_tools.py
```

Note: `uv run --project libs/agno ...` currently fails before running tests in this checkout because dependency resolution hits an unrelated optional-extra conflict between `brave-search` metadata and `a2a-sdk`/`httpx` for future Python markers. I validated with a local venv containing the focused Agno/MCP test dependencies instead.
