### PR TITLE
fix: GeminiInteractions generation_config passthrough and stateful input slicing

### DIFF
--- a/cookbook/90_models/google/gemini_interactions/multi_turn.py
+++ b/cookbook/90_models/google/gemini_interactions/multi_turn.py
@@ -7,11 +7,9 @@ After the first response, subsequent turns only send the new message
 and reference the previous interaction via `previous_interaction_id`.
 This enables implicit caching and reduces token costs.
 
-Multi-turn works either way:
-- With a db (recommended): conversation history is persisted across processes
-  and the previous_interaction_id flows through assistant message provider_data
-- Without a db: the model falls back to a per-session in-memory cache, so
-  multi-turn still works within a single process
+Multi-turn requires a db (e.g. SqliteDb) so the interaction_id from each
+turn's response is persisted on the assistant message and read back on
+the next turn.
 """
 
 from agno.agent import Agent

--- a/cookbook/90_models/google/gemini_interactions/multi_turn.py
+++ b/cookbook/90_models/google/gemini_interactions/multi_turn.py
@@ -6,6 +6,12 @@ Demonstrates server-side conversation history with the Interactions API.
 After the first response, subsequent turns only send the new message
 and reference the previous interaction via `previous_interaction_id`.
 This enables implicit caching and reduces token costs.
+
+Multi-turn works either way:
+- With a db (recommended): conversation history is persisted across processes
+  and the previous_interaction_id flows through assistant message provider_data
+- Without a db: the model falls back to a per-session in-memory cache, so
+  multi-turn still works within a single process
 """
 
 from agno.agent import Agent

--- a/libs/agno/agno/models/google/gemini_interactions.py
+++ b/libs/agno/agno/models/google/gemini_interactions.py
@@ -359,18 +359,20 @@ class GeminiInteractions(Model):
         if system_message:
             kwargs["system_instruction"] = system_message
 
-        # When previous_interaction_id is set, the server already has all turns
-        # up to and including that assistant message. Send only the messages
-        # AFTER it - this is the core value of the Interactions API: server-side
-        # state, no need to replay history.
-        previous_interaction_id, boundary_idx = self._find_previous_interaction(messages)
-        input_messages = messages if boundary_idx == -1 else messages[boundary_idx + 1 :]
+        # When store=False, the user has opted out of server-side state - send
+        # the full message history and don't chain via previous_interaction_id.
+        # Otherwise, leverage server-side state: pass previous_interaction_id
+        # and send only the messages AFTER the prior assistant turn (the server
+        # already has everything up to that point).
+        if self.store is False:
+            input_messages: List[Message] = messages
+        else:
+            previous_interaction_id, boundary_idx = self._find_previous_interaction(messages)
+            input_messages = messages if boundary_idx == -1 else messages[boundary_idx + 1 :]
+            if previous_interaction_id:
+                kwargs["previous_interaction_id"] = previous_interaction_id
 
-        input_turns = self._build_input(input_messages)
-        kwargs["input"] = input_turns
-
-        if previous_interaction_id:
-            kwargs["previous_interaction_id"] = previous_interaction_id
+        kwargs["input"] = self._build_input(input_messages)
 
         # Generation config (only params supported by the Interactions API SDK)
         generation_config: Dict[str, Any] = {}

--- a/libs/agno/agno/models/google/gemini_interactions.py
+++ b/libs/agno/agno/models/google/gemini_interactions.py
@@ -57,41 +57,6 @@ except ImportError:
     ImageContent = None  # type: ignore[assignment, misc]
 
 
