### PR TITLE
feat: add antigravity tools and external agent

### DIFF
--- a/cookbook/91_tools/TEST_LOG.md
+++ b/cookbook/91_tools/TEST_LOG.md
@@ -29,3 +29,43 @@
 **Result:** Ran `pytest libs/agno/tests/unit/tools/test_gitlab.py -q` and all 18 tests passed, including async methods, internal async client handling coverage, and `enable_*` tool-toggle coverage (with `enable_get_projects` as the canonical project-read toggle). Also ran `ruff check` for changed files and both validation scripts (`libs/agno/scripts/validate.bat`, `libs/agno_infra/scripts/validate.bat`) with no issues. Live toolkit checks passed for `get_project`, `list_issues`, and `list_merge_requests` against `SalimELMARDI/agno-gitlab-tools-test`. Negative live check also passed: `get_project('wrong-group/wrong-project')` returned expected JSON error (`404 Project Not Found`). The cookbook agent runtime file was not executed because it requires model credentials.
 
 ---
+
+### antigravity_tools.py
+
+**Status:** PENDING
+
+**Description:** Gemini-driven Agno agent delegates a research sub-task to an Antigravity sandbox via `AntigravityTools.run_antigravity_task`. The toolkit POSTs to the Gemini Agents API `/interactions` endpoint, caches `environment_id` in `agent.session_state` so the sandbox persists across calls in non-streaming mode, and returns the final text response.
+
+**Result:** Unit tests pass covering session-state caching, env-id reuse on subsequent calls, HTTP error surfacing, custom-agent creation, and the delete endpoint. Live cookbook run with a partner Gemini API key remains the gating verification before merge.
+
+---
+
+### antigravity_agents_crud_tools.py
+
+**Status:** PENDING
+
+**Description:** Gemini-driven Agno agent drives the full Agents API lifecycle via `AntigravityTools` — `create_custom_antigravity_agent`, `run_custom_antigravity_agent`, then `delete_antigravity_agent`. Toolkit also exposes `get_custom_antigravity_agent`, `update_custom_antigravity_agent`, `list_antigravity_agents`, and `list_antigravity_agent_versions` for full CRUD coverage of `/v1beta/agents`.
+
+**Result:** Unit tests pass. Live cookbook run with a partner Gemini API key remains the gating verification.
+
+---
+
+### antigravity_directory_tools.py
+
+**Status:** PENDING
+
+**Description:** `AntigravityTools(agent_directory=...)` parses a local agent folder (`agent.yaml` + `AGENTS.md` + `workspace/` + `skills/`), registers it via POST /agents (idempotent), and routes subsequent `run_antigravity_task` calls at the named agent. Re-uses the `example_agent/` folder from `cookbook/frameworks/antigravity/`.
+
+**Result:** Unit tests pass for the new constructor path (register=False parse-only, register=True POSTs, 409 = success, agent= / default_sources= conflict validation, required-key validation, run_antigravity_task routes at the named agent post-load). Live cookbook awaiting partner key.
+
+---
+
+### antigravity_snapshot_tools.py
+
+**Status:** PENDING
+
+**Description:** Gemini-driven Agno agent runs `run_antigravity_task` to write a few files in the sandbox, then calls `download_antigravity_environment_snapshot` with `environment_id="current"` to resolve the env id from `agent.session_state` and save the resulting tar to disk. Demonstrates the full sandbox-write → archive flow through tool calls.
+
+**Result:** Unit tests pass covering snapshot URL construction, byte-for-byte write to disk, "current" resolution from session_state, and the no-cached-env error path. Live cookbook awaiting partner key.
+
+---

--- a/cookbook/91_tools/antigravity/antigravity_agents_crud_tools.py
+++ b/cookbook/91_tools/antigravity/antigravity_agents_crud_tools.py
@@ -1,0 +1,51 @@
+"""
+Manage Antigravity custom agents via the Agents API toolkit.
+
+`AntigravityTools` exposes the full CRUD surface of `/v1beta/agents` as tools
+that an Agno agent can call:
+
+  - create_custom_antigravity_agent: POST /agents
+  - get_custom_antigravity_agent:    GET  /agents/{name}
+  - list_antigravity_agents:         GET  /agents
+  - list_antigravity_agent_versions: GET  /agents/{name}/versions
+  - update_custom_antigravity_agent: PATCH /agents/{name}
+  - delete_antigravity_agent:        DELETE /agents/{name}
+  - run_custom_antigravity_agent:    POST /interactions with `agent=<name>`
+
+Plus `run_antigravity_task` for one-off invocations of the base antigravity agent.
+
+This cookbook shows a Gemini-driven Agno agent driving the full lifecycle:
+create a haiku-bot definition, invoke it, then clean up.
+
+Requirements:
+    export GEMINI_API_KEY=...
+    uv pip install agno google-genai
+
+Usage:
+    .venvs/demo/bin/python cookbook/91_tools/antigravity/antigravity_agents_crud_tools.py
+"""
+
+from agno.agent import Agent
+from agno.models.google import Gemini
+from agno.tools.antigravity import AntigravityTools
+
+agent = Agent(
+    name="Antigravity Admin",
+    model=Gemini(id="gemini-2.5-pro"),
+    tools=[AntigravityTools()],
+    markdown=True,
+    instructions=[
+        "You manage custom Antigravity agents via the Agents API tools.",
+        "When asked to create an agent, use create_custom_antigravity_agent with the requested name and instructions.",
+        "When asked to invoke a named agent, use run_custom_antigravity_agent.",
+        "When asked to clean up, use delete_antigravity_agent.",
+        "Surface the agent ids / responses to the user clearly.",
+    ],
+)
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Create a custom Antigravity agent called 'demo-haiku-bot' whose only job is to "
+        "write a single haiku in response to any prompt. Then invoke it with the prompt "
+        "'autumn leaves'. Finally, delete the agent."
+    )

--- a/cookbook/91_tools/antigravity/antigravity_directory_tools.py
+++ b/cookbook/91_tools/antigravity/antigravity_directory_tools.py
@@ -1,0 +1,47 @@
+"""
+Use a local Antigravity agent directory through AntigravityTools.
+
+Pass `agent_directory=` to the toolkit constructor and it will:
+  1. Parse `agent.yaml`, `AGENTS.md`, `workspace/`, and `skills/`.
+  2. Register the agent definition via POST /v1beta/agents (idempotent).
+  3. Route all subsequent `run_antigravity_task` calls at the named custom agent.
+
+Lets a regular Agno agent (any model) delegate sub-tasks to a folder-defined
+Antigravity agent without having to wire up `/agents` calls yourself.
+
+Re-uses the example folder from
+`cookbook/frameworks/antigravity/example_agent/`.
+
+Requirements:
+    export GEMINI_API_KEY=...
+    uv pip install agno google-genai pyyaml
+
+Usage:
+    .venvs/demo/bin/python cookbook/91_tools/antigravity/antigravity_directory_tools.py
+"""
+
+from pathlib import Path
+
+from agno.agent import Agent
+from agno.models.google import Gemini
+from agno.tools.antigravity import AntigravityTools
+
+AGENT_DIR = (
+    Path(__file__).parent.parent.parent / "frameworks" / "antigravity" / "example_agent"
+)
+
+agent = Agent(
+    name="Haiku Requester",
+    model=Gemini(id="gemini-2.5-pro"),
+    # Register the folder once at construction; subsequent run_antigravity_task
+    # calls invoke the named agent (`agno-haiku-bot-from-dir`).
+    tools=[AntigravityTools(agent_directory=str(AGENT_DIR))],
+    markdown=True,
+    instructions=[
+        "When the user asks for a haiku, delegate to the Antigravity sandbox via run_antigravity_task.",
+        "Pass the topic through as-is; the sandbox agent enforces house style.",
+    ],
+)
+
+if __name__ == "__main__":
+    agent.print_response("Write a haiku about autumn maples.")

--- a/cookbook/91_tools/antigravity/antigravity_snapshot_tools.py
+++ b/cookbook/91_tools/antigravity/antigravity_snapshot_tools.py
@@ -1,0 +1,57 @@
+"""
+Download an Antigravity sandbox snapshot through AntigravityTools.
+
+`download_antigravity_environment_snapshot` hits the Files API endpoint:
+    GET /v1beta/files/environment-{env_id}:download?alt=media
+
+Pass `environment_id="current"` to resolve the env id from the calling Agno
+agent's `session_state` — it's set there by a prior `run_antigravity_task` call
+within the same session.
+
+Useful for letting an Agno agent introspect or archive what the Antigravity
+sandbox produced during a task.
+
+Requirements:
+    export GEMINI_API_KEY=...
+    uv pip install agno google-genai
+
+Usage:
+    .venvs/demo/bin/python cookbook/91_tools/antigravity/antigravity_snapshot_tools.py
+"""
+
+import tarfile
+from pathlib import Path
+
+from agno.agent import Agent
+from agno.models.google import Gemini
+from agno.tools.antigravity import AntigravityTools
+
+OUT_PATH = Path("tmp/antigravity_snapshot_from_tools.tar")
+OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+agent = Agent(
+    name="Snapshot Demo",
+    model=Gemini(id="gemini-2.5-pro"),
+    tools=[AntigravityTools()],
+    markdown=True,
+    instructions=[
+        "Step 1: Use run_antigravity_task to ask the sandbox to create a few files under /workspace/ "
+        "(e.g. notes.txt with 'hello', summary.md with a brief intro).",
+        f"Step 2: Use download_antigravity_environment_snapshot with environment_id='current' and "
+        f"output_path='{OUT_PATH}' to save the snapshot tar.",
+        "Step 3: Tell the user where the tar was saved.",
+    ],
+)
+
+if __name__ == "__main__":
+    agent.print_response(
+        "Have the sandbox create a couple of files under /workspace, then archive the environment to disk."
+    )
+
+    if OUT_PATH.exists():
+        print(f"\nSnapshot saved: {OUT_PATH} ({OUT_PATH.stat().st_size} bytes)")
+        with tarfile.open(OUT_PATH, "r") as tf:
+            members = tf.getnames()
+            print(f"Archive contains {len(members)} entries. First 10:")
+            for name in members[:10]:
+                print(f"  {name}")

--- a/cookbook/91_tools/antigravity/antigravity_tools.py
+++ b/cookbook/91_tools/antigravity/antigravity_tools.py
@@ -1,0 +1,49 @@
+"""
+Agent with Antigravity tools
+
+This example shows how to use Agno's integration with Google's Gemini Agents API
+(Antigravity) as a tool. The Agno agent's brain (Gemini, here) decides when to
+delegate a sub-task to a managed Antigravity sandbox, which runs an autonomous
+loop with web search, code execution, and file I/O built in.
+
+The sandbox persists across calls within the same Agno session, so subsequent
+calls can build on prior files and state.
+
+1. Get a Gemini API key enrolled in the Agents API EAP.
+2. Set the API key as an environment variable:
+    export GEMINI_API_KEY=<your_api_key>
+3. Install the dependencies:
+    uv pip install agno google-genai
+"""
+
+from agno.agent import Agent
+from agno.models.google import Gemini
+from agno.tools.antigravity import AntigravityTools
+
+# ---------------------------------------------------------------------------
+# Create Agent
+# ---------------------------------------------------------------------------
+
+agent = Agent(
+    name="Research Assistant with Antigravity tools",
+    model=Gemini(id="gemini-2.5-pro"),
+    tools=[AntigravityTools()],
+    markdown=True,
+    instructions=[
+        "You have access to a managed Antigravity sandbox with web search, code execution, and file I/O.",
+        "When the user asks for something that benefits from those capabilities — multi-step research, "
+        "analysing a repo, generating files, or running code you cannot run locally — delegate the work "
+        "to the sandbox via the run_antigravity_task tool.",
+        "Otherwise, answer directly without invoking the tool.",
+        "The sandbox persists across calls in the same session, so follow-up tasks can build on prior state.",
+    ],
+)
+
+# ---------------------------------------------------------------------------
+# Run Agent
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    agent.print_response(
+        "Use the Antigravity sandbox to find the latest stable Python release "
+        "and summarize what changed in it."
+    )

--- a/cookbook/frameworks/antigravity/README.md
+++ b/cookbook/frameworks/antigravity/README.md
@@ -1,0 +1,39 @@
+# Antigravity (Gemini Agents API)
+
+Examples for integrating Google's Gemini Agents API ("Antigravity") with Agno.
+
+Antigravity is a managed agent loop: a single REST call spins up a sandboxed
+Linux environment with web search, code execution, and file I/O built in,
+runs an autonomous loop to satisfy the request, and returns or streams
+events. Environments persist across turns via an `environment_id`.
+
+Agno integrates Antigravity two ways. Pick based on who drives the loop:
+
+| Integration | When to use | Example |
+|---|---|---|
+| `AntigravityAgent` (external agent) | You want Antigravity to **be** the agent — served through AgentOS, with Agno handling sessions, streaming, and the UI. | `antigravity_basic.py`, `antigravity_session_agentos.py` (this folder) |
+| `AntigravityTools` (toolkit) | You want a regular Agno agent (any model) to **delegate** a sub-task to an Antigravity sandbox as one tool call. | [`cookbook/91_tools/antigravity/antigravity_tools.py`](../../91_tools/antigravity/antigravity_tools.py) |
+
+## Setup
+
+```bash
+export GEMINI_API_KEY=...
+```
+
+## Files
+
+- `antigravity_basic.py` — minimal standalone run
+- `antigravity_session.py` — multi-turn session, environment reused across turns
+- `antigravity_sources.py` — pre-load files into the sandbox (inline / GCS / repo)
+- `antigravity_custom_agent.py` — register a named custom agent (Agents API) and invoke it
+- `antigravity_from_agent_directory.py` — load an agent from a local `agent.yaml` + `AGENTS.md` + `workspace/` + `skills/` folder (see `example_agent/`)
+- `antigravity_snapshot.py` — download an environment's filesystem as a tar archive
+- `antigravity_session_agentos.py` — same with SQLite-backed sessions
+
+For the toolkit examples (Antigravity-as-a-tool), see:
+- [`cookbook/91_tools/antigravity/antigravity_tools.py`](../../91_tools/antigravity/antigravity_tools.py) — delegate a sub-task to a sandbox
+- [`cookbook/91_tools/antigravity/antigravity_agents_crud_tools.py`](../../91_tools/antigravity/antigravity_agents_crud_tools.py) — full Agents API CRUD (create / get / update / list / versions / delete / invoke)
+- [`cookbook/91_tools/antigravity/antigravity_directory_tools.py`](../../91_tools/antigravity/antigravity_directory_tools.py) — wire a local `agent.yaml` folder into the toolkit (parses, registers, routes future tool calls at the named agent)
+- [`cookbook/91_tools/antigravity/antigravity_snapshot_tools.py`](../../91_tools/antigravity/antigravity_snapshot_tools.py) — have an Agno agent run a sandbox task then download the resulting environment as a tar
+
+Test results are tracked in `TEST_LOG.md`.

