### PR TITLE
cookbook: rename gemini-3-flash-preview to gemini-3.5-flash

### DIFF
--- a/cookbook/00_quickstart/README.md
+++ b/cookbook/00_quickstart/README.md
@@ -2,7 +2,7 @@
 
 Learn how to build agents with 12 guided cookbooks. We'll go from single tool-using agent to multi-agent teams and step-based workflows through clean, runnable examples.
 
-Each example can be run independently and contains detailed comments to help you understand what's happening under the hood. We'll use Gemini 3 Flash — fast, affordable, and excellent at tool calling but you can swap in any model with a one line change.
+Each example can be run independently and contains detailed comments to help you understand what's happening under the hood. We'll use Gemini 3.5 Flash — fast, affordable, and excellent at tool calling but you can swap in any model with a one line change.
 
 ## What You'll Build
 
@@ -93,7 +93,7 @@ Agno is model-agnostic. Same code, different provider:
 ```python
 # Gemini (default in these examples)
 from agno.models.google import Gemini
-model = Gemini(id="gemini-3-flash-preview")
+model = Gemini(id="gemini-3.5-flash")
 
 # OpenAI
 from agno.models.openai import OpenAIResponses

--- a/cookbook/00_quickstart/TEST_LOG.md
+++ b/cookbook/00_quickstart/TEST_LOG.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-02-20
 **Environment:** `.venvs/demo/bin/python` (Python 3.12)
-**Model:** `gemini-3-flash-preview`
+**Model:** `gemini-3.5-flash`
 **Pre-flight:** Structure checker 0 violations, all API keys set
 
 ---

--- a/cookbook/00_quickstart/agent_search_over_knowledge.py
+++ b/cookbook/00_quickstart/agent_search_over_knowledge.py
@@ -82,7 +82,7 @@ You are an expert on the Agno framework and building AI agents.
 # ---------------------------------------------------------------------------
 agent_with_knowledge = Agent(
     name="Agent with Knowledge",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     knowledge=knowledge,
     search_knowledge=True,

--- a/cookbook/00_quickstart/agent_with_guardrails.py
+++ b/cookbook/00_quickstart/agent_with_guardrails.py
@@ -89,7 +89,7 @@ Never share sensitive personal information in responses.\
 # ---------------------------------------------------------------------------
 agent_with_guardrails = Agent(
     name="Agent with Guardrails",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     tools=[YFinanceTools(all=True)],
     pre_hooks=[

--- a/cookbook/00_quickstart/agent_with_memory.py
+++ b/cookbook/00_quickstart/agent_with_memory.py
@@ -35,7 +35,7 @@ agent_db = SqliteDb(db_file="tmp/agents.db")
 # Memory Manager Configuration
 # ---------------------------------------------------------------------------
 memory_manager = MemoryManager(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     db=agent_db,
     additional_instructions="""
     Capture the user's favorite stocks, their risk tolerance, and their investment goals.
@@ -87,7 +87,7 @@ user_id = "investor@example.com"
 
 agent_with_memory = Agent(
     name="Agent with Memory",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     tools=[YFinanceTools(all=True)],
     db=agent_db,

--- a/cookbook/00_quickstart/agent_with_state_management.py
+++ b/cookbook/00_quickstart/agent_with_state_management.py
@@ -111,7 +111,7 @@ You are a Finance Agent that manages a stock watchlist.
 # ---------------------------------------------------------------------------
 agent_with_state_management = Agent(
     name="Agent with State Management",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     tools=[
         add_to_watchlist,

--- a/cookbook/00_quickstart/agent_with_storage.py
+++ b/cookbook/00_quickstart/agent_with_storage.py
@@ -70,7 +70,7 @@ computes key ratios, and produces concise, decision-ready insights.
 # ---------------------------------------------------------------------------
 agent_with_storage = Agent(
     name="Agent with Storage",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     tools=[YFinanceTools(all=True)],
     db=agent_db,

--- a/cookbook/00_quickstart/agent_with_structured_output.py
+++ b/cookbook/00_quickstart/agent_with_structured_output.py
@@ -87,7 +87,7 @@ computes key ratios, and produces concise, decision-ready insights.
 # ---------------------------------------------------------------------------
 agent_with_structured_output = Agent(
     name="Agent with Structured Output",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     tools=[YFinanceTools(all=True)],
     output_schema=StockAnalysis,

--- a/cookbook/00_quickstart/agent_with_tools.py
+++ b/cookbook/00_quickstart/agent_with_tools.py
@@ -59,7 +59,7 @@ computes key ratios, and produces concise, decision-ready insights.
 # ---------------------------------------------------------------------------
 agent_with_tools = Agent(
     name="Agent with Tools",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     tools=[YFinanceTools(all=True)],
     add_datetime_to_context=True,

--- a/cookbook/00_quickstart/agent_with_typed_input_output.py
+++ b/cookbook/00_quickstart/agent_with_typed_input_output.py
@@ -100,7 +100,7 @@ You receive structured requests with:
 # ---------------------------------------------------------------------------
 agent_with_typed_input_output = Agent(
     name="Agent with Typed Input Output",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     tools=[YFinanceTools(all=True)],
     input_schema=AnalysisRequest,

--- a/cookbook/00_quickstart/custom_tool_for_self_learning.py
+++ b/cookbook/00_quickstart/custom_tool_for_self_learning.py
@@ -143,7 +143,7 @@ Don't save: Raw data, one-off facts, or obvious information.\
 # ---------------------------------------------------------------------------
 self_learning_agent = Agent(
     name="Self-Learning Agent",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     tools=[
         YFinanceTools(all=True),

--- a/cookbook/00_quickstart/human_in_the_loop.py
+++ b/cookbook/00_quickstart/human_in_the_loop.py
@@ -140,7 +140,7 @@ Don't save: Raw data, one-off facts, or obvious information.\
 # ---------------------------------------------------------------------------
 human_in_the_loop_agent = Agent(
     name="Agent with Human in the Loop",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     tools=[
         YFinanceTools(all=True),

--- a/cookbook/00_quickstart/multi_agent_team.py
+++ b/cookbook/00_quickstart/multi_agent_team.py
@@ -39,7 +39,7 @@ team_db = SqliteDb(db_file="tmp/agents.db")
 bull_agent = Agent(
     name="Bull Analyst",
     role="Make the investment case FOR a stock",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     tools=[YFinanceTools(all=True)],
     db=team_db,
     instructions="""\
@@ -63,7 +63,7 @@ Be persuasive but grounded in data. Use the tools to get real numbers.\
 bear_agent = Agent(
     name="Bear Analyst",
     role="Make the investment case AGAINST a stock",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     tools=[YFinanceTools(all=True)],
     db=team_db,
     instructions="""\
@@ -86,7 +86,7 @@ Be critical but fair. Use the tools to get real numbers to support your concerns
 # ---------------------------------------------------------------------------
 multi_agent_team = Team(
     name="Multi-Agent Team",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     members=[bull_agent, bear_agent],
     instructions="""\
 You lead an investment research team with a Bull Analyst and Bear Analyst.

--- a/cookbook/00_quickstart/sequential_workflow.py
+++ b/cookbook/00_quickstart/sequential_workflow.py
@@ -34,7 +34,7 @@ workflow_db = SqliteDb(db_file="tmp/agents.db")
 # ---------------------------------------------------------------------------
 data_agent = Agent(
     name="Data Gatherer",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     tools=[YFinanceTools(all=True)],
     instructions="""\
 You are a data gathering agent. Your job is to fetch comprehensive market data.
@@ -65,7 +65,7 @@ data_step = Step(
 # ---------------------------------------------------------------------------
 analyst_agent = Agent(
     name="Analyst",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions="""\
 You are a financial analyst. You receive raw market data from the data team.
 
@@ -94,7 +94,7 @@ analysis_step = Step(
 # ---------------------------------------------------------------------------
 report_agent = Agent(
     name="Report Writer",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions="""\
 You are a report writer. You receive analysis from the research team.
 

--- a/cookbook/02_agents/12_multimodal/audio_sentiment_analysis.py
+++ b/cookbook/02_agents/12_multimodal/audio_sentiment_analysis.py
@@ -15,7 +15,7 @@ from agno.models.google import Gemini
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     add_history_to_context=True,
     markdown=True,
     db=SqliteDb(

--- a/cookbook/02_agents/12_multimodal/audio_to_text.py
+++ b/cookbook/02_agents/12_multimodal/audio_to_text.py
@@ -14,7 +14,7 @@ from agno.models.google import Gemini
 # Create Agent
 # ---------------------------------------------------------------------------
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     markdown=True,
 )
 

--- a/cookbook/03_teams/19_multimodal/TEST_LOG.md
+++ b/cookbook/03_teams/19_multimodal/TEST_LOG.md
@@ -69,7 +69,7 @@ DEBUG *** Team Run Start: fd5ae1a1-13bd-4949-b041-184dc44a5a78 ***
 DEBUG Processing tools for model                                                
 DEBUG Added tool delegate_task_to_member                                        
 DEBUG --------------- Google Response Stream Start ---------------              
-DEBUG -------------- Model: gemini-3-flash-preview ---------------              
+DEBUG -------------- Model: gemini-3.5-flash ---------------              
 DEBUG ========================== system ==========================              
 DEBUG You coordinate a team of specialized AI agents to fulfill the user's      
       request. Delegate to members when their expertise or tools are needed. For

--- a/cookbook/03_teams/19_multimodal/audio_sentiment_analysis.py
+++ b/cookbook/03_teams/19_multimodal/audio_sentiment_analysis.py
@@ -18,7 +18,7 @@ from agno.team import Team
 transcription_agent = Agent(
     name="Audio Transcriber",
     role="Transcribe audio conversations accurately",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=[
         "Transcribe audio with speaker identification",
         "Maintain conversation structure and flow",
@@ -28,7 +28,7 @@ transcription_agent = Agent(
 sentiment_analyst = Agent(
     name="Sentiment Analyst",
     role="Analyze emotional tone and sentiment in conversations",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=[
         "Analyze sentiment for each speaker separately",
         "Identify emotional patterns and conversation dynamics",
@@ -42,7 +42,7 @@ sentiment_analyst = Agent(
 sentiment_team = Team(
     name="Audio Sentiment Team",
     members=[transcription_agent, sentiment_analyst],
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=[
         "Analyze audio sentiment with conversation memory.",
         "Audio Transcriber: First transcribe audio with speaker identification.",

--- a/cookbook/03_teams/19_multimodal/audio_to_text.py
+++ b/cookbook/03_teams/19_multimodal/audio_to_text.py
@@ -17,7 +17,7 @@ from agno.team import Team
 transcription_specialist = Agent(
     name="Transcription Specialist",
     role="Convert audio to accurate text transcriptions",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=[
         "Transcribe audio with high accuracy",
         "Identify speakers clearly as Speaker A, Speaker B, etc.",
@@ -28,7 +28,7 @@ transcription_specialist = Agent(
 content_analyzer = Agent(
     name="Content Analyzer",
     role="Analyze transcribed content for insights",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=[
         "Analyze transcription for key themes and insights",
         "Provide summaries and extract important information",
@@ -40,7 +40,7 @@ content_analyzer = Agent(
 # ---------------------------------------------------------------------------
 audio_team = Team(
     name="Audio Analysis Team",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     members=[transcription_specialist, content_analyzer],
     instructions=[
         "Work together to transcribe and analyze audio content.",

--- a/cookbook/05_agent_os/advanced_demo/teams_demo.py
+++ b/cookbook/05_agent_os/advanced_demo/teams_demo.py
@@ -39,7 +39,7 @@ file_agent = Agent(
 
 video_agent = Agent(
     name="Video Understanding Agent",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     id="video-understanding-agent",
     role="Answer questions about video files",
     db=db,

--- a/cookbook/05_agent_os/interfaces/whatsapp/agent_with_media.py
+++ b/cookbook/05_agent_os/interfaces/whatsapp/agent_with_media.py
@@ -18,7 +18,7 @@ from agno.os.interfaces.whatsapp import Whatsapp
 agent_db = SqliteDb(db_file="tmp/persistent_memory.db")
 media_agent = Agent(
     name="Media Agent",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     db=agent_db,
     add_history_to_context=True,
     num_history_runs=3,

--- a/cookbook/10_reasoning/tools/gemini_finance_agent.py
+++ b/cookbook/10_reasoning/tools/gemini_finance_agent.py
@@ -17,7 +17,7 @@ from agno.tools.yfinance import YFinanceTools
 # ---------------------------------------------------------------------------
 def run_example() -> None:
     thinking_agent = Agent(
-        model=Gemini(id="gemini-3-flash-preview"),
+        model=Gemini(id="gemini-3.5-flash"),
         tools=[
             ReasoningTools(add_instructions=True),
             YFinanceTools(),

--- a/cookbook/12_context/06_slack_search_media.py
+++ b/cookbook/12_context/06_slack_search_media.py
@@ -37,12 +37,12 @@ from agno.context.slack import SlackContextProvider
 from agno.models.google import Gemini
 
 slack = SlackContextProvider(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     enable_media_tools=True,
 )
 
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     tools=slack.get_tools(),
     instructions=slack.instructions(),
     markdown=True,

--- a/cookbook/90_models/cometapi/multi_model.py
+++ b/cookbook/90_models/cometapi/multi_model.py
@@ -36,7 +36,7 @@ def main():
         ("claude-sonnet-4-20250514", "Claude Sonnet 4"),
         # Google models
         ("gemini-2.5-pro", "Gemini 2.5 Pro"),
-        ("gemini-3-flash-preview", "Gemini 3 Flash Preview"),
+        ("gemini-3.5-flash", "Gemini 3.5 Flash"),
         # DeepSeek models
         ("deepseek-v3", "DeepSeek V3"),
         ("deepseek-chat", "DeepSeek Chat"),

--- a/cookbook/90_models/google/gemini/audio_input_bytes_content.py
+++ b/cookbook/90_models/google/gemini/audio_input_bytes_content.py
@@ -15,7 +15,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/audio_input_file_upload.py
+++ b/cookbook/90_models/google/gemini/audio_input_file_upload.py
@@ -16,7 +16,7 @@ from google.genai.types import UploadFileConfig
 # Create Agent
 # ---------------------------------------------------------------------------
 
-model = Gemini(id="gemini-3-flash-preview")
+model = Gemini(id="gemini-3.5-flash")
 agent = Agent(
     model=model,
     markdown=True,

--- a/cookbook/90_models/google/gemini/audio_input_local_file_upload.py
+++ b/cookbook/90_models/google/gemini/audio_input_local_file_upload.py
@@ -16,7 +16,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/basic.py
+++ b/cookbook/90_models/google/gemini/basic.py
@@ -13,7 +13,7 @@ import asyncio
 # Create Agent
 # ---------------------------------------------------------------------------
 
-agent = Agent(model=Gemini(id="gemini-3-flash-preview"), markdown=True)
+agent = Agent(model=Gemini(id="gemini-3.5-flash"), markdown=True)
 
 # Get the response in a variable
 # run: RunOutput = agent.run("Share a 2 sentence horror story")

--- a/cookbook/90_models/google/gemini/db.py
+++ b/cookbook/90_models/google/gemini/db.py
@@ -14,7 +14,7 @@ db_url = "postgresql+psycopg://ai:ai@localhost:5532/ai"
 db = PostgresDb(db_url=db_url)
 
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     db=db,
     tools=[WebSearchTools()],
     add_history_to_context=True,

--- a/cookbook/90_models/google/gemini/external_url_input.py
+++ b/cookbook/90_models/google/gemini/external_url_input.py
@@ -12,7 +12,7 @@ This works with:
 
 Supported formats: PDF, JSON, HTML, CSS, XML, images (PNG, JPEG, WebP, GIF)
 
-Note: External URL support requires Gemini 3.x models (e.g., gemini-3-flash-preview).
+Note: External URL support requires Gemini 3.x models (e.g., gemini-3.5-flash).
       Gemini 2.0 models do not support this feature.
 """
 
@@ -25,7 +25,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/file_search_image_upload.py
+++ b/cookbook/90_models/google/gemini/file_search_image_upload.py
@@ -48,7 +48,7 @@ if not mime_type:
 # Create model and store
 # ---------------------------------------------------------------------------
 
-model = Gemini(id="gemini-3-flash-preview")
+model = Gemini(id="gemini-3.5-flash")
 agent = Agent(model=model, markdown=True)
 
 # Create a multimodal store with gemini-embedding-2 for image support

--- a/cookbook/90_models/google/gemini/file_upload_with_cache.py
+++ b/cookbook/90_models/google/gemini/file_upload_with_cache.py
@@ -56,7 +56,7 @@ if not txt_file:
 
 # Create a cache with 5min TTL
 cache = client.caches.create(
-    model="gemini-3-flash-preview",
+    model="gemini-3.5-flash",
     config={
         "system_instruction": "You are an expert at analyzing transcripts.",
         "contents": [txt_file],
@@ -70,7 +70,7 @@ cache = client.caches.create(
 
 if __name__ == "__main__":
     agent = Agent(
-        model=Gemini(id="gemini-3-flash-preview", cached_content=cache.name),
+        model=Gemini(id="gemini-3.5-flash", cached_content=cache.name),
     )
     run_output = agent.run(
         "Find a lighthearted moment from this transcript",  # No need to pass the txt file

--- a/cookbook/90_models/google/gemini/gcs_file_input.py
+++ b/cookbook/90_models/google/gemini/gcs_file_input.py
@@ -25,7 +25,7 @@ from agno.models.google import Gemini
 # Set GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION env vars
 agent = Agent(
     model=Gemini(
-        id="gemini-3-flash-preview",
+        id="gemini-3.5-flash",
         vertexai=True,
     ),
     markdown=True,

--- a/cookbook/90_models/google/gemini/grounding.py
+++ b/cookbook/90_models/google/gemini/grounding.py
@@ -16,7 +16,7 @@ from agno.models.google import Gemini
 
 agent = Agent(
     model=Gemini(
-        id="gemini-3-flash-preview",
+        id="gemini-3.5-flash",
         grounding=True,
         grounding_dynamic_threshold=0.7,  # Optional: set threshold for grounding
     ),

--- a/cookbook/90_models/google/gemini/image_editing.py
+++ b/cookbook/90_models/google/gemini/image_editing.py
@@ -19,7 +19,7 @@ from PIL import Image as PILImage
 # No system message should be provided (Gemini requires only the image)
 agent = Agent(
     model=Gemini(
-        id="gemini-3-flash-preview",
+        id="gemini-3.5-flash",
         response_modalities=["Text", "Image"],
     )
 )

--- a/cookbook/90_models/google/gemini/image_generation.py
+++ b/cookbook/90_models/google/gemini/image_generation.py
@@ -18,7 +18,7 @@ from PIL import Image
 # No system message should be provided
 agent = Agent(
     model=Gemini(
-        id="gemini-3-flash-preview",
+        id="gemini-3.5-flash",
         response_modalities=["Text", "Image"],
     )
 )

--- a/cookbook/90_models/google/gemini/knowledge.py
+++ b/cookbook/90_models/google/gemini/knowledge.py
@@ -22,7 +22,7 @@ knowledge = Knowledge(
 # Add content to the knowledge
 knowledge.insert(url="https://agno-public.s3.amazonaws.com/recipes/ThaiRecipes.pdf")
 
-agent = Agent(model=Gemini(id="gemini-3-flash-preview"), knowledge=knowledge)
+agent = Agent(model=Gemini(id="gemini-3.5-flash"), knowledge=knowledge)
 agent.print_response("How to make Thai curry?", markdown=True)
 
 # ---------------------------------------------------------------------------

--- a/cookbook/90_models/google/gemini/pdf_input_file_upload.py
+++ b/cookbook/90_models/google/gemini/pdf_input_file_upload.py
@@ -42,7 +42,7 @@ while retrieved_file is None and retries < 3:
 
 if retrieved_file is not None:
     agent = Agent(
-        model=Gemini(id="gemini-3-flash-preview"),
+        model=Gemini(id="gemini-3.5-flash"),
         markdown=True,
         add_history_to_context=True,
     )

--- a/cookbook/90_models/google/gemini/pdf_input_local.py
+++ b/cookbook/90_models/google/gemini/pdf_input_local.py
@@ -24,7 +24,7 @@ download_file(
 )
 
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     markdown=True,
     add_history_to_context=True,
 )

--- a/cookbook/90_models/google/gemini/pdf_input_url.py
+++ b/cookbook/90_models/google/gemini/pdf_input_url.py
@@ -15,7 +15,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     markdown=True,
     db=InMemoryDb(),
     add_history_to_context=True,

--- a/cookbook/90_models/google/gemini/s3_url_file_input.py
+++ b/cookbook/90_models/google/gemini/s3_url_file_input.py
@@ -10,7 +10,7 @@ Requirements:
 
 Supported formats: PDF, JSON, HTML, CSS, XML, images (PNG, JPEG, WebP, GIF)
 
-Note: External URL support requires Gemini 3.x models (e.g., gemini-3-flash-preview).
+Note: External URL support requires Gemini 3.x models (e.g., gemini-3.5-flash).
       Gemini 2.0 models do not support this feature.
 """
 
@@ -36,7 +36,7 @@ presigned_url = s3_client.generate_presigned_url(
 )
 
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/search.py
+++ b/cookbook/90_models/google/gemini/search.py
@@ -14,7 +14,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview", search=True),
+    model=Gemini(id="gemini-3.5-flash", search=True),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/vertexai.py
+++ b/cookbook/90_models/google/gemini/vertexai.py
@@ -21,7 +21,7 @@ from agno.models.google import Gemini
 # Create Agent
 # ---------------------------------------------------------------------------
 
-agent = Agent(model=Gemini(id="gemini-3-flash-preview"), markdown=True)
+agent = Agent(model=Gemini(id="gemini-3.5-flash"), markdown=True)
 
 # Get the response in a variable
 # run: RunOutput = agent.run("Share a 2 sentence horror story")

--- a/cookbook/90_models/google/gemini/vertexai_with_credentials.py
+++ b/cookbook/90_models/google/gemini/vertexai_with_credentials.py
@@ -24,7 +24,7 @@ credentials = None  # Replace with your actual credentials object
 
 # 2. Initialize the Gemini model with the credentials parameter
 model = Gemini(
-    id="gemini-3-flash-preview",
+    id="gemini-3.5-flash",
     vertexai=True,
     project_id="your-google-cloud-project-id",
     location="us-central1",

--- a/cookbook/90_models/google/gemini/video_input_bytes_content.py
+++ b/cookbook/90_models/google/gemini/video_input_bytes_content.py
@@ -15,7 +15,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/video_input_file_upload.py
+++ b/cookbook/90_models/google/gemini/video_input_file_upload.py
@@ -18,7 +18,7 @@ from google.genai.types import UploadFileConfig
 # Create Agent
 # ---------------------------------------------------------------------------
 
-model = Gemini(id="gemini-3-flash-preview")
+model = Gemini(id="gemini-3.5-flash")
 agent = Agent(
     model=model,
     markdown=True,

--- a/cookbook/90_models/google/gemini/video_input_local_file_upload.py
+++ b/cookbook/90_models/google/gemini/video_input_local_file_upload.py
@@ -16,7 +16,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini/video_input_youtube.py
+++ b/cookbook/90_models/google/gemini/video_input_youtube.py
@@ -14,7 +14,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     markdown=True,
 )
 
@@ -26,7 +26,7 @@ agent.print_response(
 # Video upload via URL is also supported with Vertex AI
 
 # agent = Agent(
-#     model=Gemini(id="gemini-3-flash-preview", vertexai=True),
+#     model=Gemini(id="gemini-3.5-flash", vertexai=True),
 #     markdown=True,
 # )
 

--- a/cookbook/90_models/google/gemini_interactions/README.md
+++ b/cookbook/90_models/google/gemini_interactions/README.md
@@ -42,7 +42,7 @@ from agno.agent import Agent
 from agno.models.google import GeminiInteractions
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3-flash-preview"),
+    model=GeminiInteractions(id="gemini-3.5-flash"),
     markdown=True,
 )
 agent.print_response("Hello!")
@@ -69,7 +69,7 @@ class MovieReview(BaseModel):
     rating: float
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3-flash-preview"),
+    model=GeminiInteractions(id="gemini-3.5-flash"),
     output_schema=MovieReview,
 )
 ```