-# Keys accepted by the Interactions API's GenerationConfigParam. Used to filter
-# raw generation_config (dict or Pydantic dump) before merging, so that passing
-# a stricter-typed object like GenerateContentConfig - which carries Gemini-only
-# keys such as http_options, tools, and system_instruction - doesn't produce
-# an invalid Interactions payload.
-_GENERATION_CONFIG_KEYS = frozenset(
-    {
-        "image_config",
-        "max_output_tokens",
-        "seed",
-        "speech_config",
-        "stop_sequences",
-        "temperature",
-        "thinking_level",
-        "thinking_summaries",
-        "tool_choice",
-        "top_p",
-    }
-)
-
-
-def _normalize_generation_config(config: Any) -> Dict[str, Any]:
-    """Convert generation_config to a dict and keep only Interactions-supported keys.
-
-    Accepts either a dict or a Pydantic-like object (e.g. GenerateContentConfig).
-    Strips None values via model_dump(exclude_none=True) and filters out keys
-    not in GenerationConfigParam.
-    """
-    if config is None:
-        return {}
-    if hasattr(config, "model_dump"):
-        config = config.model_dump(exclude_none=True)
-    return {k: v for k, v in config.items() if k in _GENERATION_CONFIG_KEYS}
-
-
 @dataclass
 class GeminiInteractions(Model):
     """
@@ -422,9 +387,13 @@ class GeminiInteractions(Model):
         if self.thinking_level is not None:
             generation_config["thinking_level"] = self.thinking_level
         # Merge user-provided raw config last - their keys override field-derived values.
-        # Normalize first: handle Pydantic objects, strip None, drop unsupported keys.
+        # If it's a Pydantic-like object (e.g. GenerateContentConfig), dump it
+        # with exclude_none so the request isn't flooded with unset fields.
         if self.generation_config:
-            generation_config.update(_normalize_generation_config(self.generation_config))
+            extra = self.generation_config
+            if hasattr(extra, "model_dump"):
+                extra = extra.model_dump(exclude_none=True)
+            generation_config.update(extra)
         if generation_config:
             kwargs["generation_config"] = generation_config
 

--- a/libs/agno/agno/models/google/gemini_interactions.py
+++ b/libs/agno/agno/models/google/gemini_interactions.py
@@ -104,11 +104,11 @@ class GeminiInteractions(Model):
     response_modalities: Optional[list[str]] = None
 
     # Raw GenerationConfigParam passthrough. Accepts either a dict or a
-    # Pydantic-like object (e.g. google.genai.types.GenerateContentConfig).
-    # Merged into the generation_config built from the fields above; keys here
-    # override field-derived values. Only Interactions-supported keys are kept
-    # (see _GENERATION_CONFIG_KEYS) - other keys are dropped.
-    generation_config: Optional[Any] = None
+    # Pydantic model (e.g. google.genai.types.GenerateContentConfig). Merged
+    # into the generation_config built from the fields above; keys here
+    # override field-derived values. Pydantic models are dumped with
+    # exclude_none so unset fields don't flood the request.
+    generation_config: Optional[Union[Dict[str, Any], BaseModel]] = None
 
     # Interactions API specific parameters
     store: Optional[bool] = None  # Whether to persist interactions server-side (default: True)
@@ -387,12 +387,14 @@ class GeminiInteractions(Model):
         if self.thinking_level is not None:
             generation_config["thinking_level"] = self.thinking_level
         # Merge user-provided raw config last - their keys override field-derived values.
-        # If it's a Pydantic-like object (e.g. GenerateContentConfig), dump it
-        # with exclude_none so the request isn't flooded with unset fields.
+        # If it's a Pydantic model (e.g. GenerateContentConfig), dump it with
+        # exclude_none so the request isn't flooded with unset fields.
         if self.generation_config:
-            extra = self.generation_config
-            if hasattr(extra, "model_dump"):
-                extra = extra.model_dump(exclude_none=True)
+            extra = (
+                self.generation_config.model_dump(exclude_none=True)
+                if isinstance(self.generation_config, BaseModel)
+                else self.generation_config
+            )
             generation_config.update(extra)
         if generation_config:
             kwargs["generation_config"] = generation_config

--- a/libs/agno/agno/models/google/gemini_interactions.py
+++ b/libs/agno/agno/models/google/gemini_interactions.py
@@ -10,7 +10,7 @@ Requires `google-genai>=2.0.0`.
 import base64
 import json
 from collections.abc import AsyncIterator
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from os import getenv
 from typing import Any, Dict, Iterator, List, Literal, Optional, Type, Union
 from uuid import uuid4
@@ -103,6 +103,11 @@ class GeminiInteractions(Model):
     seed: Optional[int] = None
     response_modalities: Optional[list[str]] = None
 
+    # Raw GenerationConfigParam passthrough. Merged into the generation_config
+    # built from the fields above; keys here override the field-derived values.
+    # Use this for advanced params not exposed as individual fields.
+    generation_config: Optional[Dict[str, Any]] = None
+
     # Interactions API specific parameters
     store: Optional[bool] = None  # Whether to persist interactions server-side (default: True)
 
@@ -127,19 +132,36 @@ class GeminiInteractions(Model):
     # Client instance
     client: Optional[GeminiClient] = None
 
-    def _get_previous_interaction_id(self, messages: List[Message]) -> Optional[str]:
-        """Extract the previous interaction ID from message provider_data.
+    # In-memory fallback cache of the last interaction_id keyed by session_id.
+    # Used when the conversation history (and the assistant message's
+    # provider_data) is not available - e.g. when no db is configured. Keyed by
+    # session so concurrent sessions on the same model instance stay isolated.
+    _session_interaction_ids: Dict[str, str] = field(default_factory=dict, init=False, repr=False)
 
-        Walks messages in reverse to find the most recent assistant message
-        with an interaction_id. This avoids storing state at instance level,
-        which would be unsafe if two concurrent agents share the same model.
+    def _get_previous_interaction_id(
+        self, messages: List[Message], run_response: Optional[RunOutput] = None
+    ) -> Optional[str]:
+        """Extract the previous interaction ID.
+
+        First checks message provider_data (the durable path - works when the
+        conversation history is persisted, e.g. via a db). Falls back to the
+        per-session in-memory cache so multi-turn still works without a db,
+        since the Interactions API manages history server-side.
         """
         for msg in reversed(messages):
             if msg.role == "assistant" and msg.provider_data:
                 iid = msg.provider_data.get("interaction_id")
                 if iid:
                     return iid
+
+        if run_response is not None and run_response.session_id:
+            return self._session_interaction_ids.get(run_response.session_id)
         return None