--- a/cookbook/frameworks/antigravity/TEST_LOG.md
+++ b/cookbook/frameworks/antigravity/TEST_LOG.md
@@ -1,0 +1,85 @@
+# Antigravity cookbook test log
+
+### antigravity_basic.py
+
+**Status:** PENDING
+
+**Description:** Smoke test — `AntigravityAgent.print_response("What is 2+2?", stream=True)`.
+
+**Result:** Awaiting live-API verification with partner key.
+
+---
+
+### antigravity_session.py
+
+**Status:** PENDING
+
+**Description:** Two-turn session — turn 1 writes notes.txt in the sandbox, turn 2 reads it back; verifies environment_id is reused across turns.
+
+**Result:** Awaiting live-API verification.
+
+---
+
+### antigravity_sources.py
+
+**Status:** PENDING
+
+**Description:** Provision a sandbox with an inline source file at /workspace/about.txt and ask the agent to read it.
+
+**Result:** Awaiting live-API verification.
+
+---
+
+### antigravity_custom_agent.py
+
+**Status:** PENDING
+
+**Description:** POST /v1beta/agents to create a haiku-writing custom agent, then invoke it through AntigravityAgent.
+
+**Result:** Awaiting live-API verification.
+
+---
+
+### antigravity_agentos.py
+
+**Status:** PENDING
+
+**Description:** Serve a AntigravityAgent through AgentOS; verify /agents list + streaming /runs.
+
+**Result:** Awaiting live-API verification.
+
+---
+
+### antigravity_session_agentos.py
+
+**Status:** PENDING
+
+**Description:** Same as antigravity_agentos.py with SqliteDb-backed sessions; verify sessions persist across restarts.
+
+**Result:** Awaiting live-API verification.
+
+---
+
+### antigravity_from_agent_directory.py
+
+**Status:** PENDING
+
+**Description:** Load an Antigravity agent from a local directory (`agent.yaml` + `AGENTS.md` + `workspace/` + `skills/`) via `AntigravityAgent.from_agent_directory()`. Auto-registers the named agent on first invocation. The `example_agent/` folder in this directory exercises all four layout elements.
+
+**Result:** Unit tests pass for the directory parser (required-key validation, AGENTS.md precedence, workspace + skills targets, 75 KB size limit). Live cookbook run awaiting partner key.
+
+---
+
+### antigravity_snapshot.py
+
+**Status:** PENDING
+
+**Description:** Run a task that writes a file in the sandbox, then download the environment snapshot tar via `AntigravityAgent.download_environment_snapshot()`. Uses non-streaming because SSE doesn't expose `environment_id` (see open partner question).
+
+**Result:** Unit tests pass for the snapshot toolkit method (env-id resolution from session_state, error surfacing). Live cookbook run awaiting partner key.
+
+---
+
+Note: the `AntigravityTools` toolkit example lives at `cookbook/91_tools/antigravity_tools.py` and is tracked in that folder's TEST_LOG.
+
+---

--- a/cookbook/frameworks/antigravity/antigravity_basic.py
+++ b/cookbook/frameworks/antigravity/antigravity_basic.py
@@ -1,0 +1,19 @@
+"""
+Standalone usage of Google's Gemini Agents API (Antigravity) via Agno's
+.run() and .print_response() methods.
+
+Requirements:
+    export GEMINI_API_KEY=...
+
+Usage:
+    .venvs/demo/bin/python cookbook/frameworks/antigravity/antigravity_basic.py
+"""
+
+from agno.agents.antigravity import AntigravityAgent
+
+agent = AntigravityAgent(name="Antigravity")
+
+agent.print_response(
+    "What is 2 + 2? Explain your reasoning briefly.",
+    stream=True,
+)

--- a/cookbook/frameworks/antigravity/antigravity_custom_agent.py
+++ b/cookbook/frameworks/antigravity/antigravity_custom_agent.py
@@ -1,0 +1,39 @@
+"""
+Antigravity with a custom (named) agent definition.
+
+Demonstrates the Agents API flow: instead of running the base `antigravity` agent
+with ad-hoc instructions, you register a named agent definition once and then
+invoke it by name. Useful when:
+
+  - You want stable, reusable agent identities to schedule / share / version.
+  - Instructions + sources should live with the agent definition, not the call.
+
+Registration is explicit: call `agent.ensure_custom_agent()` once before the
+first run. It POSTs to /v1beta/agents and treats 409 / already-exists as success,
+so re-running this script is idempotent.
+
+Requirements:
+    export GEMINI_API_KEY=...
+
+Usage:
+    .venvs/demo/bin/python cookbook/frameworks/antigravity/antigravity_custom_agent.py
+"""
+
+from agno.agents.antigravity import AntigravityAgent
+
+agent = AntigravityAgent(
+    name="Haiku Bot",
+    custom_agent_name="agno-haiku-bot",
+    custom_agent_instructions=(
+        "You are a haiku-writing assistant. Always respond with exactly one haiku "
+        "(three lines, 5-7-5 syllable structure) and nothing else."
+    ),
+    custom_agent_description="Demo custom Antigravity agent that only writes haikus.",
+)
+
+# Register the definition with the API. Idempotent — safe to re-run.
+agent.ensure_custom_agent()
+
+# Invoke the registered agent.
+agent.print_response("Write a haiku about Python.", stream=True)
+agent.print_response("Now one about the ocean.", stream=True)

--- a/cookbook/frameworks/antigravity/antigravity_from_agent_directory.py
+++ b/cookbook/frameworks/antigravity/antigravity_from_agent_directory.py
@@ -1,0 +1,43 @@
+"""
+Load an Antigravity agent from a local directory and run it.
+
+Mirrors the Managed Agents docs' "agent directory" convention:
+
+    example_agent/
+    ├── agent.yaml        # id, base_agent, description, system_instruction
+    ├── AGENTS.md         # System instructions (overrides agent.yaml.system_instruction)
+    ├── skills/           # Mounted under /.agents/skills/<name>/ in the sandbox
+    │   └── haiku/SKILL.md
+    └── workspace/        # Mounted at the sandbox root
+        └── about.txt
+
+`AntigravityAgent.from_agent_directory(...)` parses the directory, builds the
+inline source list, and (when `register=True`, the default) registers the named
+agent with the API via POST /v1beta/agents before returning. 409 / already-exists
+is treated as success, so re-running this script is idempotent.
+
+Pass `register=False` to defer registration if you want to inspect the parsed
+agent first; in that case call `agent.ensure_custom_agent()` before the first run.
+
+Files larger than 75 KB are skipped with a warning (API inline-source limit).
+Binary files are skipped — the API currently supports text files only.
+
+Requirements:
+    export GEMINI_API_KEY=...
+    pip install pyyaml
+
+Usage:
+    .venvs/demo/bin/python cookbook/frameworks/antigravity/antigravity_from_agent_directory.py
+"""
+
+from pathlib import Path
+
+from agno.agents.antigravity import AntigravityAgent
+
+AGENT_DIR = Path(__file__).parent / "example_agent"
+
+# `from_agent_directory` POSTs to /agents before returning (register=True default).
+agent = AntigravityAgent.from_agent_directory(str(AGENT_DIR))
+
+agent.print_response("Topic: autumn maples.", stream=True)
+agent.print_response("Topic: a quiet beach at dawn.", stream=True)

--- a/cookbook/frameworks/antigravity/antigravity_session.py
+++ b/cookbook/frameworks/antigravity/antigravity_session.py
@@ -1,0 +1,42 @@
+"""
+Antigravity with session persistence.
+
+Demonstrates a multi-turn conversation where the underlying Antigravity
+environment (sandbox state, files, installed packages) is reused across
+turns within the same session_id. Chat history is persisted to a local
+SQLite DB so the conversation can be resumed.
+
+Requirements:
+    export GEMINI_API_KEY=...
+
+Usage:
+    .venvs/demo/bin/python cookbook/frameworks/antigravity/antigravity_session.py
+"""
+
+from agno.agents.antigravity import AntigravityAgent
+from agno.db.sqlite import SqliteDb
+
+db = SqliteDb(db_file="tmp/antigravity.db")
+
+agent = AntigravityAgent(
+    name="Antigravity Chat",
+    db=db,
+)
+
+SESSION_ID = "antigravity-demo-1"
+
+# Turn 1 — provision the sandbox and run something
+agent.print_response(
+    "Write a file called notes.txt containing the string 'hello agno'.",
+    stream=True,
+    session_id=SESSION_ID,
+)
+
+# Turn 2 — same session: the env_id is reused, so notes.txt is still there
+agent.print_response(
+    "Read notes.txt back and tell me what it contains.",
+    stream=True,
+    session_id=SESSION_ID,
+)
+
+print(f"\n--- Session {SESSION_ID} persisted to tmp/antigravity.db ---")

--- a/cookbook/frameworks/antigravity/antigravity_session_agentos.py
+++ b/cookbook/frameworks/antigravity/antigravity_session_agentos.py
@@ -1,0 +1,35 @@
+"""
+Antigravity on AgentOS with session persistence.
+
+Serves an `AntigravityAgent` through AgentOS, backed by a SQLite DB so runs
+and sessions persist across restarts and appear in the AgentOS UI's session
+list.
+
+Requirements:
+    export GEMINI_API_KEY=...
+
+Usage:
+    .venvs/demo/bin/python cookbook/frameworks/antigravity/antigravity_session_agentos.py
+"""
+
+from agno.agents.antigravity import AntigravityAgent
+from agno.db.sqlite import SqliteDb
+from agno.os import AgentOS
+
+db = SqliteDb(db_file="tmp/antigravity_agentos.db")
+
+antigravity_agent = AntigravityAgent(
+    name="Antigravity",
+    description="Antigravity with persisted sessions",
+    db=db,
+)
+
+agent_os = AgentOS(
+    name="Antigravity Sessioned",
+    description="AgentOS serving an Antigravity-backed agent with SQLite sessions",
+    agents=[antigravity_agent],
+)
+app = agent_os.get_app()
+
+if __name__ == "__main__":
+    agent_os.serve(app="antigravity_session_agentos:app", reload=True)

--- a/cookbook/frameworks/antigravity/antigravity_snapshot.py
+++ b/cookbook/frameworks/antigravity/antigravity_snapshot.py
@@ -1,0 +1,49 @@
+"""
+Download an Antigravity environment snapshot as a tar file.
+
+After an interaction modifies files in the sandbox, you can pull the resulting
+filesystem out as a tar archive via the Files API:
+    GET /v1beta/files/environment-{environment_id}:download?alt=media
+
+Useful for inspecting what the agent produced, archiving runs, or seeding a
+new environment from a known-good state.
+
+Requirements:
+    export GEMINI_API_KEY=...
+
+Usage:
+    .venvs/demo/bin/python cookbook/frameworks/antigravity/antigravity_snapshot.py
+"""
+
+import tarfile
+from pathlib import Path
+
+from agno.agents.antigravity import AntigravityAgent
+
+OUT_PATH = Path("tmp/antigravity_snapshot.tar")
+OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+SESSION_ID = "snapshot-demo"
+
+agent = AntigravityAgent(name="Antigravity Snapshot Demo")
+
+# Run something that writes a file into the sandbox. Non-streaming so the
+# adapter captures `environment_id` from the response (SSE doesn't carry it).
+agent.print_response(
+    "Create a file /workspace/hello.txt containing the line 'snapshot test' and confirm it exists.",
+    stream=False,
+    session_id=SESSION_ID,
+)
+
+# Pull the env snapshot for the session we just ran.
+bytes_written = agent.download_environment_snapshot(
+    str(OUT_PATH),
+    session_id=SESSION_ID,
+)
+print(f"\nSnapshot saved: {OUT_PATH} ({bytes_written} bytes)")
+
+# Inspect the archive.
+with tarfile.open(OUT_PATH, "r") as tf:
+    members = tf.getnames()
+    print(f"Archive contains {len(members)} entries. First 10:")
+    for name in members[:10]:
+        print(f"  {name}")

--- a/cookbook/frameworks/antigravity/antigravity_sources.py
+++ b/cookbook/frameworks/antigravity/antigravity_sources.py
@@ -1,0 +1,36 @@
+"""
+Antigravity with pre-loaded environment sources.
+
+Demonstrates seeding the sandbox at provisioning time with files from
+GCS, a Git repository, or inline content. The agent can then immediately
+read/operate on those files.
+
+Requirements:
+    export GEMINI_API_KEY=...
+
+Usage:
+    .venvs/demo/bin/python cookbook/frameworks/antigravity/antigravity_sources.py
+"""
+
+from agno.agents.antigravity import AntigravityAgent
+
+agent = AntigravityAgent(
+    name="Antigravity with Sources",
+    sources=[
+        # Inline content: small files dropped straight into the sandbox
+        {
+            "type": "inline",
+            "content": "agno is an open-source agent framework",
+            "target": "/workspace/about.txt",
+        },
+        # Repository: clone a Git repo into a target path
+        # {"type": "repository", "source": "github://agno-agi/agno", "target": "/workspace/agno"},
+        # GCS: pull a folder from a public GCS bucket
+        # {"type": "gcs", "source": "gs://my-bucket/data/", "target": "/workspace/data"},
+    ],
+)
+
+agent.print_response(
+    "List the files under /workspace and show the contents of about.txt.",
+    stream=True,
+)