@@ -79,12 +79,12 @@ agent = Agent(
 ```python
 # Lower cost, higher latency
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3-flash-preview", service_tier="flex"),
+    model=GeminiInteractions(id="gemini-3.5-flash", service_tier="flex"),
 )
 
 # Lowest latency
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3-flash-preview", service_tier="priority"),
+    model=GeminiInteractions(id="gemini-3.5-flash", service_tier="priority"),
 )
 ```
 

--- a/cookbook/90_models/google/gemini_interactions/TEST_LOG.md
+++ b/cookbook/90_models/google/gemini_interactions/TEST_LOG.md
@@ -4,7 +4,7 @@
 
 - Python: 3.12
 - SDK: google-genai (latest)
-- Model: gemini-3-flash-preview
+- Model: gemini-3.5-flash
 - Date: 2026-05-14
 
 ---
@@ -113,7 +113,7 @@
 
 **Status:** FAIL (API limitation)
 
-**Description:** Tests image generation using response_modalities=["text", "image"]. The Interactions API does not currently support image generation output with gemini-3-flash-preview.
+**Description:** Tests image generation using response_modalities=["text", "image"]. The Interactions API does not currently support image generation output with gemini-3.5-flash.
 
 **Result:** Model returned text instead of generating an image. Image generation is not yet supported through the Interactions API. The cookbook is kept as a reference for when support is added.
 

--- a/cookbook/90_models/google/gemini_interactions/audio_understanding.py
+++ b/cookbook/90_models/google/gemini_interactions/audio_understanding.py
@@ -15,7 +15,7 @@ from agno.models.google import GeminiInteractions
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3-flash-preview"),
+    model=GeminiInteractions(id="gemini-3.5-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini_interactions/document_processing.py
+++ b/cookbook/90_models/google/gemini_interactions/document_processing.py
@@ -15,7 +15,7 @@ from agno.models.google import GeminiInteractions
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3-flash-preview"),
+    model=GeminiInteractions(id="gemini-3.5-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini_interactions/image_understanding.py
+++ b/cookbook/90_models/google/gemini_interactions/image_understanding.py
@@ -15,7 +15,7 @@ from agno.models.google import GeminiInteractions
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3-flash-preview"),
+    model=GeminiInteractions(id="gemini-3.5-flash"),
     markdown=True,
 )
 

--- a/cookbook/90_models/google/gemini_interactions/multi_turn.py
+++ b/cookbook/90_models/google/gemini_interactions/multi_turn.py
@@ -21,7 +21,7 @@ from agno.models.google import GeminiInteractions
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3-flash-preview"),
+    model=GeminiInteractions(id="gemini-3.5-flash"),
     add_history_to_context=True,
     db=SqliteDb(db_file="tmp/data.db"),
     markdown=True,

--- a/cookbook/90_models/google/gemini_interactions/search.py
+++ b/cookbook/90_models/google/gemini_interactions/search.py
@@ -16,7 +16,7 @@ from agno.models.google import GeminiInteractions
 
 agent = Agent(
     model=GeminiInteractions(
-        id="gemini-3-flash-preview",
+        id="gemini-3.5-flash",
         search=True,
     ),
     markdown=True,

--- a/cookbook/90_models/google/gemini_interactions/structured_output.py
+++ b/cookbook/90_models/google/gemini_interactions/structured_output.py
@@ -28,7 +28,7 @@ class MovieReview(BaseModel):
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3-flash-preview"),
+    model=GeminiInteractions(id="gemini-3.5-flash"),
     output_schema=MovieReview,
     markdown=True,
 )

--- a/cookbook/90_models/google/gemini_interactions/thinking.py
+++ b/cookbook/90_models/google/gemini_interactions/thinking.py
@@ -16,7 +16,7 @@ from agno.models.google import GeminiInteractions
 
 agent = Agent(
     model=GeminiInteractions(
-        id="gemini-3-flash-preview",
+        id="gemini-3.5-flash",
         thinking_level="high",
     ),
     markdown=True,

--- a/cookbook/90_models/google/gemini_interactions/tool_use.py
+++ b/cookbook/90_models/google/gemini_interactions/tool_use.py
@@ -16,7 +16,7 @@ from agno.tools.websearch import WebSearchTools
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3-flash-preview"),
+    model=GeminiInteractions(id="gemini-3.5-flash"),
     tools=[WebSearchTools()],
     markdown=True,
 )

--- a/cookbook/90_models/google/gemini_interactions/video_understanding.py
+++ b/cookbook/90_models/google/gemini_interactions/video_understanding.py
@@ -17,7 +17,7 @@ from agno.models.google import GeminiInteractions
 # ---------------------------------------------------------------------------
 
 agent = Agent(
-    model=GeminiInteractions(id="gemini-3-flash-preview"),
+    model=GeminiInteractions(id="gemini-3.5-flash"),
     markdown=True,
 )
 

--- a/cookbook/91_tools/google_bigquery_tools.py
+++ b/cookbook/91_tools/google_bigquery_tools.py
@@ -31,7 +31,7 @@ agent = Agent(
         "Always prepend the table name with your_project_id.your_dataset_name when run_sql tool is invoked",
     ],
     tools=[GoogleBigQueryTools(dataset="test_dataset")],
-    model=Gemini(id="gemini-3-flash-preview", vertexai=True),
+    model=Gemini(id="gemini-3.5-flash", vertexai=True),
 )
 
 # ---------------------------------------------------------------------------

--- a/cookbook/91_tools/todoist_tools.py
+++ b/cookbook/91_tools/todoist_tools.py
@@ -30,7 +30,7 @@ todoist_agent_all = Agent(
         "You can create, read, update, delete tasks and manage projects.",
     ],
     id="todoist-agent-all",
-    model=Gemini("gemini-3-flash-preview"),
+    model=Gemini("gemini-3.5-flash"),
     tools=[TodoistTools()],
     markdown=True,
 )