+
+    def _store_interaction_id(self, run_response: Optional[RunOutput], interaction_id: Optional[str]) -> None:
+        """Cache the interaction_id keyed by session for the no-db fallback path."""
+        if run_response is not None and run_response.session_id and interaction_id:
+            self._session_interaction_ids[run_response.session_id] = interaction_id
 
     def get_client(self) -> GeminiClient:
         """Returns an instance of the GeminiClient.
@@ -187,6 +209,7 @@ class GeminiInteractions(Model):
                 "thinking_level": self.thinking_level,
                 "store": self.store,
                 "service_tier": self.service_tier,
+                "generation_config": self.generation_config,
             }
         )
         return {k: v for k, v in model_dict.items() if v is not None}
@@ -335,6 +358,7 @@ class GeminiInteractions(Model):
         messages: List[Message],
         tools: Optional[List[Dict[str, Any]]] = None,
         response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
+        run_response: Optional[RunOutput] = None,
     ) -> Dict[str, Any]:
         """Build keyword arguments for interactions.create()."""
         kwargs: Dict[str, Any] = {
@@ -354,8 +378,9 @@ class GeminiInteractions(Model):
         if system_message:
             kwargs["system_instruction"] = system_message
 
-        # Previous interaction for multi-turn (read from message provider_data)
-        previous_interaction_id = self._get_previous_interaction_id(messages)
+        # Previous interaction for multi-turn. Falls back to session cache when
+        # history isn't propagated through messages (e.g. no db configured).
+        previous_interaction_id = self._get_previous_interaction_id(messages, run_response)
         if previous_interaction_id:
             kwargs["previous_interaction_id"] = previous_interaction_id
 
@@ -373,6 +398,9 @@ class GeminiInteractions(Model):
             generation_config["seed"] = self.seed
         if self.thinking_level is not None:
             generation_config["thinking_level"] = self.thinking_level
+        # Merge user-provided raw config last - their keys override field-derived values
+        if self.generation_config:
+            generation_config.update(self.generation_config)
         if generation_config:
             kwargs["generation_config"] = generation_config
 
@@ -652,7 +680,9 @@ class GeminiInteractions(Model):
         retry_with_guidance: bool = False,
     ) -> ModelResponse:
         """Invoke the model using the Interactions API."""
-        request_kwargs = self._get_request_kwargs(messages, tools=tools, response_format=response_format)
+        request_kwargs = self._get_request_kwargs(
+            messages, tools=tools, response_format=response_format, run_response=run_response
+        )
         log_debug(f"Calling Gemini Interactions API with params: {list(request_kwargs.keys())}", log_level=2)
 
         try:
@@ -660,7 +690,9 @@ class GeminiInteractions(Model):
             interaction = self.get_client().interactions.create(**request_kwargs)
             assistant_message.metrics.stop_timer()
 
-            return self._parse_provider_response(interaction)
+            model_response = self._parse_provider_response(interaction)
+            self._store_interaction_id(run_response, getattr(interaction, "id", None))
+            return model_response
 
         except Exception as e:
             log_error(f"Error from Gemini Interactions API: {str(e)}")
@@ -678,7 +710,9 @@ class GeminiInteractions(Model):
         retry_with_guidance: bool = False,
     ) -> Iterator[ModelResponse]:
         """Invoke the model with streaming using the Interactions API."""
-        request_kwargs = self._get_request_kwargs(messages, tools=tools, response_format=response_format)
+        request_kwargs = self._get_request_kwargs(
+            messages, tools=tools, response_format=response_format, run_response=run_response
+        )
         request_kwargs["stream"] = True
         log_debug(f"Calling Gemini Interactions API (stream) with params: {list(request_kwargs.keys())}", log_level=2)
 
@@ -686,13 +720,17 @@ class GeminiInteractions(Model):
             assistant_message.metrics.start_timer()
             stream = self.get_client().interactions.create(**request_kwargs)
             stream_state: Dict[str, Any] = {"pending_calls": {}}
+            interaction_id: Optional[str] = None
 
             for event in stream:
                 model_response, stream_state = self._parse_provider_response_delta(
                     stream_event=event, assistant_message=assistant_message, stream_state=stream_state
                 )
+                if model_response.provider_data and model_response.provider_data.get("interaction_id"):
+                    interaction_id = model_response.provider_data["interaction_id"]
                 yield model_response
 
+            self._store_interaction_id(run_response, interaction_id)
             assistant_message.metrics.stop_timer()
 
         except Exception as e:
@@ -711,7 +749,9 @@ class GeminiInteractions(Model):
         retry_with_guidance: bool = False,
     ) -> ModelResponse:
         """Async invoke the model using the Interactions API."""
-        request_kwargs = self._get_request_kwargs(messages, tools=tools, response_format=response_format)
+        request_kwargs = self._get_request_kwargs(
+            messages, tools=tools, response_format=response_format, run_response=run_response
+        )
         log_debug(f"Calling Gemini Interactions API (async) with params: {list(request_kwargs.keys())}", log_level=2)
 
         try:
@@ -719,7 +759,9 @@ class GeminiInteractions(Model):
             interaction = await self.get_client().aio.interactions.create(**request_kwargs)
             assistant_message.metrics.stop_timer()
 
-            return self._parse_provider_response(interaction)
+            model_response = self._parse_provider_response(interaction)
+            self._store_interaction_id(run_response, getattr(interaction, "id", None))
+            return model_response
 
         except Exception as e:
             log_error(f"Error from Gemini Interactions API (async): {str(e)}")
@@ -737,7 +779,9 @@ class GeminiInteractions(Model):
         retry_with_guidance: bool = False,
     ) -> AsyncIterator[ModelResponse]:
         """Async streaming invoke using the Interactions API."""
-        request_kwargs = self._get_request_kwargs(messages, tools=tools, response_format=response_format)
+        request_kwargs = self._get_request_kwargs(
+            messages, tools=tools, response_format=response_format, run_response=run_response
+        )
         request_kwargs["stream"] = True
         log_debug(
             f"Calling Gemini Interactions API (async stream) with params: {list(request_kwargs.keys())}", log_level=2
@@ -747,13 +791,17 @@ class GeminiInteractions(Model):
             assistant_message.metrics.start_timer()
             stream = await self.get_client().aio.interactions.create(**request_kwargs)
             stream_state: Dict[str, Any] = {"pending_calls": {}}
+            interaction_id: Optional[str] = None
 
             async for event in stream:
                 model_response, stream_state = self._parse_provider_response_delta(
                     stream_event=event, assistant_message=assistant_message, stream_state=stream_state
                 )
+                if model_response.provider_data and model_response.provider_data.get("interaction_id"):
+                    interaction_id = model_response.provider_data["interaction_id"]
                 yield model_response
 
+            self._store_interaction_id(run_response, interaction_id)
             assistant_message.metrics.stop_timer()
 
         except Exception as e:

--- a/libs/agno/agno/models/google/gemini_interactions.py
+++ b/libs/agno/agno/models/google/gemini_interactions.py
@@ -10,7 +10,7 @@ Requires `google-genai>=2.0.0`.
 import base64
 import json
 from collections.abc import AsyncIterator
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from os import getenv
 from typing import Any, Dict, Iterator, List, Literal, Optional, Type, Union
 from uuid import uuid4
@@ -132,36 +132,20 @@ class GeminiInteractions(Model):
     # Client instance
     client: Optional[GeminiClient] = None
 
-    # In-memory fallback cache of the last interaction_id keyed by session_id.
-    # Used when the conversation history (and the assistant message's
-    # provider_data) is not available - e.g. when no db is configured. Keyed by
-    # session so concurrent sessions on the same model instance stay isolated.
-    _session_interaction_ids: Dict[str, str] = field(default_factory=dict, init=False, repr=False)
+    def _find_previous_interaction(self, messages: List[Message]) -> tuple[Optional[str], int]:
+        """Find the most recent assistant message with an interaction_id.
 
-    def _get_previous_interaction_id(
-        self, messages: List[Message], run_response: Optional[RunOutput] = None
-    ) -> Optional[str]:
-        """Extract the previous interaction ID.
-
-        First checks message provider_data (the durable path - works when the
-        conversation history is persisted, e.g. via a db). Falls back to the
-        per-session in-memory cache so multi-turn still works without a db,
-        since the Interactions API manages history server-side.
+        Returns (interaction_id, index_in_messages) or (None, -1). The index
+        marks the last turn the server has seen; messages after it are the
+        new turns to send. Walks in reverse so we pick the most recent.
         """