--- a/cookbook/frameworks/antigravity/example_agent/AGENTS.md
+++ b/cookbook/frameworks/antigravity/example_agent/AGENTS.md
@@ -1,0 +1,11 @@
+# Haiku Bot
+
+You are a haiku-writing assistant. Whenever the user gives you a topic, respond
+with exactly one haiku — three lines, 5-7-5 syllables — and nothing else.
+
+You have a "house style" guide at `/.agents/skills/haiku/SKILL.md`. Read it
+once when you start, then apply its conventions to every haiku you write.
+
+You also have a small workspace file at `/about.txt` that describes the bot.
+You don't usually need to read it, but mention its existence if the user asks
+what's in your environment.

--- a/cookbook/frameworks/antigravity/example_agent/agent.yaml
+++ b/cookbook/frameworks/antigravity/example_agent/agent.yaml
@@ -1,0 +1,5 @@
+id: agno-haiku-bot-from-dir
+base_agent: antigravity-preview-05-2026
+description: "Haiku-writing assistant defined from a local directory."
+# system_instruction is here as a fallback; AGENTS.md overrides it if present.
+system_instruction: "You are a haiku-writing assistant."

--- a/cookbook/frameworks/antigravity/example_agent/skills/haiku/SKILL.md
+++ b/cookbook/frameworks/antigravity/example_agent/skills/haiku/SKILL.md
@@ -1,0 +1,8 @@
+# Haiku house style
+
+When writing a haiku for this bot, follow these conventions:
+
+- 5-7-5 syllable structure, strict.
+- Prefer concrete imagery over abstraction.
+- Include at least one season-word (kigo) when natural.
+- No emojis, no preamble, no closing remarks — output ONLY the haiku itself.

--- a/cookbook/frameworks/antigravity/example_agent/workspace/about.txt
+++ b/cookbook/frameworks/antigravity/example_agent/workspace/about.txt
@@ -1,0 +1,2 @@
+This is the agno-haiku-bot, defined from a local agent directory and loaded
+into an Antigravity sandbox via AntigravityAgent.from_agent_directory().

--- a/libs/agno/agno/agents/antigravity/__init__.py
+++ b/libs/agno/agno/agents/antigravity/__init__.py
@@ -1,0 +1,3 @@
+from agno.agents.antigravity.agent import AntigravityAgent
+
+__all__ = ["AntigravityAgent"]

--- a/libs/agno/agno/agents/antigravity/agent.py
+++ b/libs/agno/agno/agents/antigravity/agent.py
@@ -1,0 +1,583 @@
+import json
+from dataclasses import dataclass
+from os import getenv
+from typing import Any, AsyncIterator, Dict, List, Optional
+from uuid import uuid4
+
+from agno.agents.base import BaseExternalAgent
+from agno.models.response import ToolExecution
+from agno.run.agent import (
+    RunContentEvent,
+    RunOutputEvent,
+    ToolCallCompletedEvent,
+    ToolCallStartedEvent,
+)
+from agno.utils.log import log_debug, log_warning
+
+DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+INLINE_SOURCE_MAX_BYTES = 75 * 1024  # API limit for inline source content per file
+
+
+@dataclass
+class AntigravityAgent(BaseExternalAgent):
+    """Adapter for Google's Gemini Agents API (Antigravity).
+
+    Wraps the managed Gemini Agents API so an Antigravity-backed agent can be used
+    with AgentOS endpoints or standalone via .run() / .print_response().
+
+    Antigravity runs a full agent loop server-side inside a sandboxed Linux
+    environment. The environment persists across turns via an environment_id,
+    which this adapter caches per Agno session_id so multi-turn conversations
+    keep state.
+
+    Args:
+        name: Display name for this agent.
+        id: Unique identifier (auto-generated from name if not set).
+        api_key: Gemini API key. Falls back to GEMINI_API_KEY env var.
+        base_url: API base URL.
+        agent: Base agent name (default "antigravity-preview-05-2026") or a custom agent id.
+        sources: Optional list of source dicts (gcs/repository/inline) to seed
+            the environment on the first turn of each session.
+        timeout: Per-request timeout in seconds.
+
+    Example:
+        from agno.agents.antigravity import AntigravityAgent
+
+        agent = AntigravityAgent(name="Antigravity")
+        agent.print_response("What is 2 + 2?", stream=True)
+
+        # Or deploy with AgentOS:
+        from agno.os import AgentOS
+        AgentOS(agents=[agent])
+    """
+
+    api_key: Optional[str] = None
+    base_url: str = DEFAULT_BASE_URL
+    agent: str = "antigravity-preview-05-2026"
+    sources: Optional[List[Dict[str, Any]]] = None
+    timeout: int = 600
+    framework: str = "antigravity"
+
+    # Custom-agent definition (Agents API). When `custom_agent_name` is set, the
+    # adapter sends `agent: <name>` on /interactions. Call `ensure_custom_agent()`
+    # once to register the definition on the API before invoking.
+    custom_agent_name: Optional[str] = None
+    custom_agent_instructions: Optional[str] = None
+    custom_agent_description: Optional[str] = None
+
+    # Per-session env/interaction state lives in the persisted session's
+    # session_data, not on this instance (thread-safe, survives restarts).
+    _ENV_KEY = "antigravity_env_id"
+    _PREV_KEY = "antigravity_previous_interaction_id"
+
+    def _resolved_api_key(self) -> str:
+        key = self.api_key or getenv("GEMINI_API_KEY")
+        if not key:
+            raise ValueError("GEMINI_API_KEY not set. Pass api_key= or set the GEMINI_API_KEY environment variable.")
+        return key
+
+    def _resolved_agent(self) -> str:
+        """Which agent name to send in the /interactions body."""
+        if self.custom_agent_name:
+            return self.custom_agent_name
+        return self.agent
+
+    def ensure_custom_agent(self) -> Dict[str, Any]:
+        """Create (or confirm existence of) the custom agent definition on the API.
+
+        Idempotent: a 409/conflict is treated as 'already exists'. Returns the
+        agent metadata from the API on create, or {} if it already existed.
+
+        Raises ValueError if custom_agent_name is not set on this adapter.
+        """
+        import httpx
+
+        if not self.custom_agent_name:
+            raise ValueError("ensure_custom_agent requires custom_agent_name to be set on the adapter")
+        body: Dict[str, Any] = {
+            "name": self.custom_agent_name,
+            "base_agent": self.agent,
+        }
+        if self.custom_agent_instructions:
+            body["instructions"] = self.custom_agent_instructions
+        if self.custom_agent_description:
+            body["description"] = self.custom_agent_description
+        if self.sources:
+            body["base_environment"] = {"type": "remote", "sources": self.sources}
+
+        headers = {"Content-Type": "application/json", "x-goog-api-key": self._resolved_api_key()}
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.post(f"{self.base_url}/agents", json=body, headers=headers)
+
+        if response.status_code == 409:
+            log_debug(f"Antigravity: custom agent {self.custom_agent_name!r} already exists, reusing")
+            return {}
+        if response.status_code >= 400:
+            raise RuntimeError(f"Antigravity POST /agents returned {response.status_code}: {response.text}")
+        return response.json()
+
+    def download_environment_snapshot(
+        self, output_path: str, *, environment_id: Optional[str] = None, session_id: Optional[str] = None
+    ) -> int:
+        """Download an environment snapshot tar to `output_path`. Returns bytes written.
+
+        Resolution order for which env to snapshot:
+          1. Explicit `environment_id` arg.
+          2. The env id persisted in `session_id`'s session_data (from a prior
+             turn in that session; requires a db to be configured).
+          3. Raises ValueError if neither is available.
+        """
+        import httpx
+
+        env_id = environment_id
+        if not env_id and session_id and self.db is not None:
+            session = self.read_or_create_session(session_id)
+            env_id = (session.session_data or {}).get(self._ENV_KEY)
+        if not env_id:
+            raise ValueError(
+                "download_environment_snapshot needs an environment_id, or a session_id "
+                "(with a db configured) whose prior turn captured an env id"
+            )
+
+        url = f"{self.base_url}/files/environment-{env_id}:download?alt=media"
+        headers = {"x-goog-api-key": self._resolved_api_key()}
+        written = 0
+        with httpx.Client(timeout=self.timeout, follow_redirects=True) as client:
+            with client.stream("GET", url, headers=headers) as response:
+                if response.status_code >= 400:
+                    body = response.read().decode("utf-8", errors="replace")
+                    raise RuntimeError(f"Antigravity snapshot download returned {response.status_code}: {body}")
+                with open(output_path, "wb") as fh:
+                    for chunk in response.iter_bytes():
+                        fh.write(chunk)
+                        written += len(chunk)
+        log_debug(f"Antigravity: wrote snapshot ({written} bytes) for env {env_id} to {output_path}")
+        return written
+
+    @classmethod
+    def from_agent_directory(
+        cls,
+        directory: str,
+        *,
+        api_key: Optional[str] = None,
+        base_url: str = DEFAULT_BASE_URL,
+        register: bool = True,
+        timeout: int = 600,
+        db: Any = None,
+    ) -> "AntigravityAgent":
+        """Build a `AntigravityAgent` from a local agent directory.
+
+        Expected layout (per the Managed Agents docs):
+
+            my-agent/
+            ├── agent.yaml       # id, base_agent, description, system_instruction
+            ├── AGENTS.md        # System instructions (overrides agent.yaml.system_instruction)
+            ├── skills/          # SKILL.md files mounted under /.agents/skills/<name>/
+            └── workspace/       # Files seeded into the remote environment at root
+
+        Required keys in `agent.yaml`: `id`, `base_agent`. Other keys are optional.
+
+        Files larger than 75 KB are skipped with a warning (API inline-source limit).
+        Binary files are skipped (the API currently supports text files only).
+
+        If `register` is True (default), the agent definition is registered with
+        the API via POST /agents before returning. 409 / already-exists is treated
+        as success. Pass `register=False` to defer registration (caller must invoke
+        `agent.ensure_custom_agent()` before the first run).
+        """
+        from pathlib import Path
+
+        try:
+            import yaml  # type: ignore
+        except ImportError as e:
+            raise ImportError("from_agent_directory requires PyYAML. Install with: pip install pyyaml") from e
+
+        path = Path(directory)
+        if not path.is_dir():
+            raise FileNotFoundError(f"agent directory not found: {directory}")
+
+        config_path = path / "agent.yaml"
+        if not config_path.is_file():
+            raise FileNotFoundError(f"agent.yaml not found in {directory}")
+        config = yaml.safe_load(config_path.read_text()) or {}
+
+        agent_id = config.get("id")
+        base_agent = config.get("base_agent")
+        if not agent_id or not base_agent:
+            raise ValueError("agent.yaml must contain both `id` and `base_agent`")
+
+        # AGENTS.md takes precedence over system_instruction in the yaml
+        instructions: Optional[str] = config.get("system_instruction")
+        agents_md = path / "AGENTS.md"
+        if agents_md.is_file():
+            instructions = agents_md.read_text()
+
+        sources = cls._build_sources_from_directory(path)
+
+        agent = cls(
+            name=agent_id,
+            api_key=api_key,
+            base_url=base_url,
+            agent=str(base_agent),
+            custom_agent_name=str(agent_id),
+            custom_agent_instructions=instructions,
+            custom_agent_description=config.get("description"),
+            sources=sources or None,
+            timeout=timeout,
+            db=db,
+        )
+        if register:
+            agent.ensure_custom_agent()
+        return agent
+
+    @staticmethod
+    def _build_sources_from_directory(path: Any) -> List[Dict[str, Any]]:
+        """Walk workspace/ and skills/ and turn them into inline source dicts.
+
+        - workspace/<rel> → target /<rel>
+        - skills/<name>/<rel> → target /.agents/skills/<name>/<rel>
+        """
+        from pathlib import Path
+
+        if not isinstance(path, Path):
+            path = Path(path)
+
+        sources: List[Dict[str, Any]] = []
+
+        def add(file_path: Any, target: str) -> None:
+            try:
+                size = file_path.stat().st_size
+            except OSError as e:
+                log_warning(f"from_agent_directory: cannot stat {file_path}: {e}; skipping")
+                return
+            if size > INLINE_SOURCE_MAX_BYTES:
+                log_warning(
+                    f"from_agent_directory: {file_path} is {size} bytes > {INLINE_SOURCE_MAX_BYTES} "
+                    "inline limit; skipping. Move to GCS or a Git repo source instead."
+                )
+                return
+            try:
+                content = file_path.read_text()
+            except UnicodeDecodeError:
+                log_warning(f"from_agent_directory: {file_path} is not UTF-8 text; skipping (binary not supported)")
+                return
+            sources.append({"type": "inline", "content": content, "target": target})
+
+        workspace = path / "workspace"
+        if workspace.is_dir():
+            for f in workspace.rglob("*"):
+                if f.is_file():
+                    add(f, "/" + str(f.relative_to(workspace)))
+
+        skills = path / "skills"
+        if skills.is_dir():
+            for f in skills.rglob("*"):
+                if f.is_file():
+                    add(f, "/.agents/skills/" + str(f.relative_to(skills)))
+
+        return sources
+
+    def _read_session_env(self, session: Any) -> tuple:
+        """Return (env_id, previous_interaction_id) from the given session.
+
+        `session` is the AgentSession the base class loaded for this turn, or
+        None when no db is configured — in which case there's no cross-turn
+        persistence and each turn provisions a fresh sandbox.
+        """
+        if session is None:
+            return None, None
+        data = session.session_data or {}
+        return data.get(self._ENV_KEY), data.get(self._PREV_KEY)
+
+    def _write_session_env(
+        self,
+        session: Any,
+        environment_id: Optional[str],
+        interaction_id: Optional[str],
+    ) -> None:
+        """Stash env/interaction ids on the session's session_data in place.
+
+        The base class upserts this session after the adapter returns, so no
+        DB write happens here. No-op without a session (no-db graceful degrade).
+        """
+        if session is None or (not environment_id and not interaction_id):
+            return
+        if session.session_data is None:
+            session.session_data = {}
+        if environment_id:
+            session.session_data[self._ENV_KEY] = environment_id
+        if interaction_id:
+            session.session_data[self._PREV_KEY] = interaction_id
+
+    def _environment_field(self, cached_env_id: Optional[str]) -> Any:
+        """Pick the `environment` value for the request body.
+
+        Reuse a cached env id for subsequent turns; seed sources on the first
+        turn. When `custom_agent_name` is set, sources belong to the agent
+        definition (sent via POST /agents), so they are NOT sent here.
+        """
+        if cached_env_id:
+            return cached_env_id
+        if self.sources and not self.custom_agent_name:
+            return {"type": "remote", "sources": self.sources}
+        return "remote"
+
+    def _build_request_body(self, input: Any, session: Any, stream: bool) -> Dict[str, Any]:
+        cached_env_id, prev_id = self._read_session_env(session)
+        body: Dict[str, Any] = {
+            "agent": self._resolved_agent(),
+            "input": [{"type": "text", "text": str(input)}],
+            "environment": self._environment_field(cached_env_id),
+            "stream": stream,
+        }
+        if prev_id:
+            body["previous_interaction_id"] = prev_id
+        return body
+
+    @staticmethod
+    def _extract_final_text(response_json: Dict[str, Any]) -> str:
+        """Pull the assistant text out of a non-streaming /interactions response.
+
+        Real response shape (observed): top-level `outputs` is a list of
+        {"type": "text", "text": "..."} blocks. The docs also mention a
+        `steps[].content[]` shape; we handle both for forward-compat.
+        """
+        text_parts: List[str] = []
+
+        for block in response_json.get("outputs", []) or []:
+            if isinstance(block, dict) and block.get("type") == "text" and block.get("text"):
+                text_parts.append(str(block["text"]))
+        if text_parts:
+            return "".join(text_parts)
+
+        for step in response_json.get("steps", []) or []:
+            if step.get("type") != "model_output":
+                continue
+            for block in step.get("content", []) or []:
+                if block.get("type") == "text" and block.get("text"):
+                    text_parts.append(str(block["text"]))
+        return "".join(text_parts)
+
+    async def _arun_adapter(self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any) -> str:
+        """Non-streaming POST /interactions, return the final text."""
+        import httpx
+
+        session = kwargs.get("session")
+        session_id = kwargs.get("session_id")
+        body = self._build_request_body(input, session, stream=False)
+        headers = {"Content-Type": "application/json", "x-goog-api-key": self._resolved_api_key()}
+
+        log_debug(
+            f"Antigravity request: session_id={session_id}, environment={body['environment']!r}, "
+            f"previous_interaction_id={body.get('previous_interaction_id')!r}"
+        )
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            response = await client.post(
+                f"{self.base_url}/interactions",
+                json=body,
+                headers=headers,
+            )
+            if response.status_code >= 400:
+                raise RuntimeError(f"Antigravity /interactions returned {response.status_code}: {response.text}")
+            data = response.json()
+
+        self._write_session_env(
+            session,
+            environment_id=data.get("environment_id"),
+            interaction_id=data.get("id"),
+        )
+        return self._extract_final_text(data)
+
+    async def _arun_adapter_stream(
+        self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any
+    ) -> AsyncIterator[RunOutputEvent]:
+        """Streaming POST /interactions, translate SSE events to Agno events."""
+        import httpx
+
+        run_id = kwargs.get("run_id", str(uuid4()))
+        session = kwargs.get("session")
+        session_id = kwargs.get("session_id")
+        body = self._build_request_body(input, session, stream=True)
+        headers = {"Content-Type": "application/json", "x-goog-api-key": self._resolved_api_key()}
+
+        # Track tool calls so Started/Completed pair up by tool_call_id.
+        tool_info_map: Dict[str, Dict[str, Any]] = {}
+        final_env_id: Optional[str] = None
+        final_interaction_id: Optional[str] = None
+
+        log_debug(
+            f"Antigravity stream request: session_id={session_id}, environment={body['environment']!r}, "
+            f"previous_interaction_id={body.get('previous_interaction_id')!r}"
+        )
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            async with client.stream(
+                "POST",
+                f"{self.base_url}/interactions",
+                json=body,
+                headers=headers,
+            ) as response:
+                if response.status_code >= 400:
+                    error_text = (await response.aread()).decode("utf-8", errors="replace")
+                    raise RuntimeError(f"Antigravity /interactions returned {response.status_code}: {error_text}")
+
+                async for raw_line in response.aiter_lines():
+                    if not raw_line or not raw_line.startswith("data:"):
+                        continue
+                    payload = raw_line[len("data:") :].strip()
+                    if not payload:
+                        continue
+                    if payload == "[DONE]":
+                        break
+                    try:
+                        event = json.loads(payload)
+                    except json.JSONDecodeError as e:
+                        log_debug(f"Antigravity: skipping non-JSON SSE payload: {e}")
+                        continue
+
+                    async for translated in self._translate_sse_event(
+                        event=event,
+                        run_id=run_id,
+                        tool_info_map=tool_info_map,
+                    ):
+                        yield translated
+
+                    # Capture ids from wherever they appear. Real API shape (observed):
+                    #   {"interaction": {...}, "event_type": "interaction.status_update", "interaction_id": "v1_..."}
+                    # so try multiple known locations.
+                    final_interaction_id = (
+                        event.get("interaction_id")
+                        or event.get("id")
+                        or (event.get("interaction") or {}).get("id")
+                        or final_interaction_id
+                    )
+                    interaction_obj = event.get("interaction") or {}
+                    env_obj = interaction_obj.get("environment")
+                    final_env_id = (
+                        event.get("environment_id")
+                        or interaction_obj.get("environment_id")
+                        or (env_obj.get("id") if isinstance(env_obj, dict) else None)
+                        or final_env_id
+                    )
+
+        log_debug(
+            f"Antigravity stream complete: environment_id={final_env_id!r}, interaction_id={final_interaction_id!r}"
+        )
+        self._write_session_env(session, final_env_id, final_interaction_id)
+
+    async def _translate_sse_event(
+        self,
+        *,
+        event: Dict[str, Any],
+        run_id: str,
+        tool_info_map: Dict[str, Dict[str, Any]],
+    ) -> AsyncIterator[RunOutputEvent]:
+        """Translate a single Antigravity SSE event into zero or more Agno events.
+
+        Async generator because SSE shape may produce multiple Agno events per
+        frame (e.g. concurrent content + tool_call).
+
+        Per the API docs, content shape varies by event type and is accessed via
+        `event.delta`. We handle text deltas, tool calls, and tool results; other
+        events (thoughts, status frames) are surfaced as content where possible
+        and otherwise dropped.
+        """
+        event_type = event.get("type") or ""
+        delta = event.get("delta") or {}
+
+        # Plain text delta (final user-facing output stream)
+        if isinstance(delta, dict):
+            text = delta.get("text")
+            if text:
+                yield RunContentEvent(
+                    run_id=run_id,
+                    agent_id=self.get_id(),
+                    agent_name=self.name or "",
+                    content=str(text),
+                )
+
+            # Thought stream (model's internal reasoning) — exposed as reasoning_content
+            content_block = delta.get("content")
+            if isinstance(content_block, dict):
+                thought_text = content_block.get("text")
+                if thought_text:
+                    yield RunContentEvent(
+                        run_id=run_id,
+                        agent_id=self.get_id(),
+                        agent_name=self.name or "",
+                        content="",
+                        reasoning_content=str(thought_text),
+                    )
+
+        # Function call start. The exact discriminator field is `type` either on the
+        # event or on `delta`; we accept both.
+        is_function_call = event_type in ("function_call", "tool_call", "tool_call_started") or (
+            isinstance(delta, dict) and delta.get("type") in ("function_call", "tool_call")
+        )
+        if is_function_call:
+            tool_name = event.get("name") or (isinstance(delta, dict) and delta.get("name")) or "unknown"
+            raw_args = (
+                event.get("arguments")
+                if event.get("arguments") is not None
+                else (delta.get("arguments") if isinstance(delta, dict) else None)
+            )
+            tool_args = self._coerce_tool_args(raw_args)
+            tool_call_id = (
+                event.get("tool_call_id")
+                or event.get("id")
+                or (isinstance(delta, dict) and (delta.get("tool_call_id") or delta.get("id")))
+                or str(uuid4())
+            )
+            tool_info_map[tool_call_id] = {"name": tool_name, "args": tool_args}
+            yield ToolCallStartedEvent(
+                run_id=run_id,
+                agent_id=self.get_id(),
+                agent_name=self.name or "",
+                tool=ToolExecution(
+                    tool_call_id=tool_call_id,
+                    tool_name=str(tool_name),
+                    tool_args=tool_args,
+                ),
+            )
+
+        # Function/tool result
+        is_function_result = event_type in ("function_result", "tool_result", "tool_call_completed") or (
+            isinstance(delta, dict) and delta.get("type") in ("function_result", "tool_result")
+        )
+        if is_function_result:
+            tool_call_id = (
+                event.get("tool_call_id")
+                or event.get("id")
+                or (isinstance(delta, dict) and (delta.get("tool_call_id") or delta.get("id")))
+                or ""
+            )
+            result_value = (
+                event.get("result")
+                if event.get("result") is not None
+                else (delta.get("result") if isinstance(delta, dict) else None)
+            )
+            info = tool_info_map.get(tool_call_id, {})
+            yield ToolCallCompletedEvent(
+                run_id=run_id,
+                agent_id=self.get_id(),
+                agent_name=self.name or "",
+                tool=ToolExecution(
+                    tool_call_id=tool_call_id,
+                    tool_name=str(info.get("name", "")),
+                    tool_args=info.get("args"),
+                    result=str(result_value) if result_value is not None else None,
+                ),
+            )
+
+    @staticmethod
+    def _coerce_tool_args(raw: Any) -> Optional[Dict[str, Any]]:
+        if raw is None:
+            return None
+        if isinstance(raw, dict):
+            return raw
+        if isinstance(raw, str):
+            try:
+                parsed = json.loads(raw)
+                return parsed if isinstance(parsed, dict) else {"input": parsed}
+            except json.JSONDecodeError:
+                return {"input": raw}
+        return {"input": raw}

