### PR TITLE
fix(team): persist TeamRunOutput to DB before HITL pause in async streaming path

### DIFF
--- a/libs/agno/agno/team/_run.py
+++ b/libs/agno/agno/team/_run.py
@@ -3668,6 +3668,11 @@ async def _arun_stream(
                 # 6b. Check if delegation propagated member HITL requirements
                 if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
                     from agno.team import _hooks
+                    from agno.run.base import RunStatus
+
+                    # Persist the paused run so acontinue_run() can find it after restart
+                    run_response.status = RunStatus.paused
+                    await _acleanup_and_store(team, run_response=run_response, session=team_session)
 
                     async for item in _hooks.ahandle_team_run_paused_stream(  # type: ignore[assignment]
                         team, run_response=run_response, session=team_session, run_context=run_context


### PR DESCRIPTION
## Summary

When a Team pauses for human-in-the-loop (HITL) confirmation in the async streaming path, the outer team's `TeamRunOutput` is **never written to the database**. After process restart, `acontinue_run(run_id=outer_run_id)` cannot find the paused run in `session.runs` and fails.

## Root cause

In `libs/agno/agno/team/_run.py`, the async streaming coordinator checks for unresolved HITL requirements at line ~3669:

```python
if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
    from agno.team import _hooks

    async for item in _hooks.ahandle_team_run_paused_stream(...):
        yield item
    if yield_run_output:
        yield run_response
    return   # ← exits without calling _acleanup_and_store
```

The `return` at the end exits the generator. The `_acleanup_and_store` call that persists `TeamRunOutput` to `session.runs` is at line ~3781 — past this return point, only reached on the non-pause completion path.

This was fixed for the **Workflow** HITL pause path in PR #7916. The same fix was not applied to the **Team** streaming path.

## Fix

Add `RunStatus.paused` + `_acleanup_and_store` before the `ahandle_team_run_paused_stream` loop and `return`:

```python
if run_response.requirements and any(not req.is_resolved() for req in run_response.requirements):
    from agno.team import _hooks
    from agno.run.base import RunStatus

    # Persist the paused run so acontinue_run() can find it after restart
    run_response.status = RunStatus.paused
    await _acleanup_and_store(team, run_response=run_response, session=team_session)

    async for item in _hooks.ahandle_team_run_paused_stream(...):
        yield item
    ...
    return
```

## Relationship to open PRs

- #7760 and #7821 fix the **resume** path (lookup logic inside `acontinue_run`).
- This PR fixes the **pause** path (ensuring the run is persisted before resumption is needed).
- Both fixes are required for end-to-end cross-process HITL resume to work.

## Test plan

- [ ] After a Team HITL pause, `session.runs` contains the outer team's `TeamRunOutput` with `status=PAUSED`
- [ ] `acontinue_run(run_id=outer_run_id)` succeeds from a fresh process
- [ ] Non-HITL runs (no pause) are unaffected
- [ ] Existing Team tests pass

Fixes #7958