-        for msg in reversed(messages):
+        for i in range(len(messages) - 1, -1, -1):
+            msg = messages[i]
             if msg.role == "assistant" and msg.provider_data:
                 iid = msg.provider_data.get("interaction_id")
                 if iid:
-                    return iid
-
-        if run_response is not None and run_response.session_id:
-            return self._session_interaction_ids.get(run_response.session_id)
-        return None
-
-    def _store_interaction_id(self, run_response: Optional[RunOutput], interaction_id: Optional[str]) -> None:
-        """Cache the interaction_id keyed by session for the no-db fallback path."""
-        if run_response is not None and run_response.session_id and interaction_id:
-            self._session_interaction_ids[run_response.session_id] = interaction_id
+                    return iid, i
+        return None, -1
 
     def get_client(self) -> GeminiClient:
         """Returns an instance of the GeminiClient.
@@ -358,16 +342,11 @@ class GeminiInteractions(Model):
         messages: List[Message],
         tools: Optional[List[Dict[str, Any]]] = None,
         response_format: Optional[Union[Dict, Type[BaseModel]]] = None,
-        run_response: Optional[RunOutput] = None,
     ) -> Dict[str, Any]:
         """Build keyword arguments for interactions.create()."""
         kwargs: Dict[str, Any] = {
             "model": self.id,
         }
-
-        # Build input from messages
-        input_turns = self._build_input(messages)
-        kwargs["input"] = input_turns
 
         # System instruction from the last system message (consistent with gemini.py)
         system_message = None
@@ -378,9 +357,16 @@ class GeminiInteractions(Model):
         if system_message:
             kwargs["system_instruction"] = system_message
 
-        # Previous interaction for multi-turn. Falls back to session cache when
-        # history isn't propagated through messages (e.g. no db configured).
-        previous_interaction_id = self._get_previous_interaction_id(messages, run_response)
+        # When previous_interaction_id is set, the server already has all turns
+        # up to and including that assistant message. Send only the messages
+        # AFTER it - this is the core value of the Interactions API: server-side
+        # state, no need to replay history.
+        previous_interaction_id, boundary_idx = self._find_previous_interaction(messages)
+        input_messages = messages if boundary_idx == -1 else messages[boundary_idx + 1 :]
+
+        input_turns = self._build_input(input_messages)
+        kwargs["input"] = input_turns
+
         if previous_interaction_id:
             kwargs["previous_interaction_id"] = previous_interaction_id
 
@@ -680,9 +666,7 @@ class GeminiInteractions(Model):
         retry_with_guidance: bool = False,
     ) -> ModelResponse:
         """Invoke the model using the Interactions API."""
-        request_kwargs = self._get_request_kwargs(
-            messages, tools=tools, response_format=response_format, run_response=run_response
-        )
+        request_kwargs = self._get_request_kwargs(messages, tools=tools, response_format=response_format)
         log_debug(f"Calling Gemini Interactions API with params: {list(request_kwargs.keys())}", log_level=2)
 
         try:
@@ -690,9 +674,7 @@ class GeminiInteractions(Model):
             interaction = self.get_client().interactions.create(**request_kwargs)
             assistant_message.metrics.stop_timer()
 
-            model_response = self._parse_provider_response(interaction)
-            self._store_interaction_id(run_response, getattr(interaction, "id", None))
-            return model_response
+            return self._parse_provider_response(interaction)
 
         except Exception as e:
             log_error(f"Error from Gemini Interactions API: {str(e)}")
@@ -710,9 +692,7 @@ class GeminiInteractions(Model):
         retry_with_guidance: bool = False,
     ) -> Iterator[ModelResponse]:
         """Invoke the model with streaming using the Interactions API."""
-        request_kwargs = self._get_request_kwargs(
-            messages, tools=tools, response_format=response_format, run_response=run_response
-        )
+        request_kwargs = self._get_request_kwargs(messages, tools=tools, response_format=response_format)
         request_kwargs["stream"] = True
         log_debug(f"Calling Gemini Interactions API (stream) with params: {list(request_kwargs.keys())}", log_level=2)
 
@@ -720,17 +700,13 @@ class GeminiInteractions(Model):
             assistant_message.metrics.start_timer()
             stream = self.get_client().interactions.create(**request_kwargs)
             stream_state: Dict[str, Any] = {"pending_calls": {}}
-            interaction_id: Optional[str] = None
 
             for event in stream:
                 model_response, stream_state = self._parse_provider_response_delta(
                     stream_event=event, assistant_message=assistant_message, stream_state=stream_state
                 )
-                if model_response.provider_data and model_response.provider_data.get("interaction_id"):
-                    interaction_id = model_response.provider_data["interaction_id"]
                 yield model_response
 
-            self._store_interaction_id(run_response, interaction_id)
             assistant_message.metrics.stop_timer()
 
         except Exception as e:
@@ -749,9 +725,7 @@ class GeminiInteractions(Model):
         retry_with_guidance: bool = False,
     ) -> ModelResponse:
         """Async invoke the model using the Interactions API."""
-        request_kwargs = self._get_request_kwargs(
-            messages, tools=tools, response_format=response_format, run_response=run_response
-        )
+        request_kwargs = self._get_request_kwargs(messages, tools=tools, response_format=response_format)
         log_debug(f"Calling Gemini Interactions API (async) with params: {list(request_kwargs.keys())}", log_level=2)
 
         try:
@@ -759,9 +733,7 @@ class GeminiInteractions(Model):
             interaction = await self.get_client().aio.interactions.create(**request_kwargs)
             assistant_message.metrics.stop_timer()
 
-            model_response = self._parse_provider_response(interaction)
-            self._store_interaction_id(run_response, getattr(interaction, "id", None))
-            return model_response
+            return self._parse_provider_response(interaction)
 
         except Exception as e:
             log_error(f"Error from Gemini Interactions API (async): {str(e)}")
@@ -779,9 +751,7 @@ class GeminiInteractions(Model):
         retry_with_guidance: bool = False,
     ) -> AsyncIterator[ModelResponse]:
         """Async streaming invoke using the Interactions API."""
-        request_kwargs = self._get_request_kwargs(
-            messages, tools=tools, response_format=response_format, run_response=run_response
-        )
+        request_kwargs = self._get_request_kwargs(messages, tools=tools, response_format=response_format)
         request_kwargs["stream"] = True
         log_debug(
             f"Calling Gemini Interactions API (async stream) with params: {list(request_kwargs.keys())}", log_level=2
@@ -791,17 +761,13 @@ class GeminiInteractions(Model):
             assistant_message.metrics.start_timer()
             stream = await self.get_client().aio.interactions.create(**request_kwargs)
             stream_state: Dict[str, Any] = {"pending_calls": {}}
-            interaction_id: Optional[str] = None
 
             async for event in stream:
                 model_response, stream_state = self._parse_provider_response_delta(
                     stream_event=event, assistant_message=assistant_message, stream_state=stream_state
                 )
-                if model_response.provider_data and model_response.provider_data.get("interaction_id"):
-                    interaction_id = model_response.provider_data["interaction_id"]
                 yield model_response
 
-            self._store_interaction_id(run_response, interaction_id)
             assistant_message.metrics.stop_timer()
 
         except Exception as e:

--- a/libs/agno/agno/models/google/gemini_interactions.py
+++ b/libs/agno/agno/models/google/gemini_interactions.py
@@ -57,6 +57,41 @@ except ImportError:
     ImageContent = None  # type: ignore[assignment, misc]
 
 
+# Keys accepted by the Interactions API's GenerationConfigParam. Used to filter
+# raw generation_config (dict or Pydantic dump) before merging, so that passing
+# a stricter-typed object like GenerateContentConfig - which carries Gemini-only
+# keys such as http_options, tools, and system_instruction - doesn't produce
+# an invalid Interactions payload.
+_GENERATION_CONFIG_KEYS = frozenset(
+    {
+        "image_config",
+        "max_output_tokens",
+        "seed",
+        "speech_config",
+        "stop_sequences",
+        "temperature",
+        "thinking_level",
+        "thinking_summaries",
+        "tool_choice",
+        "top_p",
+    }
+)
+
+
+def _normalize_generation_config(config: Any) -> Dict[str, Any]:
+    """Convert generation_config to a dict and keep only Interactions-supported keys.
+
+    Accepts either a dict or a Pydantic-like object (e.g. GenerateContentConfig).
+    Strips None values via model_dump(exclude_none=True) and filters out keys
+    not in GenerationConfigParam.
+    """
+    if config is None:
+        return {}
+    if hasattr(config, "model_dump"):
+        config = config.model_dump(exclude_none=True)
+    return {k: v for k, v in config.items() if k in _GENERATION_CONFIG_KEYS}
+
+
 @dataclass
 class GeminiInteractions(Model):
     """