@@ -45,7 +45,7 @@ todoist_agent = Agent(
         "You have read access to all tasks and projects.",
     ],
     id="todoist-agent-safe",
-    model=Gemini("gemini-3-flash-preview"),
+    model=Gemini("gemini-3.5-flash"),
     tools=[TodoistTools(exclude_tools=["delete_task"])],
     markdown=True,
 )

--- a/cookbook/91_tools/whatsapp_tools.py
+++ b/cookbook/91_tools/whatsapp_tools.py
@@ -41,7 +41,7 @@ from agno.tools.whatsapp import WhatsAppTools
 
 agent = Agent(
     name="whatsapp",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     tools=[WhatsAppTools()],
 )
 

--- a/cookbook/92_integrations/discord/agent_with_media.py
+++ b/cookbook/92_integrations/discord/agent_with_media.py
@@ -14,7 +14,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 media_agent = Agent(
     name="Media Agent",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     description="A Media processing agent",
     instructions="Analyze images, audios and videos sent by the user",
     add_history_to_context=True,

--- a/cookbook/93_components/demo.py
+++ b/cookbook/93_components/demo.py
@@ -57,7 +57,7 @@ registry = Registry(
         OpenAIChat(id="gpt-5-mini"),
         OpenAIChat(id="gpt-5"),
         Claude(id="claude-sonnet-4-5"),
-        Gemini(id="gemini-3-flash-preview"),
+        Gemini(id="gemini-3.5-flash"),
     ],
     dbs=[db],
     vector_dbs=[pgvector],

--- a/cookbook/gemini_3/10_audio_input.py
+++ b/cookbook/gemini_3/10_audio_input.py
@@ -38,7 +38,7 @@ You are an audio analysis expert. Transcribe and summarize audio content clearly
 # ---------------------------------------------------------------------------
 audio_agent = Agent(
     name="Audio Analyst",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     markdown=True,
 )

--- a/cookbook/gemini_3/12_video_input.py
+++ b/cookbook/gemini_3/12_video_input.py
@@ -41,7 +41,7 @@ a clear summary.
 # ---------------------------------------------------------------------------
 video_agent = Agent(
     name="Video Analyst",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     markdown=True,
 )

--- a/cookbook/gemini_3/13_pdf_input.py
+++ b/cookbook/gemini_3/13_pdf_input.py
@@ -38,7 +38,7 @@ and provide clear summaries.
 # ---------------------------------------------------------------------------
 doc_reader = Agent(
     name="Document Reader",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     markdown=True,
 )

--- a/cookbook/gemini_3/14_csv_input.py
+++ b/cookbook/gemini_3/14_csv_input.py
@@ -45,7 +45,7 @@ with tables and summaries.
 # ---------------------------------------------------------------------------
 csv_agent = Agent(
     name="Data Analyst",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     markdown=True,
 )

--- a/cookbook/gemini_3/16_prompt_caching.py
+++ b/cookbook/gemini_3/16_prompt_caching.py
@@ -69,7 +69,7 @@ if not txt_file:
 # ---------------------------------------------------------------------------
 print("\nCreating cache (5 min TTL)...")
 cache = client.caches.create(
-    model="gemini-3-flash-preview",
+    model="gemini-3.5-flash",
     config={
         "system_instruction": "You are an expert at analyzing transcripts.",
         "contents": [txt_file],
@@ -85,7 +85,7 @@ print(f"Cache created: {cache.name}")
 cache_agent = Agent(
     name="Transcript Analyst",
     # cached_content links the agent to the pre-loaded cache
-    model=Gemini(id="gemini-3-flash-preview", cached_content=cache.name),
+    model=Gemini(id="gemini-3.5-flash", cached_content=cache.name),
 )
 
 # ---------------------------------------------------------------------------

--- a/cookbook/gemini_3/17_knowledge.py
+++ b/cookbook/gemini_3/17_knowledge.py
@@ -67,7 +67,7 @@ You are a recipe assistant with access to a Thai cookbook.
 # ---------------------------------------------------------------------------
 recipe_agent = Agent(
     name="Recipe Assistant",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     knowledge=knowledge,
     # Agent automatically searches knowledge when relevant

--- a/cookbook/gemini_3/18_memory.py
+++ b/cookbook/gemini_3/18_memory.py
@@ -83,7 +83,7 @@ You are a personal language tutor that adapts to each student.
 # ---------------------------------------------------------------------------
 tutor_agent = Agent(
     name="Personal Tutor",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     # ReasoningTools gives the agent a "think" tool for structured reasoning
     tools=[ReasoningTools()],

--- a/cookbook/gemini_3/19_team.py
+++ b/cookbook/gemini_3/19_team.py
@@ -46,7 +46,7 @@ writer = Agent(
     name="Writer",
     # role helps the team leader understand what this agent does
     role="Write engaging blog post drafts",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=writer_instructions,
     tools=[WebSearchTools()],
     db=gemini_agents_db,
@@ -78,7 +78,7 @@ You are a senior editor. Review content for quality and suggest improvements.
 editor = Agent(
     name="Editor",
     role="Review and improve content for clarity and quality",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=editor_instructions,
     db=gemini_agents_db,
     add_datetime_to_context=True,
@@ -109,7 +109,7 @@ fact_checker_member = Agent(
     name="Fact Checker",
     role="Verify factual claims using web search",
     # Uses Gemini's native search for fact-checking
-    model=Gemini(id="gemini-3-flash-preview", search=True),
+    model=Gemini(id="gemini-3.5-flash", search=True),
     instructions=fact_checker_instructions,
     db=gemini_agents_db,
     add_datetime_to_context=True,

--- a/cookbook/gemini_3/1_basic.py
+++ b/cookbook/gemini_3/1_basic.py
@@ -1,7 +1,7 @@
 """
 Basic Agent - Your First Gemini Agent
 =======================================
-Simple Agno agent with Gemini 3 Flash.
+Simple Agno agent with Gemini 3.5 Flash.
 
 Key concepts:
 - Agent: The core building block in Agno wraps a model with instructions
@@ -25,7 +25,7 @@ from agno.models.google import Gemini
 # ---------------------------------------------------------------------------
 chat_agent = Agent(
     name="Chat Assistant",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     # markdown=True renders rich formatting in the terminal
     markdown=True,
 )

--- a/cookbook/gemini_3/20_workflow.py
+++ b/cookbook/gemini_3/20_workflow.py
@@ -36,7 +36,7 @@ from db import gemini_agents_db
 # ---------------------------------------------------------------------------
 web_researcher = Agent(
     name="Web Researcher",
-    model=Gemini(id="gemini-3-flash-preview", search=True),
+    model=Gemini(id="gemini-3.5-flash", search=True),
     instructions="""\
 You are a web researcher. Search for the latest information on the given topic.
 
@@ -52,7 +52,7 @@ You are a web researcher. Search for the latest information on the given topic.
 
 deep_researcher = Agent(
     name="Deep Researcher",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     tools=[WebSearchTools()],
     instructions="""\
 You are a deep researcher. Search extensively for background context,
@@ -104,7 +104,7 @@ publication-ready report.
 
 fact_checker = Agent(
     name="Fact Checker",
-    model=Gemini(id="gemini-3-flash-preview", search=True),
+    model=Gemini(id="gemini-3.5-flash", search=True),
     instructions="""\
 You are a fact-checker. Verify the factual claims in the report.
 

--- a/cookbook/gemini_3/2_tools.py
+++ b/cookbook/gemini_3/2_tools.py
@@ -44,7 +44,7 @@ You are a finance research agent. You find and analyze current financial news.
 # ---------------------------------------------------------------------------
 finance_agent = Agent(
     name="Finance Agent",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     tools=[WebSearchTools()],
     # Adds current date/time to the system message so the agent knows "today"

--- a/cookbook/gemini_3/4_search.py
+++ b/cookbook/gemini_3/4_search.py
@@ -37,7 +37,7 @@ You are a news analyst. Summarize the latest developments clearly and concisely.
 news_agent = Agent(
     name="News Agent",
     # search=True enables Gemini's native Google Search, no extra tools needed
-    model=Gemini(id="gemini-3-flash-preview", search=True),
+    model=Gemini(id="gemini-3.5-flash", search=True),
     instructions=instructions,
     add_datetime_to_context=True,
     markdown=True,
@@ -59,7 +59,7 @@ if __name__ == "__main__":
 Native search vs tool-based search:
 
 1. Native search (this example)
-   model=Gemini(id="gemini-3-flash-preview", search=True)
+   model=Gemini(id="gemini-3.5-flash", search=True)
    - Seamless: model decides when to search
    - Less controllable: you can't see individual search calls
    - No extra packages needed

--- a/cookbook/gemini_3/8_image_input.py
+++ b/cookbook/gemini_3/8_image_input.py
@@ -40,7 +40,7 @@ and provide relevant context.
 image_agent = Agent(
     name="Image Analyst",
     # search=True lets the agent look up context about what it sees
-    model=Gemini(id="gemini-3-flash-preview", search=True),
+    model=Gemini(id="gemini-3.5-flash", search=True),
     instructions=instructions,
     markdown=True,
 )

--- a/cookbook/gemini_3/README.md
+++ b/cookbook/gemini_3/README.md
@@ -4,7 +4,7 @@ Build Agno agents with Google Gemini, progressively adding capabilities at each 
 
 This guide walks through the basics of building Agents, the easy way. Follow along to learn how to build agents with tools, storage, memory, knowledge, state, guardrails, and human in the loop. We'll also build multi-agent teams and step-based agentic workflows.
 
-Each example can be run independently and contains detailed comments + example prompts to help you understand what's happening behind the scenes. We'll use **Gemini 3 Flash** — fast, affordable, and excellent at tool calling but you can swap in any model with a one line change. We use either **Gemini 3 Flash** or **Gemini 3.1 Pro** as the model, depending on the example.
+Each example can be run independently and contains detailed comments + example prompts to help you understand what's happening behind the scenes. We'll use **Gemini 3.5 Flash** — fast, affordable, and excellent at tool calling but you can swap in any model with a one line change. We use either **Gemini 3.5 Flash** or **Gemini 3.1 Pro** as the model, depending on the example.
 
 ## Fast Path
 
@@ -125,7 +125,7 @@ Then visit [os.agno.com](https://os.agno.com/?utm_source=github&utm_medium=cookb
 | `GOOGLE_API_KEY not set` | `export GOOGLE_API_KEY=your-key` |
 | `ModuleNotFoundError` | `uv pip install -r cookbook/gemini_3/requirements.txt` |
 | `429 Rate limit exceeded` | Wait a minute, or use a different model ID |
-| `Model not found` | Check model ID spelling -- use `gemini-3-flash-preview` or `gemini-3.1-pro-preview` |
+| `Model not found` | Check model ID spelling -- use `gemini-3.5-flash` or `gemini-3.1-pro-preview` |
 
 ## Learn More
 

--- a/cookbook/gemini_3/use_cases/film_scene_breakdown.py
+++ b/cookbook/gemini_3/use_cases/film_scene_breakdown.py
@@ -21,7 +21,7 @@ from agno.team.team import Team
 video_analyst = Agent(
     name="Video Analyst",
     role="Analyze video clips for visual content, pacing, and mood",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions="""\
 You are a film analysis expert. Watch video clips and provide detailed breakdowns.
 
@@ -49,7 +49,7 @@ You are a film analysis expert. Watch video clips and provide detailed breakdown
 script_reader = Agent(
     name="Script Reader",
     role="Read film scripts and extract relevant dialogue and directions",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions="""\
 You are a script supervisor. Read scripts and extract relevant information.
 
@@ -76,7 +76,7 @@ You are a script supervisor. Read scripts and extract relevant information.
 continuity_editor = Agent(
     name="Continuity Editor",
     role="Check consistency between script and footage",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions="""\
 You are a continuity editor. Compare the script to the footage and flag issues.
 

--- a/cookbook/gemini_3/use_cases/game_concept_pitch.py
+++ b/cookbook/gemini_3/use_cases/game_concept_pitch.py
@@ -54,7 +54,7 @@ class GamePitch(BaseModel):
 art_agent = Agent(
     name="Concept Artist",
     model=Gemini(
-        id="gemini-3-flash-preview",
+        id="gemini-3.5-flash",
         response_modalities=["Text", "Image"],
     ),
 )
@@ -87,7 +87,7 @@ You are a game design consultant. Create compelling, structured game pitches.
 market_analyst = Agent(
     name="Market Analyst",
     role="Evaluate market viability and competitive landscape",
-    model=Gemini(id="gemini-3-flash-preview", search=True),
+    model=Gemini(id="gemini-3.5-flash", search=True),
     instructions="""\
 You analyze game market trends. Evaluate pitches for market viability.
 
@@ -111,7 +111,7 @@ You analyze game market trends. Evaluate pitches for market viability.
 creative_director = Agent(
     name="Creative Director",
     role="Evaluate creative vision and player experience",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions="""\
 You evaluate game concepts for creative quality and player appeal.
 

--- a/cookbook/gemini_3/use_cases/music_asset_brief.py
+++ b/cookbook/gemini_3/use_cases/music_asset_brief.py
@@ -62,7 +62,7 @@ context to produce comprehensive asset briefs for A&R and marketing teams.
 # ---------------------------------------------------------------------------
 music_analyst = Agent(
     name="Music Analyst",
-    model=Gemini(id="gemini-3-flash-preview"),
+    model=Gemini(id="gemini-3.5-flash"),
     instructions=instructions,
     tools=[WebSearchTools()],
     output_schema=TrackBrief,

--- a/cookbook/levels_of_agentic_software/README.md
+++ b/cookbook/levels_of_agentic_software/README.md
@@ -101,7 +101,7 @@ model = OpenAIResponses(id="gpt-5.2")
 
 # Google
 from agno.models.google import Gemini
-model = Gemini(id="gemini-3-flash-preview")
+model = Gemini(id="gemini-3.5-flash")
 
 # Anthropic
 from agno.models.anthropic import Claude


### PR DESCRIPTION
## Summary

Update all cookbook references from the preview model id `gemini-3-flash-preview` to the released `gemini-3.5-flash`. 82 files touched across `00_quickstart`, `02_agents`, `03_teams`, `05_agent_os`, `90_models/google/gemini*`, `gemini_3`, and other example folders (Python examples, READMEs, and TEST_LOGs).

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Improvement
- [x] Model update
- [ ] Other:

---

## Checklist

- [x] Code complies with style guidelines
- [x] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [x] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [x] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [x] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Mechanical string replacement only — no logic changes. Library default id (`libs/agno/agno/models/google/gemini_interactions.py`) and the related `gemini-3-pro-preview` -> `gemini-3.5-pro` renames are intentionally out of scope here and will be handled separately.