### PR TITLE
[fix] Resolve N1N model strings

### DIFF
--- a/libs/agno/agno/models/utils.py
+++ b/libs/agno/agno/models/utils.py
@@ -149,6 +149,11 @@ def _get_model_class(model_id: str, model_provider: str) -> Model:
 
         return MoonShot(id=model_id)
 
+    elif model_provider == "n1n":
+        from agno.models.n1n import N1N
+
+        return N1N(id=model_id)
+
     elif model_provider == "nebius":
         from agno.models.nebius import Nebius
 

--- a/libs/agno/tests/unit/utils/test_model_string.py
+++ b/libs/agno/tests/unit/utils/test_model_string.py
@@ -7,6 +7,7 @@ from agno.memory.manager import MemoryManager
 from agno.models.anthropic import Claude
 from agno.models.google import Gemini
 from agno.models.groq import Groq
+from agno.models.n1n import N1N
 from agno.models.openai import OpenAIChat, OpenAIResponses
 from agno.models.utils import get_model
 from agno.team import Team
@@ -44,6 +45,13 @@ def test_get_model_parses_anthropic_string():
     model = get_model("anthropic:claude-3-5-sonnet-20241022")
     assert isinstance(model, Claude)
     assert model.id == "claude-3-5-sonnet-20241022"
+
+
+def test_get_model_parses_n1n_string():
+    """Test get_model() parses N1N model string."""
+    model = get_model("n1n:gpt-4o")
+    assert isinstance(model, N1N)
+    assert model.id == "gpt-4o"
 
 
 def test_get_model_strips_whitespace():


### PR DESCRIPTION
## Summary

Adds the missing `n1n` provider mapping to `agno.models.utils.get_model()` so model-string paths such as `Agent(model="n1n:gpt-4o")` resolve to the existing `N1N` provider.

Related to #5036.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Focused validation run from `libs/agno` using a minimal local venv because `uv run --extra dev pytest tests/unit/utils/test_model_string.py` could not resolve all package extras in this environment (`brave-search` and `a2a-sdk` require incompatible `httpx` versions across supported Python splits).

Validation passed:

- `TMPDIR=/home/ubuntu/gh-pr/agno-worker-next/.tmp .venv/bin/python -m pytest -p no:cacheprovider tests/unit/utils/test_model_string.py`
- `TMPDIR=/home/ubuntu/gh-pr/agno-worker-next/.tmp .venv/bin/python -m pytest -p no:cacheprovider tests/unit/models/test_n1n.py`
- `.venv/bin/ruff format --check agno/models/utils.py tests/unit/utils/test_model_string.py`
- `.venv/bin/ruff check agno/models/utils.py tests/unit/utils/test_model_string.py`
- `git diff --check`