@@ -103,10 +138,12 @@ class GeminiInteractions(Model):
     seed: Optional[int] = None
     response_modalities: Optional[list[str]] = None
 
-    # Raw GenerationConfigParam passthrough. Merged into the generation_config
-    # built from the fields above; keys here override the field-derived values.
-    # Use this for advanced params not exposed as individual fields.
-    generation_config: Optional[Dict[str, Any]] = None
+    # Raw GenerationConfigParam passthrough. Accepts either a dict or a
+    # Pydantic-like object (e.g. google.genai.types.GenerateContentConfig).
+    # Merged into the generation_config built from the fields above; keys here
+    # override field-derived values. Only Interactions-supported keys are kept
+    # (see _GENERATION_CONFIG_KEYS) - other keys are dropped.
+    generation_config: Optional[Any] = None
 
     # Interactions API specific parameters
     store: Optional[bool] = None  # Whether to persist interactions server-side (default: True)
@@ -384,9 +421,10 @@ class GeminiInteractions(Model):
             generation_config["seed"] = self.seed
         if self.thinking_level is not None:
             generation_config["thinking_level"] = self.thinking_level
-        # Merge user-provided raw config last - their keys override field-derived values
+        # Merge user-provided raw config last - their keys override field-derived values.
+        # Normalize first: handle Pydantic objects, strip None, drop unsupported keys.
         if self.generation_config:
-            generation_config.update(self.generation_config)
+            generation_config.update(_normalize_generation_config(self.generation_config))
         if generation_config:
             kwargs["generation_config"] = generation_config
 

--- a/libs/agno/tests/unit/models/google/test_gemini_interactions.py
+++ b/libs/agno/tests/unit/models/google/test_gemini_interactions.py
@@ -328,6 +328,24 @@ class TestGetRequestKwargs:
         assert cfg["top_p"] == 0.95
         assert "max_output_tokens" not in cfg
 
+    def test_store_false_opts_out_of_server_state(self):
+        """store=False disables previous_interaction_id chaining; full history is sent."""
+        model = self._make_model(store=False)
+        messages = [
+            Message(role="user", content="First turn"),
+            Message(role="assistant", content="Reply 1", provider_data={"interaction_id": "interactions/abc"}),
+            Message(role="user", content="Follow up"),
+        ]
+        kwargs = model._get_request_kwargs(messages)
+        assert "previous_interaction_id" not in kwargs
+        # Full history is sent: user1 + assistant1 (no tool calls -> skipped) + user2
+        # _build_input emits a user_input step for each user message
+        input_steps = kwargs["input"]
+        user_steps = [s for s in input_steps if s["type"] == "user_input"]
+        assert len(user_steps) == 2
+        assert user_steps[0]["content"][0]["text"] == "First turn"
+        assert user_steps[1]["content"][0]["text"] == "Follow up"
+
     def test_input_sliced_when_previous_interaction_id_set(self):
         """When previous_interaction_id is set, only messages after the prior assistant turn are sent."""
         model = self._make_model()

--- a/libs/agno/tests/unit/models/google/test_gemini_interactions.py
+++ b/libs/agno/tests/unit/models/google/test_gemini_interactions.py
@@ -292,23 +292,58 @@ class TestGetRequestKwargs:
         assert kwargs["response_modalities"] == ["text", "image"]
 
     def test_generation_config_passthrough_merges_with_fields(self):
