### PR TITLE
fix: harden Anthropic server tool content block handling

### DIFF
--- a/libs/agno/agno/models/anthropic/claude.py
+++ b/libs/agno/agno/models/anthropic/claude.py
@@ -1117,8 +1117,11 @@ class Claude(Model):
         model_response = ModelResponse()
 
         if isinstance(response, (ContentBlockStartEvent, BetaRawContentBlockStartEvent)):
-            if response.content_block.type == "redacted_reasoning_content":
-                model_response.redacted_reasoning_content = response.content_block.data
+            # The Anthropic SDK emits "redacted_thinking" for these blocks; accept the legacy
+            # "redacted_reasoning_content" spelling too in case it appears via a rehydrated event.
+            block_type = getattr(response.content_block, "type", None)
+            if block_type in ("redacted_thinking", "redacted_reasoning_content"):
+                model_response.redacted_reasoning_content = getattr(response.content_block, "data", None)
 
         if isinstance(response, (ContentBlockDeltaEvent, BetaRawContentBlockDeltaEvent)):
             # Handle text content

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -96,12 +96,12 @@ def _anthropic_coerce_content_block(item: Any) -> Optional[Any]:
     model_dump = getattr(item, "model_dump", None)
     if callable(model_dump):
         try:
-            dumped = model_dump(exclude_none=True)
+            block_dict = model_dump(exclude_none=True)
         except Exception as e:
             log_warning(f"Failed to serialize Anthropic content block of type {type(item).__name__}: {e}")
             return None
-        if isinstance(dumped, dict) and dumped.get("type"):
-            return dumped
+        if isinstance(block_dict, dict) and block_dict.get("type"):
+            return block_dict
     return None
 
 

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -87,6 +87,25 @@ ROLE_MAP = {
 }
 
 
+def _anthropic_block_identity(block: Any) -> Optional[Tuple[str, str]]:
+    """Return a stable identity key for an Anthropic content block, or None if untrackable.
+
+    Server tool blocks pair a ``server_tool_use`` (carrying ``id``) with a result block
+    (carrying ``tool_use_id`` referencing that id). The (type, id-or-tool_use_id) tuple
+    lets us dedupe across provider_data["server_tool_blocks"] and list-shaped message.content
+    without dropping blocks that exist in only one source.
+    """
+    if not isinstance(block, dict):
+        return None
+    block_type = block.get("type")
+    if not block_type:
+        return None
+    block_id = block.get("id") or block.get("tool_use_id")
+    if not isinstance(block_id, str):
+        return None
+    return (block_type, block_id)
+
+
 def _anthropic_coerce_content_block(item: Any) -> Optional[Any]:
     """Normalize a stored message content item into an Anthropic Messages API block dict."""
     if item is None:
@@ -507,7 +526,7 @@ def format_messages(
             # Extract structured blocks from list-shaped content (used when callers persist and
             # rehydrate full assistant turns rather than the text-only + provider_data split).
             structured_from_list: List[Any] = []
-            list_has_server_blocks = False
+            list_block_identities: set = set()
             if isinstance(message.content, list):
                 for item in message.content:
                     blk = _anthropic_coerce_content_block(item)
@@ -516,14 +535,19 @@ def format_messages(
                     block_type = blk.get("type") if isinstance(blk, dict) else None
                     if block_type == "tool_use" and message.tool_calls:
                         continue
-                    if block_type not in ("text", "thinking", "redacted_thinking", "tool_use"):
-                        list_has_server_blocks = True
+                    identity = _anthropic_block_identity(blk)
+                    if identity is not None:
+                        list_block_identities.add(identity)
                     structured_from_list.append(blk)
 
             # Reconstruct server tool blocks (web_fetch, web_search, etc.) from provider_data.
-            # Skip when list-content already carries them to avoid duplicate emission.
-            if not list_has_server_blocks and message.provider_data and message.provider_data.get("server_tool_blocks"):
+            # Merge by identity (type, id-or-tool_use_id) so blocks already present in list-content
+            # aren't duplicated, but blocks that exist only in provider_data are still emitted.
+            if message.provider_data and message.provider_data.get("server_tool_blocks"):
                 for block_dict in message.provider_data["server_tool_blocks"]:
+                    identity = _anthropic_block_identity(block_dict)
+                    if identity is not None and identity in list_block_identities:
+                        continue
                     content.append(block_dict)
 
             if structured_from_list:

--- a/libs/agno/agno/utils/models/claude.py
+++ b/libs/agno/agno/utils/models/claude.py
@@ -97,10 +97,11 @@ def _anthropic_coerce_content_block(item: Any) -> Optional[Any]:
     if callable(model_dump):
         try:
             dumped = model_dump(exclude_none=True)
-            if isinstance(dumped, dict) and dumped.get("type"):
-                return dumped
-        except Exception:
-            pass
+        except Exception as e:
+            log_warning(f"Failed to serialize Anthropic content block of type {type(item).__name__}: {e}")
+            return None
+        if isinstance(dumped, dict) and dumped.get("type"):
+            return dumped
     return None
 
 
@@ -501,17 +502,12 @@ def format_messages(
             if message.redacted_reasoning_content is not None:
                 from anthropic.types import RedactedThinkingBlock
 
-                content.append(
-                    RedactedThinkingBlock(data=message.redacted_reasoning_content, type="redacted_reasoning_content")
-                )
+                content.append(RedactedThinkingBlock(data=message.redacted_reasoning_content, type="redacted_thinking"))
 
-            # Reconstruct server tool blocks (web_fetch, web_search, etc.) from provider_data
-            # Inserted between thinking and text blocks to match Anthropic's native ordering
-            if message.provider_data and message.provider_data.get("server_tool_blocks"):
-                for block_dict in message.provider_data["server_tool_blocks"]:
-                    content.append(block_dict)
-
+            # Extract structured blocks from list-shaped content (used when callers persist and
+            # rehydrate full assistant turns rather than the text-only + provider_data split).
             structured_from_list: List[Any] = []
+            list_has_server_blocks = False
             if isinstance(message.content, list):
                 for item in message.content:
                     blk = _anthropic_coerce_content_block(item)
@@ -520,7 +516,15 @@ def format_messages(
                     block_type = blk.get("type") if isinstance(blk, dict) else None
                     if block_type == "tool_use" and message.tool_calls:
                         continue
+                    if block_type not in ("text", "thinking", "redacted_thinking", "tool_use"):
+                        list_has_server_blocks = True
                     structured_from_list.append(blk)
+
+            # Reconstruct server tool blocks (web_fetch, web_search, etc.) from provider_data.
+            # Skip when list-content already carries them to avoid duplicate emission.
+            if not list_has_server_blocks and message.provider_data and message.provider_data.get("server_tool_blocks"):
+                for block_dict in message.provider_data["server_tool_blocks"]:
+                    content.append(block_dict)
 
             if structured_from_list:
                 content.extend(structured_from_list)
@@ -548,7 +552,13 @@ def format_messages(
                 normalized_blocks: List[Any] = []
                 for item in tool_result:
                     coerced = _anthropic_coerce_content_block(item)
-                    normalized_blocks.append(coerced if coerced is not None else item)
+                    if coerced is not None:
+                        normalized_blocks.append(coerced)
+                    else:
+                        # Fall back to a text block so unknown items still reach the model rather
+                        # than being silently dropped or breaking the request shape.
+                        log_warning(f"Coercing non-block tool_result item of type {type(item).__name__} to text")
+                        normalized_blocks.append({"type": "text", "text": str(item)})
                 tool_payload: Union[str, List[Any]] = normalized_blocks
             else:
                 tool_payload = str(tool_result)

--- a/libs/agno/tests/unit/models/test_cross_model_tool_calls.py
+++ b/libs/agno/tests/unit/models/test_cross_model_tool_calls.py
@@ -402,6 +402,57 @@ class TestClaudeFormatMessages:
         assert isinstance(tool_result["content"], list)
         assert tool_result["content"][0]["type"] == "text"
 
+    def test_server_tool_blocks_not_duplicated_across_sources(self):
+        """When list-content and provider_data both carry server tool blocks, emit once."""
+        from agno.utils.models.claude import format_messages
+
+        server_use = {"type": "server_tool_use", "id": "srvtoolu_dup", "name": "web_search", "input": {}}
+        msg = Message(
+            role="assistant",
+            content=[server_use, {"type": "text", "text": "done"}],
+            provider_data={"server_tool_blocks": [server_use]},
+        )
+        formatted, _ = format_messages([Message(role="user", content="hi"), msg])
+        blocks = formatted[1]["content"]
+        types = [b.get("type") if isinstance(b, dict) else getattr(b, "type", None) for b in blocks]
+        assert types.count("server_tool_use") == 1
+        assert "text" in types
+
+    def test_tool_result_non_block_item_coerced_to_text(self):
+        """Tool result list items that aren't valid blocks should be coerced to text, not passed through."""
+        from agno.utils.models.claude import format_messages
+
+        tc = _make_tool_call("toolu_nb01", name="code_execution")
+        msgs = [
+            Message(role="user", content="Hi"),
+            _assistant_msg([tc]),
+            Message(
+                role="tool",
+                tool_call_id="toolu_nb01",
+                tool_name="code_execution",
+                content=[12345, {"type": "text", "text": "ok"}],
+            ),
+        ]
+        formatted, _ = format_messages(msgs)
+        tool_result = formatted[2]["content"][0]
+        assert tool_result["type"] == "tool_result"
+        assert isinstance(tool_result["content"], list)
+        assert tool_result["content"][0] == {"type": "text", "text": "12345"}
+        assert tool_result["content"][1]["type"] == "text"
+
+    def test_redacted_thinking_block_uses_canonical_type(self):
+        """RedactedThinkingBlock must be constructed with the Anthropic SDK's literal type."""
+        from agno.utils.models.claude import format_messages
+
+        msgs = [
+            Message(role="user", content="hi"),
+            Message(role="assistant", content="hello", redacted_reasoning_content="opaque-bytes"),
+        ]
+        formatted, _ = format_messages(msgs)
+        blocks = formatted[1]["content"]
+        types = [b.get("type") if isinstance(b, dict) else getattr(b, "type", None) for b in blocks]
+        assert "redacted_thinking" in types
+
 
 # ---------------------------------------------------------------------------
 # Gemini format — individual tool messages

--- a/libs/agno/tests/unit/models/test_cross_model_tool_calls.py
+++ b/libs/agno/tests/unit/models/test_cross_model_tool_calls.py
@@ -403,7 +403,7 @@ class TestClaudeFormatMessages:
         assert tool_result["content"][0]["type"] == "text"
 
     def test_server_tool_blocks_not_duplicated_across_sources(self):
-        """When list-content and provider_data both carry server tool blocks, emit once."""
+        """When list-content and provider_data both carry the same block, emit once."""
         from agno.utils.models.claude import format_messages
 
         server_use = {"type": "server_tool_use", "id": "srvtoolu_dup", "name": "web_search", "input": {}}
@@ -417,6 +417,35 @@ class TestClaudeFormatMessages:
         types = [b.get("type") if isinstance(b, dict) else getattr(b, "type", None) for b in blocks]
         assert types.count("server_tool_use") == 1
         assert "text" in types
+
+    def test_server_tool_blocks_merged_by_identity(self):
+        """Partial overlap: provider_data blocks not present in list-content must still be emitted.
+
+        Regression guard: a previous version flipped a binary list_has_server_blocks flag and
+        dropped all provider_data blocks whenever list-content carried any server block,
+        silently losing blocks that existed only in provider_data.
+        """
+        from agno.utils.models.claude import format_messages
+
+        shared = {"type": "server_tool_use", "id": "srvtoolu_A", "name": "web_search", "input": {}}
+        only_in_provider = {
+            "type": "web_search_tool_result",
+            "tool_use_id": "srvtoolu_B",
+            "content": [],
+        }
+        msg = Message(
+            role="assistant",
+            content=[shared, {"type": "text", "text": "done"}],
+            provider_data={"server_tool_blocks": [shared, only_in_provider]},
+        )
+        formatted, _ = format_messages([Message(role="user", content="hi"), msg])
+        blocks = formatted[1]["content"]
+        ids = [b.get("id") or b.get("tool_use_id") if isinstance(b, dict) else None for b in blocks]
+        types = [b.get("type") if isinstance(b, dict) else getattr(b, "type", None) for b in blocks]
+        assert types.count("server_tool_use") == 1
+        assert "web_search_tool_result" in types
+        assert "srvtoolu_A" in ids
+        assert "srvtoolu_B" in ids
 
     def test_tool_result_non_block_item_coerced_to_text(self):
         """Tool result list items that aren't valid blocks should be coerced to text, not passed through."""


### PR DESCRIPTION
## Summary

Follow-up to #7766. Addresses review findings on top of the original fix:

- **Canonical `redacted_thinking` literal.** `RedactedThinkingBlock(type="redacted_reasoning_content")` fails pydantic validation in the current Anthropic SDK (`Literal["redacted_thinking"]`). Switched to the canonical type so any code path that hits `message.redacted_reasoning_content` does not crash when reconstructing the block.
- **Streaming start-event accepts both spellings.** Accept `redacted_thinking` (what the SDK emits) and keep the legacy `redacted_reasoning_content` form for any rehydrated events. Refactored to use `getattr` so mypy narrowing is preserved (the tuple form regressed 26 pre-existing-clean union-attr errors).
- **Dedup guard for server tool blocks.** When list-shaped assistant `content` already carries server tool blocks, skip `provider_data["server_tool_blocks"]` to avoid double-emission on round-trip.
- **Visible coercion failures.** Replaced `except Exception: pass` in `_anthropic_coerce_content_block` with `log_warning`.
- **Tool result non-block items coerced to text.** Previously, items that did not coerce to a block dict were passed through to the API as-is. Now they are converted to a `{"type": "text", "text": str(item)}` block with a warning.
- **Regression tests.** Three new tests covering duplication, non-coercible tool-result items, and the redacted-thinking type literal.

(Related: #7766)

## Type of change

- [x] Bug fix

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [x] Tested in clean environment
- [x] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [x] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

`./scripts/validate.sh` reports the same 3 pre-existing mypy errors as `origin/main` (none in the files this PR touches).

Test run scoped to the touched areas:

- `libs/agno/tests/unit/models/test_cross_model_tool_calls.py::TestClaudeFormatMessages` — 10 passed
- `libs/agno/tests/unit/models/anthropic/` (excluding bedrock tests that require optional `boto3`) — 63 passed