### PR TITLE
chore: drop unused available_models field from EvalsDomainConfig

### DIFF
--- a/libs/agno/agno/os/config.py
+++ b/libs/agno/agno/os/config.py
@@ -30,7 +30,6 @@ class EvalsDomainConfig(BaseModel):
     """Configuration for the Evals domain of the AgentOS"""
 
     display_name: Optional[str] = None
-    available_models: Optional[List[str]] = None
 
 
 class SessionDomainConfig(BaseModel):


### PR DESCRIPTION
## Summary

The Evals UI "Evaluation model" dropdown is populated from the top-level `AgentOSConfig.available_models` field returned by `GET /config` (see `libs/agno/agno/os/router.py:174` and `libs/agno/agno/os/mcp.py:82`).

`EvalsDomainConfig.available_models` was declared but **never read anywhere** in the codebase — setting it under `evals.dbs[].domain_config`

This PR removes the unused field. The top-level `AgentOSConfig.available_models` becomes the only supported path, matching what the frontend already consumes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [x] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable) — no cookbooks reference the removed field
- [x] Tested in clean environment
- [ ] Tests added/updated (if applicable) — pure cleanup, no behavior change to test

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.) — drafted with Claude Code; verification and review by author

---