-        """generation_config dict is merged in - its keys override field-derived values."""
+        """Supported keys from generation_config are merged into the request config."""
         model = self._make_model(
             temperature=0.5,
-            generation_config={"top_p": 0.9, "top_k": 40, "presence_penalty": 0.1},
+            generation_config={"top_p": 0.9, "thinking_summaries": "auto", "tool_choice": "auto"},
         )
         kwargs = model._get_request_kwargs([Message(role="user", content="Hi")])
         cfg = kwargs["generation_config"]
         assert cfg["temperature"] == 0.5
         assert cfg["top_p"] == 0.9
-        assert cfg["top_k"] == 40
-        assert cfg["presence_penalty"] == 0.1
+        assert cfg["thinking_summaries"] == "auto"
+        assert cfg["tool_choice"] == "auto"
 
     def test_generation_config_passthrough_overrides_fields(self):
-        """When the same key is set on both, the passthrough dict wins."""
+        """When the same key is set on both, the passthrough wins."""
         model = self._make_model(temperature=0.5, generation_config={"temperature": 0.9})
         kwargs = model._get_request_kwargs([Message(role="user", content="Hi")])
         assert kwargs["generation_config"]["temperature"] == 0.9
+
+    def test_generation_config_filters_unsupported_keys(self):
+        """Keys not in GenerationConfigParam are dropped (e.g. http_options, system_instruction)."""
+        model = self._make_model(
+            generation_config={
+                "temperature": 0.7,
+                "http_options": {"timeout": 30},  # GenerateContentConfig-only
+                "system_instruction": "ignored",  # GenerateContentConfig-only
+                "tools": [],  # GenerateContentConfig-only
+                "top_k": 40,  # generateContent-only
+            }
+        )
+        kwargs = model._get_request_kwargs([Message(role="user", content="Hi")])
+        cfg = kwargs["generation_config"]
+        assert cfg == {"temperature": 0.7}
+
+    def test_generation_config_accepts_pydantic_object(self):
+        """Passing a Pydantic-like config (e.g. GenerateContentConfig) is normalized via model_dump."""
+
+        class FakeConfig:
+            def model_dump(self, exclude_none=True):
+                # Simulate GenerateContentConfig's wide dump: many None fields plus
+                # Gemini-only keys that the Interactions API doesn't accept.
+                return {
+                    "temperature": 0.8,
+                    "top_p": 0.95,
+                    "http_options": {"timeout": 30},
+                    "system_instruction": "ignored",
+                    "tools": [],
+                }
+
+        model = self._make_model(generation_config=FakeConfig())
+        kwargs = model._get_request_kwargs([Message(role="user", content="Hi")])
+        cfg = kwargs["generation_config"]
+        assert cfg == {"temperature": 0.8, "top_p": 0.95}
 
     def test_input_sliced_when_previous_interaction_id_set(self):
         """When previous_interaction_id is set, only messages after the prior assistant turn are sent."""

--- a/libs/agno/tests/unit/models/google/test_gemini_interactions.py
+++ b/libs/agno/tests/unit/models/google/test_gemini_interactions.py
@@ -311,18 +311,22 @@ class TestGetRequestKwargs:
         assert kwargs["generation_config"]["temperature"] == 0.9
 
     def test_generation_config_accepts_pydantic_object(self):
-        """Pydantic-like configs (e.g. GenerateContentConfig) are dumped with exclude_none."""
+        """Pydantic models (e.g. GenerateContentConfig) are dumped with exclude_none."""
+        from typing import Optional as _Opt
 
-        class FakeConfig:
-            def model_dump(self, exclude_none=True):
-                # exclude_none drops the None fields the SDK declares for completeness
-                return {"temperature": 0.8, "top_p": 0.95}
+        from pydantic import BaseModel as _PydBase
 
-        model = self._make_model(generation_config=FakeConfig())
+        class FakeConfig(_PydBase):
+            temperature: _Opt[float] = None
+            top_p: _Opt[float] = None
+            max_output_tokens: _Opt[int] = None  # unset, should be excluded
+
+        model = self._make_model(generation_config=FakeConfig(temperature=0.8, top_p=0.95))
         kwargs = model._get_request_kwargs([Message(role="user", content="Hi")])
         cfg = kwargs["generation_config"]
         assert cfg["temperature"] == 0.8
         assert cfg["top_p"] == 0.95
+        assert "max_output_tokens" not in cfg
 
     def test_input_sliced_when_previous_interaction_id_set(self):
         """When previous_interaction_id is set, only messages after the prior assistant turn are sent."""

--- a/libs/agno/tests/unit/models/google/test_gemini_interactions.py
+++ b/libs/agno/tests/unit/models/google/test_gemini_interactions.py
@@ -310,48 +310,49 @@ class TestGetRequestKwargs:
         kwargs = model._get_request_kwargs([Message(role="user", content="Hi")])
         assert kwargs["generation_config"]["temperature"] == 0.9
 
-    def test_previous_interaction_id_falls_back_to_session_cache(self):
-        """When messages lack provider_data, fall back to per-session cache."""
-        from agno.run.agent import RunOutput
-
+    def test_input_sliced_when_previous_interaction_id_set(self):
+        """When previous_interaction_id is set, only messages after the prior assistant turn are sent."""
         model = self._make_model()
-        model._session_interaction_ids["sess-1"] = "interactions/cached-id"
-        run_response = RunOutput(session_id="sess-1")
-        messages = [Message(role="user", content="Follow up")]
-        kwargs = model._get_request_kwargs(messages, run_response=run_response)
-        assert kwargs["previous_interaction_id"] == "interactions/cached-id"
-
-    def test_provider_data_takes_precedence_over_session_cache(self):
-        """When messages have provider_data, that wins over the cache (db path is authoritative)."""
-        from agno.run.agent import RunOutput
-
-        model = self._make_model()
-        model._session_interaction_ids["sess-1"] = "interactions/stale"
-        run_response = RunOutput(session_id="sess-1")
         messages = [
-            Message(role="user", content="First"),
-            Message(role="assistant", content="Response", provider_data={"interaction_id": "interactions/fresh"}),
+            Message(role="user", content="First turn"),
+            Message(role="assistant", content="Reply 1", provider_data={"interaction_id": "interactions/abc"}),
             Message(role="user", content="Follow up"),
         ]
