### PR TITLE
chore: release 2.6.8

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "agno"
-version = "2.6.7"
+version = "2.6.8"
 description = "The programming language for agentic software."
 requires-python = ">=3.7,<4"
 readme = "README.md"


### PR DESCRIPTION
# Changelog

## New Features:

- **Antigravity:** Added first-party support for Google's Antigravity API in two shapes — `AntigravityAgent` (a `BaseExternalAgent` served through AgentOS with native sessions/streaming/UI) and `AntigravityTools` (a `Toolkit` that lets any Agno agent delegate a sub-task to a managed Antigravity sandbox).
- **Gemini Managed Agents:** Added `GeminiInteractions` support for Google's managed agents — **Deep Research** (autonomous research with citations, background streaming with reconnect/`last_event_id` resume) and **Antigravity** (general-purpose agent in a managed Linux sandbox). New `agent` / `agent_config` / `environment` fields, per-agent forcing of `background` and `store`, and support for `mcp_servers` + `file_search_store_names` on the agent path.
- **Cookbook - Data Labeling:** Added `cookbook/data_labeling/` with 18 self-contained workflows covering text, image, audio, video, document, and composed (LLM-as-judge, quality review) labeling primitives.
- **Cookbook - Slack HITL:** Added a deterministic Slack HITL incident-commander demo showing structured pauses via `tool_choice="required"`, user_input echo, and clean termination via `stop_after_tool_call=True`.

## Improvements:

- **Path Safety (Security):** Centralized path-safety into a new `agno.utils.path_safety` module with `safe_join` and `safe_join_subpath`. Hardened `FileGenerationTools`, `SlackTools`, `Toolkit._check_path`, `agno.skills.utils.is_safe_path`, and `FileTools.check_escape` against path traversal, symlink escape, control-char injection, Windows MagicDot, and Unicode normalization attacks. Introduced `PathSecurityError` (`FileGenerationSecurityError` kept as deprecation alias). Bumped `requires-python` to `>=3.9,<4`.
- **Parallel MCP:** `ParallelMCPBackend` now sends `User-Agent: agno/<version>` on every request so Parallel can attribute traffic to agno.
- **Evals Config:** Dropped the unused `available_models` field from `EvalsDomainConfig`; the top-level `AgentOSConfig.available_models` is now the only supported source for the Evals UI dropdown.
- **Chonkie:** Updated chonkie dependency pin (follow-up to #7869).
- **Cookbook:** Renamed `gemini-3-flash-preview` to `gemini-3.5-flash` across the Gemini Interactions cookbooks.

## Bug Fixes:

- **AG-UI Teams:** Fixed a typo (`stream_steps` → `stream_events`) that caused teams running via AG-UI to silently drop all intermediate streaming events (lifecycle, reasoning, tool calls, member delegations) for ~7 months.
- **Slack Extra:** Added `aiohttp>=3.7.3,<4` to the `slack` optional extra — `AsyncWebClient` imports `aiohttp` at module load, so `pip install agno[slack]` was broken for all Slack operations.
- **Google Drive:** Surfaced the Drive API `incompleteSearch` flag from `GoogleDriveTools.search_files()` so `corpora="allDrives"` callers can detect when Drive did not search every drive.
- **GeminiInteractions:** Added a `generation_config` passthrough field for advanced controls (`top_k`, `presence_penalty`, etc.) and fixed history handling — when `previous_interaction_id` is set, only the new turn is sent rather than replaying the full history. Now actually leverages server-side statefulness.
- **Anthropic Server Tools:** Preserved `server_tool_use` and code-execution content blocks in message history so multi-turn server-tool flows no longer break across turns.
- **Anthropic Hardening:** Follow-up to the above — switched to the canonical `redacted_thinking` type literal (the SDK rejects `redacted_reasoning_content`), accepted both spellings on the streaming start event, added a dedup guard on round-tripped server tool blocks, made coercion failures visible via `log_warning`, and coerced non-block tool-result items to text.
- **Gemini Errors:** Generic Gemini errors now include the exception type when `str(error)` is empty or weak, preserving error context across `invoke` / `invoke_stream` / `ainvoke` / `ainvoke_stream`.
- **N1N:** Added the missing `n1n` provider mapping in `get_model()` so `Agent(model="n1n:...")` model-string paths now resolve correctly.