### PR TITLE
chore: bump chonkie to `>=1.6.7`

### DIFF
--- a/libs/agno/pyproject.toml
+++ b/libs/agno/pyproject.toml
@@ -192,7 +192,7 @@ csv = ["aiofiles"]
 excel = ["openpyxl", "xlrd"]
 markdown = ["unstructured<0.18.31", "markdown", "aiofiles"]
 chonkie = [
-    "chonkie[semantic,code]>=1.6.6",
+    "chonkie[semantic,code]>=1.6.7",
 ]
 
 # Dependencies for AG-UI integration

--- a/libs/agno/tests/unit/knowledge/chunking/test_code_chunking.py
+++ b/libs/agno/tests/unit/knowledge/chunking/test_code_chunking.py
@@ -44,7 +44,7 @@ function goodbye() {
 
 def test_code_chunking_basic(sample_python_code):
     """Test basic code chunking with default parameters."""
-    chunker = CodeChunking(language="python")
+    chunker = CodeChunking()
     doc = Document(content=sample_python_code, name="test.py")
 
     chunks = chunker.chunk(doc)
@@ -188,7 +188,7 @@ def test_code_chunking_metadata(sample_python_code):
 
 def test_code_chunking_empty_content():
     """Test handling of empty content."""
-    chunker = CodeChunking(language="python")
+    chunker = CodeChunking()
     doc = Document(content="", name="empty.py")
 
     chunks = chunker.chunk(doc)


### PR DESCRIPTION
## Summary

Following up on #7904, there was another [reported issue](https://github.com/chonkie-inc/chonkie/issues/583#issuecomment-4448807389) in chonkie with auto-detection of language, which is shipped [v1.6.7](https://github.com/chonkie-inc/chonkie/issues/583#issuecomment-4492666117) to fix this regression in 1.6.6. 

This PR bumps the version and removes the temporary test workarounds that were added in #7904 to dodge that bug.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Improvement
- [ ] Model update
- [ ] Other:

---

## Checklist

- [ ] Code complies with style guidelines
- [ ] Ran format/validation scripts (`./scripts/format.sh` and `./scripts/validate.sh`)
- [ ] Self-review completed
- [ ] Documentation updated (comments, docstrings)
- [ ] Examples and guides: Relevant cookbook examples have been included or updated (if applicable)
- [ ] Tested in clean environment
- [ ] Tests added/updated (if applicable)

### Duplicate and AI-Generated PR Check

- [ ] I have searched existing [open pull requests](../../pulls) and confirmed that no other PR already addresses this issue
- [ ] If a similar PR exists, I have explained below why this PR is a better approach
- [ ] Check if this PR was entirely AI-generated (by Copilot, Claude Code, Cursor, etc.)

---

## Additional Notes

Add any important context (deployment instructions, screenshots, security considerations, etc.)