-        kwargs = model._get_request_kwargs(messages, run_response=run_response)
-        assert kwargs["previous_interaction_id"] == "interactions/fresh"
+        kwargs = model._get_request_kwargs(messages)
+        assert kwargs["previous_interaction_id"] == "interactions/abc"
+        # Only the new user message should be in input - server has the prior turns
+        input_steps = kwargs["input"]
+        assert len(input_steps) == 1
+        assert input_steps[0]["type"] == "user_input"
+        assert input_steps[0]["content"][0]["text"] == "Follow up"
 
-    def test_session_cache_isolated_per_session(self):
-        """Different sessions on the same model instance must not see each other's interaction ids."""
-        from agno.run.agent import RunOutput
-
+    def test_input_includes_all_messages_on_first_turn(self):
+        """Without a previous_interaction_id, full message history is sent."""
         model = self._make_model()
-        model._session_interaction_ids["sess-A"] = "interactions/A"
-        model._session_interaction_ids["sess-B"] = "interactions/B"
+        messages = [Message(role="user", content="Hello")]
+        kwargs = model._get_request_kwargs(messages)
+        assert "previous_interaction_id" not in kwargs
+        assert kwargs["input"][0]["content"][0]["text"] == "Hello"
 
-        kwargs_a = model._get_request_kwargs(
-            [Message(role="user", content="Hi")], run_response=RunOutput(session_id="sess-A")
-        )
-        kwargs_b = model._get_request_kwargs(
-            [Message(role="user", content="Hi")], run_response=RunOutput(session_id="sess-B")
-        )
-        assert kwargs_a["previous_interaction_id"] == "interactions/A"
-        assert kwargs_b["previous_interaction_id"] == "interactions/B"
+    def test_input_sliced_includes_tool_results_after_assistant(self):
+        """Mid-tool-call: send only tool result steps after the prior assistant turn."""
+        model = self._make_model()
+        messages = [
+            Message(role="user", content="Weather?"),
+            Message(
+                role="assistant",
+                tool_calls=[{"id": "c1", "type": "function", "function": {"name": "weather", "arguments": "{}"}}],
+                provider_data={"interaction_id": "interactions/abc"},
+            ),
+            Message(role="tool", tool_call_id="c1", tool_name="weather", content="Sunny"),
+        ]
+        kwargs = model._get_request_kwargs(messages)
+        assert kwargs["previous_interaction_id"] == "interactions/abc"
+        input_steps = kwargs["input"]
+        assert len(input_steps) == 1
+        assert input_steps[0]["type"] == "function_result"
+        assert input_steps[0]["call_id"] == "c1"
+        assert input_steps[0]["result"] == "Sunny"
 
 
 class TestParseInteractionResponse:
@@ -614,24 +615,6 @@ class TestInvoke:
 
         response = model.invoke(messages, assistant_message)
         assert response.provider_data["interaction_id"] == "interactions/tracked1"
-
-    def test_invoke_caches_interaction_id_for_session(self):
-        """After a successful invoke with a run_response, the interaction_id is cached by session."""
-        from agno.run.agent import RunOutput
-
-        model = self._make_model()
-        mock_client = MagicMock()
-        model.client = mock_client
-
-        mock_interaction = MagicMock()
-        mock_interaction.id = "interactions/sess-cached"
-        mock_interaction.steps = []
-        mock_interaction.usage = None
-        mock_client.interactions.create.return_value = mock_interaction
-
-        run_response = RunOutput(session_id="sess-X")
-        model.invoke([Message(role="user", content="Hi")], Message(role="assistant"), run_response=run_response)
-        assert model._session_interaction_ids["sess-X"] == "interactions/sess-cached"
 
 
 class TestInvokeAsync:

--- a/libs/agno/tests/unit/models/google/test_gemini_interactions.py
+++ b/libs/agno/tests/unit/models/google/test_gemini_interactions.py
@@ -310,40 +310,19 @@ class TestGetRequestKwargs:
         kwargs = model._get_request_kwargs([Message(role="user", content="Hi")])
         assert kwargs["generation_config"]["temperature"] == 0.9
 
-    def test_generation_config_filters_unsupported_keys(self):
-        """Keys not in GenerationConfigParam are dropped (e.g. http_options, system_instruction)."""
-        model = self._make_model(
-            generation_config={
-                "temperature": 0.7,
-                "http_options": {"timeout": 30},  # GenerateContentConfig-only
-                "system_instruction": "ignored",  # GenerateContentConfig-only
-                "tools": [],  # GenerateContentConfig-only
-                "top_k": 40,  # generateContent-only
-            }
-        )
-        kwargs = model._get_request_kwargs([Message(role="user", content="Hi")])
-        cfg = kwargs["generation_config"]
-        assert cfg == {"temperature": 0.7}
-
     def test_generation_config_accepts_pydantic_object(self):
-        """Passing a Pydantic-like config (e.g. GenerateContentConfig) is normalized via model_dump."""
+        """Pydantic-like configs (e.g. GenerateContentConfig) are dumped with exclude_none."""
 
         class FakeConfig:
             def model_dump(self, exclude_none=True):
-                # Simulate GenerateContentConfig's wide dump: many None fields plus
-                # Gemini-only keys that the Interactions API doesn't accept.
-                return {
-                    "temperature": 0.8,
-                    "top_p": 0.95,
-                    "http_options": {"timeout": 30},
-                    "system_instruction": "ignored",
-                    "tools": [],
-                }
+                # exclude_none drops the None fields the SDK declares for completeness
+                return {"temperature": 0.8, "top_p": 0.95}
 
         model = self._make_model(generation_config=FakeConfig())
         kwargs = model._get_request_kwargs([Message(role="user", content="Hi")])
         cfg = kwargs["generation_config"]
-        assert cfg == {"temperature": 0.8, "top_p": 0.95}
+        assert cfg["temperature"] == 0.8
+        assert cfg["top_p"] == 0.95
 
     def test_input_sliced_when_previous_interaction_id_set(self):
         """When previous_interaction_id is set, only messages after the prior assistant turn are sent."""

--- a/libs/agno/tests/unit/models/google/test_gemini_interactions.py
+++ b/libs/agno/tests/unit/models/google/test_gemini_interactions.py
@@ -291,6 +291,68 @@ class TestGetRequestKwargs:
         kwargs = model._get_request_kwargs(messages)
         assert kwargs["response_modalities"] == ["text", "image"]
 