--- a/libs/agno/agno/agents/base.py
+++ b/libs/agno/agno/agents/base.py
@@ -581,7 +581,7 @@ class BaseExternalAgent:
             history = self._get_history_from_session(session)
 
         try:
-            content = await self._arun_adapter(input, history=history, run_id=run_id, **kwargs)
+            content = await self._arun_adapter(input, history=history, run_id=run_id, session=session, **kwargs)
             run_output = self._build_run_output(
                 run_id=run_id,
                 session_id=session_id,
@@ -645,7 +645,9 @@ class BaseExternalAgent:
             # Map tool_call_id -> ToolExecution for merging started+completed
             tool_map: Dict[str, ToolExecution] = {}
 
-            async for event in self._arun_adapter_stream(input, history=history, run_id=run_id, **kwargs):
+            async for event in self._arun_adapter_stream(
+                input, history=history, run_id=run_id, session=session, **kwargs
+            ):
                 if isinstance(event, RunContentEvent):
                     accumulated_content += event.content or ""
                 elif isinstance(event, ToolCallStartedEvent) and event.tool:
@@ -746,7 +748,13 @@ class BaseExternalAgent:
     # ---------------------------------------------------------------------------
 
     async def _arun_adapter(self, input: Any, *, history: Optional[List[Dict[str, Any]]] = None, **kwargs: Any) -> Any:
-        """Non-streaming execution. Return the response content."""
+        """Non-streaming execution. Return the response content.
+
+        kwargs includes `session` (the loaded AgentSession, or None if no db).
+        Mutate `session.session_data` in place to persist adapter-specific
+        per-session state — the base class upserts the session after this
+        returns, so no separate DB write is needed.
+        """
         raise NotImplementedError(f"{self.__class__.__name__} must implement _arun_adapter")
 
     async def _arun_adapter_stream(

--- a/libs/agno/agno/tools/antigravity.py
+++ b/libs/agno/agno/tools/antigravity.py
@@ -1,0 +1,528 @@
+import json
+from os import getenv
+from textwrap import dedent
+from typing import Any, Dict, List, Optional, Union
+
+import httpx
+
+from agno.agent import Agent
+from agno.team import Team
+from agno.tools import Toolkit
+from agno.utils.log import log_debug, log_error, log_warning
+
+DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+INLINE_SOURCE_MAX_BYTES = 75 * 1024  # API limit for inline source content per file
+
+DEFAULT_INSTRUCTIONS = dedent(
+    """\
+    You have access to Google's Gemini Agents API (Antigravity) for delegating
+    complex sub-tasks to an autonomous, sandboxed agent.
+
+    Use `run_antigravity_task` when the user asks for something that benefits from
+    a fresh sandboxed Linux environment with web search, file I/O, and code execution
+    available — e.g. multi-step research, analysing a repo, generating files, or
+    running code you cannot run locally.
+
+    The sandbox persists across calls within the same Agno session, so subsequent
+    `run_antigravity_task` calls can build on prior files and state.
+
+    Use `create_custom_antigravity_agent` / `list_antigravity_agents` /
+    `delete_antigravity_agent` only for admin tasks the user has explicitly requested.
+    """
+)
+
+
+class AntigravityTools(Toolkit):
+    """Toolkit that lets an Agno agent delegate sub-tasks to Google's Gemini Agents API.
+
+    An Antigravity sandbox is provisioned lazily on the first `run_antigravity_task` call
+    and its environment_id is cached in the agent's session_state so subsequent calls
+    in the same session reuse the same environment (and prior files).
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        base_url: str = DEFAULT_BASE_URL,
+        agent: str = "antigravity-preview-05-2026",
+        default_sources: Optional[List[Dict[str, Any]]] = None,
+        persistent: bool = True,
+        timeout: int = 600,
+        instructions: Optional[str] = None,
+        add_instructions: bool = False,
+        agent_directory: Optional[str] = None,
+        register: bool = True,
+        **kwargs,
+    ):
+        """
+        Args:
+            agent_directory: Optional path to an agent directory (per the Managed
+                Agents docs: agent.yaml + AGENTS.md + workspace/ + skills/). When
+                set, the toolkit parses the folder, sets `agent` to the yaml's
+                `id`, and seeds `default_sources` from workspace/ + skills/.
+            register: When `agent_directory` is set and `register=True` (default),
+                POST the agent definition to /v1beta/agents on construction.
+                Treats 409/already-exists as success. Set False to defer.
+        """
+        self.api_key = api_key or getenv("GEMINI_API_KEY")
+        if not self.api_key:
+            raise ValueError("GEMINI_API_KEY not set. Pass api_key= or set the GEMINI_API_KEY environment variable.")
+        self.base_url = base_url
+        self.agent = agent
+        self.default_sources = default_sources
+        self.persistent = persistent
+        self.timeout = timeout
+        self.instructions = instructions or DEFAULT_INSTRUCTIONS
+
+        if agent_directory:
+            # Validate conflicting args before touching the filesystem.
+            if agent != "antigravity-preview-05-2026":
+                raise ValueError("agent_directory conflicts with explicit `agent=` argument")
+            if default_sources:
+                raise ValueError("agent_directory conflicts with explicit `default_sources=` argument")
+            self._load_agent_directory(agent_directory, register=register)
+
+        tools: List[Any] = [
+            self.run_antigravity_task,
+            self.run_custom_antigravity_agent,
+            self.create_custom_antigravity_agent,
+            self.update_custom_antigravity_agent,
+            self.get_custom_antigravity_agent,
+            self.list_antigravity_agents,
+            self.list_antigravity_agent_versions,
+            self.delete_antigravity_agent,
+            self.download_antigravity_environment_snapshot,
+        ]
+        super().__init__(
+            name="antigravity_tools",
+            tools=tools,
+            instructions=self.instructions,
+            add_instructions=add_instructions,
+            **kwargs,
+        )
+
+    # ---------------------------------------------------------------------------
+    # Internal HTTP helpers
+    # ---------------------------------------------------------------------------
+
+    def _headers(self) -> Dict[str, str]:
+        return {"Content-Type": "application/json", "x-goog-api-key": self.api_key or ""}
+
+    def _post(self, path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.post(f"{self.base_url}{path}", json=body, headers=self._headers())
+            if response.status_code >= 400:
+                raise RuntimeError(f"Antigravity {path} returned {response.status_code}: {response.text}")
+            return response.json()
+
+    def _get(self, path: str) -> Dict[str, Any]:
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.get(f"{self.base_url}{path}", headers=self._headers())
+            if response.status_code >= 400:
+                raise RuntimeError(f"Antigravity {path} returned {response.status_code}: {response.text}")
+            return response.json()
+
+    def _delete(self, path: str) -> None:
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.delete(f"{self.base_url}{path}", headers=self._headers())
+            if response.status_code >= 400:
+                raise RuntimeError(f"Antigravity {path} returned {response.status_code}: {response.text}")
+
+    def _patch(self, path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        with httpx.Client(timeout=self.timeout) as client:
+            response = client.patch(f"{self.base_url}{path}", json=body, headers=self._headers())
+            if response.status_code >= 400:
+                raise RuntimeError(f"Antigravity {path} returned {response.status_code}: {response.text}")
+            return response.json()
+
+    def _load_agent_directory(self, directory: str, *, register: bool) -> None:
+        """Parse an Antigravity agent directory and apply it to this toolkit.
+
+        Expected layout (per the Managed Agents docs):
+
+            my-agent/
+            ├── agent.yaml       # id, base_agent, description, system_instruction
+            ├── AGENTS.md        # Overrides agent.yaml.system_instruction if present
+            ├── skills/          # SKILL.md files → /.agents/skills/<name>/
+            └── workspace/       # Files seeded into the remote environment at root
+
+        Required keys in agent.yaml: `id`, `base_agent`. Other keys are optional.
+
+        Sets `self.agent` to the yaml `id` so subsequent tool calls invoke that
+        named agent, and seeds `self.default_sources` from workspace/ + skills/.
+        When `register=True`, POSTs the definition to /agents (409 = success).
+        """
+        from pathlib import Path
+
+        try:
+            import yaml  # type: ignore
+        except ImportError as e:
+            raise ImportError("agent_directory requires PyYAML. Install with: pip install pyyaml") from e
+
+        path = Path(directory)
+        if not path.is_dir():
+            raise FileNotFoundError(f"agent directory not found: {directory}")
+        config_path = path / "agent.yaml"
+        if not config_path.is_file():
+            raise FileNotFoundError(f"agent.yaml not found in {directory}")
+        config = yaml.safe_load(config_path.read_text()) or {}
+
+        agent_id = config.get("id")
+        base_agent = config.get("base_agent")
+        if not agent_id or not base_agent:
+            raise ValueError("agent.yaml must contain both `id` and `base_agent`")
+
+        instructions = config.get("system_instruction")
+        agents_md = path / "AGENTS.md"
+        if agents_md.is_file():
+            instructions = agents_md.read_text()
+
+        sources = self._build_sources_from_directory(path)
+
+        # Apply to this toolkit so all subsequent run_antigravity_task calls
+        # invoke the named agent with the right env sources.
+        self.agent = str(agent_id)
+        self.default_sources = sources or None
+
+        if register:
+            body: Dict[str, Any] = {"name": agent_id, "base_agent": str(base_agent)}
+            if instructions:
+                body["instructions"] = instructions
+            if config.get("description"):
+                body["description"] = config["description"]
+            if sources:
+                body["base_environment"] = {"type": "remote", "sources": sources}
+            log_debug(f"Antigravity: registering agent {agent_id!r} from {directory}")
+            with httpx.Client(timeout=self.timeout) as client:
+                response = client.post(f"{self.base_url}/agents", json=body, headers=self._headers())
+            if response.status_code == 409:
+                log_debug(f"Antigravity: agent {agent_id!r} already exists, reusing")
+            elif response.status_code >= 400:
+                raise RuntimeError(f"Antigravity POST /agents returned {response.status_code}: {response.text}")
+
+    @staticmethod
+    def _build_sources_from_directory(path: Any) -> List[Dict[str, Any]]:
+        """Walk workspace/ and skills/ and turn them into inline source dicts.
+
+        - workspace/<rel> → target /<rel>
+        - skills/<name>/<rel> → target /.agents/skills/<name>/<rel>
+
+        Files larger than 75 KB are skipped with a warning (API inline-source limit).
+        Binary files are skipped (the API supports text files only).
+        """
+        from pathlib import Path
+
+        if not isinstance(path, Path):
+            path = Path(path)
+
+        sources: List[Dict[str, Any]] = []
+
+        def add(file_path: Any, target: str) -> None:
+            try:
+                size = file_path.stat().st_size
+            except OSError as e:
+                log_warning(f"agent_directory: cannot stat {file_path}: {e}; skipping")
+                return
+            if size > INLINE_SOURCE_MAX_BYTES:
+                log_warning(
+                    f"agent_directory: {file_path} is {size} bytes > {INLINE_SOURCE_MAX_BYTES} "
+                    "inline limit; skipping. Move to GCS or a Git repo source instead."
+                )
+                return
+            try:
+                content = file_path.read_text()
+            except UnicodeDecodeError:
+                log_warning(f"agent_directory: {file_path} is not UTF-8 text; skipping (binary not supported)")
+                return
+            sources.append({"type": "inline", "content": content, "target": target})
+
+        workspace = path / "workspace"
+        if workspace.is_dir():
+            for f in workspace.rglob("*"):
+                if f.is_file():
+                    add(f, "/" + str(f.relative_to(workspace)))
+
+        skills = path / "skills"
+        if skills.is_dir():
+            for f in skills.rglob("*"):
+                if f.is_file():
+                    add(f, "/.agents/skills/" + str(f.relative_to(skills)))
+
+        return sources
+
+    @staticmethod
+    def _session_state(agent: Optional[Union[Agent, Team]]) -> Optional[Dict[str, Any]]:
+        if agent is None or not hasattr(agent, "session_state"):
+            return None
+        if agent.session_state is None:
+            agent.session_state = {}
+        return agent.session_state
+
+    @staticmethod
+    def _extract_final_text(response_json: Dict[str, Any]) -> str:
+        """Real response shape: top-level `outputs` is a list of text blocks.
+        Docs also mention `steps[].content[]`; handle both for forward-compat."""
+        parts: List[str] = []
+        for block in response_json.get("outputs", []) or []:
+            if isinstance(block, dict) and block.get("type") == "text" and block.get("text"):
+                parts.append(str(block["text"]))
+        if parts:
+            return "".join(parts)
+        for step in response_json.get("steps", []) or []:
+            if step.get("type") != "model_output":
+                continue
+            for block in step.get("content", []) or []:
+                if block.get("type") == "text" and block.get("text"):
+                    parts.append(str(block["text"]))
+        return "".join(parts)
+
+    # ---------------------------------------------------------------------------
+    # Agent-callable tools
+    # ---------------------------------------------------------------------------
+
+    def run_antigravity_task(self, agent: Union[Agent, Team], task: str) -> str:
+        """Delegate a task to an Antigravity sandbox and return its final response.
+
+        The sandbox is created on first use and reused across calls within the
+        same session. State (files, installed packages) persists.
+
+        Args:
+            agent: Calling Agno agent (injected automatically by the toolkit).
+            task: Natural-language task description for the Antigravity agent.
+
+        Returns:
+            The final text response from the Antigravity agent.
+        """
+        try:
+            state = self._session_state(agent) if self.persistent else None
+            environment_value: Any
+            if state and state.get("antigravity_env_id"):
+                environment_value = state["antigravity_env_id"]
+            elif self.default_sources:
+                environment_value = {"type": "remote", "sources": self.default_sources}
+            else:
+                environment_value = "remote"
+
+            body: Dict[str, Any] = {
+                "agent": self.agent,
+                "input": [{"type": "text", "text": task}],
+                "environment": environment_value,
+                "stream": False,
+            }
+            if state and state.get("antigravity_previous_interaction_id"):
+                body["previous_interaction_id"] = state["antigravity_previous_interaction_id"]
+
+            log_debug(f"Antigravity: dispatching task (env reused={bool(state and state.get('antigravity_env_id'))})")
+            data = self._post("/interactions", body)
+            log_debug(f"Antigravity response keys: {list(data.keys())}, status={data.get('status')}")
+
+            if state is not None:
+                if data.get("environment_id"):
+                    state["antigravity_env_id"] = data["environment_id"]
+                if data.get("id"):
+                    state["antigravity_previous_interaction_id"] = data["id"]
+
+            text = self._extract_final_text(data)
+            if text:
+                return text
+            # No model_output text block found. Surface the raw payload so the
+            # calling model has something to work with rather than retrying blindly.
+            return json.dumps(data)
+        except Exception as e:
+            log_error(f"Antigravity run_antigravity_task failed: {e}")
+            return json.dumps({"status": "error", "message": str(e)})
+
+    def run_custom_antigravity_agent(self, agent: Union[Agent, Team], custom_agent_name: str, task: str) -> str:
+        """Invoke a named custom Antigravity agent (created via /agents) and return its response.
+
+        Use this when the user has already registered a custom agent definition and wants
+        to invoke it by name. The sandbox environment is per-session (cached in
+        agent.session_state under a key scoped to the custom agent name).
+
+        Args:
+            agent: Calling Agno agent (injected automatically).
+            custom_agent_name: Name of the previously-created custom agent.
+            task: Natural-language task for the custom agent.
+
+        Returns:
+            The final text response, or a JSON error string.
+        """
+        try:
+            state = self._session_state(agent) if self.persistent else None
+            env_key = f"antigravity_env_id__{custom_agent_name}"
+            prev_key = f"antigravity_previous_interaction_id__{custom_agent_name}"
+
+            environment_value: Any = state.get(env_key) if state and state.get(env_key) else "remote"
+
+            body: Dict[str, Any] = {
+                "agent": custom_agent_name,
+                "input": [{"type": "text", "text": task}],
+                "environment": environment_value,
+                "stream": False,
+            }
+            if state and state.get(prev_key):
+                body["previous_interaction_id"] = state[prev_key]
+
+            log_debug(f"Antigravity: invoking custom agent {custom_agent_name!r}")
+            data = self._post("/interactions", body)
+
+            if state is not None:
+                if data.get("environment_id"):
+                    state[env_key] = data["environment_id"]
+                if data.get("id"):
+                    state[prev_key] = data["id"]
+
+            return self._extract_final_text(data) or json.dumps(data)
+        except Exception as e:
+            log_error(f"Antigravity run_custom_antigravity_agent failed: {e}")
+            return json.dumps({"status": "error", "message": str(e)})
+
+    def create_custom_antigravity_agent(
+        self,
+        name: str,
+        instructions: str,
+        sources: Optional[List[Dict[str, Any]]] = None,
+        base_env_id: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> str:
+        """Create a named, reusable Antigravity agent via POST /agents.
+
+        Two ways to seed the agent's base environment (mutually exclusive):
+          - `sources`: fresh environment built from inline/GCS/repository sources.
+          - `base_env_id`: fork an existing successful environment by id.
+
+        Args:
+            name: Identifier for the custom agent.
+            instructions: System instructions for the agent.
+            sources: Optional list of source dicts for a fresh base environment.
+            base_env_id: Optional env id to fork from (alternative to `sources`).
+            description: Optional human-readable description.
+
+        Returns:
+            JSON string with the created agent's metadata, or an error.
+        """
+        try:
+            body: Dict[str, Any] = {
+                "name": name,
+                "base_agent": self.agent,
+                "instructions": instructions,
+            }
+            if description:
+                body["description"] = description
+            if base_env_id:
+                body["base_environment"] = {"env_id": base_env_id}
+            elif sources:
+                body["base_environment"] = {"type": "remote", "sources": sources}
+            data = self._post("/agents", body)
+            return json.dumps(data)
+        except Exception as e:
+            log_error(f"Antigravity create_custom_antigravity_agent failed: {e}")
+            return json.dumps({"status": "error", "message": str(e)})
+
+    def update_custom_antigravity_agent(
+        self,
+        name: str,
+        instructions: Optional[str] = None,
+        description: Optional[str] = None,
+    ) -> str:
+        """Update mutable fields on a custom Antigravity agent via PATCH /agents/{name}.
+
+        Args:
+            name: Identifier of the agent to update.
+            instructions: New system instructions (if changing).
+            description: New human-readable description (if changing).
+
+        Returns:
+            JSON string with the updated agent's metadata, or an error.
+        """
+        try:
+            body: Dict[str, Any] = {}
+            if instructions is not None:
+                body["instructions"] = instructions
+            if description is not None:
+                body["description"] = description
+            if not body:
+                return json.dumps({"status": "error", "message": "no fields to update"})
+            return json.dumps(self._patch(f"/agents/{name}", body))
+        except Exception as e:
+            log_error(f"Antigravity update_custom_antigravity_agent failed: {e}")
+            return json.dumps({"status": "error", "message": str(e)})
+
+    def get_custom_antigravity_agent(self, name: str) -> str:
+        """Fetch a single custom Antigravity agent by name via GET /agents/{name}."""
+        try:
+            return json.dumps(self._get(f"/agents/{name}"))
+        except Exception as e:
+            log_error(f"Antigravity get_custom_antigravity_agent failed: {e}")
+            return json.dumps({"status": "error", "message": str(e)})
+
+    def list_antigravity_agents(self) -> str:
+        """List all custom Antigravity agents owned by the API key."""
+        try:
+            return json.dumps(self._get("/agents"))
+        except Exception as e:
+            log_error(f"Antigravity list_antigravity_agents failed: {e}")
+            return json.dumps({"status": "error", "message": str(e)})
+
+    def list_antigravity_agent_versions(self, name: str) -> str:
+        """List versions of a custom Antigravity agent via GET /agents/{name}/versions."""
+        try:
+            return json.dumps(self._get(f"/agents/{name}/versions"))
+        except Exception as e:
+            log_error(f"Antigravity list_antigravity_agent_versions failed: {e}")
+            return json.dumps({"status": "error", "message": str(e)})
+
+    def delete_antigravity_agent(self, name: str) -> str:
+        """Delete a custom Antigravity agent by name."""
+        try:
+            self._delete(f"/agents/{name}")
+            return json.dumps({"status": "ok", "deleted": name})
+        except Exception as e:
+            log_error(f"Antigravity delete_antigravity_agent failed: {e}")
+            return json.dumps({"status": "error", "message": str(e)})
+
+    def download_antigravity_environment_snapshot(
+        self, environment_id: str, output_path: str, agent: Optional[Union[Agent, Team]] = None
+    ) -> str:
+        """Download a sandbox environment snapshot as a tar file.
+
+        Hits GET /v1beta/files/environment-{environment_id}:download?alt=media. The
+        endpoint redirects to the actual content host, so we follow redirects.
+
+        Args:
+            environment_id: The env id to snapshot. Pass "current" to use the env id
+                cached in the calling agent's session_state (from a prior
+                run_antigravity_task call).
+            output_path: Local filesystem path to write the tar file to.
+            agent: Calling Agno agent (injected automatically); used only when
+                environment_id == "current".
+
+        Returns:
+            JSON status string with `path` and `bytes` on success.
+        """
+        try:
+            env_id = environment_id
+            if env_id == "current":
+                state = self._session_state(agent)
+                if not state or not state.get("antigravity_env_id"):
+                    return json.dumps(
+                        {"status": "error", "message": "no cached env id; run a task first or pass an explicit id"}
+                    )
+                env_id = state["antigravity_env_id"]
+
+            url = f"{self.base_url}/files/environment-{env_id}:download?alt=media"
+            with httpx.Client(timeout=self.timeout, follow_redirects=True) as client:
+                with client.stream("GET", url, headers=self._headers()) as response:
+                    if response.status_code >= 400:
+                        body = response.read().decode("utf-8", errors="replace")
+                        raise RuntimeError(f"Antigravity snapshot download returned {response.status_code}: {body}")
+                    written = 0
+                    with open(output_path, "wb") as fh:
+                        for chunk in response.iter_bytes():
+                            fh.write(chunk)
+                            written += len(chunk)
+            log_debug(f"Antigravity: wrote snapshot ({written} bytes) for env {env_id} to {output_path}")
+            return json.dumps({"status": "ok", "path": output_path, "bytes": written, "environment_id": env_id})
+        except Exception as e:
+            log_error(f"Antigravity download_antigravity_environment_snapshot failed: {e}")
+            return json.dumps({"status": "error", "message": str(e)})

--- a/libs/agno/tests/unit/agents/test_antigravity.py
+++ b/libs/agno/tests/unit/agents/test_antigravity.py
@@ -1,0 +1,544 @@
+"""Unit tests for AntigravityAgent.
+
+These exercise the adapter's request shape, session-keyed state caching,
+and SSE event translation by stubbing httpx with MockTransport. They do
+not hit the live Gemini Agents API.
+"""
+
+import json
+import os
+import tempfile
+from typing import List, Optional, Tuple
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from agno.agents.antigravity import AntigravityAgent
+from agno.db.sqlite import SqliteDb
+from agno.run.agent import (
+    RunCompletedEvent,
+    RunContentEvent,
+    RunStartedEvent,
+    ToolCallCompletedEvent,
+    ToolCallStartedEvent,
+)
+
+
+@pytest.fixture
+def tmp_db():
+    """Fresh file-backed SqliteDb per test (env/interaction state persists here now)."""
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    try:
+        yield SqliteDb(db_file=path)
+    finally:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+def _session_env(agent: AntigravityAgent, session_id: str) -> Tuple[Optional[str], Optional[str]]:
+    """Read back (env_id, previous_interaction_id) from the persisted session_data."""
+    session = agent.read_or_create_session(session_id)
+    data = session.session_data or {}
+    return data.get(agent._ENV_KEY), data.get(agent._PREV_KEY)
+
+
+def _interaction_response(env_id: str = "env-1", interaction_id: str = "int-1", text: str = "hi"):
+    """Real /interactions response shape observed against the live API."""
+    return {
+        "id": interaction_id,
+        "status": "completed",
+        "outputs": [{"type": "text", "text": text}],
+        "usage": {"total_tokens": 1},
+        "environment_id": env_id,
+        "service_tier": "default",
+        "object": "interaction",
+        "agent": "antigravity-preview-05-2026",
+    }
+
+
+def _mock_transport(handler):
+    """Build an httpx MockTransport from a request->Response handler."""
+    return httpx.MockTransport(handler)
+
+
+def _patch_async_client(transport):
+    """Patch httpx.AsyncClient to use the given MockTransport.
+
+    Adapter constructs `httpx.AsyncClient(timeout=...)` directly; we patch
+    AsyncClient at the module level inside agno.agents.antigravity.agent.
+    """
+    original_init = httpx.AsyncClient.__init__
+
+    def patched_init(self, *args, **kwargs):
+        kwargs["transport"] = transport
+        original_init(self, *args, **kwargs)
+
+    return patch("httpx.AsyncClient.__init__", patched_init)
+
+
+def test_first_call_sends_remote_environment_and_caches_env_id(tmp_db):
+    captured: List[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content.decode()))
+        return httpx.Response(200, json=_interaction_response(env_id="env-42", interaction_id="int-7"))
+
+    agent = AntigravityAgent(
+        name="Test",
+        api_key="dummy",
+        sources=[{"type": "inline", "content": "x", "target": "/a"}],
+        db=tmp_db,
+    )
+
+    with _patch_async_client(_mock_transport(handler)):
+        result = agent.run("hello", session_id="s1")
+
+    assert result.content == "hi"
+    assert len(captured) == 1
+    body = captured[0]
+    # First call seeds sources, NOT a cached env id
+    assert body["environment"] == {"type": "remote", "sources": [{"type": "inline", "content": "x", "target": "/a"}]}
+    assert body["stream"] is False
+    assert "previous_interaction_id" not in body
+
+    # State persisted to the session for next turn
+    assert _session_env(agent, "s1") == ("env-42", "int-7")
+
+
+def test_second_call_reuses_cached_env_id_and_previous_interaction(tmp_db):
+    captured: List[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content.decode()))
+        return httpx.Response(200, json=_interaction_response(env_id="env-42", interaction_id="int-9"))
+
+    agent = AntigravityAgent(name="Test", api_key="dummy", db=tmp_db)
+
+    # Seed prior-turn state into the persisted session.
+    session = agent.read_or_create_session("s1")
+    session.session_data = {agent._ENV_KEY: "env-42", agent._PREV_KEY: "int-7"}
+    agent.upsert_session(session)
+
+    with _patch_async_client(_mock_transport(handler)):
+        agent.run("follow up", session_id="s1")
+
+    body = captured[0]
+    assert body["environment"] == "env-42"
+    assert body["previous_interaction_id"] == "int-7"
+    # And the second turn's response updated the interaction id.
+    assert _session_env(agent, "s1") == ("env-42", "int-9")
+
+
+def test_http_error_surfaces_as_runerror():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    agent = AntigravityAgent(name="Test", api_key="dummy")
+
+    with _patch_async_client(_mock_transport(handler)):
+        result = agent.run("hello", session_id="s1")
+
+    # BaseExternalAgent catches the exception and builds an error RunOutput
+    assert result.status.value.lower() == "error"
+    assert "500" in str(result.content)
+
+
+def test_extract_final_text_concatenates_text_blocks():
+    data = {
+        "steps": [
+            {"type": "model_output", "content": [{"type": "text", "text": "Hello "}]},
+            {"type": "tool_call", "content": []},
+            {"type": "model_output", "content": [{"type": "text", "text": "world"}]},
+        ]
+    }
+    assert AntigravityAgent._extract_final_text(data) == "Hello world"
+
+
+def test_resolved_api_key_raises_when_missing():
+    agent = AntigravityAgent(name="Test")
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(ValueError, match="GEMINI_API_KEY"):
+            agent._resolved_api_key()
+
+
+def test_streaming_translates_sse_to_agno_events(tmp_db):
+    """Feed a real-shape SSE response and verify content + tool events are produced.
+
+    Frame taxonomy here matches what the live API actually emits (observed):
+    interaction.start, content.delta with delta.text / delta.type=function_call /
+    delta.type=function_result, interaction.complete. The API does NOT include
+    environment_id anywhere in the SSE stream — see _arun_adapter_stream comments.
+    """
+    sse_lines = [
+        'data: {"event_type": "interaction.start", "interaction": {"id": "v1_abc", "status": "in_progress", "object": "interaction", "agent": "antigravity-preview-05-2026"}}',
+        'data: {"event_type": "content.delta", "index": 0, "delta": {"text": "Hello", "type": "text"}}',
+        'data: {"event_type": "content.delta", "index": 0, "delta": {"text": " world", "type": "text"}}',
+        'data: {"event_type": "content.delta", "index": 1, "delta": {"name": "google_search", "arguments": {"q": "agno"}, "type": "function_call", "id": "call-1"}}',
+        'data: {"event_type": "content.delta", "index": 2, "delta": {"name": "google_search", "result": {"ok": true}, "type": "function_result", "tool_call_id": "call-1"}}',
+        'data: {"event_type": "interaction.complete", "interaction": {"id": "v1_abc", "status": "completed", "outputs": [{"text": "Hello world", "type": "text"}]}}',
+        "data: [DONE]",
+    ]
+    body = "\n\n".join(sse_lines).encode()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            content=body,
+            headers={"content-type": "text/event-stream"},
+        )
+
+    agent = AntigravityAgent(name="Test", api_key="dummy", db=tmp_db)
+
+    events: List = []
+    with _patch_async_client(_mock_transport(handler)):
+        for event in agent.run("hello", stream=True, session_id="s1"):
+            events.append(event)
+
+    assert isinstance(events[0], RunStartedEvent)
+    assert isinstance(events[-1], RunCompletedEvent)
+
+    middle = events[1:-1]
+    content_events = [e for e in middle if isinstance(e, RunContentEvent)]
+    tool_started = [e for e in middle if isinstance(e, ToolCallStartedEvent)]
+    tool_completed = [e for e in middle if isinstance(e, ToolCallCompletedEvent)]
+
+    assert len(content_events) >= 2
+    assert "".join(str(e.content or "") for e in content_events) == "Hello world"
+    assert len(tool_started) == 1
+    assert tool_started[0].tool.tool_name == "google_search"
+    assert tool_started[0].tool.tool_call_id == "call-1"
+    assert len(tool_completed) == 1
+    assert tool_completed[0].tool.tool_call_id == "call-1"
+
+    # interaction_id captured from event.interaction.id (the real shape) and
+    # persisted to session_data. environment_id is NOT in SSE, so it stays None.
+    env_id, prev_id = _session_env(agent, "s1")
+    assert prev_id == "v1_abc"
+    assert env_id is None
+
+
+def test_coerce_tool_args_handles_dict_string_and_none():
+    assert AntigravityAgent._coerce_tool_args(None) is None
+    assert AntigravityAgent._coerce_tool_args({"a": 1}) == {"a": 1}
+    assert AntigravityAgent._coerce_tool_args('{"a": 1}') == {"a": 1}
+    assert AntigravityAgent._coerce_tool_args("plain") == {"input": "plain"}
+
+
+def test_extract_final_text_prefers_outputs_over_steps():
+    """Real API uses top-level outputs[]; docs example showed steps[].content[]."""
+    outputs_shape = {"outputs": [{"type": "text", "text": "from outputs"}]}
+    assert AntigravityAgent._extract_final_text(outputs_shape) == "from outputs"
+
+    steps_shape = {"steps": [{"type": "model_output", "content": [{"type": "text", "text": "from steps"}]}]}
+    assert AntigravityAgent._extract_final_text(steps_shape) == "from steps"
+
+
+def test_resolved_agent_uses_custom_agent_name_when_set():
+    base = AntigravityAgent(name="T", api_key="dummy")
+    assert base._resolved_agent() == "antigravity-preview-05-2026"
+
+    custom = AntigravityAgent(name="T", api_key="dummy", custom_agent_name="my-bot")
+    assert custom._resolved_agent() == "my-bot"
+
+
+def test_run_with_custom_agent_sends_agent_name_in_body_and_omits_sources():
+    """When custom_agent_name is set, sources belong on the agent definition,
+    NOT on the /interactions request."""
+    captured: List[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content.decode()))
+        return httpx.Response(200, json=_interaction_response(text="haiku here"))
+
+    agent = AntigravityAgent(
+        name="T",
+        api_key="dummy",
+        custom_agent_name="my-bot",
+        sources=[{"type": "inline", "content": "x", "target": "/a"}],
+    )
+
+    with _patch_async_client(_mock_transport(handler)):
+        result = agent.run("hi", session_id="s1")
+
+    assert result.content == "haiku here"
+    body = captured[0]
+    assert body["agent"] == "my-bot"
+    # Sources should NOT be on the interaction body — they go with /agents.
+    assert body["environment"] == "remote"
+
+
+def test_ensure_custom_agent_posts_agent_definition():
+    captured: List[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(
+            {
+                "method": request.method,
+                "url": str(request.url),
+                "body": json.loads(request.content.decode()) if request.content else {},
+            }
+        )
+        return httpx.Response(200, json={"name": "my-bot"})
+
+    agent = AntigravityAgent(
+        name="T",
+        api_key="dummy",
+        custom_agent_name="my-bot",
+        custom_agent_instructions="be terse",
+        custom_agent_description="desc",
+        sources=[{"type": "inline", "content": "x", "target": "/a"}],
+    )
+
+    # ensure_custom_agent is sync and constructs its own httpx.Client; the same
+    # patch utility works because it patches both AsyncClient.__init__ behavior
+    # only — patch sync httpx.Client directly here.
+    from unittest.mock import patch as _patch
+
+    original_init = httpx.Client.__init__
+
+    def patched(self, *args, **kwargs):
+        kwargs["transport"] = _mock_transport(handler)
+        original_init(self, *args, **kwargs)
+
+    with _patch("httpx.Client.__init__", patched):
+        result = agent.ensure_custom_agent()
+
+    assert result == {"name": "my-bot"}
+    assert captured[0]["method"] == "POST"
+    assert captured[0]["url"].endswith("/agents")
+    posted = captured[0]["body"]
+    assert posted["name"] == "my-bot"
+    assert posted["base_agent"] == "antigravity-preview-05-2026"
+    assert posted["instructions"] == "be terse"
+    assert posted["description"] == "desc"
+    assert posted["base_environment"] == {
+        "type": "remote",
+        "sources": [{"type": "inline", "content": "x", "target": "/a"}],
+    }
+
+
+def test_ensure_custom_agent_treats_409_as_already_exists():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(409, text="conflict: already exists")
+
+    agent = AntigravityAgent(name="T", api_key="dummy", custom_agent_name="my-bot")
+    from unittest.mock import patch as _patch
+
+    original_init = httpx.Client.__init__
+
+    def patched(self, *args, **kwargs):
+        kwargs["transport"] = _mock_transport(handler)
+        original_init(self, *args, **kwargs)
+
+    with _patch("httpx.Client.__init__", patched):
+        result = agent.ensure_custom_agent()
+
+    assert result == {}
+
+
+def test_ensure_custom_agent_requires_custom_agent_name():
+    agent = AntigravityAgent(name="T", api_key="dummy")
+    with pytest.raises(ValueError, match="custom_agent_name"):
+        agent.ensure_custom_agent()
+
+
+# ---------------------------------------------------------------------------
+# from_agent_directory
+# ---------------------------------------------------------------------------
+
+from pathlib import Path  # noqa: E402
+
+
+def _make_agent_dir(tmp: Path, *, with_agents_md: bool = True, system_instruction: str = "yaml-instructions") -> Path:
+    (tmp / "agent.yaml").write_text(
+        f"id: my-bot\nbase_agent: antigravity-preview-05-2026\ndescription: Test bot\nsystem_instruction: {system_instruction}\n"
+    )
+    if with_agents_md:
+        (tmp / "AGENTS.md").write_text("agents-md-instructions")
+    (tmp / "workspace").mkdir()
+    (tmp / "workspace" / "about.txt").write_text("workspace content")
+    (tmp / "workspace" / "nested").mkdir()
+    (tmp / "workspace" / "nested" / "deep.txt").write_text("deep content")
+    (tmp / "skills").mkdir()
+    (tmp / "skills" / "haiku").mkdir()
+    (tmp / "skills" / "haiku" / "SKILL.md").write_text("# Haiku skill")
+    return tmp
+
+
+def test_from_agent_directory_parses_yaml_and_uses_agents_md_for_instructions():
+    with tempfile.TemporaryDirectory() as d:
+        _make_agent_dir(Path(d))
+        agent = AntigravityAgent.from_agent_directory(d, api_key="dummy", register=False)
+
+    assert agent.custom_agent_name == "my-bot"
+    assert agent.agent == "antigravity-preview-05-2026"
+    assert agent.custom_agent_description == "Test bot"
+    # AGENTS.md takes precedence over yaml system_instruction
+    assert agent.custom_agent_instructions == "agents-md-instructions"
+
+
+def test_from_agent_directory_falls_back_to_yaml_system_instruction_when_no_agents_md():
+    with tempfile.TemporaryDirectory() as d:
+        _make_agent_dir(Path(d), with_agents_md=False)
+        agent = AntigravityAgent.from_agent_directory(d, api_key="dummy", register=False)
+
+    assert agent.custom_agent_instructions == "yaml-instructions"
+
+
+def test_from_agent_directory_builds_sources_with_correct_targets():
+    with tempfile.TemporaryDirectory() as d:
+        _make_agent_dir(Path(d))
+        agent = AntigravityAgent.from_agent_directory(d, api_key="dummy", register=False)
+
+    assert agent.sources is not None
+    targets = {s["target"] for s in agent.sources}
+    # Workspace files → root, skills files → /.agents/skills/<name>/
+    assert "/about.txt" in targets
+    assert "/nested/deep.txt" in targets
+    assert "/.agents/skills/haiku/SKILL.md" in targets
+    # All inline
+    assert all(s["type"] == "inline" for s in agent.sources)
+
+
+def test_from_agent_directory_requires_id_and_base_agent():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d)
+        (p / "agent.yaml").write_text("description: missing required keys\n")
+        with pytest.raises(ValueError, match="id.*base_agent"):
+            AntigravityAgent.from_agent_directory(d, api_key="dummy")
+
+
+def test_from_agent_directory_skips_files_over_75kb():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d)
+        (p / "agent.yaml").write_text("id: my-bot\nbase_agent: antigravity-preview-05-2026\n")
+        (p / "workspace").mkdir()
+        (p / "workspace" / "small.txt").write_text("ok")
+        (p / "workspace" / "big.txt").write_text("x" * (80 * 1024))
+
+        agent = AntigravityAgent.from_agent_directory(d, api_key="dummy", register=False)
+
+    targets = {s["target"] for s in agent.sources or []}
+    assert "/small.txt" in targets
+    assert "/big.txt" not in targets
+
+
+def test_from_agent_directory_skips_binary_files():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d)
+        (p / "agent.yaml").write_text("id: my-bot\nbase_agent: antigravity-preview-05-2026\n")
+        (p / "workspace").mkdir()
+        (p / "workspace" / "ok.txt").write_text("text")
+        (p / "workspace" / "binary.bin").write_bytes(b"\x00\x01\x02\xff\xfe")
+
+        agent = AntigravityAgent.from_agent_directory(d, api_key="dummy", register=False)
+
+    targets = {s["target"] for s in agent.sources or []}
+    assert "/ok.txt" in targets
+    assert "/binary.bin" not in targets
+
+
+def test_from_agent_directory_missing_directory_raises():
+    with pytest.raises(FileNotFoundError, match="agent directory not found"):
+        AntigravityAgent.from_agent_directory("/does/not/exist", api_key="dummy")
+
+
+def test_from_agent_directory_missing_yaml_raises():
+    with tempfile.TemporaryDirectory() as d:
+        with pytest.raises(FileNotFoundError, match="agent.yaml"):
+            AntigravityAgent.from_agent_directory(d, api_key="dummy")
+
+
+def test_from_agent_directory_register_true_calls_post_agents():
+    """When register=True (default), the classmethod should POST to /agents before returning."""
+    captured: List[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(
+            {"method": request.method, "url": str(request.url), "body": json.loads(request.content.decode())}
+        )
+        return httpx.Response(200, json={"name": "my-bot"})
+
+    with tempfile.TemporaryDirectory() as d:
+        _make_agent_dir(Path(d))
+
+        original_init = httpx.Client.__init__
+
+        def patched(self, *args, **kwargs):
+            kwargs["transport"] = _mock_transport(handler)
+            original_init(self, *args, **kwargs)
+
+        with patch("httpx.Client.__init__", patched):
+            AntigravityAgent.from_agent_directory(d, api_key="dummy")  # register=True is the default
+
+    assert len(captured) == 1
+    assert captured[0]["method"] == "POST"
+    assert captured[0]["url"].endswith("/agents")
+    assert captured[0]["body"]["name"] == "my-bot"
+
+
+# ---------------------------------------------------------------------------
+# download_environment_snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_download_environment_snapshot_writes_bytes_and_uses_cached_env_id(tmp_db):
+    snapshot_body = b"FAKE_TAR_DATA_" + b"x" * 100
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert "/files/environment-env-99:download" in str(request.url)
+        return httpx.Response(200, content=snapshot_body)
+
+    agent = AntigravityAgent(name="T", api_key="dummy", db=tmp_db)
+    # Seed the env id into the persisted session, as a prior turn would have.
+    session = agent.read_or_create_session("s1")
+    session.session_data = {agent._ENV_KEY: "env-99"}
+    agent.upsert_session(session)
+
+    original_init = httpx.Client.__init__
+
+    def patched(self, *args, **kwargs):
+        kwargs["transport"] = _mock_transport(handler)
+        original_init(self, *args, **kwargs)
+
+    with tempfile.NamedTemporaryFile(suffix=".tar", delete=False) as f:
+        out_path = f.name
+    try:
+        with patch("httpx.Client.__init__", patched):
+            written = agent.download_environment_snapshot(out_path, session_id="s1")
+        assert written == len(snapshot_body)
+        with open(out_path, "rb") as fh:
+            assert fh.read() == snapshot_body
+    finally:
+        import os
+
+        os.unlink(out_path)
+
+
+def test_download_environment_snapshot_requires_an_env_id():
+    agent = AntigravityAgent(name="T", api_key="dummy")
+    with pytest.raises(ValueError, match="environment_id"):
+        agent.download_environment_snapshot("/tmp/x.tar")
+
+
+def test_no_db_degrades_gracefully_no_cross_turn_reuse():
+    """Without a db there is no session persistence: every turn provisions a
+    fresh sandbox ('remote') and never sends previous_interaction_id. Must not error."""
+    captured: List[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content.decode()))
+        return httpx.Response(200, json=_interaction_response(env_id="env-1", interaction_id="int-1"))
+
+    agent = AntigravityAgent(name="T", api_key="dummy")  # no db
+
+    with _patch_async_client(_mock_transport(handler)):
+        agent.run("turn one", session_id="s1")
+        agent.run("turn two", session_id="s1")
+
+    # Both turns provisioned fresh — no cached env id, no interaction linkage.
+    for body in captured:
+        assert body["environment"] == "remote"
+        assert "previous_interaction_id" not in body

--- a/libs/agno/tests/unit/tools/test_antigravity.py
+++ b/libs/agno/tests/unit/tools/test_antigravity.py
@@ -1,0 +1,494 @@
+"""Unit tests for AntigravityTools."""
+
+import json
+from typing import List
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from agno.tools.antigravity import AntigravityTools
+
+
+def _interaction_response(env_id: str = "env-1", interaction_id: str = "int-1", text: str = "done"):
+    return {
+        "id": interaction_id,
+        "status": "completed",
+        "environment_id": env_id,
+        "steps": [{"type": "model_output", "content": [{"type": "text", "text": text}]}],
+    }
+
+
+def _patch_sync_client(transport):
+    original_init = httpx.Client.__init__
+
+    def patched_init(self, *args, **kwargs):
+        kwargs["transport"] = transport
+        original_init(self, *args, **kwargs)
+
+    return patch("httpx.Client.__init__", patched_init)
+
+
+def test_init_requires_api_key():
+    with patch.dict("os.environ", {}, clear=True):
+        with pytest.raises(ValueError, match="GEMINI_API_KEY"):
+            AntigravityTools()
+
+
+def test_init_registers_expected_tools():
+    tools = AntigravityTools(api_key="dummy")
+    tool_names = {f.name for f in tools.functions.values()}
+    assert tool_names == {
+        "run_antigravity_task",
+        "run_custom_antigravity_agent",
+        "create_custom_antigravity_agent",
+        "update_custom_antigravity_agent",
+        "get_custom_antigravity_agent",
+        "list_antigravity_agents",
+        "list_antigravity_agent_versions",
+        "delete_antigravity_agent",
+        "download_antigravity_environment_snapshot",
+    }
+
+
+def test_run_antigravity_task_first_call_stores_env_id_in_session_state():
+    captured: List[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content.decode()))
+        return httpx.Response(200, json=_interaction_response(env_id="env-99", interaction_id="int-1"))
+
+    tools = AntigravityTools(api_key="dummy")
+    fake_agent = MagicMock()
+    fake_agent.session_state = {}
+
+    with _patch_sync_client(httpx.MockTransport(handler)):
+        result = tools.run_antigravity_task(fake_agent, "do a thing")
+
+    assert result == "done"
+    assert captured[0]["environment"] == "remote"
+    assert fake_agent.session_state["antigravity_env_id"] == "env-99"
+    assert fake_agent.session_state["antigravity_previous_interaction_id"] == "int-1"
+
+
+def test_run_antigravity_task_reuses_cached_env_on_subsequent_call():
+    captured: List[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content.decode()))
+        return httpx.Response(200, json=_interaction_response(env_id="env-99", interaction_id="int-2"))
+
+    tools = AntigravityTools(api_key="dummy")
+    fake_agent = MagicMock()
+    fake_agent.session_state = {
+        "antigravity_env_id": "env-99",
+        "antigravity_previous_interaction_id": "int-1",
+    }
+
+    with _patch_sync_client(httpx.MockTransport(handler)):
+        tools.run_antigravity_task(fake_agent, "follow up")
+
+    body = captured[0]
+    assert body["environment"] == "env-99"
+    assert body["previous_interaction_id"] == "int-1"
+
+
+def test_run_antigravity_task_returns_error_json_on_http_failure():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    tools = AntigravityTools(api_key="dummy")
+    fake_agent = MagicMock()
+    fake_agent.session_state = {}
+
+    with _patch_sync_client(httpx.MockTransport(handler)):
+        result = tools.run_antigravity_task(fake_agent, "hi")
+
+    parsed = json.loads(result)
+    assert parsed["status"] == "error"
+    assert "500" in parsed["message"]
+
+
+def test_create_custom_antigravity_agent_posts_to_agents_endpoint():
+    captured: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"name": "test-agent"})
+
+    tools = AntigravityTools(api_key="dummy")
+
+    with _patch_sync_client(httpx.MockTransport(handler)):
+        result = tools.create_custom_antigravity_agent(
+            name="test-agent",
+            instructions="be helpful",
+            sources=[{"type": "inline", "content": "x", "target": "/a"}],
+        )
+
+    assert json.loads(result) == {"name": "test-agent"}
+    assert captured[0].url.path.endswith("/agents")
+    body = json.loads(captured[0].content.decode())
+    assert body["name"] == "test-agent"
+    assert body["instructions"] == "be helpful"
+    assert body["base_environment"] == {
+        "type": "remote",
+        "sources": [{"type": "inline", "content": "x", "target": "/a"}],
+    }
+
+
+def test_delete_antigravity_agent_calls_delete():
+    captured: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(204)
+
+    tools = AntigravityTools(api_key="dummy")
+
+    with _patch_sync_client(httpx.MockTransport(handler)):
+        result = tools.delete_antigravity_agent("test-agent")
+
+    assert json.loads(result) == {"status": "ok", "deleted": "test-agent"}
+    assert captured[0].method == "DELETE"
+    assert captured[0].url.path.endswith("/agents/test-agent")
+
+
+def test_run_custom_antigravity_agent_sends_custom_name_in_body():
+    captured: List[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content.decode()))
+        return httpx.Response(
+            200,
+            json={
+                "id": "int-1",
+                "status": "completed",
+                "outputs": [{"type": "text", "text": "haiku"}],
+                "environment_id": "env-1",
+            },
+        )
+
+    tools = AntigravityTools(api_key="dummy")
+    fake_agent = MagicMock()
+    fake_agent.session_state = {}
+
+    with _patch_sync_client(httpx.MockTransport(handler)):
+        result = tools.run_custom_antigravity_agent(fake_agent, "my-bot", "write a haiku")
+
+    assert result == "haiku"
+    body = captured[0]
+    assert body["agent"] == "my-bot"
+    assert body["input"] == [{"type": "text", "text": "write a haiku"}]
+    assert body["stream"] is False
+    # State is keyed per-custom-agent so different named agents don't share envs.
+    assert fake_agent.session_state["antigravity_env_id__my-bot"] == "env-1"
+    assert fake_agent.session_state["antigravity_previous_interaction_id__my-bot"] == "int-1"
+
+
+def test_run_custom_antigravity_agent_reuses_per_agent_session_state():
+    captured: List[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(json.loads(request.content.decode()))
+        return httpx.Response(
+            200,
+            json={"id": "int-2", "status": "completed", "outputs": [{"type": "text", "text": "ok"}]},
+        )
+
+    tools = AntigravityTools(api_key="dummy")
+    fake_agent = MagicMock()
+    fake_agent.session_state = {
+        "antigravity_env_id__my-bot": "env-1",
+        "antigravity_previous_interaction_id__my-bot": "int-1",
+    }
+
+    with _patch_sync_client(httpx.MockTransport(handler)):
+        tools.run_custom_antigravity_agent(fake_agent, "my-bot", "follow up")
+
+    body = captured[0]
+    assert body["environment"] == "env-1"
+    assert body["previous_interaction_id"] == "int-1"
+
+
+def test_update_custom_antigravity_agent_sends_patch():
+    captured: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"name": "my-bot", "instructions": "new"})
+
+    tools = AntigravityTools(api_key="dummy")
+
+    with _patch_sync_client(httpx.MockTransport(handler)):
+        result = tools.update_custom_antigravity_agent("my-bot", instructions="new")
+
+    assert json.loads(result) == {"name": "my-bot", "instructions": "new"}
+    assert captured[0].method == "PATCH"
+    assert captured[0].url.path.endswith("/agents/my-bot")
+    body = json.loads(captured[0].content.decode())
+    assert body == {"instructions": "new"}
+
+
+def test_update_custom_antigravity_agent_rejects_empty_update():
+    tools = AntigravityTools(api_key="dummy")
+    result = tools.update_custom_antigravity_agent("my-bot")
+    assert json.loads(result)["status"] == "error"
+
+
+def test_get_custom_antigravity_agent_hits_correct_path():
+    captured: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"name": "my-bot"})
+
+    tools = AntigravityTools(api_key="dummy")
+    with _patch_sync_client(httpx.MockTransport(handler)):
+        result = tools.get_custom_antigravity_agent("my-bot")
+
+    assert json.loads(result) == {"name": "my-bot"}
+    assert captured[0].method == "GET"
+    assert captured[0].url.path.endswith("/agents/my-bot")
+
+
+def test_list_antigravity_agent_versions_hits_versions_path():
+    captured: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"versions": []})
+
+    tools = AntigravityTools(api_key="dummy")
+    with _patch_sync_client(httpx.MockTransport(handler)):
+        tools.list_antigravity_agent_versions("my-bot")
+
+    assert captured[0].url.path.endswith("/agents/my-bot/versions")
+
+
+def test_create_with_base_env_id_uses_env_id_form():
+    captured: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json={"name": "my-bot"})
+
+    tools = AntigravityTools(api_key="dummy")
+    with _patch_sync_client(httpx.MockTransport(handler)):
+        tools.create_custom_antigravity_agent(name="my-bot", instructions="be helpful", base_env_id="env-42")
+
+    body = json.loads(captured[0].content.decode())
+    assert body["base_environment"] == {"env_id": "env-42"}
+
+
+def test_download_environment_snapshot_writes_file_and_returns_status():
+    import os
+    import tempfile
+
+    snapshot_body = b"FAKE_TAR_" + b"y" * 50
+
+    captured: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, content=snapshot_body)
+
+    tools = AntigravityTools(api_key="dummy")
+    with tempfile.NamedTemporaryFile(suffix=".tar", delete=False) as f:
+        out_path = f.name
+    try:
+        with _patch_sync_client(httpx.MockTransport(handler)):
+            result = tools.download_antigravity_environment_snapshot("env-77", out_path)
+
+        parsed = json.loads(result)
+        assert parsed["status"] == "ok"
+        assert parsed["bytes"] == len(snapshot_body)
+        assert parsed["environment_id"] == "env-77"
+        assert "/files/environment-env-77:download" in str(captured[0].url)
+        with open(out_path, "rb") as fh:
+            assert fh.read() == snapshot_body
+    finally:
+        os.unlink(out_path)
+
+
+def test_download_environment_snapshot_current_resolves_from_session_state():
+    import os
+    import tempfile
+
+    captured: List[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, content=b"tar")
+
+    tools = AntigravityTools(api_key="dummy")
+    fake_agent = MagicMock()
+    fake_agent.session_state = {"antigravity_env_id": "env-cached"}
+
+    with tempfile.NamedTemporaryFile(suffix=".tar", delete=False) as f:
+        out_path = f.name
+    try:
+        with _patch_sync_client(httpx.MockTransport(handler)):
+            result = tools.download_antigravity_environment_snapshot("current", out_path, agent=fake_agent)
+        parsed = json.loads(result)
+        assert parsed["status"] == "ok"
+        assert parsed["environment_id"] == "env-cached"
+        assert "/files/environment-env-cached:download" in str(captured[0].url)
+    finally:
+        os.unlink(out_path)
+
+
+def test_download_environment_snapshot_current_without_cached_env_returns_error():
+    import os
+    import tempfile
+
+    tools = AntigravityTools(api_key="dummy")
+    fake_agent = MagicMock()
+    fake_agent.session_state = {}
+
+    with tempfile.NamedTemporaryFile(suffix=".tar", delete=False) as f:
+        out_path = f.name
+    try:
+        result = tools.download_antigravity_environment_snapshot("current", out_path, agent=fake_agent)
+        parsed = json.loads(result)
+        assert parsed["status"] == "error"
+        assert "no cached env id" in parsed["message"]
+    finally:
+        os.unlink(out_path)
+
+
+# ---------------------------------------------------------------------------
+# agent_directory loading
+# ---------------------------------------------------------------------------
+
+import tempfile  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+
+def _make_toolkit_agent_dir(tmp: Path) -> Path:
+    (tmp / "agent.yaml").write_text(
+        "id: my-bot\nbase_agent: antigravity-preview-05-2026\ndescription: A bot\nsystem_instruction: be brief\n"
+    )
+    (tmp / "AGENTS.md").write_text("haiku writer instructions")
+    (tmp / "workspace").mkdir()
+    (tmp / "workspace" / "about.txt").write_text("about content")
+    (tmp / "skills").mkdir()
+    (tmp / "skills" / "haiku").mkdir()
+    (tmp / "skills" / "haiku" / "SKILL.md").write_text("# Haiku skill")
+    return tmp
+
+
+def test_agent_directory_register_false_parses_without_network():
+    with tempfile.TemporaryDirectory() as d:
+        _make_toolkit_agent_dir(Path(d))
+        tools = AntigravityTools(api_key="dummy", agent_directory=d, register=False)
+
+    assert tools.agent == "my-bot"
+    assert tools.default_sources is not None
+    targets = {s["target"] for s in tools.default_sources}
+    assert "/about.txt" in targets
+    assert "/.agents/skills/haiku/SKILL.md" in targets
+
+
+def test_agent_directory_register_true_posts_to_agents():
+    captured: List[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(
+            {"method": request.method, "url": str(request.url), "body": json.loads(request.content.decode())}
+        )
+        return httpx.Response(200, json={"name": "my-bot"})
+
+    with tempfile.TemporaryDirectory() as d:
+        _make_toolkit_agent_dir(Path(d))
+        with _patch_sync_client(httpx.MockTransport(handler)):
+            tools = AntigravityTools(api_key="dummy", agent_directory=d)  # register=True default
+
+    assert tools.agent == "my-bot"
+    assert len(captured) == 1
+    assert captured[0]["method"] == "POST"
+    assert captured[0]["url"].endswith("/agents")
+    body = captured[0]["body"]
+    assert body["name"] == "my-bot"
+    assert body["base_agent"] == "antigravity-preview-05-2026"
+    # AGENTS.md beat system_instruction
+    assert body["instructions"] == "haiku writer instructions"
+    assert body["description"] == "A bot"
+    # sources were attached
+    assert body["base_environment"]["type"] == "remote"
+    targets = {s["target"] for s in body["base_environment"]["sources"]}
+    assert "/about.txt" in targets
+    assert "/.agents/skills/haiku/SKILL.md" in targets
+
+
+def test_agent_directory_treats_409_as_success():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(409, text="already exists")
+
+    with tempfile.TemporaryDirectory() as d:
+        _make_toolkit_agent_dir(Path(d))
+        with _patch_sync_client(httpx.MockTransport(handler)):
+            tools = AntigravityTools(api_key="dummy", agent_directory=d)
+
+    # Construction succeeded; toolkit is wired to invoke the named agent.
+    assert tools.agent == "my-bot"
+
+
+def test_agent_directory_conflicts_with_explicit_agent_arg():
+    with tempfile.TemporaryDirectory() as d:
+        _make_toolkit_agent_dir(Path(d))
+        with pytest.raises(ValueError, match="conflicts with explicit `agent="):
+            AntigravityTools(api_key="dummy", agent_directory=d, agent="other", register=False)
+
+
+def test_agent_directory_conflicts_with_explicit_default_sources():
+    with tempfile.TemporaryDirectory() as d:
+        _make_toolkit_agent_dir(Path(d))
+        with pytest.raises(ValueError, match="conflicts with explicit `default_sources="):
+            AntigravityTools(api_key="dummy", agent_directory=d, default_sources=[{}], register=False)
+
+
+def test_agent_directory_requires_id_and_base_agent():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d)
+        (p / "agent.yaml").write_text("description: missing required keys\n")
+        with pytest.raises(ValueError, match="id.*base_agent"):
+            AntigravityTools(api_key="dummy", agent_directory=d, register=False)
+
+
+def test_agent_directory_post_400_raises():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    with tempfile.TemporaryDirectory() as d:
+        _make_toolkit_agent_dir(Path(d))
+        with _patch_sync_client(httpx.MockTransport(handler)):
+            with pytest.raises(RuntimeError, match="500"):
+                AntigravityTools(api_key="dummy", agent_directory=d)
+
+
+def test_run_antigravity_task_after_agent_directory_uses_named_agent():
+    """After agent_directory wires up self.agent, run_antigravity_task should
+    invoke the named agent, not the bare 'antigravity' one."""
+    request_bodies: List[dict] = []
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # First request is POST /agents (registration); second is /interactions.
+        call_count["n"] += 1
+        if request.url.path.endswith("/agents"):
+            return httpx.Response(200, json={"name": "my-bot"})
+        request_bodies.append(json.loads(request.content.decode()))
+        return httpx.Response(
+            200,
+            json={"id": "int-1", "outputs": [{"type": "text", "text": "ok"}], "environment_id": "env-1"},
+        )
+
+    fake_agent = MagicMock()
+    fake_agent.session_state = {}
+    with tempfile.TemporaryDirectory() as d:
+        _make_toolkit_agent_dir(Path(d))
+        with _patch_sync_client(httpx.MockTransport(handler)):
+            tools = AntigravityTools(api_key="dummy", agent_directory=d)
+            tools.run_antigravity_task(fake_agent, "do a thing")
+
+    assert request_bodies[0]["agent"] == "my-bot"  # not "antigravity-preview-05-2026"


### PR DESCRIPTION
## Summary

Adds first-party support for Google's Gemini Agents API ("Antigravity") in Agno, in two integration shapes mapped to the API's two natural use cases:

- **`AntigravityAgent`** (`agno.agents.antigravity`) — a `BaseExternalAgent` adapter so an Antigravity-backed agent can be served through AgentOS with native sessions, streaming, and UI. Mirrors the existing `ClaudeAgent` / `LangGraphAgent` / `DSPyAgent` pattern.
- **`AntigravityTools`** (`agno.tools.antigravity`) — a `Toolkit` so a regular Agno agent (any model) can delegate a sub-task to a managed Antigravity sandbox as a single tool call. Mirrors the `DaytonaTools` / `E2BTools` pattern

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [x] I have searched existing open pull requests and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)