+    def test_generation_config_passthrough_merges_with_fields(self):
+        """generation_config dict is merged in - its keys override field-derived values."""
+        model = self._make_model(
+            temperature=0.5,
+            generation_config={"top_p": 0.9, "top_k": 40, "presence_penalty": 0.1},
+        )
+        kwargs = model._get_request_kwargs([Message(role="user", content="Hi")])
+        cfg = kwargs["generation_config"]
+        assert cfg["temperature"] == 0.5
+        assert cfg["top_p"] == 0.9
+        assert cfg["top_k"] == 40
+        assert cfg["presence_penalty"] == 0.1
+
+    def test_generation_config_passthrough_overrides_fields(self):
+        """When the same key is set on both, the passthrough dict wins."""
+        model = self._make_model(temperature=0.5, generation_config={"temperature": 0.9})
+        kwargs = model._get_request_kwargs([Message(role="user", content="Hi")])
+        assert kwargs["generation_config"]["temperature"] == 0.9
+
+    def test_previous_interaction_id_falls_back_to_session_cache(self):
+        """When messages lack provider_data, fall back to per-session cache."""
+        from agno.run.agent import RunOutput
+
+        model = self._make_model()
+        model._session_interaction_ids["sess-1"] = "interactions/cached-id"
+        run_response = RunOutput(session_id="sess-1")
+        messages = [Message(role="user", content="Follow up")]
+        kwargs = model._get_request_kwargs(messages, run_response=run_response)
+        assert kwargs["previous_interaction_id"] == "interactions/cached-id"
+
+    def test_provider_data_takes_precedence_over_session_cache(self):
+        """When messages have provider_data, that wins over the cache (db path is authoritative)."""
+        from agno.run.agent import RunOutput
+
+        model = self._make_model()
+        model._session_interaction_ids["sess-1"] = "interactions/stale"
+        run_response = RunOutput(session_id="sess-1")
+        messages = [
+            Message(role="user", content="First"),
+            Message(role="assistant", content="Response", provider_data={"interaction_id": "interactions/fresh"}),
+            Message(role="user", content="Follow up"),
+        ]
+        kwargs = model._get_request_kwargs(messages, run_response=run_response)
+        assert kwargs["previous_interaction_id"] == "interactions/fresh"
+
+    def test_session_cache_isolated_per_session(self):
+        """Different sessions on the same model instance must not see each other's interaction ids."""
+        from agno.run.agent import RunOutput
+
+        model = self._make_model()
+        model._session_interaction_ids["sess-A"] = "interactions/A"
+        model._session_interaction_ids["sess-B"] = "interactions/B"
+
+        kwargs_a = model._get_request_kwargs(
+            [Message(role="user", content="Hi")], run_response=RunOutput(session_id="sess-A")
+        )
+        kwargs_b = model._get_request_kwargs(
+            [Message(role="user", content="Hi")], run_response=RunOutput(session_id="sess-B")
+        )
+        assert kwargs_a["previous_interaction_id"] == "interactions/A"
+        assert kwargs_b["previous_interaction_id"] == "interactions/B"
+
 
 class TestParseInteractionResponse:
     """Tests for parsing Interaction API responses."""
@@ -552,6 +614,24 @@ class TestInvoke:
 
         response = model.invoke(messages, assistant_message)
         assert response.provider_data["interaction_id"] == "interactions/tracked1"
+
+    def test_invoke_caches_interaction_id_for_session(self):
+        """After a successful invoke with a run_response, the interaction_id is cached by session."""
+        from agno.run.agent import RunOutput
+
+        model = self._make_model()
+        mock_client = MagicMock()
+        model.client = mock_client
+
+        mock_interaction = MagicMock()
+        mock_interaction.id = "interactions/sess-cached"
+        mock_interaction.steps = []
+        mock_interaction.usage = None
+        mock_client.interactions.create.return_value = mock_interaction
+
+        run_response = RunOutput(session_id="sess-X")
+        model.invoke([Message(role="user", content="Hi")], Message(role="assistant"), run_response=run_response)
+        assert model._session_interaction_ids["sess-X"] == "interactions/sess-cached"
 
 
 class TestInvokeAsync:


### PR DESCRIPTION
## Summary

Fixes both issues reported in #7970:

1. **`generation_config` passthrough.** Users couldn't pass advanced `GenerationConfigParam` controls (e.g. `top_k`, `presence_penalty`) because we only exposed individual fields. Add a `generation_config: Optional[Dict[str, Any]]` field that gets merged into the built generation_config. Field-level values are used first; passthrough keys override them.

2. **Actually leverage Interactions API statefulness.** Previously, when `previous_interaction_id` was set, we still sent the full message history as `input` - so the server had it (via the ID) and we resent it. Wasted tokens and latency. Now we slice: when `previous_interaction_id` is set, only send messages AFTER the prior assistant turn. The server already has everything up to that point.

   This addresses the user's complaint that \"automatically merging historical messages into the cloud does not work\" - it now does, in the intended sense: no replay, just the delta.

(Issue: #7970)

## Type of change

- [x] Bug fix

## Multi-turn requires a db

To use multi-turn with the Interactions API, you still need a db so the `interaction_id` is persisted on the assistant message between `print_response` calls (see the updated `multi_turn.py` cookbook). This is consistent with how Agno persistence works for OpenAIResponses and other stateful providers. The slicing fix means that when a db IS configured, the model now correctly leverages server-side state instead of replaying history.

Mid-run tool call iterations also benefit automatically - the assistant message with `interaction_id` lives in memory during the run, so the slicing correctly sends only the new tool result steps to the next invoke iteration.

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts
- [x] Self-review completed
- [x] Documentation updated
- [x] Examples updated - `multi_turn.py` cookbook docstring clarifies db requirement
- [x] Tested in clean environment (live test with db: multi-turn works; tool_use cookbook passes)
- [x] Tests added/updated - 5 new unit tests covering slicing and generation_config passthrough; 71 tests pass

### Duplicate and AI-Generated PR Check

- [x] No duplicate PRs found
- [x] Co-authored with Claude Code